### PR TITLE
CAMS-39: Include new environment variables in settings

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -388,13 +388,13 @@ jobs:
           MSSQL_USER=${{ secrets.AZ_MSSQL_USER }} \
           MSSQL_PASS=${{ secrets.AZ_MSSQL_PASS }} \
           MSSQL_ENCRYPT=${{ secrets.AZ_MSSQL_ENCRYPT }} \
-          MSSQL_TRUST_UNSIGNED_CERT=${{ secrets.AZ_MSSQL_TRUST_UNSIGNED_CERT }}" \
+          MSSQL_TRUST_UNSIGNED_CERT=${{ secrets.AZ_MSSQL_TRUST_UNSIGNED_CERT }} \
           PACER_TOKEN_URL=${{ vars.PACER_TOKEN_URL }} \
           PACER_CASE_LOCATOR_URL=${{ vars.PACER_CASE_LOCATOR_URL }} \
           PACER_TOKEN_LOGIN_ID=${{ secrets.PACER_QA_LOGIN_ID }} \
           PACER_TOKEN_PASSWORD=${{ secrets.PACER_QA_PASSWORD }} \
           AZURE_KEY_VAULT_URL=${{ secrets.AZURE_KEY_VAULT_URL }} \
-          PACER_TOKEN_SECRET_NAME=${{ secrets.PACER_TOKEN_SECRET_NAME }}
+          PACER_TOKEN_SECRET_NAME=${{ secrets.PACER_TOKEN_SECRET_NAME }}"
 
   smoke-test-application:
     runs-on: ubuntu-latest


### PR DESCRIPTION
New environment variables were not included in the `--settings` option when calling `az-func-deploy.sh`.