### PR TITLE
106: Add CC0 license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Public contributions
 
-We're so glad you're thinking about contributing to a DOJ USTP open source project! If you're unsure about anything, just [send us an email](mailto:18f@gsa.gov) with your question — or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
+We're so glad you're thinking about contributing to a DOJ USTP open source project! If you feel you have something to add to the project, please submit a pull request. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
 
 We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+## Public contributions
+
+We're so glad you're thinking about contributing to a DOJ USTP open source project! If you're unsure about anything, just [send us an email](mailto:18f@gsa.gov) with your question — or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
+
+We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
+
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
+
+* If you see an error or have feedback, the best way to let us know is to file an issue.
+* To contribute a specific change to the site, outside contributors will need to fork this repo.
+
+## Public domain
+
+For detailed license information, see [LICENSE](LICENSE.md).
+
+All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We're so glad you're thinking about contributing to a DOJ USTP open source project! If you feel you have something to add to the project, please submit a pull request. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
 
-We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
+We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://handbook.tts.gsa.gov/about-us/code-of-conduct/) and all contributors should do the same.
 
 We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,25 @@
+# License
+
+As a work of the [United States government](https://www.usa.gov/), this project is in the public domain within the United States of America.
+
+Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of their rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute, and perform the work, even for commercial purposes, all without asking permission.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.
+
+### Contributions to this project
+
+As stated in [CONTRIBUTING](CONTRIBUTING.md), all contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.


### PR DESCRIPTION
# CC0 License

Add CC0 license to LICENSE.md
Add CONTRIBUTING.md with disclaimer of waiver of rights pursuant to the CC0 license

## LICENSE.md Text

The text used comes from a couple of 18f sources, combining a couple of things from [the 18f.gsa.gov license](https://github.com/18F/18f.gsa.gov/blob/main/LICENSE.md) and the markdown from [the 18F Open Source Policy](https://github.com/18F/open-source-policy/blob/master/LICENSE.md).

The summary can be found on [the Creative Commons](https://creativecommons.org/choose/zero/) website.

## CONTRIBUTING.md

As was done on [the 18f.gsa.gov license](https://github.com/18F/18f.gsa.gov/blob/main/LICENSE.md), we've added a disclaimer to the contribution guidelines to inform contributors of their waiver of rights to contributions.

### Contact Email

USTP is requesting an email address be created for the product. Once that email is in place, we should add something like the following to this file:

```
If you're unsure about anything, just [send us an email](mailto:email@doj.gov) with your question — or submit the issue or pull request anyway.
```