### PR TITLE
CAMS-103 Refactoring related to application insights setup

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -242,7 +242,7 @@ jobs:
           export CAMS_SERVER_PORT=${{ vars.CAMS_SERVER_PORT }}
           export CAMS_SERVER_PROTOCOL=${{ vars.CAMS_SERVER_PROTOCOL }}
           export CAMS_BASE_PATH=${{ vars.CAMS_BASE_PATH }}
-          export APPlICATIONINSIGHTS_CONNECTION_STRING='TESTSTRING'
+          export APPLICATIONINSIGHTS_CONNECTION_STRING=""
           npm run build --if-present
 
       - name: Execute Test
@@ -282,7 +282,7 @@ jobs:
 
       - name: Execute Tests
         run: |
-          export APPINSIGHTS_CONNECTION_STRING="TESTSTRING" && npm run test
+          npm run test
 
       - name: Package Application
         run: OUT=${{ needs.build-info.outputs.apiName }} npm run pack
@@ -430,8 +430,6 @@ jobs:
           MSSQL_ENCRYPT=${{ secrets.AZ_MSSQL_ENCRYPT }} \
           MSSQL_TRUST_UNSIGNED_CERT=${{ secrets.AZ_MSSQL_TRUST_UNSIGNED_CERT }} \
           PACER_TOKEN_URL=${{ vars.PACER_TOKEN_URL }} \
-          APPINSIGHTS_CONNECTION_STRING=${{ secrets.API_APPINSIGHTS_CONNECTION_STRING }}
-          APPINSIGHTS_INSTRUMENTATIONKEY=${{ secrets.API_APPINSIGHTS_INSTRUMENTATION_KEY }}
           PACER_CASE_LOCATOR_URL=${{ vars.PACER_CASE_LOCATOR_URL }} \
           AZURE_KEY_VAULT_URL=${{ secrets.AZURE_KEY_VAULT_URL }} \
           PACER_TOKEN_SECRET_NAME=${{ secrets.PACER_TOKEN_SECRET_NAME }} \

--- a/backend/functions/attorneys/attorneys.function.ts
+++ b/backend/functions/attorneys/attorneys.function.ts
@@ -10,7 +10,7 @@ dotenv.config();
 // enable instrumentation for Azure Application Insights
 if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
   const appInsights = require('applicationinsights');
-  appInsights.start();
+  appInsights.setup().start();
 }
 
 const NAMESPACE = 'ATTORNEYS-FUNCTION';

--- a/backend/functions/attorneys/attorneys.function.ts
+++ b/backend/functions/attorneys/attorneys.function.ts
@@ -7,9 +7,11 @@ import * as dotenv from 'dotenv';
 
 dotenv.config();
 
-console.log(process.env.APPINSIGHTS_CONNECTION_STRING);
-const appInsights = require('applicationinsights');
-appInsights.setup(process.env.APPINSIGHTS_CONNECTION_STRING).start();
+// enable instrumentation for Azure Application Insights
+if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
+  const appInsights = require('applicationinsights');
+  appInsights.start();
+}
 
 const NAMESPACE = 'ATTORNEYS-FUNCTION';
 

--- a/backend/functions/cases/cases.function.ts
+++ b/backend/functions/cases/cases.function.ts
@@ -10,7 +10,7 @@ dotenv.config();
 // enable instrumentation for Azure Application Insights
 if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
   const appInsights = require('applicationinsights');
-  appInsights.start();
+  appInsights.setup().start();
 }
 
 const NAMESPACE = 'CASES-FUNCTION';

--- a/backend/functions/cases/cases.function.ts
+++ b/backend/functions/cases/cases.function.ts
@@ -7,8 +7,11 @@ import * as dotenv from 'dotenv';
 
 dotenv.config();
 
-const appInsights = require('applicationinsights');
-appInsights.setup(process.env.APPINSIGHTS_CONNECTION_STRING).start();
+// enable instrumentation for Azure Application Insights
+if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
+  const appInsights = require('applicationinsights');
+  appInsights.start();
+}
 
 const NAMESPACE = 'CASES-FUNCTION';
 

--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -40,7 +40,7 @@
     "prestart": "npm run build",
     "start": "func start --typescript",
     "start:dev": "nodemon --esm src/server.ts",
-    "test": "DATABASE_MOCK='true' APPINSIGHTS_CONNECTION_STRING='test' jest -c jest.config.js",
+    "test": "DATABASE_MOCK='true' jest -c jest.config.js",
     "test:integration": "DATABASE_MOCK='true' jest -c jest.integration.config.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix",

--- a/backend/functions/users/users.function.ts
+++ b/backend/functions/users/users.function.ts
@@ -7,8 +7,11 @@ import * as dotenv from 'dotenv';
 
 dotenv.config();
 
-const appInsights = require('applicationinsights');
-appInsights.setup(process.env.APPINSIGHTS_CONNECTION_STRING).start();
+// enable instrumentation for Azure Application Insights
+if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
+  const appInsights = require('applicationinsights');
+  appInsights.start();
+}
 
 const NAMESPACE = 'USERS-FUNCTION';
 

--- a/backend/functions/users/users.function.ts
+++ b/backend/functions/users/users.function.ts
@@ -10,7 +10,7 @@ dotenv.config();
 // enable instrumentation for Azure Application Insights
 if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
   const appInsights = require('applicationinsights');
-  appInsights.start();
+  appInsights.setup().start();
 }
 
 const NAMESPACE = 'USERS-FUNCTION';

--- a/docs/running.md
+++ b/docs/running.md
@@ -79,7 +79,7 @@ MSSQL_PASS={the SQL Server Admin user password}
 MSSQL_ENCRYPT="true"
 MSSQL_TRUST_UNSIGNED_CERT="true"
 AZURE_MANAGED_IDENTITY=
-APPINSIGHTS_CONNECTION_STRING="TESTSTRING"
+APPLICATIONINSIGHTS_CONNECTION_STRING=
 ```
 
 !> Replace the curly braces and their contents with the appropriate string.

--- a/ops/cloud-deployment/app-insights/app-insights.bicep
+++ b/ops/cloud-deployment/app-insights/app-insights.bicep
@@ -22,86 +22,11 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-var logRetentionPolicy = {
-  days: 30
-  enabled: true
-}
-
-var metricRetentionPolicy = {
-  days: 30
-  enabled: true
-}
-
-@description('Enable all diagnostic logs/metrics for an Application Insight resource and send data to target Log Analytics workspace for ingestion.')
-resource diagnosticLogsToLogAnalyticsWorkspace 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(workspaceResourceId)) {
-  name: appInsights.name
-  scope: appInsights
-  properties: {
-    workspaceId: workspaceResourceId
-    logs: [
-      {
-        category: 'AppAvailabilityResults'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppBrowserTimings'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppEvents'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppMetrics'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppDependencies'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppExceptions'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppPageViews'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppPerformanceCounters'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppRequests'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppSystemEvents'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-      {
-        category: 'AppTraces'
-        enabled: true
-        retentionPolicy: logRetentionPolicy
-      }
-    ]
-    metrics: [
-      {
-        category: 'AllMetrics'
-        enabled: true
-        retentionPolicy: metricRetentionPolicy
-      }
-    ]
+module diagnosticsSettings 'diagnostics-settings-appi.bicep' = {
+  name: '${appInsightsName}-diag-settings-module'
+  params: {
+    appInsightsName: appInsights.name
+    workspaceResourceId: workspaceResourceId
   }
 }
 

--- a/ops/cloud-deployment/app-insights/app-insights.bicep
+++ b/ops/cloud-deployment/app-insights/app-insights.bicep
@@ -1,7 +1,15 @@
 param location string = resourceGroup().location
+
+@description('Name of Application Insight resource')
 param appInsightsName string
-param workspaceResourceId string
+
+@description('OPTIONAL. Resource id of log analytics workspace which data will be ingested to.')
+param workspaceResourceId string = ''
+
+@allowed([ 'web' ])
 param applicationType string
+
+@allowed([ 'web' ])
 param kind string
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
@@ -10,12 +18,22 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   kind: kind
   properties: {
     Application_Type: applicationType
-    WorkspaceResourceId: workspaceResourceId
-
+    WorkspaceResourceId: !empty(workspaceResourceId) ? workspaceResourceId : null
   }
 }
 
-resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+var logRetentionPolicy = {
+  days: 30
+  enabled: true
+}
+
+var metricRetentionPolicy = {
+  days: 30
+  enabled: true
+}
+
+@description('Enable all diagnostic logs/metrics for an Application Insight resource and send data to target Log Analytics workspace for ingestion.')
+resource diagnosticLogsToLogAnalyticsWorkspace 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(workspaceResourceId)) {
   name: appInsights.name
   scope: appInsights
   properties: {
@@ -23,112 +41,65 @@ resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-previe
     logs: [
       {
         category: 'AppAvailabilityResults'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppBrowserTimings'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppEvents'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppMetrics'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppDependencies'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppExceptions'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppPageViews'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppPerformanceCounters'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppRequests'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppSystemEvents'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
       {
         category: 'AppTraces'
-        categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: logRetentionPolicy
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 30
-          enabled: true
-        }
+        retentionPolicy: metricRetentionPolicy
       }
     ]
   }
@@ -136,4 +107,3 @@ resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-previe
 
 output id string = appInsights.id
 output connectionString string = appInsights.properties.ConnectionString
-output instrumentationKey string = appInsights.properties.InstrumentationKey

--- a/ops/cloud-deployment/app-insights/diagnostics-settings-appi.bicep
+++ b/ops/cloud-deployment/app-insights/diagnostics-settings-appi.bicep
@@ -1,0 +1,105 @@
+/*
+  Enable all logs and metrics for Azure Application Insights resource
+
+  Azure provides the following destination options
+  - Send to Log Analytics workspace   [SUPPORTED]
+  - Archive to a storage account      [NOT YET SUPPORTED]
+  - Stream to an event hub            [NOT YET SUPPORTED]
+  - Send to partner solution          [NOT YET SUPPORTED]
+*/
+@description('Name of Application Insight resource')
+param appInsightsName string
+
+@description('OPTIONAL. Resource id of log analytics workspace which data will be ingested to.')
+param workspaceResourceId string = '' // For "Send to Log Analytics workspace"
+
+resource appInsight 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: appInsightsName
+}
+
+var logRetentionPolicy = {
+  days: 30
+  enabled: true
+}
+
+var metricRetentionPolicy = {
+  days: 30
+  enabled: true
+}
+
+var metricsEnableAll = [
+  {
+    category: 'AllMetrics'
+    enabled: true
+    retentionPolicy: metricRetentionPolicy
+  }
+]
+
+var applicationInsightsLogsEnableAll = [
+  {
+    category: 'AppAvailabilityResults'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppBrowserTimings'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppEvents'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppMetrics'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppDependencies'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppExceptions'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppPageViews'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppPerformanceCounters'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppRequests'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppSystemEvents'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+  {
+    category: 'AppTraces'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+]
+
+@description('Enable all diagnostic logs/metrics for an Application Insight resource and send data to target Log Analytics workspace for ingestion.')
+resource diagnosticLogsToLogAnalyticsWorkspace 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(workspaceResourceId)) {
+  name: appInsight.name
+  scope: appInsight
+  properties: {
+    workspaceId: workspaceResourceId
+    logs: applicationInsightsLogsEnableAll
+    metrics: metricsEnableAll
+  }
+}

--- a/ops/cloud-deployment/app-insights/diagnostics-settings-func.bicep
+++ b/ops/cloud-deployment/app-insights/diagnostics-settings-func.bicep
@@ -1,0 +1,55 @@
+/*
+  Enable all logs and metrics for Azure Function App resource
+
+  Azure provides the following destination options
+  - Send to Log Analytics workspace   [SUPPORTED]
+  - Archive to a storage account      [NOT YET SUPPORTED]
+  - Stream to an event hub            [NOT YET SUPPORTED]
+  - Send to partner solution          [NOT YET SUPPORTED]
+*/
+@description('Name of Function App resource')
+param functionAppName string
+
+@description('OPTIONAL. Resource id of log analytics workspace which data will be ingested to.')
+param workspaceResourceId string = '' // For "Send to Log Analytics workspace"
+
+resource functionApp 'Microsoft.Web/sites@2022-09-01' existing = {
+  name: functionAppName
+}
+
+var logRetentionPolicy = {
+  days: 30
+  enabled: true
+}
+
+var metricRetentionPolicy = {
+  days: 30
+  enabled: true
+}
+
+var metricsEnableAll = [
+  {
+    category: 'AllMetrics'
+    enabled: true
+    retentionPolicy: metricRetentionPolicy
+  }
+]
+
+var functionAppLogsEnableAll = [
+  {
+    category: 'FunctionAppLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+]
+
+@description('Enable all diagnostic logs/metrics for a Function App resource and send data to target Log Analytics workspace for ingestion.')
+resource diagnosticLogsToLogAnalyticsWorkspace 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(workspaceResourceId)) {
+  name: functionApp.name
+  scope: functionApp
+  properties: {
+    workspaceId: workspaceResourceId
+    logs: functionAppLogsEnableAll
+    metrics: metricsEnableAll
+  }
+}

--- a/ops/cloud-deployment/app-insights/diagnostics-settings-webapp.bicep
+++ b/ops/cloud-deployment/app-insights/diagnostics-settings-webapp.bicep
@@ -1,0 +1,97 @@
+/*
+  Enable all logs and metrics for Azure WebApp resource
+
+  Azure provides the following destination options
+  - Send to Log Analytics workspace   [SUPPORTED]
+  - Archive to a storage account      [NOT YET SUPPORTED]
+  - Stream to an event hub            [NOT YET SUPPORTED]
+  - Send to partner solution          [NOT YET SUPPORTED]
+*/
+@description('Name of Function App resource')
+param webappName string
+
+@description('OPTIONAL. Resource id of log analytics workspace which data will be ingested to.')
+param workspaceResourceId string = '' // For "Send to Log Analytics workspace"
+
+resource webapp 'Microsoft.Web/sites@2022-09-01' existing = {
+  name: webappName
+}
+
+var logRetentionPolicy = {
+  days: 30
+  enabled: true
+}
+
+var metricRetentionPolicy = {
+  days: 30
+  enabled: true
+}
+
+var metricsEnableAll = [
+  {
+    category: 'AllMetrics'
+    enabled: true
+    retentionPolicy: metricRetentionPolicy
+  }
+]
+
+var webappLogsEnableAll = [
+  {
+    category: 'AppServiceAntivirusScanAuditLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+
+  {
+    category: 'AppServiceHTTPLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+
+  {
+    category: 'AppServiceConsoleLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+
+  {
+    category: 'AppServiceAppLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+
+  {
+    category: 'AppServiceFileAuditLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+
+  {
+    category: 'AppServiceAuditLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+
+  {
+    category: 'AppServiceIPSecAuditLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+
+  {
+    category: 'AppServicePlatformLogs'
+    enabled: true
+    retentionPolicy: logRetentionPolicy
+  }
+]
+
+@description('Enable all diagnostic logs/metrics for a Function App resource and send data to target Log Analytics workspace for ingestion.')
+resource diagnosticLogsToLogAnalyticsWorkspace 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(workspaceResourceId)) {
+  name: webapp.name
+  scope: webapp
+  properties: {
+    workspaceId: workspaceResourceId
+    logs: webappLogsEnableAll
+    metrics: metricsEnableAll
+  }
+}

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -202,7 +202,8 @@ resource pacerKVManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentitie
 var pacerKeyVaultManagedIdentity = pacerKVManagedIdentity.id
 var pacerKeyVaultManagedIdentityClientId = pacerKVManagedIdentity.properties.clientId
 
-module appInsights './app-insights/app-insights.bicep' = if (deployAppInsights) {
+var createApplicationInsights = deployAppInsights && !empty(analyticsWorkspaceId)
+module appInsights './app-insights/app-insights.bicep' = if (createApplicationInsights) {
   name: '${functionName}-application-insights-module'
   params: {
     location: location
@@ -212,6 +213,7 @@ module appInsights './app-insights/app-insights.bicep' = if (deployAppInsights) 
     workspaceResourceId: analyticsWorkspaceId
   }
 }
+
 /*
   Create functionapp
 */
@@ -252,7 +254,7 @@ var applicationSettings = concat([
     }
   ],
   !empty(databaseConnectionString) ? [ { name: 'SQL_SERVER_CONN_STRING', value: databaseConnectionString } ] : [],
-  deployAppInsights ? [ { name: 'APPINSIGHTS_CONNECTION_STRING', value: appInsights.outputs.connectionString }, { name: 'APPINSIGHTS_INSTRUMENTATIONKEY', value: appInsights.outputs.instrumentationKey } ] : []
+  createApplicationInsights ? [ { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsights.outputs.connectionString } ] : []
 )
 var ipSecurityRestrictionsRules = concat([ {
       ipAddress: 'Any'

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -214,6 +214,17 @@ module appInsights './app-insights/app-insights.bicep' = if (createApplicationIn
   }
 }
 
+module diagnosticSettings 'app-insights/diagnostics-settings-func.bicep' = {
+  name: '${functionName}-diagnostic-settings-module'
+  params: {
+    functionAppName: functionName
+    workspaceResourceId: analyticsWorkspaceId
+  }
+  dependsOn: [
+    appInsights
+  ]
+}
+
 /*
   Create functionapp
 */

--- a/ops/cloud-deployment/frontend-webapp-deploy.bicep
+++ b/ops/cloud-deployment/frontend-webapp-deploy.bicep
@@ -116,6 +116,7 @@ module privateEndpoint './subnet/network-subnet-private-endpoint.bicep' = {
     privateLinkServiceId: webapp.id
   }
 }
+
 module appInsights './app-insights/app-insights.bicep' = if (deployAppInsights) {
   name: '${webappName}-application-insights-module'
   params: {
@@ -126,6 +127,18 @@ module appInsights './app-insights/app-insights.bicep' = if (deployAppInsights) 
     workspaceResourceId: analyticsWorkspaceId
   }
 }
+
+module diagnosticSettings 'app-insights/diagnostics-settings-webapp.bicep' = {
+  name: '${webappName}-diagnostic-settings-module'
+  params: {
+    webappName: webappName
+    workspaceResourceId: analyticsWorkspaceId
+  }
+  dependsOn: [
+    appInsights
+  ]
+}
+
 /*
   Create webapp
 */
@@ -141,35 +154,35 @@ resource webapp 'Microsoft.Web/sites@2022-03-01' = {
   }
 }
 var applicationSettings = concat(deployAppInsights ? [
-  {
-    name: 'ApplicationInsightsAgent_EXTENSION_VERSION'
-    value: '~2'
-  }
-  {
-    name: 'DiagnosticServices_EXTENSION_VERSION'
-    value: '~3'
-  }
-  {
-    name: 'APPINSIGHTS_PROFILERFEATURE_VERSION'
-    value: '1.0.0'
-  }
-  {
-    name: 'APPINSIGHTS_SNAPSHOTFEATURE_VERSION'
-    value: '1.0.0'
-  }
-  {
-    name: 'XDT_MicrosoftApplicationInsights_Mode'
-    value: '1'
-  }
-  {
-    name: 'XDT_MicrosoftApplicationInsights_NodeJS'
-    value: '1'
-  }
-  {
-    name: 'APPlICATIONINSIGHTS_CONNECTION_STRING'
-    value: appInsights.outputs.connectionString
-  }
-]:[]
+    {
+      name: 'ApplicationInsightsAgent_EXTENSION_VERSION'
+      value: '~2'
+    }
+    {
+      name: 'DiagnosticServices_EXTENSION_VERSION'
+      value: '~3'
+    }
+    {
+      name: 'APPINSIGHTS_PROFILERFEATURE_VERSION'
+      value: '1.0.0'
+    }
+    {
+      name: 'APPINSIGHTS_SNAPSHOTFEATURE_VERSION'
+      value: '1.0.0'
+    }
+    {
+      name: 'XDT_MicrosoftApplicationInsights_Mode'
+      value: '1'
+    }
+    {
+      name: 'XDT_MicrosoftApplicationInsights_NodeJS'
+      value: '1'
+    }
+    {
+      name: 'APPlICATIONINSIGHTS_CONNECTION_STRING'
+      value: appInsights.outputs.connectionString
+    }
+  ] : []
 )
 
 var ipSecurityRestrictionsRules = concat([ {

--- a/ops/cloud-deployment/frontend-webapp-deploy.bicep
+++ b/ops/cloud-deployment/frontend-webapp-deploy.bicep
@@ -169,10 +169,6 @@ var applicationSettings = concat(deployAppInsights ? [
     name: 'APPlICATIONINSIGHTS_CONNECTION_STRING'
     value: appInsights.outputs.connectionString
   }
-  {
-    name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-    value: appInsights.outputs.instrumentationKey
-  }
 ]:[]
 )
 

--- a/user-interface/src/ApplicationInsightsService.tsx
+++ b/user-interface/src/ApplicationInsightsService.tsx
@@ -1,7 +1,7 @@
 import { ApplicationInsights, ITelemetryItem } from '@microsoft/applicationinsights-web';
 import { ReactPlugin } from '@microsoft/applicationinsights-react-js';
 
-const appInsightsConnectionString = import.meta.env['APPINSIGHTS_CONNECTION_STRING'];
+const appInsightsConnectionString = import.meta.env['APPLICATIONINSIGHTS_CONNECTION_STRING']; // TODO : NEED TO VERIFY THIS SNIPPET
 const reactPlugin = new ReactPlugin();
 
 const appInsights = new ApplicationInsights({


### PR DESCRIPTION
# Purpose

Branch off of CAMS-103-frontend-logging to test out some changes in a separate environment without impacting the last known good.

# Major Changes

- Leverage **APPLICATIONINSIGHTS_CONNECTION_STRING** instead of the using **APPINSIGHTS_INSTRUMENTATIONKEY**
- Handle corner cases when provisioning Application Insights resource and code clean up in bicep.

# Testing/Validation

WIP

# Notes


