### PR TITLE
CAMS-148: Get count of cases assigned to attorneys

### DIFF
--- a/backend/functions/case-assignments/case.assignment.function.ts
+++ b/backend/functions/case-assignments/case.assignment.function.ts
@@ -21,12 +21,8 @@ const httpTrigger: AzureFunction = async function (
   const role = request.body && request.body.role;
 
   try {
-    if (request.method === 'POST') {
-      validateRequestParameters(caseId, functionContext, listOfAttorneyNames, role);
-      await handlePostMethod(functionContext, caseId, listOfAttorneyNames, role);
-    } else if (request.method === 'GET') {
-      await handleGetMethod(functionContext);
-    }
+    validateRequestParameters(caseId, functionContext, listOfAttorneyNames, role);
+    await handlePostMethod(functionContext, caseId, listOfAttorneyNames, role);
   } catch (e) {
     if (e instanceof AssignmentException) {
       functionContext.res = httpError(functionContext, e, e.status);
@@ -84,14 +80,6 @@ async function handlePostMethod(functionContext: Context, caseId, listOfAttorney
       role,
     });
   functionContext.res = httpSuccess(functionContext, trialAttorneyAssignmentResponse);
-}
-
-async function handleGetMethod(functionContext: Context) {
-  const caseAssignmentController: CaseAssignmentController = new CaseAssignmentController(
-    functionContext,
-  );
-  const assignments = await caseAssignmentController.getAllAssignments();
-  functionContext.res = httpSuccess(functionContext, assignments);
 }
 
 export default httpTrigger;

--- a/backend/functions/case-assignments/function.json
+++ b/backend/functions/case-assignments/function.json
@@ -8,8 +8,7 @@
       "cardinality": "many",
       "route": "case-assignments",
       "methods": [
-        "post",
-        "get"
+        "post"
       ]
     },
     {

--- a/backend/functions/lib/adapters/controllers/case.assignment.controller.test.ts
+++ b/backend/functions/lib/adapters/controllers/case.assignment.controller.test.ts
@@ -36,7 +36,7 @@ describe('Chapter 15 Case Assignment Creation Tests', () => {
 
     expect(resultAssignmentId).toBeTruthy();
     expect((assignments.body[0] as CaseAttorneyAssignment).caseId).toBe(testCaseAssignment.caseId);
-    expect((assignments.body[0] as CaseAttorneyAssignment).attorneyName).toBe(
+    expect((assignments.body[0] as CaseAttorneyAssignment).name).toBe(
       testCaseAssignment.listOfAttorneyNames[0],
     );
     expect((assignments.body[0] as CaseAttorneyAssignment).role).toBe(testCaseAssignment.role);
@@ -87,7 +87,7 @@ describe('Chapter 15 Case Assignment Creation Tests', () => {
     ).rejects.toThrow(AssignmentException);
 
     expect(assignmentCreated1.caseId).toBe(testCaseAssignment1.caseId);
-    expect(assignmentCreated1.attorneyName).toBe(testCaseAssignment1.listOfAttorneyNames[0]);
+    expect(assignmentCreated1.name).toBe(testCaseAssignment1.listOfAttorneyNames[0]);
     expect(assignmentCreated1.role).toBe(testCaseAssignment1.role);
   });
 
@@ -112,19 +112,19 @@ describe('Chapter 15 Case Assignment Creation Tests', () => {
     const assignments = await assignmentController.getAllAssignments();
 
     expect((assignments.body[0] as CaseAttorneyAssignment).caseId).toBe(testCaseAssignment.caseId);
-    expect((assignments.body[0] as CaseAttorneyAssignment).attorneyName).toBe(
+    expect((assignments.body[0] as CaseAttorneyAssignment).name).toBe(
       testCaseAssignment.listOfAttorneyNames[0],
     );
     expect((assignments.body[0] as CaseAttorneyAssignment).role).toBe(testCaseAssignment.role);
 
     expect((assignments.body[1] as CaseAttorneyAssignment).caseId).toBe(testCaseAssignment.caseId);
-    expect((assignments.body[1] as CaseAttorneyAssignment).attorneyName).toBe(
+    expect((assignments.body[1] as CaseAttorneyAssignment).name).toBe(
       testCaseAssignment.listOfAttorneyNames[1],
     );
     expect((assignments.body[1] as CaseAttorneyAssignment).role).toBe(testCaseAssignment.role);
 
     expect((assignments.body[2] as CaseAttorneyAssignment).caseId).toBe(testCaseAssignment.caseId);
-    expect((assignments.body[2] as CaseAttorneyAssignment).attorneyName).toBe(
+    expect((assignments.body[2] as CaseAttorneyAssignment).name).toBe(
       testCaseAssignment.listOfAttorneyNames[2],
     );
     expect((assignments.body[2] as CaseAttorneyAssignment).role).toBe(testCaseAssignment.role);

--- a/backend/functions/lib/adapters/controllers/case.assignment.controller.ts
+++ b/backend/functions/lib/adapters/controllers/case.assignment.controller.ts
@@ -48,26 +48,4 @@ export class CaseAssignmentController {
       }
     }
   }
-
-  public async getAllAssignments(): Promise<AttorneyAssignmentResponseInterface> {
-    const assignmentUseCase = new CaseAssignment(this.applicationContext);
-    const assignments = await assignmentUseCase.getAllAssignments();
-    let response;
-    if (assignments.length > 0) {
-      response = {
-        success: true,
-        message: '',
-        count: assignments.length,
-        body: assignments,
-      };
-    } else {
-      response = {
-        success: false,
-        message: 'Found no case assignments',
-        count: 0,
-        body: undefined,
-      };
-    }
-    return response;
-  }
 }

--- a/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.test.ts
@@ -7,6 +7,9 @@ import { randomUUID } from 'crypto';
 const context = require('azure-function-context-mock');
 
 const appContext = applicationContextCreator(context);
+const perryMason = 'Perry Mason';
+const benMatlock = 'Ben Matlock';
+const clairHuxtable = 'Clair Huxtable';
 describe('Test case assignment cosmosdb repository tests', () => {
   let repository: CaseAssignmentCosmosDbRepository;
   beforeEach(() => {
@@ -139,36 +142,36 @@ describe('Test case assignment cosmosdb repository tests', () => {
     const caseNumberOne = randomUUID();
     const testCaseAttorneyAssignment1: CaseAttorneyAssignment = new CaseAttorneyAssignment(
       caseNumberOne,
-      'Perry Mason',
+      perryMason,
       CaseAssignmentRole.TrialAttorney,
     );
     const testCaseAttorneyAssignment2: CaseAttorneyAssignment = new CaseAttorneyAssignment(
       caseNumberOne,
-      'Ben Matlock',
+      benMatlock,
       CaseAssignmentRole.TrialAttorney,
     );
 
     const caseNumberTwo = randomUUID();
     const testCaseAttorneyAssignment3: CaseAttorneyAssignment = new CaseAttorneyAssignment(
       caseNumberTwo,
-      'Clair Huxtable',
+      clairHuxtable,
       CaseAssignmentRole.TrialAttorney,
     );
     const testCaseAttorneyAssignment4: CaseAttorneyAssignment = new CaseAttorneyAssignment(
       caseNumberTwo,
-      'Perry Mason',
+      perryMason,
       CaseAssignmentRole.TrialAttorney,
     );
 
     const caseNumberThree = randomUUID();
     const testCaseAttorneyAssignment5: CaseAttorneyAssignment = new CaseAttorneyAssignment(
       caseNumberThree,
-      'Clair Huxtable',
+      clairHuxtable,
       CaseAssignmentRole.TrialAttorney,
     );
     const testCaseAttorneyAssignment6: CaseAttorneyAssignment = new CaseAttorneyAssignment(
       caseNumberThree,
-      'Ben Matlock',
+      benMatlock,
       CaseAssignmentRole.TrialAttorney,
     );
 
@@ -179,12 +182,74 @@ describe('Test case assignment cosmosdb repository tests', () => {
     await repository.createAssignment(testCaseAttorneyAssignment5);
     await repository.createAssignment(testCaseAttorneyAssignment6);
 
-    const perryAssignments = await repository.findAssignmentsByAssigneeName('Perry Mason');
-    const clairAssignments = await repository.findAssignmentsByAssigneeName('Clair Huxtable');
-    const benAssignments = await repository.findAssignmentsByAssigneeName('Ben Matlock');
+    const perryAssignments = await repository.findAssignmentsByAssigneeName(perryMason);
+    const clairAssignments = await repository.findAssignmentsByAssigneeName(clairHuxtable);
+    const benAssignments = await repository.findAssignmentsByAssigneeName(benMatlock);
 
     expect(perryAssignments.length).toEqual(2);
+    expect(perryAssignments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          caseId: caseNumberOne,
+          name: perryMason,
+          role: CaseAssignmentRole.TrialAttorney,
+        }),
+        expect.objectContaining({
+          caseId: caseNumberTwo,
+          name: perryMason,
+          role: CaseAssignmentRole.TrialAttorney,
+        }),
+      ]),
+    );
+    expect(perryAssignments).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ name: clairHuxtable })]),
+    );
+    expect(perryAssignments).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ name: benMatlock })]),
+    );
+
     expect(clairAssignments.length).toEqual(2);
+    expect(clairAssignments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          caseId: caseNumberTwo,
+          name: clairHuxtable,
+          role: CaseAssignmentRole.TrialAttorney,
+        }),
+        expect.objectContaining({
+          caseId: caseNumberThree,
+          name: clairHuxtable,
+          role: CaseAssignmentRole.TrialAttorney,
+        }),
+      ]),
+    );
+    expect(clairAssignments).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ name: perryMason })]),
+    );
+    expect(clairAssignments).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ name: benMatlock })]),
+    );
+
     expect(benAssignments.length).toEqual(2);
+    expect(benAssignments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          caseId: caseNumberOne,
+          name: benMatlock,
+          role: CaseAssignmentRole.TrialAttorney,
+        }),
+        expect.objectContaining({
+          caseId: caseNumberThree,
+          name: benMatlock,
+          role: CaseAssignmentRole.TrialAttorney,
+        }),
+      ]),
+    );
+    expect(benAssignments).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ name: perryMason })]),
+    );
+    expect(benAssignments).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ name: clairHuxtable })]),
+    );
   });
 });

--- a/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.test.ts
@@ -134,4 +134,57 @@ describe('Test case assignment cosmosdb repository tests', () => {
       expect((e as Error).message).toEqual('Failed to authenticate to Azure');
     }
   });
+
+  test('should find all assignments for a given attorney', async () => {
+    const caseNumberOne = randomUUID();
+    const testCaseAttorneyAssignment1: CaseAttorneyAssignment = new CaseAttorneyAssignment(
+      caseNumberOne,
+      'Perry Mason',
+      CaseAssignmentRole.TrialAttorney,
+    );
+    const testCaseAttorneyAssignment2: CaseAttorneyAssignment = new CaseAttorneyAssignment(
+      caseNumberOne,
+      'Ben Matlock',
+      CaseAssignmentRole.TrialAttorney,
+    );
+
+    const caseNumberTwo = randomUUID();
+    const testCaseAttorneyAssignment3: CaseAttorneyAssignment = new CaseAttorneyAssignment(
+      caseNumberTwo,
+      'Clair Huxtable',
+      CaseAssignmentRole.TrialAttorney,
+    );
+    const testCaseAttorneyAssignment4: CaseAttorneyAssignment = new CaseAttorneyAssignment(
+      caseNumberTwo,
+      'Perry Mason',
+      CaseAssignmentRole.TrialAttorney,
+    );
+
+    const caseNumberThree = randomUUID();
+    const testCaseAttorneyAssignment5: CaseAttorneyAssignment = new CaseAttorneyAssignment(
+      caseNumberThree,
+      'Clair Huxtable',
+      CaseAssignmentRole.TrialAttorney,
+    );
+    const testCaseAttorneyAssignment6: CaseAttorneyAssignment = new CaseAttorneyAssignment(
+      caseNumberThree,
+      'Ben Matlock',
+      CaseAssignmentRole.TrialAttorney,
+    );
+
+    await repository.createAssignment(testCaseAttorneyAssignment1);
+    await repository.createAssignment(testCaseAttorneyAssignment2);
+    await repository.createAssignment(testCaseAttorneyAssignment3);
+    await repository.createAssignment(testCaseAttorneyAssignment4);
+    await repository.createAssignment(testCaseAttorneyAssignment5);
+    await repository.createAssignment(testCaseAttorneyAssignment6);
+
+    const perryAssignments = await repository.findAssignmentsByAssigneeName('Perry Mason');
+    const clairAssignments = await repository.findAssignmentsByAssigneeName('Clair Huxtable');
+    const benAssignments = await repository.findAssignmentsByAssigneeName('Ben Matlock');
+
+    expect(perryAssignments.length).toEqual(2);
+    expect(clairAssignments.length).toEqual(2);
+    expect(benAssignments.length).toEqual(2);
+  });
 });

--- a/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.test.ts
@@ -41,10 +41,10 @@ describe('Test case assignment cosmosdb repository tests', () => {
 
     expect(assignment1.caseId).toEqual(testCaseAttorneyAssignment1.caseId);
     expect(assignment1.role).toEqual(testCaseAttorneyAssignment1.role);
-    expect(assignment1.attorneyName).toEqual(testCaseAttorneyAssignment1.attorneyName);
+    expect(assignment1.name).toEqual(testCaseAttorneyAssignment1.name);
     expect(assignment2.caseId).toEqual(testCaseAttorneyAssignment2.caseId);
     expect(assignment2.role).toEqual(testCaseAttorneyAssignment2.role);
-    expect(assignment2.attorneyName).toEqual(testCaseAttorneyAssignment2.attorneyName);
+    expect(assignment2.name).toEqual(testCaseAttorneyAssignment2.name);
   });
 
   test('should find only assignments for the requested case', async () => {
@@ -73,7 +73,7 @@ describe('Test case assignment cosmosdb repository tests', () => {
 
     expect(assignment1.caseId).toEqual(testCaseAttorneyAssignment1.caseId);
     expect(assignment1.role).toEqual(testCaseAttorneyAssignment1.role);
-    expect(assignment1.attorneyName).toEqual(testCaseAttorneyAssignment1.attorneyName);
+    expect(assignment1.name).toEqual(testCaseAttorneyAssignment1.name);
     expect(assignment2).toBeFalsy();
 
     const actualAssignmentsTwo = await repository.findAssignmentsByCaseId(caseNumberTwo);
@@ -85,7 +85,7 @@ describe('Test case assignment cosmosdb repository tests', () => {
 
     expect(assignmentTwo.caseId).toEqual(testCaseAttorneyAssignment2.caseId);
     expect(assignmentTwo.role).toEqual(testCaseAttorneyAssignment2.role);
-    expect(assignmentTwo.attorneyName).toEqual(testCaseAttorneyAssignment2.attorneyName);
+    expect(assignmentTwo.name).toEqual(testCaseAttorneyAssignment2.name);
     expect(assignmentOne).toBeFalsy();
   });
 

--- a/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.ts
@@ -49,42 +49,33 @@ export class CaseAssignmentCosmosDbRepository implements CaseAssignmentRepositor
   }
 
   async findAssignmentsByCaseId(caseId: string): Promise<CaseAttorneyAssignment[]> {
-    try {
-      // Check read access
-      const querySpec = {
-        query: 'SELECT * FROM c WHERE c.caseId = @caseId',
-        parameters: [
-          {
-            name: '@caseId',
-            value: caseId,
-          },
-        ],
-      };
-      const { resources: results } = await this.cosmosDbClient
-        .database(this.cosmosConfig.databaseName)
-        .container(this.containerName)
-        .items.query(querySpec)
-        .fetchAll();
-      return results;
-    } catch (e) {
-      log.error(this.appContext, NAMESPACE, `${e.status} : ${e.name} : ${e.message}`);
-      if (e instanceof AggregateAuthenticationError) {
-        throw new AssignmentException(403, 'Failed to authenticate to Azure');
-      }
-    }
+    const querySpec = {
+      query: 'SELECT * FROM c WHERE c.caseId = @caseId',
+      parameters: [
+        {
+          name: '@caseId',
+          value: caseId,
+        },
+      ],
+    };
+    return await this.queryData(querySpec);
   }
 
   async findAssignmentsByAssigneeName(name: string): Promise<CaseAttorneyAssignment[]> {
+    const querySpec = {
+      query: 'SELECT * FROM c WHERE c.name = @name',
+      parameters: [
+        {
+          name: '@name',
+          value: name,
+        },
+      ],
+    };
+    return await this.queryData(querySpec);
+  }
+
+  private async queryData(querySpec: object): Promise<CaseAttorneyAssignment[]> {
     try {
-      const querySpec = {
-        query: 'SELECT * FROM c WHERE c.name = @name',
-        parameters: [
-          {
-            name: '@name',
-            value: name,
-          },
-        ],
-      };
       const { resources: results } = await this.cosmosDbClient
         .database(this.cosmosConfig.databaseName)
         .container(this.containerName)
@@ -96,19 +87,6 @@ export class CaseAssignmentCosmosDbRepository implements CaseAssignmentRepositor
       if (e instanceof AggregateAuthenticationError) {
         throw new AssignmentException(403, 'Failed to authenticate to Azure');
       }
-    }
-  }
-
-  async getAllAssignments(): Promise<CaseAttorneyAssignment[]> {
-    try {
-      const { resources: results } = await this.cosmosDbClient
-        .database(this.cosmosConfig.databaseName)
-        .container(this.containerName)
-        .items.readAll()
-        .fetchAll();
-      return results;
-    } catch (e) {
-      throw new AssignmentException(500, 'Failed to retrieve assignments from the database.');
     }
   }
 }

--- a/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.ts
@@ -74,6 +74,31 @@ export class CaseAssignmentCosmosDbRepository implements CaseAssignmentRepositor
     }
   }
 
+  async findAssignmentsByAttorneyName(attorney: string): Promise<CaseAttorneyAssignment[]> {
+    try {
+      const querySpec = {
+        query: 'SELECT * FROM c WHERE c.name = @attorney',
+        parameters: [
+          {
+            name: '@attorney',
+            value: attorney,
+          },
+        ],
+      };
+      const { resources: results } = await this.cosmosDbClient
+        .database(this.cosmosConfig.databaseName)
+        .container(this.containerName)
+        .items.query(querySpec)
+        .fetchAll();
+      return results;
+    } catch (e) {
+      log.error(this.appContext, NAMESPACE, `${e.status} : ${e.name} : ${e.message}`);
+      if (e instanceof AggregateAuthenticationError) {
+        throw new AssignmentException(403, 'Failed to authenticate to Azure');
+      }
+    }
+  }
+
   async getAllAssignments(): Promise<CaseAttorneyAssignment[]> {
     try {
       const { resources: results } = await this.cosmosDbClient

--- a/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.ts
@@ -74,14 +74,14 @@ export class CaseAssignmentCosmosDbRepository implements CaseAssignmentRepositor
     }
   }
 
-  async findAssignmentsByAttorneyName(attorney: string): Promise<CaseAttorneyAssignment[]> {
+  async findAssignmentsByAssigneeName(name: string): Promise<CaseAttorneyAssignment[]> {
     try {
       const querySpec = {
-        query: 'SELECT * FROM c WHERE c.name = @attorney',
+        query: 'SELECT * FROM c WHERE c.name = @name',
         parameters: [
           {
-            name: '@attorney',
-            value: attorney,
+            name: '@name',
+            value: name,
           },
         ],
       };

--- a/backend/functions/lib/adapters/gateways/case.assignment.local.repository.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.local.repository.ts
@@ -31,10 +31,6 @@ export class CaseAssignmentLocalRepository implements CaseAssignmentRepositoryIn
     return this.caseAttorneyAssignments.filter((assignment) => assignment.caseId === caseId);
   }
 
-  public async getAllAssignments(): Promise<CaseAttorneyAssignment[]> {
-    return this.caseAttorneyAssignments;
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   findAssignmentsByAssigneeName(attorney: string): Promise<CaseAttorneyAssignment[]> {
     return Promise.resolve([]);

--- a/backend/functions/lib/adapters/gateways/case.assignment.local.repository.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.local.repository.ts
@@ -18,7 +18,7 @@ export class CaseAssignmentLocalRepository implements CaseAssignmentRepositoryIn
     const assignmentId = this.nextUnusedId;
     caseAssignment.id = assignmentId.toString();
     this.caseAttorneyAssignments.push(caseAssignment);
-    log.info(this.appContext, NAMESPACE, caseAssignment.attorneyName);
+    log.info(this.appContext, NAMESPACE, caseAssignment.name);
     ++this.nextUnusedId;
     return assignmentId.toString();
   }
@@ -33,5 +33,10 @@ export class CaseAssignmentLocalRepository implements CaseAssignmentRepositoryIn
 
   public async getAllAssignments(): Promise<CaseAttorneyAssignment[]> {
     return this.caseAttorneyAssignments;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  findAssignmentsByAttorneyName(attorney: string): Promise<CaseAttorneyAssignment[]> {
+    return Promise.resolve([]);
   }
 }

--- a/backend/functions/lib/adapters/gateways/case.assignment.local.repository.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.local.repository.ts
@@ -36,7 +36,7 @@ export class CaseAssignmentLocalRepository implements CaseAssignmentRepositoryIn
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  findAssignmentsByAttorneyName(attorney: string): Promise<CaseAttorneyAssignment[]> {
+  findAssignmentsByAssigneeName(attorney: string): Promise<CaseAttorneyAssignment[]> {
     return Promise.resolve([]);
   }
 }

--- a/backend/functions/lib/adapters/types/attorney.class.ts
+++ b/backend/functions/lib/adapters/types/attorney.class.ts
@@ -1,56 +1,52 @@
+import { ObjectKeyVal } from './basic';
+
 export class Attorney {
-  private _firstName: string;
-  private _middleName: string;
-  private _lastName: string;
-  private _generation: string;
-  private _courtId: string;
-  private _office: string;
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  generation: string;
+  courtId: string;
+  office: string;
+  caseLoad: number;
 
-  get firstName(): string {
-    return this._firstName;
+  constructor(attorney?: ObjectKeyVal) {
+    if (attorney) {
+      Object.entries(attorney).forEach(([key, value]) => {
+        if (key === 'firstName') {
+          this.firstName = value as string;
+        } else if (key === 'middleName') {
+          this.middleName = value as string;
+        } else if (key === 'lastName') {
+          this.lastName = value as string;
+        } else if (key === 'generation') {
+          this.generation = value as string;
+        }
+      });
+    }
   }
 
-  set firstName(value: string) {
-    this._firstName = value;
+  getFullName(fullMiddle = false) {
+    let full = this.firstName;
+    if (this.middleName) {
+      const middle = fullMiddle ? ' ' + this.middleName : ' ' + this.middleName.slice(0, 1);
+      full += middle;
+    }
+    full += ' ' + this.lastName;
+    if (this.generation) {
+      full += ' ' + this.generation;
+    }
+    return full;
   }
 
-  get middleName(): string {
-    return this._middleName;
-  }
-
-  set middleName(value: string) {
-    this._middleName = value;
-  }
-
-  get lastName(): string {
-    return this._lastName;
-  }
-
-  set lastName(value: string) {
-    this._lastName = value;
-  }
-
-  get generation(): string {
-    return this._generation;
-  }
-
-  set generation(value: string) {
-    this._generation = value;
-  }
-
-  get courtId(): string {
-    return this._courtId;
-  }
-
-  set courtId(value: string) {
-    this._courtId = value;
-  }
-
-  get office(): string {
-    return this._office;
-  }
-
-  set office(value: string) {
-    this._office = value;
+  getAsObjectKeyVal(): ObjectKeyVal {
+    return {
+      firstName: this.firstName,
+      middleName: this.middleName,
+      lastName: this.lastName,
+      generation: this.generation,
+      courtId: this.courtId,
+      office: this.office,
+      caseLoad: this.caseLoad,
+    };
   }
 }

--- a/backend/functions/lib/adapters/types/attorney.class.ts
+++ b/backend/functions/lib/adapters/types/attorney.class.ts
@@ -5,7 +5,6 @@ export class Attorney {
   middleName: string;
   lastName: string;
   generation: string;
-  courtId: string;
   office: string;
   caseLoad: number;
 
@@ -44,7 +43,6 @@ export class Attorney {
       middleName: this.middleName,
       lastName: this.lastName,
       generation: this.generation,
-      courtId: this.courtId,
       office: this.office,
       caseLoad: this.caseLoad,
     };

--- a/backend/functions/lib/adapters/types/case.attorney.assignment.ts
+++ b/backend/functions/lib/adapters/types/case.attorney.assignment.ts
@@ -3,12 +3,12 @@ import { CaseAssignmentRole } from './case.assignment.role';
 export class CaseAttorneyAssignment {
   id: string;
   caseId: string;
-  attorneyName: string;
+  name: string;
   role: CaseAssignmentRole;
 
   constructor(caseId: string, name: string, role: CaseAssignmentRole) {
     this.caseId = caseId;
-    this.attorneyName = name;
+    this.name = name;
     this.role = role;
   }
 }

--- a/backend/functions/lib/cosmos-humble-objects/fake.cosmos-client-humble.ts
+++ b/backend/functions/lib/cosmos-humble-objects/fake.cosmos-client-humble.ts
@@ -48,6 +48,9 @@ export default class FakeCosmosClientHumble {
                       if (caseItem.caseId === params.value) {
                         result.push(caseItem);
                       }
+                      if (caseItem.name === params.value) {
+                        result.push(caseItem);
+                      }
                     });
                   });
                   return { resources: result };

--- a/backend/functions/lib/interfaces/case.assignment.repository.interface.d.ts
+++ b/backend/functions/lib/interfaces/case.assignment.repository.interface.d.ts
@@ -5,5 +5,5 @@ export interface CaseAssignmentRepositoryInterface {
   getAllAssignments(): Promise<CaseAttorneyAssignment[]>;
   getAssignment(assignmentId: string): Promise<CaseAttorneyAssignment>;
   findAssignmentsByCaseId(caseId: string): Promise<CaseAttorneyAssignment[]>;
-  findAssignmentsByAttorneyName(attorney: string): Promise<CaseAttorneyAssignment[]>;
+  findAssignmentsByAssigneeName(attorney: string): Promise<CaseAttorneyAssignment[]>;
 }

--- a/backend/functions/lib/interfaces/case.assignment.repository.interface.d.ts
+++ b/backend/functions/lib/interfaces/case.assignment.repository.interface.d.ts
@@ -2,7 +2,6 @@ import { CaseAttorneyAssignment } from '../adapters/types/case.attorney.assignme
 
 export interface CaseAssignmentRepositoryInterface {
   createAssignment(caseAssignment: CaseAttorneyAssignment): Promise<string>;
-  getAllAssignments(): Promise<CaseAttorneyAssignment[]>;
   getAssignment(assignmentId: string): Promise<CaseAttorneyAssignment>;
   findAssignmentsByCaseId(caseId: string): Promise<CaseAttorneyAssignment[]>;
   findAssignmentsByAssigneeName(attorney: string): Promise<CaseAttorneyAssignment[]>;

--- a/backend/functions/lib/interfaces/case.assignment.repository.interface.d.ts
+++ b/backend/functions/lib/interfaces/case.assignment.repository.interface.d.ts
@@ -5,4 +5,5 @@ export interface CaseAssignmentRepositoryInterface {
   getAllAssignments(): Promise<CaseAttorneyAssignment[]>;
   getAssignment(assignmentId: string): Promise<CaseAttorneyAssignment>;
   findAssignmentsByCaseId(caseId: string): Promise<CaseAttorneyAssignment[]>;
+  findAssignmentsByAttorneyName(attorney: string): Promise<CaseAttorneyAssignment[]>;
 }

--- a/backend/functions/lib/use-cases/attorneys.ts
+++ b/backend/functions/lib/use-cases/attorneys.ts
@@ -2,6 +2,8 @@ import { AttorneyGatewayInterface } from './attorney.gateway.interface';
 import { AttorneyListDbResult } from '../adapters/types/attorneys';
 import { ApplicationContext } from '../adapters/types/basic';
 import { getAttorneyGateway } from '../factory';
+import { CaseAssignment } from './case.assignment';
+import { Attorney } from '../adapters/types/attorney.class';
 
 export default class AttorneysList {
   gateway: AttorneyGatewayInterface;
@@ -18,6 +20,18 @@ export default class AttorneysList {
     context: ApplicationContext,
     fields: { officeId?: string },
   ): Promise<AttorneyListDbResult> {
-    return await this.gateway.getAttorneys(context, fields);
+    const assignmentsUseCase = new CaseAssignment(context);
+    const attorneys = await this.gateway.getAttorneys(context, fields);
+
+    const attorneysWithCaseLoad = [];
+
+    for (const atty of attorneys.body.attorneyList) {
+      const attorney = new Attorney(atty);
+      attorney.caseLoad = await assignmentsUseCase.getCaseLoad(attorney.getFullName());
+      attorneysWithCaseLoad.push(attorney.getAsObjectKeyVal());
+    }
+
+    attorneys.body.attorneyList = attorneysWithCaseLoad;
+    return attorneys;
   }
 }

--- a/backend/functions/lib/use-cases/case.assignment.ts
+++ b/backend/functions/lib/use-cases/case.assignment.ts
@@ -69,10 +69,6 @@ export class CaseAssignment {
     return existingAssignments.length === 0;
   }
 
-  public async getAllAssignments(): Promise<CaseAttorneyAssignment[]> {
-    return await this.assignmentRepository.getAllAssignments();
-  }
-
   public async findAssignmentsByCaseId(caseId: string): Promise<CaseAttorneyAssignment[]> {
     return await this.assignmentRepository.findAssignmentsByCaseId(caseId);
   }

--- a/backend/functions/lib/use-cases/case.assignment.ts
+++ b/backend/functions/lib/use-cases/case.assignment.ts
@@ -76,4 +76,9 @@ export class CaseAssignment {
   public async findAssignmentsByCaseId(caseId: string): Promise<CaseAttorneyAssignment[]> {
     return await this.assignmentRepository.findAssignmentsByCaseId(caseId);
   }
+
+  public async getCaseLoad(name: string): Promise<number> {
+    const assignments = await this.assignmentRepository.findAssignmentsByAttorneyName(name);
+    return assignments.length;
+  }
 }

--- a/backend/functions/lib/use-cases/case.assignment.ts
+++ b/backend/functions/lib/use-cases/case.assignment.ts
@@ -78,7 +78,7 @@ export class CaseAssignment {
   }
 
   public async getCaseLoad(name: string): Promise<number> {
-    const assignments = await this.assignmentRepository.findAssignmentsByAttorneyName(name);
+    const assignments = await this.assignmentRepository.findAssignmentsByAssigneeName(name);
     return assignments.length;
   }
 }

--- a/backend/functions/lib/use-cases/chapter-15.case-list.test.ts
+++ b/backend/functions/lib/use-cases/chapter-15.case-list.test.ts
@@ -18,13 +18,13 @@ const assignments: CaseAttorneyAssignment[] = [
   {
     id: '1',
     caseId: '23-01176',
-    attorneyName: attorneyJaneSmith,
+    name: attorneyJaneSmith,
     role: CaseAssignmentRole.TrialAttorney,
   },
   {
     id: '2',
     caseId: '23-01176',
-    attorneyName: attorneyJoeNobel,
+    name: attorneyJoeNobel,
     role: CaseAssignmentRole.TrialAttorney,
   },
 ];

--- a/backend/functions/lib/use-cases/chapter-15.case-list.ts
+++ b/backend/functions/lib/use-cases/chapter-15.case-list.ts
@@ -30,7 +30,7 @@ export class Chapter15CaseList {
       for (let i = 0; i < cases.length; i++) {
         assignment = await caseAssignment.findAssignmentsByCaseId(cases[i].caseNumber);
         cases[i].assignments = assignment.map((ass) => {
-          return ass.attorneyName;
+          return ass.name;
         });
       }
 

--- a/user-interface/src/components/AssignAttorneyModal.tsx
+++ b/user-interface/src/components/AssignAttorneyModal.tsx
@@ -186,7 +186,7 @@ function AssignAttorneyModalComponent(
                           />
                         </td>
                         <td className="assign-attorney-case-count-column">
-                          <div className="usa-fieldset">{Math.round(Math.random() * 10)}</div>
+                          <div className="usa-fieldset">{attorney.caseLoad}</div>
                         </td>
                       </tr>
                     );

--- a/user-interface/src/components/CaseAssignment.tsx
+++ b/user-interface/src/components/CaseAssignment.tsx
@@ -151,7 +151,7 @@ export const CaseAssignment = () => {
         const attorney = new Attorney(atty.firstName, atty.lastName, atty.office);
         if (atty.middleName !== undefined) attorney.middleName = atty.middleName;
         if (atty.generation !== undefined) attorney.generation = atty.generation;
-        if (atty.caseCount !== undefined) attorney.caseCount = atty.caseCount;
+        if (atty.caseLoad !== undefined) attorney.caseLoad = atty.caseLoad;
         return attorney;
       });
       setAttorneyList(attorneys);

--- a/user-interface/src/components/CaseAssignment.tsx
+++ b/user-interface/src/components/CaseAssignment.tsx
@@ -122,13 +122,13 @@ export const CaseAssignment = () => {
         tempAssignedCaseList.sort(sortMethod);
         setAssignedCaseList(tempAssignedCaseList);
 
-        if (bCase) {
-          const alertMessage = `${selectedAttorneyList
-            .map((attorney) => attorney)
-            .join(', ')} assigned to case ${bCase.caseNumber} ${bCase.caseTitle}`;
-          setAssignmentAlert({ message: alertMessage, type: UswdsAlertStyle.Success });
-          alertRef.current?.show();
-        }
+        setAttorneyList([]);
+
+        const alertMessage = `${selectedAttorneyList
+          .map((attorney) => attorney)
+          .join(', ')} assigned to case ${bCase.caseNumber} ${bCase.caseTitle}`;
+        setAssignmentAlert({ message: alertMessage, type: UswdsAlertStyle.Success });
+        alertRef.current?.show();
 
         setTimeout(() => {
           setInTableTransferMode('');

--- a/user-interface/src/type-declarations/attorneys.ts
+++ b/user-interface/src/type-declarations/attorneys.ts
@@ -4,13 +4,13 @@ export class AttorneyInfo {
   lastName: string;
   generation?: string;
   office: string;
-  caseCount?: number;
+  caseLoad?: number;
 
   constructor(
     firstName: string,
     lastName: string,
     office: string,
-    optionals?: { middleName?: string; generation?: string; caseCount?: number },
+    optionals?: { middleName?: string; generation?: string; caseLoad?: number },
   ) {
     this.firstName = firstName;
     this.lastName = lastName;
@@ -18,7 +18,7 @@ export class AttorneyInfo {
     if (optionals) {
       this.middleName = optionals.middleName || undefined;
       this.generation = optionals.generation || undefined;
-      this.caseCount = optionals.caseCount || undefined;
+      this.caseLoad = optionals.caseLoad || undefined;
     }
   }
 }
@@ -28,7 +28,7 @@ export class Attorney extends AttorneyInfo {
     first: string,
     last: string,
     office: string,
-    optionals?: { middleName?: string; generation?: string; caseCount?: number },
+    optionals?: { middleName?: string; generation?: string; caseLoad?: number },
   ) {
     super(first, last, office, optionals);
   }


### PR DESCRIPTION
# Purpose

We had generated random numbers for case count on the assignment modal and needed to get real numbers.

# Major Changes

When we retrieve the list of attorneys from the backend we now also get a count of how many chapter 15 case assignments they have.

# Testing/Validation

Validated locally by hitting the databases deployed in Azure.

Unit testing included.

# Further Work

We are just returning an empty array from `case.assignment.local.repository.ts` (for local development) when we get the assignments for an attorney. We need to decide on an approach for this to let us develop locally without hitting deployed databases.

# Notes

Renamed `attorneyName` to `name` in the `CaseAttorneyAssignment` class—and consequently the Cosmos DB data for the `assignments` container.
