### PR TITLE
111: Add pre-commit-java hooks

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -3,6 +3,14 @@ name: Continuous Deployment
 on: [push]
 
 jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3 # v2 minimum required
+      - uses: axel-op/googlejavaformat-action@v3
+        with:
+          args: "--skip-sorting-imports --replace"
+
   build:
     defaults:
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,3 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip: [pretty-format-java]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,9 @@ repos:
       -   id: detect-secrets
           args: [ '--baseline', '.secrets.baseline' ]
           exclude: package.lock.json
+  -   repo: https://github.com/gherynos/pre-commit-java
+      rev: v0.2.1  # Use the ref you want to point at
+      hooks:
+       -  id: pmd
+       -  id: cpd
+       -  id: checkstyle

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,33 @@
 repos:
-  -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v3.2.0
-      hooks:
-        -   id: trailing-whitespace
-        -   id: end-of-file-fixer
-        -   id: check-yaml
-        -   id: check-added-large-files
-  -   repo: https://github.com/pre-commit/mirrors-eslint
-      rev: ''  # Use the sha / tag you want to point at
-      hooks:
-        - id: eslint
-          files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
-          types: [ file ]
-          additional_dependencies:
-          -   eslint@8.32.0
-          -   eslint-config-prettier@8.6.0
-          -   eslint-plugin-prettier@4.2.1
-          -   eslint-plugin-react@7.32.1
-          -   typescript
-          -   '@typescript-eslint/eslint-plugin'
-          -   '@typescript-eslint/parser'
-  -   repo: https://github.com/Yelp/detect-secrets
-      rev: v1.4.0
-      hooks:
-      -   id: detect-secrets
-          args: [ '--baseline', '.secrets.baseline' ]
-          exclude: package.lock.json
-  -   repo: https://github.com/gherynos/pre-commit-java
-      rev: v0.2.1  # Use the ref you want to point at
-      hooks:
-       -  id: pmd
-       -  id: cpd
-       -  id: checkstyle
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: ''  # Use the sha / tag you want to point at
+    hooks:
+      - id: eslint
+        files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
+        types: [ file ]
+        additional_dependencies:
+          - eslint@8.32.0
+          - eslint-config-prettier@8.6.0
+          - eslint-plugin-prettier@4.2.1
+          - eslint-plugin-react@7.32.1
+          - typescript
+          - '@typescript-eslint/eslint-plugin'
+          - '@typescript-eslint/parser'
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: [ '--baseline', '.secrets.baseline' ]
+        exclude: package.lock.json
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.7.0
+    hooks:
+      - id: pretty-format-java
+        args: [ --autofix ]

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -39,4 +39,3 @@ nb-configuration.xml
 */**/.env*
 .env
 .env*
-

--- a/api/src/main/java/gov/doj/Application.java
+++ b/api/src/main/java/gov/doj/Application.java
@@ -6,17 +6,17 @@ import io.quarkus.runtime.annotations.QuarkusMain;
 
 @QuarkusMain
 public class Application {
-    public static void main(String... args) {
-        Quarkus.run(BOSS.class, args);
-    }
+  public static void main(String... args) {
+    Quarkus.run(BOSS.class, args);
+  }
 
-    public static class BOSS implements QuarkusApplication {
+  public static class BOSS implements QuarkusApplication {
 
-        @Override
-        public int run(String... args) throws Exception {
-            RuntimeObjectFactory.init();
-            Quarkus.waitForExit();
-            return 0;
-        }
+    @Override
+    public int run(String... args) throws Exception {
+      RuntimeObjectFactory.init();
+      Quarkus.waitForExit();
+      return 0;
     }
+  }
 }

--- a/api/src/main/java/gov/doj/ObjectFactory.java
+++ b/api/src/main/java/gov/doj/ObjectFactory.java
@@ -4,22 +4,22 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class ObjectFactory {
-    private static final Map<String, Object> objectMap = new HashMap<>();
+  private static final Map<String, Object> objectMap = new HashMap<>();
 
-    protected ObjectFactory() {}
+  protected ObjectFactory() {}
 
-    public static <T> T getObjectByAbstractClass(final Class<T> clazz) {
-        @SuppressWarnings("unchecked")
-        final T object = (T) objectMap.get(clazz.getName());
+  public static <T> T getObjectByAbstractClass(final Class<T> clazz) {
+    @SuppressWarnings("unchecked")
+    final T object = (T) objectMap.get(clazz.getName());
 
-        if (object == null) {
-            throw new IllegalArgumentException("Couldn't find object for " + clazz.getName());
-        }
-
-        return object;
+    if (object == null) {
+      throw new IllegalArgumentException("Couldn't find object for " + clazz.getName());
     }
 
-    public static void registerObject(final Class<?> clazz, final Object reference) {
-        objectMap.put(clazz.getName(), reference);
-    }
+    return object;
+  }
+
+  public static void registerObject(final Class<?> clazz, final Object reference) {
+    objectMap.put(clazz.getName(), reference);
+  }
 }

--- a/api/src/main/java/gov/doj/Presenter.java
+++ b/api/src/main/java/gov/doj/Presenter.java
@@ -1,7 +1,7 @@
 package gov.doj;
 
 public interface Presenter {
-    void onSuccess(Object content);
+  void onSuccess(Object content);
 
-    void onFailure(Exception e);
+  void onFailure(Exception e);
 }

--- a/api/src/main/java/gov/doj/RuntimeObjectFactory.java
+++ b/api/src/main/java/gov/doj/RuntimeObjectFactory.java
@@ -5,37 +5,35 @@ import gov.doj.adapters.gateways.LocalPersistenceGateway;
 import gov.doj.adapters.presenters.JsonPresenter;
 import gov.doj.usecases.PersistenceGateway;
 import io.quarkus.runtime.configuration.ConfigUtils;
-
 import java.util.List;
 
 public class RuntimeObjectFactory extends ObjectFactory {
-    public static void init() {
-        registerObject(Presenter.class, new JsonPresenter());
+  public static void init() {
+    registerObject(Presenter.class, new JsonPresenter());
 
-        List<String> profiles = ConfigUtils.getProfiles();
-        if (profiles.contains("dev") && !profiles.contains("azure")) {
-            initLocal();
-        } else {
-            initProd();
-        }
-
+    List<String> profiles = ConfigUtils.getProfiles();
+    if (profiles.contains("dev") && !profiles.contains("azure")) {
+      initLocal();
+    } else {
+      initProd();
     }
+  }
 
-    private static void initLocal() {
-        registerObject(PersistenceGateway.class, new LocalPersistenceGateway());
-    }
+  private static void initLocal() {
+    registerObject(PersistenceGateway.class, new LocalPersistenceGateway());
+  }
 
-    private static void initProd() {
-        registerObject(PersistenceGateway.class, new AzureSqlGateway());
-    }
-//    public static void init() {
-//        registerObject(Presenter.class, new JsonPresenter());
-//        registerObject(PersistenceGateway.class, new LocalPersistenceGateway());
-//    }
-//
-//    public static void initCloud()
-//    {
-//        registerObject(Presenter.class, new JsonPresenter());
-//        registerObject(PersistenceGateway.class, new AzureSqlGateway());
-//    }
+  private static void initProd() {
+    registerObject(PersistenceGateway.class, new AzureSqlGateway());
+  }
+  //    public static void init() {
+  //        registerObject(Presenter.class, new JsonPresenter());
+  //        registerObject(PersistenceGateway.class, new LocalPersistenceGateway());
+  //    }
+  //
+  //    public static void initCloud()
+  //    {
+  //        registerObject(Presenter.class, new JsonPresenter());
+  //        registerObject(PersistenceGateway.class, new AzureSqlGateway());
+  //    }
 }

--- a/api/src/main/java/gov/doj/adapters/controllers/CaseListController.java
+++ b/api/src/main/java/gov/doj/adapters/controllers/CaseListController.java
@@ -4,77 +4,73 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.doj.entities.Case;
 import gov.doj.usecases.CasesUseCase;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("/cases")
 public class CaseListController {
 
-    private CasesUseCase caseUseCase = new CasesUseCase();
+  private CasesUseCase caseUseCase = new CasesUseCase();
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    public String getCases() throws JsonProcessingException {
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getCases() throws JsonProcessingException {
 
-        List<Case> cases = caseUseCase.getCases();
+    List<Case> cases = caseUseCase.getCases();
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        String json = objectMapper.writeValueAsString(cases);
+    ObjectMapper objectMapper = new ObjectMapper();
+    String json = objectMapper.writeValueAsString(cases);
 
-        return json;
+    return json;
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/{caseId}")
+  public String getCaseById(long caseId) throws JsonProcessingException {
+
+    Optional<Case> _case = caseUseCase.getCaseById(caseId);
+
+    Case caseValue = _case.get();
+    if (caseValue.getCases_id() == 0) {
+      return "No Cases found with case Id : " + " " + caseId;
+    } else {
+
+      ObjectMapper objectMapper = new ObjectMapper();
+      String json = objectMapper.writeValueAsString(_case.get());
+
+      return json;
     }
+  }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path("/{caseId}")
-    public String getCaseById(long caseId) throws JsonProcessingException{
+  @Consumes(MediaType.APPLICATION_JSON)
+  @POST
+  @Path("/create")
+  public boolean create(String payload) {
+    long val = 0L; // case id generation value.
+    Case obj = new Case(val, "Betty", "Gates2", "Complete", Timestamp.from(Instant.now()), 3);
+    var response = Response.ok(caseUseCase.createCase(obj)).build();
+    return false;
+  }
 
-        Optional<Case> _case = caseUseCase.getCaseById(caseId);
+  @Consumes(MediaType.APPLICATION_JSON)
+  @PUT
+  @Path("/{caseId}")
+  public boolean update(long caseId, String payload) {
+    Case obj = new Case(caseId, "Betty", "Gates2", "Complete", Timestamp.from(Instant.now()), 3);
+    var response = Response.ok(caseUseCase.updateCase(obj)).build();
+    return false;
+  }
 
-        Case caseValue = _case.get();
-        if(caseValue.getCases_id() == 0){
-            return "No Cases found with case Id : " + " " + caseId;
-        }
-        else{
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            String json = objectMapper.writeValueAsString(_case.get());
-
-            return json;
-        }
-    }
-
-    @Consumes(MediaType.APPLICATION_JSON)
-    @POST
-    @Path("/create")
-    public boolean create(String payload){
-        long val = 0L; //case id generation value.
-        Case obj = new Case(val, "Betty", "Gates2", "Complete", Timestamp.from(Instant.now()), 3);
-        var response = Response.ok(caseUseCase.createCase(obj)).build();
-        return false;
-    }
-
-    @Consumes(MediaType.APPLICATION_JSON)
-    @PUT
-    @Path("/{caseId}")
-    public boolean update(long caseId, String payload)
-    {
-        Case obj = new Case(caseId, "Betty", "Gates2", "Complete", Timestamp.from(Instant.now()), 3);
-        var response = Response.ok(caseUseCase.updateCase(obj)).build();
-        return false;
-    }
-
-    @Produces(MediaType.APPLICATION_JSON)
-    @DELETE
-    @Path("/{caseId}")
-    public boolean delete(long caseId)
-    {
-        return caseUseCase.deleteCase(caseId);
-    }
+  @Produces(MediaType.APPLICATION_JSON)
+  @DELETE
+  @Path("/{caseId}")
+  public boolean delete(long caseId) {
+    return caseUseCase.deleteCase(caseId);
+  }
 }

--- a/api/src/main/java/gov/doj/adapters/gateways/AzureSqlGateway.java
+++ b/api/src/main/java/gov/doj/adapters/gateways/AzureSqlGateway.java
@@ -2,7 +2,6 @@ package gov.doj.adapters.gateways;
 
 import gov.doj.entities.Case;
 import gov.doj.usecases.PersistenceGateway;
-
 import java.sql.*;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -11,155 +10,162 @@ import java.util.Optional;
 
 public class AzureSqlGateway implements PersistenceGateway {
 
-    protected  ConnectionManager connectionManager;
+  protected ConnectionManager connectionManager;
 
-    public AzureSqlGateway(){
-        connectionManager = new ConnectionManager();
+  public AzureSqlGateway() {
+    connectionManager = new ConnectionManager();
+  }
+
+  @Override
+  public List<Case> getCases() {
+
+    List<Case> casesList = new ArrayList<>();
+    ResultSet resultSet = null;
+    String selectSql =
+        "SELECT cases_id, staff1, staff2, idi_status, idi_date, chapters_id from Cases";
+
+    try (Connection connection = this.connectionManager.getConnection();
+        Statement statement = connection.createStatement(); ) {
+
+      resultSet = statement.executeQuery(selectSql);
+      while (resultSet.next()) {
+        long id = resultSet.getLong("cases_id");
+        String staff1 = resultSet.getString("staff1");
+        String staff2 = resultSet.getString("staff2");
+        String idi_status = resultSet.getString("idi_status");
+        Timestamp idi_date = resultSet.getTimestamp("idi_date");
+        int chapters_id = resultSet.getInt("chapters_id");
+
+        Case _case = new Case(id, staff1, staff2, idi_status, idi_date, chapters_id);
+        casesList.add(_case);
+
+        System.out.println(
+            resultSet.getString(1)
+                + " "
+                + resultSet.getString(2)
+                + " "
+                + resultSet.getString(3)
+                + " "
+                + resultSet.getString(4)
+                + " "
+                + resultSet.getString(5)
+                + " "
+                + resultSet.getString(6)
+                + " ");
+      }
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
 
-    @Override
-    public List<Case> getCases() {
+    return casesList;
+  }
 
-        List<Case> casesList = new ArrayList<>();
-        ResultSet resultSet = null;
-        String selectSql = "SELECT cases_id, staff1, staff2, idi_status, idi_date, chapters_id from Cases";
+  @Override
+  public Optional<Case> getCase(long caseId) {
+    String selectSql =
+        "SELECT cases_id, staff1, staff2, idi_status, idi_date, chapters_id from Cases where"
+            + " cases_id = ?";
+    long cases_id = 0;
+    String staff1 = "", staff2 = "", idi_status = "";
+    Timestamp idi_date = Timestamp.from(Instant.now());
+    int chapters_id = 0;
 
-        try (Connection connection = this.connectionManager.getConnection();
-              Statement statement = connection.createStatement(); ){
+    try (Connection connection = this.connectionManager.getConnection();
+        PreparedStatement statement = connection.prepareStatement(selectSql); ) {
 
-            resultSet = statement.executeQuery(selectSql);
-            while (resultSet.next()) {
-                long id = resultSet.getLong("cases_id");
-                String staff1 = resultSet.getString("staff1");
-                String staff2 = resultSet.getString("staff2");
-                String idi_status = resultSet.getString("idi_status");
-                Timestamp idi_date = resultSet.getTimestamp("idi_date");
-                int chapters_id = resultSet.getInt("chapters_id");
+      statement.setString(1, String.valueOf(caseId));
+      ResultSet resultSet = statement.executeQuery();
 
-                Case _case = new Case(id, staff1, staff2, idi_status, idi_date, chapters_id);
-                casesList.add(_case);
+      if (resultSet.next()) {
+        cases_id = resultSet.getLong("cases_id");
+        staff1 = resultSet.getString("staff1");
+        staff2 = resultSet.getString("staff2");
+        idi_status = resultSet.getString("idi_status");
+        idi_date = resultSet.getTimestamp("idi_date");
+        chapters_id = resultSet.getInt("chapters_id");
+      }
 
+      return Optional.of(new Case(cases_id, staff1, staff2, idi_status, idi_date, chapters_id));
 
-                System.out.println(resultSet.getString(1) + " "
-                        + resultSet.getString(2) + " "
-                        + resultSet.getString(3) + " "
-                        + resultSet.getString(4) + " "
-                        + resultSet.getString(5) + " "
-                        + resultSet.getString(6) + " "
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-                );
-            }
+  @Override
+  public boolean createCase(Case aCaseObj) {
 
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    String sql =
+        "INSERT into Cases (staff1, staff2, idi_status, idi_date, chapters_id) VALUES (?, ?, ?, ?,"
+            + " ?)";
+    boolean rowInserted = false;
 
-        return casesList;
+    try (Connection connection = this.connectionManager.getConnection();
+        PreparedStatement statement = connection.prepareStatement(sql); ) {
+
+      statement.setString(1, aCaseObj.getStaff1());
+      statement.setString(2, aCaseObj.getStaff2());
+      statement.setString(3, aCaseObj.getIdi_status());
+      statement.setTimestamp(4, aCaseObj.getIdi_date());
+      statement.setInt(5, aCaseObj.getChapters_id());
+
+      rowInserted = statement.executeUpdate() > 0;
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
 
-    @Override
-    public Optional<Case> getCase(long caseId) {
-        String selectSql = "SELECT cases_id, staff1, staff2, idi_status, idi_date, chapters_id from Cases where cases_id = ?";
-        long cases_id = 0;
-        String staff1 = "", staff2 = "", idi_status = "";
-        Timestamp idi_date = Timestamp.from(Instant.now());
-        int chapters_id = 0;
+    return rowInserted;
+  }
 
-        try (Connection connection = this.connectionManager.getConnection();
-             PreparedStatement statement = connection.prepareStatement(selectSql); ) {
+  @Override
+  public boolean updateCase(Case aCaseObj) {
 
-            statement.setString(1, String.valueOf(caseId));
-            ResultSet resultSet = statement.executeQuery();
+    String sql =
+        "UPDATE Cases "
+            + "SET staff1 = ?, "
+            + "SET staff2 = ?, "
+            + "SET idi_status = ?,"
+            + "SET idi_date = ?,"
+            + "SET chapters_id = ?,";
+    sql += " WHERE cases_id = ?";
 
-            if(resultSet.next()) {
-                cases_id = resultSet.getLong("cases_id");
-                staff1 = resultSet.getString("staff1");
-                staff2 = resultSet.getString("staff2");
-                idi_status = resultSet.getString("idi_status");
-                idi_date = resultSet.getTimestamp("idi_date");
-                chapters_id = resultSet.getInt("chapters_id");
-            }
+    boolean rowUpdated = false;
+    try (Connection connection = this.connectionManager.getConnection();
+        PreparedStatement statement = connection.prepareStatement(sql); ) {
 
-            return Optional.of(new Case(cases_id, staff1, staff2, idi_status, idi_date, chapters_id));
+      statement.setString(1, aCaseObj.getStaff1());
+      statement.setString(2, aCaseObj.getStaff2());
+      statement.setString(3, aCaseObj.getIdi_status());
+      statement.setTimestamp(4, aCaseObj.getIdi_date());
+      statement.setInt(5, aCaseObj.getChapters_id());
+      statement.setLong(6, aCaseObj.getCases_id());
 
-        }catch (Exception e){
-            throw new RuntimeException(e);
-        }
+      rowUpdated = statement.executeUpdate() > 0;
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
 
-    @Override
-    public boolean createCase(Case aCaseObj) {
+    return rowUpdated;
+  }
 
-        String sql = "INSERT into Cases (staff1, staff2, idi_status, idi_date, chapters_id) VALUES (?, ?, ?, ?, ?)";
-        boolean rowInserted = false;
+  @Override
+  public boolean deleteCase(long caseId) {
 
-        try (Connection connection = this.connectionManager.getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql);){
+    String sql = "DELETE FROM cases where cases_id = ?";
+    boolean rowDeleted = false;
 
-            statement.setString(1, aCaseObj.getStaff1());
-            statement.setString(2, aCaseObj.getStaff2());
-            statement.setString(3,aCaseObj.getIdi_status());
-            statement.setTimestamp(4, aCaseObj.getIdi_date());
-            statement.setInt(5, aCaseObj.getChapters_id());
+    try (Connection connection = this.connectionManager.getConnection();
+        PreparedStatement statement = connection.prepareStatement(sql); ) {
 
-            rowInserted = statement.executeUpdate() > 0;
+      statement.setLong(1, caseId);
 
-        }catch (Exception e){
-            throw new RuntimeException(e);
-        }
-
-
-        return rowInserted;
-    }
-
-    @Override
-    public boolean updateCase(Case aCaseObj) {
-
-        String sql = "UPDATE Cases " +
-                "SET staff1 = ?, " +
-                "SET staff2 = ?, " +
-                "SET idi_status = ?," +
-                "SET idi_date = ?," +
-                "SET chapters_id = ?,";
-        sql+= " WHERE cases_id = ?";
-
-        boolean rowUpdated = false;
-        try (Connection connection = this.connectionManager.getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql);) {
-
-            statement.setString(1, aCaseObj.getStaff1());
-            statement.setString(2, aCaseObj.getStaff2());
-            statement.setString(3,aCaseObj.getIdi_status());
-            statement.setTimestamp(4, aCaseObj.getIdi_date());
-            statement.setInt(5, aCaseObj.getChapters_id());
-            statement.setLong(6, aCaseObj.getCases_id());
-
-            rowUpdated = statement.executeUpdate() > 0;
-
-        }catch(Exception e){
-            throw new RuntimeException(e);
-        }
-
-        return rowUpdated;
+      rowDeleted = statement.executeUpdate() > 0;
+    } catch (Exception e) {
 
     }
-
-    @Override
-    public boolean deleteCase(long caseId) {
-
-        String sql = "DELETE FROM cases where cases_id = ?";
-        boolean rowDeleted = false;
-
-        try (Connection connection = this.connectionManager.getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql);) {
-
-            statement.setLong(1, caseId);
-
-            rowDeleted = statement.executeUpdate() > 0;
-        }catch(Exception e){
-
-
-        }
-        return false;
-    }
+    return false;
+  }
 }

--- a/api/src/main/java/gov/doj/adapters/gateways/ConnectionManager.java
+++ b/api/src/main/java/gov/doj/adapters/gateways/ConnectionManager.java
@@ -1,44 +1,43 @@
 package gov.doj.adapters.gateways;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 public class ConnectionManager {
 
-    private final String connectionUrl;
-    private final Properties properties;
-    private Connection connection;
+  private final String connectionUrl;
+  private final Properties properties;
+  private Connection connection;
 
-    public ConnectionManager() {
-        this.connectionUrl = ConfigProvider.getConfig().getValue("url", String.class);
-        String user = ConfigProvider.getConfig().getValue("sql.user", String.class);
-        String password = ConfigProvider.getConfig().getValue("password", String.class);
-        properties = new Properties();
-        properties.put("user", user);
-        properties.put("password", password);
+  public ConnectionManager() {
+    this.connectionUrl = ConfigProvider.getConfig().getValue("url", String.class);
+    String user = ConfigProvider.getConfig().getValue("sql.user", String.class);
+    String password = ConfigProvider.getConfig().getValue("password", String.class);
+    properties = new Properties();
+    properties.put("user", user);
+    properties.put("password", password);
+  }
+
+  public Connection getConnection() {
+
+    try {
+      connection = DriverManager.getConnection(connectionUrl, properties);
+    } catch (SQLException e) {
+      e.printStackTrace();
     }
 
-    public Connection getConnection() {
+    return connection;
+  }
 
-        try {
-            connection = DriverManager.getConnection(connectionUrl, properties);
-        }catch (SQLException e){
-            e.printStackTrace();
-        }
+  public void closeConnection() {
 
-        return connection;
+    try {
+      this.connection.close();
+    } catch (SQLException e) {
+      e.printStackTrace();
     }
-
-    public void closeConnection() {
-
-        try {
-            this.connection.close();
-        }catch (SQLException e){
-            e.printStackTrace();
-        }
-    }
-
+  }
 }

--- a/api/src/main/java/gov/doj/adapters/gateways/LocalPersistenceGateway.java
+++ b/api/src/main/java/gov/doj/adapters/gateways/LocalPersistenceGateway.java
@@ -2,43 +2,46 @@ package gov.doj.adapters.gateways;
 
 import gov.doj.entities.Case;
 import gov.doj.usecases.PersistenceGateway;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public class LocalPersistenceGateway implements PersistenceGateway {
-    List<String> caseList = new ArrayList<>();
+  List<String> caseList = new ArrayList<>();
 
-    public LocalPersistenceGateway() {
-        caseList.add("Case Number: 477-14-12211, Chapter: 11, Debtor: Debby Debtor, Staff1: Brian BusinessAnalyst");
-        caseList.add("Case Number: 477-14-12151, Chapter: 11, Debtor: Testy McTesterson, Staff1: Brian BusinessAnalyst");
-    }
+  public LocalPersistenceGateway() {
+    caseList.add(
+        "Case Number: 477-14-12211, Chapter: 11, Debtor: Debby Debtor, Staff1: Brian"
+            + " BusinessAnalyst");
+    caseList.add(
+        "Case Number: 477-14-12151, Chapter: 11, Debtor: Testy McTesterson, Staff1: Brian"
+            + " BusinessAnalyst");
+  }
 
-    @Override
-    public List<Case> getCases() {
-        return new ArrayList<>();
-    }
+  @Override
+  public List<Case> getCases() {
+    return new ArrayList<>();
+  }
 
-    @Override
-    public Optional<Case> getCase(long caseId) {
-        return null;
-    }
+  @Override
+  public Optional<Case> getCase(long caseId) {
+    return null;
+  }
 
-    @Override
-    public boolean createCase(Case aCaseObj) {
-        return false;
-    }
+  @Override
+  public boolean createCase(Case aCaseObj) {
+    return false;
+  }
 
-    @Override
-    public boolean updateCase(Case aCaseObj) {
+  @Override
+  public boolean updateCase(Case aCaseObj) {
 
-        return false;
-    }
+    return false;
+  }
 
-    @Override
-    public boolean deleteCase(long casesId) {
+  @Override
+  public boolean deleteCase(long casesId) {
 
-        return false;
-    }
+    return false;
+  }
 }

--- a/api/src/main/java/gov/doj/adapters/presenters/JsonPresenter.java
+++ b/api/src/main/java/gov/doj/adapters/presenters/JsonPresenter.java
@@ -4,13 +4,13 @@ import gov.doj.Presenter;
 
 public class JsonPresenter implements Presenter {
 
-    @Override
-    public void onSuccess(Object content) {
-        System.out.println(content);
-    }
+  @Override
+  public void onSuccess(Object content) {
+    System.out.println(content);
+  }
 
-    @Override
-    public void onFailure(Exception e) {
-        System.out.println(e);
-    }
+  @Override
+  public void onFailure(Exception e) {
+    System.out.println(e);
+  }
 }

--- a/api/src/main/java/gov/doj/entities/Case.java
+++ b/api/src/main/java/gov/doj/entities/Case.java
@@ -3,78 +3,83 @@ package gov.doj.entities;
 import java.sql.Timestamp;
 
 public class Case {
-    protected long cases_id;
-    public String staff1;
-    public String staff2;
-    public String idi_status;
-    public Timestamp idi_date;
-    public int chapters_id;
-    public Case(){
-    }
+  protected long cases_id;
+  public String staff1;
+  public String staff2;
+  public String idi_status;
+  public Timestamp idi_date;
+  public int chapters_id;
 
-    public Case(long id){
-        this.cases_id = id;
-    }
+  public Case() {}
 
-    public Case(long id, String staff1, String staff2, String idi_status, Timestamp timeStamp, int chapters_id)
-    {
-        this.cases_id = id;
-        this.staff1 = staff1;
-        this.staff2 = staff2;
-        this.idi_status = idi_status;
-        this.idi_date = timeStamp;
-        this.chapters_id = chapters_id;
-    }
+  public Case(long id) {
+    this.cases_id = id;
+  }
 
-    public Case(String staff1, String staff2, String idiStatus, Timestamp idiDate, int chaptersId) {
-        this.staff1 = staff1;
-        this.staff2 = staff2;
-        this.idi_status = idiStatus;
-        this.idi_date = idiDate;
-        this.chapters_id = chapters_id;
-    }
+  public Case(
+      long id,
+      String staff1,
+      String staff2,
+      String idi_status,
+      Timestamp timeStamp,
+      int chapters_id) {
+    this.cases_id = id;
+    this.staff1 = staff1;
+    this.staff2 = staff2;
+    this.idi_status = idi_status;
+    this.idi_date = timeStamp;
+    this.chapters_id = chapters_id;
+  }
 
-    public long getCases_id() {
-        return cases_id;
-    }
+  public Case(String staff1, String staff2, String idiStatus, Timestamp idiDate, int chaptersId) {
+    this.staff1 = staff1;
+    this.staff2 = staff2;
+    this.idi_status = idiStatus;
+    this.idi_date = idiDate;
+    this.chapters_id = chapters_id;
+  }
 
-    public String getStaff1() {
-        return staff1;
-    }
+  public long getCases_id() {
+    return cases_id;
+  }
 
-    public void setStaff1(String staff1) {
-        this.staff1 = staff1;
-    }
+  public String getStaff1() {
+    return staff1;
+  }
 
-    public String getStaff2() {
-        return staff2;
-    }
+  public void setStaff1(String staff1) {
+    this.staff1 = staff1;
+  }
 
-    public void setStaff2(String staff2) {
-        this.staff2 = staff2;
-    }
+  public String getStaff2() {
+    return staff2;
+  }
 
-    public String getIdi_status() {
-        return idi_status;
-    }
+  public void setStaff2(String staff2) {
+    this.staff2 = staff2;
+  }
 
-    public void setIdi_status(String idi_status) {
-        this.idi_status = idi_status;
-    }
+  public String getIdi_status() {
+    return idi_status;
+  }
 
-    public Timestamp getIdi_date() {
-        return idi_date;
-    }
+  public void setIdi_status(String idi_status) {
+    this.idi_status = idi_status;
+  }
 
-    public void setIdi_date(Timestamp idi_date) {
-        this.idi_date = idi_date;
-    }
+  public Timestamp getIdi_date() {
+    return idi_date;
+  }
 
-    public int getChapters_id() {
-        return chapters_id;
-    }
+  public void setIdi_date(Timestamp idi_date) {
+    this.idi_date = idi_date;
+  }
 
-    public void setChapters_id(int chapters_id) {
-        this.chapters_id = chapters_id;
-    }
+  public int getChapters_id() {
+    return chapters_id;
+  }
+
+  public void setChapters_id(int chapters_id) {
+    this.chapters_id = chapters_id;
+  }
 }

--- a/api/src/main/java/gov/doj/usecases/CasesUseCase.java
+++ b/api/src/main/java/gov/doj/usecases/CasesUseCase.java
@@ -8,48 +8,42 @@ import java.util.Optional;
 
 public class CasesUseCase {
 
-    private PersistenceGateway persistenceGateway;
-    private Presenter presenter;
+  private PersistenceGateway persistenceGateway;
+  private Presenter presenter;
 
-    public CasesUseCase()
-    {
-        persistenceGateway = ObjectFactory.getObjectByAbstractClass(PersistenceGateway.class);
-        presenter = ObjectFactory.getObjectByAbstractClass(Presenter.class);
-    }
+  public CasesUseCase() {
+    persistenceGateway = ObjectFactory.getObjectByAbstractClass(PersistenceGateway.class);
+    presenter = ObjectFactory.getObjectByAbstractClass(Presenter.class);
+  }
 
-    public List<Case> getCases(){
-        List<Case> cases = persistenceGateway.getCases();
-        presenter.onSuccess(cases.toString());
-        return cases;
-    }
+  public List<Case> getCases() {
+    List<Case> cases = persistenceGateway.getCases();
+    presenter.onSuccess(cases.toString());
+    return cases;
+  }
 
-    public Optional<Case> getCaseById(long cases_id){
-        Optional<Case> aCase = persistenceGateway.getCase(cases_id);
-        presenter.onSuccess(aCase.toString());
-        return aCase;
-    }
+  public Optional<Case> getCaseById(long cases_id) {
+    Optional<Case> aCase = persistenceGateway.getCase(cases_id);
+    presenter.onSuccess(aCase.toString());
+    return aCase;
+  }
 
-    public boolean createCase(Case aCaseObj){
+  public boolean createCase(Case aCaseObj) {
 
-        boolean caseCreated = persistenceGateway.createCase(aCaseObj);
-        presenter.onSuccess(caseCreated);
-        return caseCreated;
-    }
+    boolean caseCreated = persistenceGateway.createCase(aCaseObj);
+    presenter.onSuccess(caseCreated);
+    return caseCreated;
+  }
 
-    public boolean updateCase(Case aCaseObj)
-    {
-        boolean caseUpdated = persistenceGateway.updateCase(aCaseObj);
-        presenter.onSuccess("true");
-        return true;
-    }
+  public boolean updateCase(Case aCaseObj) {
+    boolean caseUpdated = persistenceGateway.updateCase(aCaseObj);
+    presenter.onSuccess("true");
+    return true;
+  }
 
-    public boolean deleteCase(long cases_id)
-    {
-        boolean caseDeleted = persistenceGateway.deleteCase(cases_id);
-        presenter.onSuccess("true");
-        return true;
-    }
-
-
-
+  public boolean deleteCase(long cases_id) {
+    boolean caseDeleted = persistenceGateway.deleteCase(cases_id);
+    presenter.onSuccess("true");
+    return true;
+  }
 }

--- a/api/src/main/java/gov/doj/usecases/PersistenceGateway.java
+++ b/api/src/main/java/gov/doj/usecases/PersistenceGateway.java
@@ -5,13 +5,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PersistenceGateway {
-    List<Case> getCases();
+  List<Case> getCases();
 
-    Optional<Case> getCase(long caseId);
+  Optional<Case> getCase(long caseId);
 
-    boolean createCase(Case aCaseObj);
+  boolean createCase(Case aCaseObj);
 
-    boolean updateCase(Case aCaseObj);
+  boolean updateCase(Case aCaseObj);
 
-    boolean deleteCase(long casesId);
+  boolean deleteCase(long casesId);
 }

--- a/api/src/test/java/gov/doj/CaseListTest.java
+++ b/api/src/test/java/gov/doj/CaseListTest.java
@@ -1,33 +1,28 @@
 package gov.doj;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
-
 @QuarkusTest
 public class CaseListTest {
 
-    @BeforeAll
-    public static void init()
-    {
-        TestObjectFactory.init();
-    }
-    @Test
-    public void testGetCases(){
+  @BeforeAll
+  public static void init() {
+    TestObjectFactory.init();
+  }
 
-        given().when().get("/cases").then().statusCode(204);
-    }
+  @Test
+  public void testGetCases() {
 
-    @Test
-    public void testGetCasesEndPoint(){
-        given()
-                .when().get("/cases")
-                .then()
-                .statusCode(200)
-                .body(containsString("1"));
+    given().when().get("/cases").then().statusCode(204);
+  }
 
-    }
+  @Test
+  public void testGetCasesEndPoint() {
+    given().when().get("/cases").then().statusCode(200).body(containsString("1"));
+  }
 }

--- a/api/src/test/java/gov/doj/TestObjectFactory.java
+++ b/api/src/test/java/gov/doj/TestObjectFactory.java
@@ -4,13 +4,13 @@ import gov.doj.adapters.gateways.AzureSqlGateway;
 import gov.doj.adapters.presenters.JsonPresenter;
 import gov.doj.usecases.PersistenceGateway;
 
-public class TestObjectFactory extends ObjectFactory  {
+public class TestObjectFactory extends ObjectFactory {
 
-    public static void init() {
-        registerObject(Presenter.class, new JsonPresenter());
+  public static void init() {
+    registerObject(Presenter.class, new JsonPresenter());
 
-        //List<String> profiles = ConfigUtils.getProfiles(); // uncomment this when a test context/profile is added later
-        registerObject(PersistenceGateway.class, new AzureSqlGateway()); // switch back to Local
-    }
-
+    // List<String> profiles = ConfigUtils.getProfiles(); // uncomment this when a test
+    // context/profile is added later
+    registerObject(PersistenceGateway.class, new AzureSqlGateway()); // switch back to Local
+  }
 }


### PR DESCRIPTION
# Java Formatting

Adds the use of the Google Java Formatter.

## pre-commit

For local development, commits will trigger the formatter if the developer has `pre-commit` installed—which they should.

### Auto-fix

Files will automatically be fixed by the hook, but will need to be manually committed.

## GitHub

Because `pre-commit.ci` fails to run this check successfully, the `pretty-format-java` hook is skipped for CI in favor of running the [axel-op/googlejavaformat-action@v3 GitHub Action](https://github.com/axel-op/googlejavaformat-action). 

> Note:
> We should not be relying on either pre-commit.ci or Github Actions to run our hooks, rather they are performed on GitHub as a failsafe.

### Auto-fix

The Action should automatically fix files and push a commit.