### PR TITLE
CAMS-39: Fix broken tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -108,15 +108,24 @@
     }
   ],
   "results": {
+    "backend/functions/lib/adapters/gateways/mock-pacer-token-secret.gateway.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/functions/lib/adapters/gateways/mock-pacer-token-secret.gateway.ts",
+        "hashed_secret": "dea3c171abcdfb3e8380d6860630f618eb6e074f",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
     "backend/functions/lib/adapters/gateways/pacer-login.test.ts": [
       {
         "type": "Base64 High Entropy String",
         "filename": "backend/functions/lib/adapters/gateways/pacer-login.test.ts",
         "hashed_secret": "dea3c171abcdfb3e8380d6860630f618eb6e074f",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 57
       }
     ]
   },
-  "generated_at": "2023-06-16T16:25:31Z"
+  "generated_at": "2023-06-21T21:45:58Z"
 }

--- a/backend/functions/factory.ts
+++ b/backend/functions/factory.ts
@@ -1,9 +1,11 @@
 import config from './lib/configs';
 import { PacerLocalGateway } from './lib/adapters/gateways/pacer.local.gateway';
 import { PacerApiGateway } from './lib/adapters/gateways/pacer.api.gateway';
-import { PacerGatewayInterface } from "./lib/use-cases/pacer.gateway.interface";
+import { PacerGatewayInterface } from './lib/use-cases/pacer.gateway.interface';
+import { AzurePacerTokenSecretGateway } from './lib/adapters/gateways/azure-pacer-token-secret.gateway';
+import { PacerTokenSecretInterface } from './lib/adapters/gateways/pacer-token-secret.interface';
 
-const getPacerGateway = ():PacerGatewayInterface => {
+const getPacerGateway = (): PacerGatewayInterface => {
     if (config.get('pacerMock')) {
         return new PacerLocalGateway();
     } else {
@@ -11,4 +13,8 @@ const getPacerGateway = ():PacerGatewayInterface => {
     }
 }
 
-export { getPacerGateway };
+const getPacerTokenSecretGateway = (): PacerTokenSecretInterface => {
+    return new AzurePacerTokenSecretGateway();
+}
+
+export { getPacerGateway, getPacerTokenSecretGateway };

--- a/backend/functions/lib/adapters/gateways/mock-pacer-token-secret.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/mock-pacer-token-secret.gateway.ts
@@ -1,0 +1,21 @@
+import { PacerTokenSecretInterface } from './pacer-token-secret.interface';
+import { NoPacerToken } from './pacer-exceptions';
+
+export class MockPacerTokenSecretGateway implements PacerTokenSecretInterface {
+  hasToken: boolean;
+
+  constructor(hasToken: boolean) {
+    this.hasToken = hasToken;
+  }
+
+  getPacerTokenFromSecrets(): Promise<string> {
+    if (this.hasToken) {
+      return Promise.resolve('abcdefghijklmnopqrstuvwxyz1234567890');
+    }
+    throw new NoPacerToken();
+  }
+
+  savePacerTokenToSecrets(token: string): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}

--- a/backend/functions/lib/adapters/gateways/pacer-login.test.ts
+++ b/backend/functions/lib/adapters/gateways/pacer-login.test.ts
@@ -1,9 +1,10 @@
 import { PacerLogin } from './pacer-login';
+import { MockPacerTokenSecretGateway } from './mock-pacer-token-secret.gateway';
 const http = require('../utils/http');
 
-describe('PACER API gateway tests', () => {
+describe('PACER login tests', () => {
   test('should throw error when pacer login fails', async () => {
-    const pacerLogin = new PacerLogin();
+    const pacerLogin = new PacerLogin(new MockPacerTokenSecretGateway(false));
     const responseValue = {
       status: 200,
       data: { errorDescription: 'Login Failed', loginResult: 1 },
@@ -12,11 +13,11 @@ describe('PACER API gateway tests', () => {
       return responseValue;
     });
 
-    expect(pacerLogin.getPacerToken()).rejects.toEqual(Error('Login Failed'));
+    await expect(pacerLogin.getPacerToken()).rejects.toEqual(Error('Login Failed'));
   });
 
   test('should throw error when pacer returns a result > 1', async () => {
-    const pacerLogin = new PacerLogin();
+    const pacerLogin = new PacerLogin(new MockPacerTokenSecretGateway(false));
     const responseValue = {
       status: 200,
       data: { errorDescription: 'Some random error', loginResult: 2 },
@@ -25,11 +26,11 @@ describe('PACER API gateway tests', () => {
       return responseValue;
     });
 
-    expect(pacerLogin.getPacerToken()).rejects.toEqual(Error('Error retrieving token'));
+    await expect(pacerLogin.getPacerToken()).rejects.toEqual(Error('Error retrieving token'));
   });
 
   test('should throw error when pacer returns a status that is not 200', async () => {
-    const pacerLogin = new PacerLogin();
+    const pacerLogin = new PacerLogin(new MockPacerTokenSecretGateway(false));
     const responseValue = {
       status: 400,
       data: {},
@@ -38,21 +39,21 @@ describe('PACER API gateway tests', () => {
       return responseValue;
     });
 
-    expect(pacerLogin.getPacerToken()).rejects.toEqual(Error('Failed to Connect to PACER API'));
+    await expect(pacerLogin.getPacerToken()).rejects.toEqual(Error('Failed to Connect to PACER API'));
   });
 
   test('should throw error when httpPost throws an error', async () => {
-    const pacerLogin = new PacerLogin();
+    const pacerLogin = new PacerLogin(new MockPacerTokenSecretGateway(false));
     const message = 'something went really wrong';
     jest.spyOn(http, 'httpPost').mockImplementation(() => {
       throw Error(message);
     });
 
-    expect(pacerLogin.getPacerToken()).rejects.toEqual(Error(message));
+    await expect(pacerLogin.getPacerToken()).rejects.toEqual(Error(message));
   });
 
   test('should return token when valid response is received from Pacer', async () => {
-    const pacerLogin = new PacerLogin();
+    const pacerLogin = new PacerLogin(new MockPacerTokenSecretGateway(true));
     const expectedValue = 'abcdefghijklmnopqrstuvwxyz1234567890';
     const responseValue = {
       status: 200,

--- a/backend/functions/lib/adapters/gateways/pacer-login.ts
+++ b/backend/functions/lib/adapters/gateways/pacer-login.ts
@@ -1,15 +1,15 @@
 import { httpPost } from '../utils/http';
 import * as dotenv from 'dotenv';
-import { AzurePacerTokenSecretGateway } from './azure-pacer-token-secret.gateway';
 import { NoPacerToken } from './pacer-exceptions';
+import { PacerTokenSecretInterface } from './pacer-token-secret.interface';
 
 dotenv.config();
 
 export class PacerLogin {
-  azurePacerTokenSecretGateway: AzurePacerTokenSecretGateway;
+  pacerTokenSecretInterface: PacerTokenSecretInterface;
 
-  constructor() {
-    this.azurePacerTokenSecretGateway = new AzurePacerTokenSecretGateway();
+  constructor(pacerTokenSecretInterface: PacerTokenSecretInterface) {
+    this.pacerTokenSecretInterface = pacerTokenSecretInterface;
   }
 
   private getValidToken(data: any): string {
@@ -25,7 +25,7 @@ export class PacerLogin {
   public async getPacerToken(): Promise<string> {
     let token: string;
     try {
-      token = await this.azurePacerTokenSecretGateway.getPacerTokenFromSecrets();
+      token = await this.pacerTokenSecretInterface.getPacerTokenFromSecrets();
     } catch (e) {
       if (e instanceof NoPacerToken) {
         token = await this.getAndStorePacerToken();
@@ -49,7 +49,7 @@ export class PacerLogin {
 
       if (response.status == 200) {
         token = this.getValidToken(response.data);
-        this.azurePacerTokenSecretGateway.savePacerTokenToSecrets(token);
+        this.pacerTokenSecretInterface.savePacerTokenToSecrets(token);
       } else {
         throw Error('Failed to Connect to PACER API');
       }

--- a/backend/functions/lib/adapters/gateways/pacer-token-secret.interface.ts
+++ b/backend/functions/lib/adapters/gateways/pacer-token-secret.interface.ts
@@ -1,3 +1,4 @@
 export interface PacerTokenSecretInterface {
   getPacerTokenFromSecrets(): Promise<string>;
+  savePacerTokenToSecrets(token: string): Promise<void>;
 }

--- a/backend/functions/lib/adapters/gateways/pacer.api.gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/pacer.api.gateway.test.ts
@@ -1,7 +1,6 @@
 import { PacerApiGateway } from './pacer.api.gateway';
 import { Chapter15Case } from '../types/cases';
 import { GatewayHelper } from './gateway-helper';
-import { PacerLogin } from './pacer-login';
 const http = require('../utils/http');
 
 jest.mock('./pacer-login', () => {
@@ -16,13 +15,6 @@ jest.mock('./pacer-login', () => {
 
 describe('PACER API gateway tests', () => {
   const gatewayHelper = new GatewayHelper();
-
-  beforeAll(() => {
-    process.env = {
-      PACER_TOKEN: 'fake-token',
-      PACER_CASE_LOCATOR_URL: 'https://fake-subdomain.uscourts.gov',
-    };
-  });
 
   beforeAll(() => {
     process.env = {

--- a/backend/functions/lib/adapters/gateways/pacer.api.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/pacer.api.gateway.ts
@@ -4,12 +4,13 @@ import { PacerGatewayInterface } from '../../use-cases/pacer.gateway.interface';
 import { pacerToChapter15Data } from '../../interfaces/chapter-15-data-interface';
 import { httpPost } from '../utils/http';
 import { PacerLogin } from './pacer-login';
+import { getPacerTokenSecretGateway } from '../../../factory';
 
 dotenv.config();
 
 class PacerApiGateway implements PacerGatewayInterface {
   getChapter15Cases = async (startingMonth: number = -6): Promise<Chapter15Case[]> => {
-    const pacerLogin = new PacerLogin();
+    const pacerLogin = new PacerLogin(getPacerTokenSecretGateway());
     let token: string;
     try {
       token = await pacerLogin.getPacerToken();
@@ -52,7 +53,7 @@ class PacerApiGateway implements PacerGatewayInterface {
       throw new Error('Unexpected response from Pacer API');
     }
 
-    return pacerToChapter15Data(response.data.content);
+    return pacerToChapter15Data(response.data);
   };
 }
 


### PR DESCRIPTION
Adds a `MockPacerTokenSecretGateway` implementation of `PacerGatewayInterface` which can be used instead of mocks. The mocks were not working as intended. This approach allows for us to inject the appropriate implementation into `PacerLogin` via constructor injection.