### PR TITLE
Cams 98 format date

### DIFF
--- a/backend/functions/lib/adapters/gateways/cases.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/cases.dxtr.gateway.ts
@@ -27,7 +27,7 @@ export default class CasesDxtrGateway implements CasesInterface {
     const query = `select TOP 20
         Format(CS_DATE_FILED, 'yy') + '-' + CS_CASE_NUMBER as caseNumber,
         CS_SHORT_TITLE as caseTitle,
-        CS_DATE_FILED as dateFiled
+        FORMAT(CS_DATE_FILED, 'MM-dd-yyyy') as dateFiled
         FROM [dbo].[AO_CS]
         WHERE CS_CHAPTER = '15'
         AND GRP_DES = '${MANHATTAN_GROUP_DESIGNATOR}'
@@ -40,6 +40,7 @@ export default class CasesDxtrGateway implements CasesInterface {
       input,
     );
 
+    console.log(queryResult.results);
     if (queryResult.success) {
       log.debug(context, MODULENAME, `Results received from DXTR ${queryResult}`);
 

--- a/backend/functions/lib/adapters/gateways/cases.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/cases.dxtr.gateway.ts
@@ -40,7 +40,6 @@ export default class CasesDxtrGateway implements CasesInterface {
       input,
     );
 
-    console.log(queryResult.results);
     if (queryResult.success) {
       log.debug(context, MODULENAME, `Results received from DXTR ${queryResult}`);
 

--- a/backend/functions/lib/adapters/gateways/cases.local.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/cases.local.gateway.ts
@@ -3,6 +3,7 @@ import { ApplicationContext } from '../types/basic';
 import { Chapter15CaseInterface } from '../types/cases';
 import { GatewayHelper } from './gateway-helper';
 import log from '../services/logger.service';
+import { convertYearMonthDayToMonthDayYear } from '../utils/date-helper';
 
 const NAMESPACE = 'CASES-LOCAL-GATEWAY';
 
@@ -19,6 +20,9 @@ export class CasesLocalGateway implements CasesInterface {
 
     try {
       cases = gatewayHelper.chapter15MockExtract();
+      cases.map((bCase) => {
+        bCase.dateFiled = convertYearMonthDayToMonthDayYear(bCase.dateFiled);
+      });
     } catch (err) {
       log.error(context, NAMESPACE, 'Failed to read mock cases.', err);
       const message = (err as Error).message;

--- a/backend/functions/lib/adapters/utils/date-helper.test.ts
+++ b/backend/functions/lib/adapters/utils/date-helper.test.ts
@@ -1,4 +1,9 @@
-import { getDate, calculateDifferenceInMonths, getCamsDateStringFromDate } from './date-helper';
+import {
+  getDate,
+  calculateDifferenceInMonths,
+  getCamsDateStringFromDate,
+  convertYearMonthDayToMonthDayYear,
+} from './date-helper';
 
 describe('date-helper tests', () => {
   describe('getDate tests', () => {
@@ -186,6 +191,12 @@ describe('date-helper tests', () => {
 
     test('should properly handle date later than Dec 31, 9999', async () => {
       expect(getCamsDateStringFromDate(new Date(10000, 0, 1))).toEqual('+010000-01-01');
+    });
+  });
+
+  describe('convertYearMonthDayToMonthDayYear tests', () => {
+    test('should convert 2023-12-31 to 12-31-2023', async () => {
+      expect(convertYearMonthDayToMonthDayYear('2023-12-31')).toEqual('12-31-2023');
     });
   });
 });

--- a/backend/functions/lib/adapters/utils/date-helper.ts
+++ b/backend/functions/lib/adapters/utils/date-helper.ts
@@ -38,6 +38,8 @@ export function getCamsDateStringFromDate(date: Date) {
 }
 
 export function convertYearMonthDayToMonthDayYear(date: string) {
+  // example: 2023-12-31 -> 12-31-2023
+  // index:      0  1  2 ->  1  2  0
   const parts = date.split('-');
   return `${parts[1]}-${parts[2]}-${parts[0]}`;
 }

--- a/backend/functions/lib/adapters/utils/date-helper.ts
+++ b/backend/functions/lib/adapters/utils/date-helper.ts
@@ -38,8 +38,6 @@ export function getCamsDateStringFromDate(date: Date) {
 }
 
 export function convertYearMonthDayToMonthDayYear(date: string) {
-  // example: 2023-12-31 -> 12-31-2023
-  // index:      0  1  2 ->  1  2  0
   const parts = date.split('-');
   return `${parts[1]}-${parts[2]}-${parts[0]}`;
 }

--- a/backend/functions/lib/adapters/utils/date-helper.ts
+++ b/backend/functions/lib/adapters/utils/date-helper.ts
@@ -36,3 +36,8 @@ export function calculateDifferenceInMonths(left: Date, right: Date): number {
 export function getCamsDateStringFromDate(date: Date) {
   return date.toISOString().split('T')[0];
 }
+
+export function convertYearMonthDayToMonthDayYear(date: string) {
+  const parts = date.split('-');
+  return `${parts[1]}-${parts[2]}-${parts[0]}`;
+}

--- a/user-interface/src/components/CaseAssignment.tsx
+++ b/user-interface/src/components/CaseAssignment.tsx
@@ -14,7 +14,6 @@ import { Attorney } from '../type-declarations/attorneys';
 const modalId = 'assign-attorney-modal';
 
 interface Chapter15Node extends Chapter15Type {
-  prettyDateFiled: string;
   sortableDateFiled: string;
 }
 
@@ -52,16 +51,17 @@ export const CaseAssignment = () => {
           ?.map((theCase) => {
             const caseNode = theCase as Chapter15Node;
             const dateFiled = caseNode.dateFiled.split('-');
-            caseNode.prettyDateFiled = `${dateFiled[1]}-${dateFiled[2]}-${dateFiled[0]}`;
-            caseNode.sortableDateFiled = `${dateFiled[0]}${dateFiled[1]}${dateFiled[2]}`;
+            // Filing date formatted in SQL query as MM-dd-yyyy (ISO is yyyy-MM-dd)
+            // dateFiled[0] = month, dateFiled[1] = day, dateFiled[2] = year
+            caseNode.sortableDateFiled = `${dateFiled[2]}${dateFiled[0]}${dateFiled[1]}`;
             return caseNode;
           })
           .sort((a, b): number => {
             const recordA: Chapter15Node = a as Chapter15Node;
             const recordB: Chapter15Node = b as Chapter15Node;
-            if (recordA.dateFiled < recordB.dateFiled) {
+            if (recordA.sortableDateFiled < recordB.sortableDateFiled) {
               return 1;
-            } else if (recordA.dateFiled > recordB.dateFiled) {
+            } else if (recordA.sortableDateFiled > recordB.sortableDateFiled) {
               return -1;
             } else {
               return 0;
@@ -222,7 +222,7 @@ export const CaseAssignment = () => {
                           data-sort-active={true}
                         >
                           <span className="mobile-title">Filing Date:</span>
-                          {theCase.prettyDateFiled}
+                          {theCase.dateFiled}
                         </td>
                         <td data-testid={`attorney-list-${idx}`} className="attorney-list">
                           <span className="mobile-title">Assigned Attorney:</span>


### PR DESCRIPTION
# Purpose

The date format coming from PACER was `yyyy-MM-dd`, but from DXTR is an ISO date string. Our frontend code was splitting the `date filed` on the `-` and as a result was displaying a messed up ISO date instead of the `MM-dd-yyyy` format we were looking for.

# Major Changes

We format the date filed field in our query from DXTR. For the local gateway which was originally based on PACER data, we leave the source data the same, but add a helper function which converts the date. 

# Testing/Validation

Added a test for the new helper function. Validated the date format running locally with both the DXTR and local data sources.

# Notes

If we find the new helper function useful for more use cases, some validation would be needed. For now, it is only being used on hard coded data, so that would add unnecessary complexity.
