### PR TITLE
Fix Azure Functions warning locally

### DIFF
--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -27,7 +27,7 @@
     "build": "tsc --project tsconfig.build.json",
     "watch": "tsc --project tsconfig.build.json -w",
     "prestart": "npm run build",
-    "start": "func start",
+    "start": "func start --typescript",
     "start:dev": "nodemon --esm src/server.ts",
     "test": "DATABASE_MOCK='true' jest",
     "pack": "mkdir -p /tmp/build && zip -q -r /tmp/build/$OUT.zip . --exclude @.funcignore --exclude .funcignore && mv /tmp/build/$OUT.zip .",


### PR DESCRIPTION
When running `npm start`, the Azure Function console output included warnings that the language was not determinable from the source code. Adding `--typescript` to the script resolves this issue.