### PR TITLE
111: Update Hearing Date and Time Column

### DIFF
--- a/gui/src/components/CaseList.tsx
+++ b/gui/src/components/CaseList.tsx
@@ -79,7 +79,7 @@ export const CaseList = () => {
               <th>Debtor Name</th>
               <th>Current Chapter Date</th>
               <th>Hearing Code</th>
-              <th>Initial Hearing Date/Time</th>
+              <th>Hearing Date and Time</th>
               <th>Hearing Disposition</th>
               <th>{caseList.body.staff1Label}</th>
               <th>{caseList.body.staff2Label}</th>

--- a/gui/tests/unit/CaseList.test.tsx
+++ b/gui/tests/unit/CaseList.test.tsx
@@ -100,7 +100,7 @@ describe('Base App Tests', () => {
         expect(tableHeader[1].textContent).toBe('Debtor Name');
         expect(tableHeader[2].textContent).toBe('Current Chapter Date');
         expect(tableHeader[3].textContent).toBe('Hearing Code');
-        expect(tableHeader[4].textContent).toBe('Initial Hearing Date/Time');
+        expect(tableHeader[4].textContent).toBe('Hearing Date and Time');
         expect(tableHeader[5].textContent).toBe('Hearing Disposition');
         expect(tableHeader[6].textContent).toBe('Trial Attorney');
         expect(tableHeader[7].textContent).toBe('Auditor');


### PR DESCRIPTION
Updated the title column to Hearing Date and Time to remove ambiguity with multiple rows for the same case number.