### PR TITLE
CAMS-39: Use correct environment variable name

### DIFF
--- a/backend/functions/lib/adapters/gateways/azure-pacer-token-secret.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/azure-pacer-token-secret.gateway.ts
@@ -17,7 +17,7 @@ class AzurePacerTokenSecretGateway implements PacerTokenSecretInterface {
     } else {
       this.secretClient = secretClient;
     }
-    this.pacerTokenName = process.env.KEYVAULT_PACER_TOKEN_NAME;
+    this.pacerTokenName = process.env.PACER_TOKEN_SECRET_NAME;
   }
 
   public async savePacerTokenToSecrets(token: string) {


### PR DESCRIPTION
Use the same name for the environment variable as it is defined in `continuous-deployment.yml`.