### PR TITLE
CAMS-143 Fix post deployment test failures

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -453,7 +453,7 @@ jobs:
         working-directory: backend/functions
 
     runs-on: ubuntu-latest
-    needs: [build-info, deploy-webapp, deploy-service]
+    needs: [build-info, smoke-test-application]
     environment: ${{ needs.build-info.outputs.environment }}
     env:
       stackName: ${{ needs.build-info.outputs.stackName }}

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -447,60 +447,6 @@ jobs:
           --identities "${{ needs.deploy.outputs.cosmosDbPrincipalId }}" \
           --identitiesResourceGroup ${{ secrets.AZURE_RG }}
 
-  integration-test:
-    defaults:
-      run:
-        working-directory: backend/functions
-
-    runs-on: ubuntu-latest
-    needs: [build-info, smoke-test-application]
-    environment: ${{ needs.build-info.outputs.environment }}
-    env:
-      stackName: ${{ needs.build-info.outputs.stackName }}
-      apiName: ${{ needs.build-info.outputs.apiName }}
-      ruleNumber: 100
-
-    strategy:
-      matrix:
-        node-version: [18.x]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install
-        run: npm ci
-
-      - uses: cloudposse/github-action-secret-outputs@main
-        id: rgApp
-        with:
-          secret: ${{ secrets.PGP_SIGNING_PASSPHRASE }}
-          op: decode
-          in: ${{ needs.build-info.outputs.azResourceGrpAppEncrypted }}
-
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-          environment: ${{ vars.AZURE_ENVIRONMENT }}
-
-      - name: Enable GHA runner access
-        run: |
-          ../../ops/helper-scripts/dev-add-allowed-ip.sh \
-          -g ${{ steps.rgApp.outputs.out }} \
-          -s ${{ env.stackName }} \
-          -p ${{ env.ruleNumber }} \
-          --is-cicd
-
-      - name: Execute Integration Tests
-        run: |
-          export CASES_FUNCTION_URL="https://${{ env.apiName }}.azurewebsites${{ vars.AZ_HOSTNAME_SUFFIX }}/api"
-          npm run test:integration
-
-      - name: Disable GHA runner access
-        if: always()
-        run: |
-          name="gha-${{ env.ruleNumber }}-${{ env.stackName }}"
-          ../../ops/helper-scripts/dev-rm-allowed-ip.sh ${{ steps.rgApp.outputs.out }} ${{ env.stackName }} ${name:0:32}
-
   smoke-test-application:
     runs-on: ubuntu-latest
     needs: [build-info, deploy-webapp, deploy-service]
@@ -540,6 +486,10 @@ jobs:
             echo "Health check error. Response codes webStatusCode=$webStatusCode apiStatusCode=$apiStatusCode"
             exit 1
           fi
+      - name: Execute Integration Tests
+        run: |
+          export CASES_FUNCTION_URL="https://${{ env.apiName }}.azurewebsites${{ vars.AZ_HOSTNAME_SUFFIX }}/api"
+          npm run test:integration
       - name: Disable GHA runner access
         if: always()
         run: |

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -458,6 +458,7 @@ jobs:
     env:
       stackName: ${{ needs.build-info.outputs.stackName }}
       apiName: ${{ needs.build-info.outputs.apiName }}
+      ruleNumber: 100
 
     strategy:
       matrix:
@@ -486,7 +487,7 @@ jobs:
           ../../ops/helper-scripts/dev-add-allowed-ip.sh \
           -g ${{ steps.rgApp.outputs.out }} \
           -s ${{ env.stackName }} \
-          -p 100 \
+          -p ${{ env.ruleNumber }} \
           --is-cicd
 
       - name: Execute Integration Tests
@@ -497,7 +498,7 @@ jobs:
       - name: Disable GHA runner access
         if: always()
         run: |
-          name="gha-agent-${{ env.stackName }}"
+          name="gha-${{ env.ruleNumber }}-${{ env.stackName }}"
           ../../ops/helper-scripts/dev-rm-allowed-ip.sh ${{ steps.rgApp.outputs.out }} ${{ env.stackName }} ${name:0:32}
 
   smoke-test-application:
@@ -508,6 +509,7 @@ jobs:
       stackName: ${{ needs.build-info.outputs.stackName }}
       webappName: ${{ needs.build-info.outputs.webappName }}
       apiName: ${{ needs.build-info.outputs.apiName }}
+      ruleNumber: 200
     steps:
       - uses: actions/checkout@v3
       - uses: azure/login@v1
@@ -525,7 +527,7 @@ jobs:
           ops/helper-scripts/dev-add-allowed-ip.sh \
           -g ${{ steps.rgApp.outputs.out }} \
           -s ${{ env.stackName }} \
-          -p 100 \
+          -p ${{ env.ruleNumber }} \
           --is-cicd
       - name: Health check api
         run: |
@@ -541,7 +543,7 @@ jobs:
       - name: Disable GHA runner access
         if: always()
         run: |
-          name="gha-agent-${{ env.stackName }}"
+          name="gha-${{ env.ruleNumber }}-${{ env.stackName }}"
           ops/helper-scripts/dev-rm-allowed-ip.sh ${{ steps.rgApp.outputs.out }} ${{ env.stackName }} ${name:0:32}
 
   enable-access:
@@ -551,6 +553,7 @@ jobs:
     env:
       webappName: ${{ needs.build-info.outputs.webappName }}
       apiName: ${{ needs.build-info.outputs.apiName }}
+
     steps:
       - uses: azure/login@v1
         with:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -456,6 +456,9 @@ jobs:
       webappName: ${{ needs.build-info.outputs.webappName }}
       apiName: ${{ needs.build-info.outputs.apiName }}
       ruleNumber: 200
+    strategy:
+    matrix:
+      node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
       - uses: azure/login@v1
@@ -488,8 +491,11 @@ jobs:
           fi
       - name: Execute Integration Tests
         run: |
+          pushd backend/functions
+          npm ci
           export CASES_FUNCTION_URL="https://${{ env.apiName }}.azurewebsites${{ vars.AZ_HOSTNAME_SUFFIX }}/api"
           npm run test:integration
+          popd
       - name: Disable GHA runner access
         if: always()
         run: |

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -455,7 +455,7 @@ jobs:
       stackName: ${{ needs.build-info.outputs.stackName }}
       webappName: ${{ needs.build-info.outputs.webappName }}
       apiName: ${{ needs.build-info.outputs.apiName }}
-      ruleNumber: 200
+      priority: 200
     strategy:
       matrix:
         node-version: [18.x]
@@ -476,7 +476,7 @@ jobs:
           ops/helper-scripts/dev-add-allowed-ip.sh \
           -g ${{ steps.rgApp.outputs.out }} \
           -s ${{ env.stackName }} \
-          -p ${{ env.ruleNumber }} \
+          -p ${{ env.priority }} \
           --is-cicd
       - name: Health check api
         run: |
@@ -499,7 +499,7 @@ jobs:
       - name: Disable GHA runner access
         if: always()
         run: |
-          name="gha-${{ env.ruleNumber }}-${{ env.stackName }}"
+          name="gha-${{ env.priority }}-${{ env.stackName }}"
           ops/helper-scripts/dev-rm-allowed-ip.sh ${{ steps.rgApp.outputs.out }} ${{ env.stackName }} ${name:0:32}
 
   enable-access:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -457,8 +457,8 @@ jobs:
       apiName: ${{ needs.build-info.outputs.apiName }}
       ruleNumber: 200
     strategy:
-    matrix:
-      node-version: [18.x]
+      matrix:
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
       - uses: azure/login@v1

--- a/ops/helper-scripts/dev-add-allowed-ip.sh
+++ b/ops/helper-scripts/dev-add-allowed-ip.sh
@@ -58,7 +58,7 @@ fi
 if [[ -z "${ci}" ]]; then
     ruleName="dev-agent-${agentIp}"
 else
-    ruleName="gha-agent-${stack_name}"
+    ruleName="gha-${priority}-${stack_name}"
 fi
 
 ruleName=${ruleName:0:32} # trim up to 32 character limit


### PR DESCRIPTION
# Problem

Pipeline run experiencing intermittent smoke test and integration failures. Determine that failure is most likely cause by non-unique names created for allow rules for making network request to webapp and api. The other cause is that integration test executes before the webapp is online.

# Solution

- Modify approach to add rule to allow target GHA runner access to execute test request to webapp and api. Rule name created should be unique
- Move integration test after smoke test. 

# Testing/Validation

- Manual execution of pipeline with all tests passing

# Other Changes


