### PR TITLE
CAMS-87: Use local attorney gateway in deployed environment

### DIFF
--- a/backend/functions/lib/factory.ts
+++ b/backend/functions/lib/factory.ts
@@ -19,6 +19,7 @@ export const getAttorneyGateway = (): AttorneyGatewayInterface => {
   if (config.get('dbMock')) {
     return new AttorneyLocalGateway();
   } else {
+    return new AttorneyLocalGateway();
     // return new AttorneyApiGateway(); // not yet implemented
   }
 };


### PR DESCRIPTION
# Purpose

The local attorney gateway was not being used unless the database mock variable was set. Since we determined to hard code the attorneys this is what should be used until we get attorneys from persistence or some other source.

# Major Changes

Update the factory to use the local gateway in the deployed environment.

# Testing/Validation

Validated that the modal works once we're using the local gateway.
