### PR TITLE
Ignore package-lock.json on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       hooks:
         -   id: trailing-whitespace
         -   id: end-of-file-fixer
+            exclude: '^.*/package-lock.json$'
         -   id: check-yaml
         -   id: check-added-large-files
   -   repo: https://github.com/pre-commit/mirrors-eslint

--- a/user-interface/package-lock.json
+++ b/user-interface/package-lock.json
@@ -5152,6 +5152,18 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
     },
+    "node_modules/svgo/node_modules/css-what": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/svgo/node_modules/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -9332,18 +9344,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/svgo/node_modules/css-select/node_modules/css-what": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/walker": {
@@ -32368,15 +32368,13 @@
             "css-what": "^3.2.1",
             "domutils": "^1.7.0",
             "nth-check": "2.0.1"
-          },
-          "dependencies": {
-            "css-what": {
-              "version": "3.4.2",
-              "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-              "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
-              "dev": true
-            }
           }
+        },
+        "css-what": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+          "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+          "dev": true
         },
         "dom-serializer": {
           "version": "0.2.2",


### PR DESCRIPTION
# The Problem

If you delete `package-lock.json` and generate a new one, then the `end-of-file-fixer` pre-commit hook stops you from committing the file without first adding a newline to the end. 

# The Solution

This particular file is unnecessary to check so we can just ignore it.