### PR TITLE
Cams 109 add architecture diagram

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '*.md'
       - '**/*.md'
+      - '**/*.dsl'
   workflow_dispatch:
     inputs:
       deployBranch:

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ hs_err_pid*
 
 # OSX
 **/.DS_Store
+
+# Temporary Mermaid Files
+architecture/structurizr-*

--- a/architecture/cams.dsl
+++ b/architecture/cams.dsl
@@ -1,0 +1,105 @@
+workspace {
+
+    model {
+        # People
+        aust = person "AUST" "Assistant United States Trustee - manages a USTP office"
+        attorney = person "Trial Attorney" "Represents USTP in court regarding bankruptcy cases"
+
+        # System
+        cams = softwareSystem "CAMS" "CAse Management System" {
+            webapp = container "Webapp" "The user interface for CAMS" {
+                casesScreen = component "Cases Screen" "Displays case metadata in a tabular format"
+                assignScreen = component "Assignments Screen" "Displays case assignment data and provides for creating assignments"
+            }
+            nodeapi = container "API" "An Azure Functions App (Node.js)" {
+                cases = component "Cases" "Cases API"
+                assign = component "Assignments" "Assignments API"
+            }
+            dxtrsql = container "DXTR DB" "DXTR SQL Database"
+            cosmos = container "Cosmos DB" "NoSQL Database"
+        }
+
+        # Relationships
+        ## People to system components
+        aust -> webapp "Assigns cases to attorneys"
+        attorney -> webapp "Views bankruptcy cases"
+        attorney -> casesScreen "Views bankruptcy cases"
+        aust -> assignScreen "Assigns cases to attorneys"
+        attorney -> assignScreen "Views cases assigned to them"
+
+        ## System components to system components
+        webapp -> nodeapi "Reads and writes case data and assignments"
+        webapp -> cases "Reads and writes case data"
+        webapp -> assign "Reads and writes case assignments"
+        nodeapi -> cosmos "Reads and writes case assignments"
+        cases -> dxtrsql "Gets case data"
+        cases -> cosmos "Reads case assignments"
+        assign -> cosmos "Reads and writes case assignments"
+    }
+
+    views {
+        systemlandscape "SystemLandscape" {
+            include *
+            autoLayout
+        }
+
+        container cams "CAMSContainers" {
+            include *
+            animation {
+                aust
+                webapp
+                nodeapi
+                dxtrsql
+                cosmos
+            }
+            autoLayout
+        }
+
+        component webapp "CAMSWebapp" {
+            include *
+            animation {
+                aust
+                attorney
+                casesScreen
+                assignScreen
+            }
+            autoLayout
+        }
+
+        component nodeapi "FunctionsAPI" {
+            include *
+            animation {
+                webapp
+                cases
+                assign
+                dxtrsql
+                cosmos
+            }
+            autolayout
+        }
+
+        component nodeapi "FunctionsAPIwithWebapp" {
+            include *
+            animation {
+                webapp
+                cases
+                assign
+            }
+            autolayout
+        }
+
+        styles {
+            element "Software System" {
+                background #1168bd
+                color #ffffff
+            }
+            element "Person" {
+                shape person
+                background #08427b
+                color #ffffff
+            }
+        }
+        theme default
+    }
+
+}

--- a/architecture/export-architecture-diagrams.sh
+++ b/architecture/export-architecture-diagrams.sh
@@ -4,5 +4,51 @@
 structurizr.sh export -workspace architecture/cams.dsl -format mermaid
 
 # Produce Docsify Content
-#   This should replace the content of the appropriate markdown file,
-#     wrapping the mermaid in a code tag.
+pushd architecture
+
+## CAMS System Context
+mermaid_file="./structurizr-SystemLandscape.mmd"
+{
+  echo "# CAMS System Context\n\n\`\`\`mermaid"
+  cat "$mermaid_file"
+  echo "\n\`\`\`"
+} > temp_file.md
+mv temp_file.md ../docs/architecture/diagrams/cams-context.md
+
+## CAMS Containers
+mermaid_file="./structurizr-CAMSContainers.mmd"
+{
+  echo "# CAMS Containers\n\n\`\`\`mermaid"
+  cat "$mermaid_file"
+  echo "\n\`\`\`"
+} > temp_file.md
+mv temp_file.md ../docs/architecture/diagrams/cams-containers.md
+
+## CAMS Functions API with Webapp
+mermaid_file="./structurizr-FunctionsAPIwithWebapp.mmd"
+{
+  echo "# CAMS Webapp with Functions API\n\n\`\`\`mermaid"
+  cat "$mermaid_file"
+  echo "\n\`\`\`"
+} > temp_file.md
+mv temp_file.md ../docs/architecture/diagrams/cams-webapp-with-functions-api.md
+
+## CAMS Webapp Components
+mermaid_file="./structurizr-CAMSWebapp.mmd"
+{
+  echo "# CAMS Webapp Components\n\n\`\`\`mermaid"
+  cat "$mermaid_file"
+  echo "\n\`\`\`"
+} > temp_file.md
+mv temp_file.md ../docs/architecture/diagrams/cams-webapp-components.md
+
+## CAMS Functions API Components
+mermaid_file="./structurizr-FunctionsAPI.mmd"
+{
+  echo "# CAMS Functions API Components\n\n\`\`\`mermaid"
+  cat "$mermaid_file"
+  echo "\n\`\`\`"
+} > temp_file.md
+mv temp_file.md ../docs/architecture/diagrams/cams-functions-api-components.md
+
+popd

--- a/architecture/export-architecture-diagrams.sh
+++ b/architecture/export-architecture-diagrams.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Export the diagrams from our model
+structurizr.sh export -workspace architecture/cams.dsl -format mermaid
+
+# Produce Docsify Content
+#   This should replace the content of the appropriate markdown file,
+#     wrapping the mermaid in a code tag.

--- a/docs/architecture/_sidebar.md
+++ b/docs/architecture/_sidebar.md
@@ -2,3 +2,4 @@
 
 * [< Back](/)
 * [Decision Records](/architecture/decision-records/README.md)
+* [CAMS Context](/architecture/diagrams/cams-context.md)

--- a/docs/architecture/_sidebar.md
+++ b/docs/architecture/_sidebar.md
@@ -3,3 +3,7 @@
 * [< Back](/)
 * [Decision Records](/architecture/decision-records/README.md)
 * [CAMS Context](/architecture/diagrams/cams-context.md)
+* [CAMS Containers](/architecture/diagrams/cams-containers.md)
+* [CAMS Webapp with Functions API](/architecture/diagrams/cams-webapp-with-functions-api.md)
+* [CAMS Webapp Components](/architecture/diagrams/cams-webapp-components.md)
+* [CAMS Functions API Components](/architecture/diagrams/cams-functions-api-components.md)

--- a/docs/architecture/diagrams/cams-containers.md
+++ b/docs/architecture/diagrams/cams-containers.md
@@ -1,0 +1,34 @@
+# CAMS Containers
+
+```mermaid
+graph TB
+  linkStyle default fill:#ffffff
+
+  subgraph diagram [CAMS - Containers]
+    style diagram fill:#ffffff,stroke:#ffffff
+
+    1["<div style='font-weight: bold'>AUST</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Assistant United States<br />Trustee - manages a USTP<br />office</div>"]
+    style 1 fill:#08427b,stroke:#052e56,color:#ffffff
+    2["<div style='font-weight: bold'>Trial Attorney</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Represents USTP in court<br />regarding bankruptcy cases</div>"]
+    style 2 fill:#08427b,stroke:#052e56,color:#ffffff
+
+    subgraph 3 [CAMS]
+      style 3 fill:#ffffff,stroke:#0b4884,color:#0b4884
+
+      10("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
+      style 10 fill:#438dd5,stroke:#2e6295,color:#ffffff
+      11("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
+      style 11 fill:#438dd5,stroke:#2e6295,color:#ffffff
+      4("<div style='font-weight: bold'>Webapp</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>The user interface for CAMS</div>")
+      style 4 fill:#438dd5,stroke:#2e6295,color:#ffffff
+      7("<div style='font-weight: bold'>API</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>An Azure Functions App<br />(Node.js)</div>")
+      style 7 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    end
+
+    1-. "<div>Assigns cases to attorneys</div><div style='font-size: 70%'></div>" .->4
+    2-. "<div>Views bankruptcy cases</div><div style='font-size: 70%'></div>" .->4
+    4-. "<div>Reads and writes case data<br />and assignments</div><div style='font-size: 70%'></div>" .->7
+    7-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->11
+    7-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->10
+  end
+```

--- a/docs/architecture/diagrams/cams-context.md
+++ b/docs/architecture/diagrams/cams-context.md
@@ -1,0 +1,5 @@
+# CAMS System Context
+
+```mermaid
+[cams-context](../structurizr-SystemLandscape.mmd ':include')
+```

--- a/docs/architecture/diagrams/cams-context.md
+++ b/docs/architecture/diagrams/cams-context.md
@@ -1,5 +1,20 @@
 # CAMS System Context
 
 ```mermaid
-[cams-context](../structurizr-SystemLandscape.mmd ':include')
+graph TB
+  linkStyle default fill:#ffffff
+
+  subgraph diagram [System Landscape]
+    style diagram fill:#ffffff,stroke:#ffffff
+
+    1["<div style='font-weight: bold'>AUST</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Assistant United States<br />Trustee - manages a USTP<br />office</div>"]
+    style 1 fill:#08427b,stroke:#052e56,color:#ffffff
+    2["<div style='font-weight: bold'>Trial Attorney</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Represents USTP in court<br />regarding bankruptcy cases</div>"]
+    style 2 fill:#08427b,stroke:#052e56,color:#ffffff
+    3("<div style='font-weight: bold'>CAMS</div><div style='font-size: 70%; margin-top: 0px'>[Software System]</div><div style='font-size: 80%; margin-top:10px'>CAse Management System</div>")
+    style 3 fill:#1168bd,stroke:#0b4884,color:#ffffff
+
+    1-. "<div>Assigns cases to attorneys</div><div style='font-size: 70%'></div>" .->3
+    2-. "<div>Views bankruptcy cases</div><div style='font-size: 70%'></div>" .->3
+  end
 ```

--- a/docs/architecture/diagrams/cams-functions-api-components.md
+++ b/docs/architecture/diagrams/cams-functions-api-components.md
@@ -1,0 +1,32 @@
+# CAMS Functions API Components
+
+```mermaid
+graph TB
+  linkStyle default fill:#ffffff
+
+  subgraph diagram [CAMS - API - Components]
+    style diagram fill:#ffffff,stroke:#ffffff
+
+    11("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
+    style 11 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    4("<div style='font-weight: bold'>Webapp</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>The user interface for CAMS</div>")
+    style 4 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    10("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
+    style 10 fill:#438dd5,stroke:#2e6295,color:#ffffff
+
+    subgraph 7 [API]
+      style 7 fill:#ffffff,stroke:#2e6295,color:#2e6295
+
+      8("<div style='font-weight: bold'>Cases</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Cases API</div>")
+      style 8 fill:#85bbf0,stroke:#5d82a8,color:#000000
+      9("<div style='font-weight: bold'>Assignments</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Assignments API</div>")
+      style 9 fill:#85bbf0,stroke:#5d82a8,color:#000000
+    end
+
+    4-. "<div>Reads and writes case data</div><div style='font-size: 70%'></div>" .->8
+    4-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->9
+    8-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->10
+    8-. "<div>Reads case assignments</div><div style='font-size: 70%'></div>" .->11
+    9-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->11
+  end
+```

--- a/docs/architecture/diagrams/cams-webapp-components.md
+++ b/docs/architecture/diagrams/cams-webapp-components.md
@@ -1,0 +1,28 @@
+# CAMS Webapp Components
+
+```mermaid
+graph TB
+  linkStyle default fill:#ffffff
+
+  subgraph diagram [CAMS - Webapp - Components]
+    style diagram fill:#ffffff,stroke:#ffffff
+
+    1["<div style='font-weight: bold'>AUST</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Assistant United States<br />Trustee - manages a USTP<br />office</div>"]
+    style 1 fill:#08427b,stroke:#052e56,color:#ffffff
+    2["<div style='font-weight: bold'>Trial Attorney</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Represents USTP in court<br />regarding bankruptcy cases</div>"]
+    style 2 fill:#08427b,stroke:#052e56,color:#ffffff
+
+    subgraph 4 [Webapp]
+      style 4 fill:#ffffff,stroke:#2e6295,color:#2e6295
+
+      5("<div style='font-weight: bold'>Cases Screen</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Displays case metadata in a<br />tabular format</div>")
+      style 5 fill:#85bbf0,stroke:#5d82a8,color:#000000
+      6("<div style='font-weight: bold'>Assignments Screen</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Displays case assignment data<br />and provides for creating<br />assignments</div>")
+      style 6 fill:#85bbf0,stroke:#5d82a8,color:#000000
+    end
+
+    2-. "<div>Views bankruptcy cases</div><div style='font-size: 70%'></div>" .->5
+    1-. "<div>Assigns cases to attorneys</div><div style='font-size: 70%'></div>" .->6
+    2-. "<div>Views cases assigned to them</div><div style='font-size: 70%'></div>" .->6
+  end
+```

--- a/docs/architecture/diagrams/cams-webapp-with-functions-api.md
+++ b/docs/architecture/diagrams/cams-webapp-with-functions-api.md
@@ -1,0 +1,32 @@
+# CAMS Webapp with Functions API
+
+```mermaid
+graph TB
+  linkStyle default fill:#ffffff
+
+  subgraph diagram [CAMS - API - Components]
+    style diagram fill:#ffffff,stroke:#ffffff
+
+    11("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
+    style 11 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    4("<div style='font-weight: bold'>Webapp</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>The user interface for CAMS</div>")
+    style 4 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    10("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
+    style 10 fill:#438dd5,stroke:#2e6295,color:#ffffff
+
+    subgraph 7 [API]
+      style 7 fill:#ffffff,stroke:#2e6295,color:#2e6295
+
+      8("<div style='font-weight: bold'>Cases</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Cases API</div>")
+      style 8 fill:#85bbf0,stroke:#5d82a8,color:#000000
+      9("<div style='font-weight: bold'>Assignments</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Assignments API</div>")
+      style 9 fill:#85bbf0,stroke:#5d82a8,color:#000000
+    end
+
+    4-. "<div>Reads and writes case data</div><div style='font-size: 70%'></div>" .->8
+    4-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->9
+    8-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->10
+    8-. "<div>Reads case assignments</div><div style='font-size: 70%'></div>" .->11
+    9-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->11
+  end
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,12 +19,12 @@
       loadSidebar: true,
     }
   </script>
+  <script src="//unpkg.com/docsify-mermaid@2.0.0/dist/docsify-mermaid.js"></script>
   <script type="module">
     import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
     mermaid.initialize({ startOnLoad: true });
     window.mermaid = mermaid;
   </script>
-  <script src="//unpkg.com/docsify-mermaid@2.0.0/dist/docsify-mermaid.js"></script>
   <!-- Docsify v4 -->
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,31 +1,60 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Document</title>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="Description">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
-</head>
-<body>
-  <div id="app"></div>
-  <script>
-    window.$docsify = {
-      name: 'CAse Management System',
-      repo: 'https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems',
+  <head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="description" content="Description">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>
+      window.$docsify = {
+        name: 'CAse Management System',
+        repo: 'https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems',
 
-      // load from _sidebar.md
-      loadSidebar: true,
-    }
-  </script>
-  <script src="//unpkg.com/docsify-mermaid@2.0.0/dist/docsify-mermaid.js"></script>
-  <script type="module">
-    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
-    mermaid.initialize({ startOnLoad: true });
-    window.mermaid = mermaid;
-  </script>
-  <!-- Docsify v4 -->
-  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
-</body>
+        // load from _sidebar.md
+        loadSidebar: true,
+        plugins: [
+          function (hook) {
+            hook.afterEach(function (html, next) {
+              // We load the HTML inside a DOM node to allow for manipulation
+              const htmlElement = document.createElement("div");
+              htmlElement.innerHTML = html;
+
+              htmlElement
+                .querySelectorAll("pre[data-lang=mermaid]")
+                .forEach((element) => {
+                  // Create a <div class="mermaid"> to replace the <pre>
+                  const replacement = document.createElement("div");
+                  replacement.textContent = element.textContent;
+                  replacement.classList.add("mermaid");
+
+                  // Replace
+                  element.parentNode.replaceChild(replacement, element);
+                });
+              next(htmlElement.innerHTML);
+            });
+            hook.doneEach(function () {
+              let mermaidConfig = {
+                querySelector: ".mermaid",
+              };
+              mermaid.run(mermaidConfig);
+            });
+          }
+        ],
+      }
+    </script>
+    <script src="//unpkg.com/docsify-mermaid@2.0.0/dist/docsify-mermaid.js"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+
+      mermaid.initialize({startOnLoad: true});
+      window.mermaid = mermaid;
+    </script>
+    <!-- Docsify v4 -->
+    <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,12 @@
       loadSidebar: true,
     }
   </script>
+  <script type="module">
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+    mermaid.initialize({ startOnLoad: true });
+    window.mermaid = mermaid;
+  </script>
+  <script src="//unpkg.com/docsify-mermaid@2.0.0/dist/docsify-mermaid.js"></script>
   <!-- Docsify v4 -->
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
 </body>


### PR DESCRIPTION
# Purpose

Adds diagrams as code to support threat modeling.

# Major Changes

We define the architecture using the [Structurizr domain-specific-language](https://github.com/structurizr/dsl/tree/master/docs/cookbook/introduction) and then use an [accompanying CLI](https://github.com/structurizr/cli) to output [Mermaid](https://mermaid.js.org/). Then we copy the Mermaid code into markdown files for inclusion in our Docsify pages.

# Testing/Validation

GitHub Pages is currently set to deploy from this branch and behavior can be validated [here](https://us-trustee-program.github.io/Bankruptcy-Oversight-Support-Systems/#/).

# Notes

This approach allows us to generate several levels of diagram that might be used for different purposes. This is called the C4 Model and you can learn more [here](https://c4model.com/).
