### PR TITLE
CAMS-97: Add getCamsDateStringFromDate method

### DIFF
--- a/backend/functions/lib/adapters/gateways/cases.local.gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/cases.local.gateway.test.ts
@@ -1,6 +1,6 @@
 import { CasesLocalGateway } from './cases.local.gateway';
 import { GatewayHelper } from './gateway-helper';
-import { calculateDifferenceInMonths } from '../utils/date-helper';
+import { calculateDifferenceInMonths, getCamsDateStringFromDate } from '../utils/date-helper';
 
 const context = require('azure-function-context-mock');
 let gatewayHelper: GatewayHelper;
@@ -30,12 +30,12 @@ describe('CasesLocalGateway tests', () => {
         {
           caseNumber: '21-1234',
           caseTitle: 'Case A',
-          dateFiled: excludedDate.toISOString().slice(0, 10),
+          dateFiled: getCamsDateStringFromDate(excludedDate),
         },
         {
           caseNumber: '21-4321',
           caseTitle: 'Case B',
-          dateFiled: includedDate.toISOString().slice(0, 10),
+          dateFiled: getCamsDateStringFromDate(includedDate),
         },
       ];
     };
@@ -46,7 +46,7 @@ describe('CasesLocalGateway tests', () => {
       {
         caseNumber: '21-4321',
         caseTitle: 'Case B',
-        dateFiled: includedDate.toISOString().slice(0, 10),
+        dateFiled: getCamsDateStringFromDate(includedDate),
       },
     ]);
   });

--- a/backend/functions/lib/adapters/gateways/cases.local.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/cases.local.gateway.ts
@@ -3,6 +3,7 @@ import { ApplicationContext } from '../types/basic';
 import { Chapter15Case } from '../types/cases';
 import { GatewayHelper } from './gateway-helper';
 import log from '../services/logger.service';
+import { getCamsDateStringFromDate } from '../utils/date-helper';
 
 const NAMESPACE = 'CASES-LOCAL-GATEWAY';
 
@@ -18,7 +19,7 @@ export class CasesLocalGateway implements CasesInterface {
     let cases: Chapter15Case[];
     const date = new Date();
     date.setMonth(date.getMonth() + (options.startingMonth || -6));
-    const dateFiledFrom = date.toISOString().split('T')[0];
+    const dateFiledFrom = getCamsDateStringFromDate(date);
 
     try {
       cases = _gatewayHelper.chapter15MockExtract();

--- a/backend/functions/lib/adapters/gateways/mock-pacer.api.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/mock-pacer.api.gateway.ts
@@ -2,6 +2,7 @@ import { CasesInterface } from '../../use-cases/cases.interface';
 import { Chapter15Case } from '../types/cases';
 import { Context } from '@azure/functions';
 import { GatewayHelper } from './gateway-helper';
+import { getCamsDateStringFromDate } from '../utils/date-helper';
 
 export class MockPacerApiGateway implements CasesInterface {
   startingMonth: number;
@@ -42,23 +43,23 @@ export class MockPacerApiGateway implements CasesInterface {
       {
         caseNumber: '44449',
         caseTitle: 'Flo Esterly and Neas Van Sampson',
-        dateFiled: new Date(today.getFullYear() - 4, today.getMonth() - 10, today.getDate())
-          .toISOString()
-          .split('T')[0],
+        dateFiled: getCamsDateStringFromDate(
+          new Date(today.getFullYear() - 4, today.getMonth() - 10, today.getDate()),
+        ),
       },
       {
         caseNumber: '1122',
         caseTitle: 'Jennifer Millhouse',
-        dateFiled: new Date(today.getFullYear(), today.getMonth() - 7, today.getDate())
-          .toISOString()
-          .split('T')[0],
+        dateFiled: getCamsDateStringFromDate(
+          new Date(today.getFullYear(), today.getMonth() - 7, today.getDate()),
+        ),
       },
       {
         caseNumber: '1166',
         caseTitle: 'Heather Anne Real',
-        dateFiled: new Date(today.getFullYear() - 10, today.getMonth(), today.getDate())
-          .toISOString()
-          .split('T')[0],
+        dateFiled: getCamsDateStringFromDate(
+          new Date(today.getFullYear() - 10, today.getMonth(), today.getDate()),
+        ),
       },
     );
     this.chapter15CaseList.push(oldCases[0], oldCases[1], oldCases[2]);
@@ -70,23 +71,23 @@ export class MockPacerApiGateway implements CasesInterface {
       {
         caseNumber: '1167',
         caseTitle: 'Heather Anne Real',
-        dateFiled: new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
-          .toISOString()
-          .split('T')[0],
+        dateFiled: getCamsDateStringFromDate(
+          new Date(today.getFullYear(), today.getMonth() - 1, today.getDate()),
+        ),
       },
       {
         caseNumber: '1175',
         caseTitle: 'James P. Tennor',
-        dateFiled: new Date(today.getFullYear(), today.getMonth() - 3, today.getDate())
-          .toISOString()
-          .split('T')[0],
+        dateFiled: getCamsDateStringFromDate(
+          new Date(today.getFullYear(), today.getMonth() - 3, today.getDate()),
+        ),
       },
       {
         caseNumber: '1176',
         caseTitle: 'Tommy Testformiddlena tennor',
-        dateFiled: new Date(today.getFullYear(), today.getMonth() - 2, today.getDate())
-          .toISOString()
-          .split('T')[0],
+        dateFiled: getCamsDateStringFromDate(
+          new Date(today.getFullYear(), today.getMonth() - 2, today.getDate()),
+        ),
       },
     );
     this.chapter15CaseList.push(newCases[0], newCases[1], newCases[2]);

--- a/backend/functions/lib/adapters/gateways/pacer.api.gateway.chapter15.date.test.ts
+++ b/backend/functions/lib/adapters/gateways/pacer.api.gateway.chapter15.date.test.ts
@@ -1,13 +1,14 @@
 import { MockPacerApiGateway } from './mock-pacer.api.gateway';
 import { CasesInterface } from '../../use-cases/cases.interface';
+import { getCamsDateStringFromDate } from '../utils/date-helper';
 const context = require('azure-function-context-mock');
 
 describe('Test the date filter on chapter 15 cases', () => {
   test('should return cases in the last 6 months when no starting month filter set', async () => {
     const today = new Date();
-    const expectedStartDate = new Date(today.getFullYear(), today.getMonth() - 6, today.getDate())
-      .toISOString()
-      .split('T')[0];
+    const expectedStartDate = getCamsDateStringFromDate(
+      new Date(today.getFullYear(), today.getMonth() - 6, today.getDate()),
+    );
 
     const mockPacerApiGateway: CasesInterface = new MockPacerApiGateway();
     const actual = await mockPacerApiGateway.getChapter15Cases(context, {});
@@ -22,21 +23,15 @@ describe('Test the date filter on chapter 15 cases', () => {
 
   test('should return cases as per the given starting month filter set', async () => {
     const testStartingMonthFilter = -60;
-    const today = new Date();
-    const expectedStartDate = new Date(
-      today.getFullYear(),
-      today.getMonth() + testStartingMonthFilter,
-      today.getDate(),
-    )
-      .toISOString()
-      .split('T')[0];
+    const expectedStartDate = new Date();
+    expectedStartDate.setMonth(expectedStartDate.getMonth() + testStartingMonthFilter);
     const mockPacerApiGateway: CasesInterface = new MockPacerApiGateway();
     const actual = await mockPacerApiGateway.getChapter15Cases(context, {
       startingMonth: testStartingMonthFilter,
     });
 
     function checkDate(aCase) {
-      const verify = aCase.dateFiled >= expectedStartDate;
+      const verify = aCase.dateFiled >= getCamsDateStringFromDate(expectedStartDate);
       return verify;
     }
 

--- a/backend/functions/lib/adapters/gateways/pacer.api.gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/pacer.api.gateway.test.ts
@@ -2,6 +2,7 @@ import { PacerApiGateway } from './pacer.api.gateway';
 import { Chapter15Case } from '../types/cases';
 import { GatewayHelper } from './gateway-helper';
 import { applicationContextCreator } from '../utils/application-context-creator';
+import { getCamsDateStringFromDate } from '../utils/date-helper';
 const http = require('../utils/http');
 const context = require('azure-function-context-mock');
 
@@ -73,11 +74,10 @@ describe('PACER API gateway tests', () => {
   });
 
   test('should set the starting month to -6 if a starting month is not passed into getChapter15Cases', async () => {
-    gatewayHelper.pacerMockExtract().slice(0, 2);
     const expectedStartingMonth = -6;
     const date = new Date();
     date.setMonth(date.getMonth() + expectedStartingMonth);
-    const expectedDate = date.toISOString().split('T')[0];
+    const expectedDate = getCamsDateStringFromDate(date);
 
     const httpPostSpy = jest.spyOn(http, 'httpPost').mockImplementation(() => {
       return {
@@ -101,11 +101,10 @@ describe('PACER API gateway tests', () => {
   });
 
   test('should set the starting month to -6 if undefined is passed into getChapter15Cases', async () => {
-    gatewayHelper.pacerMockExtract().slice(0, 2);
     const expectedStartingMonth = -6;
     const date = new Date();
     date.setMonth(date.getMonth() + expectedStartingMonth);
-    const expectedDate = date.toISOString().split('T')[0];
+    const expectedDate = getCamsDateStringFromDate(date);
 
     const httpPostSpy = jest.spyOn(http, 'httpPost').mockImplementation(() => {
       return {
@@ -129,11 +128,10 @@ describe('PACER API gateway tests', () => {
   });
 
   test('should set the starting month to value passed into getChapter15Cases', async () => {
-    gatewayHelper.pacerMockExtract().slice(0, 2);
     const expectedStartingMonth = -25;
     const date = new Date();
     date.setMonth(date.getMonth() + expectedStartingMonth);
-    const expectedDate = date.toISOString().split('T')[0];
+    const expectedDate = getCamsDateStringFromDate(date);
     const gateway = new PacerApiGateway();
 
     const getCasesListFromPacerApiSpy = jest.spyOn(gateway, 'getCasesListFromPacerApi');

--- a/backend/functions/lib/adapters/gateways/pacer.api.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/pacer.api.gateway.ts
@@ -10,6 +10,7 @@ import { HttpResponse } from '../types/http';
 import { ApplicationContext } from '../types/basic';
 import log from '../services/logger.service';
 import { GatewayHelper } from './gateway-helper';
+import { getCamsDateStringFromDate } from '../utils/date-helper';
 
 const NAMESPACE = 'PACER-API-GATEWAY';
 dotenv.config();
@@ -33,7 +34,7 @@ class PacerApiGateway implements CasesInterface {
   ): Promise<Chapter15Case[]> {
     const date = new Date();
     date.setMonth(date.getMonth() + startingMonth);
-    const dateFileFrom = date.toISOString().split('T')[0];
+    const dateFileFrom = getCamsDateStringFromDate(date);
     const regionTwoPacerCourtIds = ['cm8bk', 'nyebk', 'nynbk', 'nysbk', 'nywbk', 'vtbk', 'ctbk'];
 
     const body = {

--- a/backend/functions/lib/adapters/utils/date-helper.test.ts
+++ b/backend/functions/lib/adapters/utils/date-helper.test.ts
@@ -1,4 +1,4 @@
-import { getDate, calculateDifferenceInMonths } from './date-helper';
+import { getDate, calculateDifferenceInMonths, getCamsDateStringFromDate } from './date-helper';
 
 describe('date-helper tests', () => {
   describe('getDate tests', () => {
@@ -172,6 +172,20 @@ describe('date-helper tests', () => {
       );
 
       expect(monthsDifference).toEqual(60);
+    });
+  });
+
+  describe('getCamsDateStringFromDate tests', () => {
+    test('should properly handle dates between Jan 1, 1000 and Dec 31, 9999', async () => {
+      expect(getCamsDateStringFromDate(new Date(2023, 6, 19))).toEqual('2023-07-19');
+    });
+
+    test('should properly handle dates prior to Jan 1, 1000', async () => {
+      expect(getCamsDateStringFromDate(new Date(680, 0, 1))).toEqual('0680-01-01');
+    });
+
+    test('should properly handle date later than Dec 31, 9999', async () => {
+      expect(getCamsDateStringFromDate(new Date(10000, 0, 1))).toEqual('+010000-01-01');
     });
   });
 });

--- a/backend/functions/lib/adapters/utils/date-helper.ts
+++ b/backend/functions/lib/adapters/utils/date-helper.ts
@@ -32,3 +32,7 @@ export function calculateDifferenceInMonths(left: Date, right: Date): number {
   const monthsDiff = incompleteYear ? years * 12 + realMonths - 12 : years * 12 + realMonths;
   return incompleteMonth ? monthsDiff - 1 : monthsDiff;
 }
+
+export function getCamsDateStringFromDate(date: Date) {
+  return date.toISOString().split('T')[0];
+}

--- a/backend/functions/lib/use-cases/chapter-15.case-list.test.ts
+++ b/backend/functions/lib/use-cases/chapter-15.case-list.test.ts
@@ -4,6 +4,7 @@ import { MockPacerApiGateway } from '../adapters/gateways/mock-pacer.api.gateway
 import { CasesInterface } from './cases.interface';
 import { applicationContextCreator } from '../adapters/utils/application-context-creator';
 import { GatewayHelper } from '../adapters/gateways/gateway-helper';
+import { getCamsDateStringFromDate } from '../adapters/utils/date-helper';
 const context = require('azure-function-context-mock');
 
 const appContext = applicationContextCreator(context);
@@ -61,9 +62,9 @@ describe('Chapter 15 case tests', () => {
 
   test('Calling getChapter15CaseList without a starting month filter should return valid chapter 15 data for the last 6 months of default', async () => {
     const today = new Date();
-    const expectedStartDate = new Date(today.getFullYear(), today.getMonth() - 6, today.getDate())
-      .toISOString()
-      .split('T')[0];
+    const expectedStartDate = getCamsDateStringFromDate(
+      new Date(today.getFullYear(), today.getMonth() - 6, today.getDate()),
+    );
 
     const mockPacerGateway: CasesInterface = new MockPacerApiGateway();
     const chapter15CaseList: Chapter15CaseList = new Chapter15CaseList(mockPacerGateway);


### PR DESCRIPTION
# Purpose

Add a helper method to standardize how we get the strings we use from an instance of the `Date` class.

# Interesting Edge Cases

I'm sure we will not need to be processing valid dates that do not have 4-digit years, but dates prior to the year 1000 get a leading `0` in the ISO String, and dates following the year 9999 get a leading `+0`. If for some reason we wanted to be able to display these dates, we would perhaps want to change the method to do more than take the part of the ISO string before the `T`.

# Optional

This is not strictly necessary, I just thought it might be nice to have.