### PR TITLE
CAMS-69 temporarily disable scans

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -114,6 +114,7 @@ jobs:
         run: ../ops/helper-scripts/accessibility-test.sh
 
   security-sast-scan:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     needs: [ build-info ]
     environment: ${{ needs.build-info.outputs.environment }}
@@ -150,6 +151,7 @@ jobs:
           az storage blob upload --account-name ${{ secrets.az_stor_veracode_name }} --account-key ${{ secrets.az_stor_veracode_key }} -f filtered_results.json -c results -n filtered_results-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.ref_name }}.json
 
   security-sca-scan-frontend:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     name: Scan repository frontend with Veracode SCA
 
@@ -168,6 +170,7 @@ jobs:
           path: user-interface/
 
   security-sca-scan-backend:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     name: Scan repository backend with Veracode SCA
 
@@ -191,7 +194,7 @@ jobs:
         working-directory: user-interface
 
     runs-on: ubuntu-latest
-    needs: [ build-info, security-sca-scan-frontend, security-sast-scan ]
+    needs: [ build-info ]
     environment: ${{ needs.build-info.outputs.environment }}
 
     strategy:
@@ -239,7 +242,7 @@ jobs:
         working-directory: backend/functions
 
     runs-on: ubuntu-latest
-    needs: [ build-info, security-sca-scan-backend, security-sast-scan ]
+    needs: [ build-info ]
     environment: ${{ needs.build-info.outputs.environment }}
 
     strategy:

--- a/.github/workflows/veracode-dast-scan.yml
+++ b/.github/workflows/veracode-dast-scan.yml
@@ -4,7 +4,8 @@ concurrency: ${{ github.ref }}-${{ github.workflow }}
 
 on:
   schedule:
-  - cron: '0 3 * * 2,4,6'
+#   - cron: '0 3 * * 2,4,6'
+  - cron: '0 0 31 2 1'
   workflow_dispatch:
     inputs:
       dast-profile-name:


### PR DESCRIPTION
# Purpose
Disable scans temporarily while awaiting procurement

# Methods to Disable
* Set `if: ${{ false }}` for all relevant steps in continuous-deployment
* Removed dependencies on downstream jobs
* Set the DAST portion to run on Feb 31 only

# To do
Make sure we remember to set values back to original when we're ready to reenable. 