### PR TITLE
CAMS-64 Update pipeline with plan type

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -299,7 +299,7 @@ jobs:
             --resourceGroup ${{ steps.rgApp.outputs.out }} \
             --file ./ops/cloud-deployment/ustp-cams.bicep \
             --parameters 'appName=${{ needs.build-info.outputs.stackName }} deployVnet=${{ needs.build-info.outputs.execVnetDeploy }} deployNetwork=true networkResourceGroupName=${{ steps.rgNetwork.outputs.out }} virtualNetworkName=${{ vars.AZ_NETWORK_VNET_NAME }} deployWebapp=true webappResourceGroupName=${{ steps.rgApp.outputs.out }} deployFunctions=true apiFunctionsResourceGroupName=${{ steps.rgApp.outputs.out }} sqlServerName=${{ secrets.AZ_SQL_SERVER_NAME }} sqlServerResourceGroupName=${{ secrets.AZURE_RG }} allowVeracodeScan=true webappPlanType=${{ vars.AZ_PLAN_TYPE }} apiPlanType=${{ vars.AZ_PLAN_TYPE }}'
-            
+
           v1=$(cat ./outputs.json | jq -r .functionAppName.value)
           echo "functionAppName=${v1}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -10,7 +10,6 @@ jobs:
     environment: ${{ endsWith(github.ref,'refs/heads/main') && 'Main' || 'Develop' }}
     outputs:
       environment: ${{ vars.ENVIRONMENT }}
-      branchHashCode: ${{ steps.build-info.outputs.branchHashCode }}
       stackName: ${{ steps.build-info.outputs.stackName }}
       webappName: ${{ steps.build-info.outputs.webappName }}
       apiName: ${{ steps.build-info.outputs.apiName }}
@@ -21,6 +20,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Check environment
+        id: check-env
+        if: ${{ vars.ENVIRONMENT }} != 'Main' # Generate deterministic hash to append to resource group names
+        run: |
+          hash=$(echo -n ${{ github.ref_name }} | openssl sha256 | awk '{print $2}')
+          shortHash="-dev-${hash:0:6}"
+          echo "branchHashCode=${shortHash}" >> $GITHUB_OUTPUT
+
       - name: Print build info
         id: build-info
         run: |
@@ -30,12 +37,10 @@ jobs:
           echo "Git SHA: ${{ github.sha }}"
 
           # Generate resource group name(s)
-          hash=$(echo -n ${{ github.ref_name }} | openssl sha256 | awk '{print $2}')
-          short_hash=${hash:0:6}
-          echo "Hash generated from ${{ github.ref_name }} : ${hash}  ${short_hash}"
-          echo "branchHashCode=${short_hash}" >> $GITHUB_OUTPUT
-          echo "azResourceGrpApp=${{ secrets.AZ_APP_RG }}-${short_hash}" >> $GITHUB_OUTPUT
-          echo "azResourceGrpNetwork=${{ secrets.AZ_NETWORK_RG }}-${short_hash}" >> $GITHUB_OUTPUT
+          branchHashCode=${{ steps.check-env.outputs.branchHashCode || '' }}
+          echo "Resource group appended with the following: ${branchHashCode}"
+          echo "azResourceGrpApp=${{ secrets.AZ_APP_RG }}${branchHashCode}" >> $GITHUB_OUTPUT
+          echo "azResourceGrpNetwork=${{ secrets.AZ_NETWORK_RG }}${branchHashCode}" >> $GITHUB_OUTPUT
 
           # Stack name used downstream to label build artifacts and Azure resources
           stackName=$(ops/helper-scripts/generate-stackname.sh ${{ vars.ENVIRONMENT }} ${{ vars.APP_NAME }} ${{ vars.DEV_SUFFIX }} ${{ github.ref_name }})

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -25,6 +25,7 @@ jobs:
         id: build-info
         run: |
           echo "Printing build info"
+          echo "Azure Plan Type: ${{ vars.AZ_PLAN_TYPE }}"
           echo "Environment: ${{ vars.ENVIRONMENT }}"
           echo "Git SHA: ${{ github.sha }}"
 
@@ -297,8 +298,8 @@ jobs:
             --show-what-if \
             --resourceGroup ${{ steps.rgApp.outputs.out }} \
             --file ./ops/cloud-deployment/ustp-cams.bicep \
-            --parameters 'appName=${{ needs.build-info.outputs.stackName }} deployVnet=${{ needs.build-info.outputs.execVnetDeploy }} deployNetwork=true networkResourceGroupName=${{ steps.rgNetwork.outputs.out }} virtualNetworkName=${{ vars.AZ_NETWORK_VNET_NAME }} deployWebapp=true webappResourceGroupName=${{ steps.rgApp.outputs.out }} deployFunctions=true apiFunctionsResourceGroupName=${{ steps.rgApp.outputs.out }} sqlServerName=${{ secrets.AZ_SQL_SERVER_NAME }} sqlServerResourceGroupName=${{ secrets.AZURE_RG }} allowVeracodeScan=true'
-
+            --parameters 'appName=${{ needs.build-info.outputs.stackName }} deployVnet=${{ needs.build-info.outputs.execVnetDeploy }} deployNetwork=true networkResourceGroupName=${{ steps.rgNetwork.outputs.out }} virtualNetworkName=${{ vars.AZ_NETWORK_VNET_NAME }} deployWebapp=true webappResourceGroupName=${{ steps.rgApp.outputs.out }} deployFunctions=true apiFunctionsResourceGroupName=${{ steps.rgApp.outputs.out }} sqlServerName=${{ secrets.AZ_SQL_SERVER_NAME }} sqlServerResourceGroupName=${{ secrets.AZURE_RG }} allowVeracodeScan=true webappPlanType=${{ vars.AZ_PLAN_TYPE }} apiPlanType=${{ vars.AZ_PLAN_TYPE }}'
+            
           v1=$(cat ./outputs.json | jq -r .functionAppName.value)
           echo "functionAppName=${v1}" >> $GITHUB_OUTPUT
 

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -5,20 +5,20 @@ param planName string
 
 @description('Plan type to determine plan Sku')
 @allowed([
-  'production'
-  'development'
+  'P1v2'
+  'B2'
 ])
-param planType string = 'development'
+param planType string = 'P1v2'
 
 var planTypeToSkuMap = {
-  production: {
+  P1v2: {
     name: 'P1v2'
     tier: 'PremiumV2'
     size: 'P1v2'
     family: 'Pv2'
     capacity: 1
   }
-  development: {
+  B2: {
     name: 'B2'
     tier: 'Basic'
     size: 'B2'

--- a/ops/cloud-deployment/frontend-webapp-deploy.bicep
+++ b/ops/cloud-deployment/frontend-webapp-deploy.bicep
@@ -5,20 +5,20 @@ param planName string
 
 @description('Plan type to determine plan Sku')
 @allowed([
-  'production'
-  'development'
+  'P1v2'
+  'B2'
 ])
-param planType string = 'development'
+param planType string = 'P1v2'
 
 var planTypeToSkuMap = {
-  production: {
+  P1v2: {
     name: 'P1v2'
     tier: 'PremiumV2'
     size: 'P1v2'
     family: 'Pv2'
     capacity: 1
   }
-  development: {
+  B2: {
     name: 'B2'
     tier: 'Basic'
     size: 'B2'

--- a/ops/cloud-deployment/ustp-cams.bicep
+++ b/ops/cloud-deployment/ustp-cams.bicep
@@ -18,6 +18,13 @@ param webappSubnetAddressPrefix string = '10.10.10.0/28'
 param webappPrivateEndpointSubnetName string = 'snet-${webappName}-pep'
 param webappPrivateEndpointSubnetAddressPrefix string = '10.10.11.0/28'
 param webappPlanName string = 'plan-${webappName}'
+@description('Plan type to determine plan Sku')
+@allowed([
+  'P1v2'
+  'B2'
+])
+param webappPlanType string
+
 
 param deployFunctions bool = true
 param apiName string = '${appName}-node-api'
@@ -27,6 +34,13 @@ param apiFunctionsSubnetAddressPrefix string = '10.10.12.0/28'
 param apiPrivateEndpointSubnetName string = 'snet-${apiName}-pep'
 param apiPrivateEndpointSubnetAddressPrefix string = '10.10.13.0/28'
 param apiPlanName string = 'plan-${apiName}'
+@description('Plan type to determine plan Sku')
+@allowed([
+  'P1v2'
+  'B2'
+])
+param apiPlanType string
+
 
 param privateDnsZoneName string = 'privatelink.azurewebsites.net'
 
@@ -64,6 +78,7 @@ module ustpWebapp './frontend-webapp-deploy.bicep' = if (deployWebapp) {
   scope: resourceGroup(webappResourceGroupName)
   params: {
     planName: webappPlanName
+    planType: webappPlanType
     webappName: webappName
     location: location
     privateDnsZoneName: ustpNetwork.outputs.privateDnsZoneName
@@ -80,6 +95,7 @@ module ustpWebapp './frontend-webapp-deploy.bicep' = if (deployWebapp) {
 var funcParams = [
   {// Define api node function resources
     planName: apiPlanName
+    planType: apiPlanType
     functionName: apiName
     functionsRuntime: 'node'
     functionSubnetName: apiFunctionsSubnetName


### PR DESCRIPTION
Follow up to the following PR https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/pull/57

Received the following on Main deployment
`ERROR: ***"error":***"code":"AuthorizationFailed","message":"The client '9e84c910-9d80-4d04-9c7c-8594aefbac3f' with object id '9e84c910-9d80-4d04-9c7c-8594aefbac3f' does not have authorization to perform action 'Microsoft.Resources/deployments/whatIf/action' over scope '/subscriptions/***/resourcegroups/***/providers/Microsoft.Resources/deployments/ustp-cams' or the scope is invalid. If access was recently granted, please refresh your credentials."***`

Running the /ops/helper-scripts/azure-deploy.sh locally works. Suspect the the problem is an incorrectly set resource group name which should be fixed in this pull request. If this problem persist on Main environment, we might want to add a check if the resource group name exist to the deploy script.