### PR TITLE
CAMS-110: Compare inputs.deployBranch against a string not as a boolean

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info, build-frontend, build-service, accessibility-test]
     environment: ${{ needs.build-info.outputs.environment }}
-    if: ((github.ref == 'refs/heads/main') || inputs.deployBranch)
+    if: ((github.ref == 'refs/heads/main') || (inputs.deployBranch == 'true'))
     outputs:
       functionAppName: ${{ steps.azure-deploy.outputs.functionAppName }}
       webappName: ${{ steps.azure-deploy.outputs.webappName }}


### PR DESCRIPTION
# Problem

When the manual workflow was run with the `deployBranch` input set to `false`, the deploy job was being run.

# Solution

When evaluating expressions, output is converted to a string. As noted in the [documentation of the `jobs.<job_id>.if` syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif), GitHub Actions evaluates the condition as an expression and as a consequence `false` is evaluated as `'false'` which is truthy. We simply need to evaluate `${{ inputs.deployBranch == 'true' }}` to get the expected behavior.

> Note the expression syntax—`${{ expr }}`—is not needed as mentioned in the documentation.

# Testing/Validation

[Manual run with deploy set to false.](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/5739808305)
[Manual run with deploy set to true (I cancelled the workflow once the deploy job began)](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/5739878635)
