### PR TITLE
CAMS-157: Hide unassigned table when its empty

### DIFF
--- a/user-interface/src/components/CaseAssignment.test.tsx
+++ b/user-interface/src/components/CaseAssignment.test.tsx
@@ -116,8 +116,7 @@ describe('CaseAssignment Component Tests', () => {
     );
   });
 
-  // if api.list returns an empty set, then screen should contain an empty table with valid header but no content
-  test('/cases should contain an empty table with valid header but no table body when api.list returns an empty set', async () => {
+  test('/cases should not contain any Unassigned Cases table when all cases are assigned', async () => {
     vi.spyOn(Chapter15MockApi, 'list')
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .mockImplementation((_path: string): Promise<ResponseData> => {
@@ -125,7 +124,26 @@ describe('CaseAssignment Component Tests', () => {
           message: 'not found',
           count: 0,
           body: {
-            caseList: [],
+            caseList: [
+              {
+                caseNumber: '23-44463',
+                caseTitle: 'Flo Esterly and Neas Van Sampson',
+                dateFiled: '2023-05-04',
+                assignments: ['Sara', 'Bob'],
+              },
+              {
+                caseNumber: '23-44462',
+                caseTitle: 'Bridget Maldonado',
+                dateFiled: '2023-04-14',
+                assignments: ['Frank', 'Sue'],
+              },
+              {
+                caseNumber: '23-44461',
+                caseTitle: 'Talia Torres and Tylor Stevenson',
+                dateFiled: '2023-04-04',
+                assignments: ['Joe', 'Sam'],
+              },
+            ],
           },
         });
       });
@@ -139,15 +157,120 @@ describe('CaseAssignment Component Tests', () => {
     );
 
     await waitFor(() => {
-      const tableHeader = screen.getAllByRole('columnheader');
-      expect(tableHeader[0].textContent).toBe('Case Number');
-      expect(tableHeader[1].textContent).toBe('Case Title (Debtor)');
-      expect(tableHeader[2].textContent).toBe('Filing Date');
-      const tableBody = screen.getAllByTestId('case-assignment-table-body');
+      screen.getAllByTestId('assigned-table-body');
+    });
+    let unassignedTableBody;
+    try {
+      unassignedTableBody = screen.getAllByTestId('unassigned-table-body');
+      expect(true).toBeFalsy();
+    } catch (err) {
+      expect(unassignedTableBody).toBeUndefined();
+      console.log('unassigned table does not exist');
+    }
+  });
+
+  test('/cases should contain table displaying assigned cases when all cases are assigned', async () => {
+    vi.spyOn(Chapter15MockApi, 'list')
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .mockImplementation((_path: string): Promise<ResponseData> => {
+        return Promise.resolve({
+          message: 'not found',
+          count: 0,
+          body: {
+            caseList: [
+              {
+                caseNumber: '23-44463',
+                caseTitle: 'Flo Esterly and Neas Van Sampson',
+                dateFiled: '2023-05-04',
+                assignments: ['Sara', 'Bob'],
+              },
+              {
+                caseNumber: '23-44462',
+                caseTitle: 'Bridget Maldonado',
+                dateFiled: '2023-04-14',
+                assignments: ['Frank', 'Sue'],
+              },
+              {
+                caseNumber: '23-44461',
+                caseTitle: 'Talia Torres and Tylor Stevenson',
+                dateFiled: '2023-04-04',
+                assignments: ['Joe', 'Sam'],
+              },
+            ],
+          },
+        });
+      });
+
+    render(
+      <BrowserRouter>
+        <Provider store={store}>
+          <CaseAssignment />
+        </Provider>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      const tableBody = screen.getAllByTestId('assigned-table-body');
       const data = tableBody[0].querySelectorAll('tr');
-      expect(data).toHaveLength(0);
+      expect(data).toHaveLength(3);
     });
   });
+
+  test('/cases should contain table displaying 1 unassigned case and table with 2 assigned cases when 2 cases are assigned and 1 is not', async () => {
+    vi.spyOn(Chapter15MockApi, 'list')
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .mockImplementation((_path: string): Promise<ResponseData> => {
+        return Promise.resolve({
+          message: 'not found',
+          count: 0,
+          body: {
+            caseList: [
+              {
+                caseNumber: '23-44463',
+                caseTitle: 'Flo Esterly and Neas Van Sampson',
+                dateFiled: '2023-05-04',
+                assignments: ['Sara', 'Bob'],
+              },
+              {
+                caseNumber: '23-44462',
+                caseTitle: 'Bridget Maldonado',
+                dateFiled: '2023-04-14',
+                assignments: [],
+              },
+              {
+                caseNumber: '23-44461',
+                caseTitle: 'Talia Torres and Tylor Stevenson',
+                dateFiled: '2023-04-04',
+                assignments: ['Joe', 'Sam'],
+              },
+            ],
+          },
+        });
+      });
+
+    render(
+      <BrowserRouter>
+        <Provider store={store}>
+          <CaseAssignment />
+        </Provider>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      const unassignedTableBody = screen.getAllByTestId('unassigned-table-body');
+      const unassignedData = unassignedTableBody[0].querySelectorAll('tr');
+      expect(unassignedData).toHaveLength(1);
+      const assignedTableBody = screen.getAllByTestId('assigned-table-body');
+      const assignedData = assignedTableBody[0].querySelectorAll('tr');
+      expect(assignedData).toHaveLength(2);
+    });
+  });
+
+  /**
+   * We need to add a test that starts with 1 unassigned case and assignes attorneys to it.
+   * The attorneys table should then contain the 1 case and the unassigned cases table
+   * should go away.
+   */
 
   // if api.list returns more than 0 results, then all results will be displayed in table body content
   /*

--- a/user-interface/src/components/CaseAssignment.tsx
+++ b/user-interface/src/components/CaseAssignment.tsx
@@ -38,6 +38,7 @@ export const CaseAssignment = () => {
   }>({ message: '', type: UswdsAlertStyle.Success });
   const [attorneyList, setAttorneyList] = useState<Attorney[]>([]);
   const [inTableTransferMode, setInTableTransferMode] = useState<string>('');
+  const [retrievedCases, setRetrievedCases] = useState<boolean>(false);
 
   // temporarily hard code a chapter, until we provide a way for the user to select one
   const chapter = '15';
@@ -86,8 +87,10 @@ export const CaseAssignment = () => {
         setUnassignedCaseList(sortedNonAssignedList || []);
         setAssignedCaseList(sortedAssignedList || []);
         setIsLoading(false);
+        setRetrievedCases(true);
       })
       .catch((reason) => {
+        setRetrievedCases(false);
         console.log((reason as Error).message);
       });
   };
@@ -139,8 +142,10 @@ export const CaseAssignment = () => {
 
   // Fetch all cases from CAMS API
   useEffect(() => {
-    fetchCases();
-  }, [!isLoading, chapter]);
+    if (!isLoading) {
+      fetchCases();
+    }
+  }, [retrievedCases, chapter]);
 
   // Fetch list of Attorney Names from CAMS API for display in the Create Assignment Modal
   useEffect(() => {
@@ -230,103 +235,102 @@ export const CaseAssignment = () => {
                   </tr>
                 </thead>
                 <tbody data-testid="unassigned-table-body">
-                  {unassignedCaseList.length > 0 &&
-                    (unassignedCaseList as Array<Chapter15Node>).map(
-                      (theCase: Chapter15Node, idx: number) => {
-                        return (
-                          <tr key={idx}>
-                            <td className="case-number">
-                              <span className="mobile-title">Case Number:</span>
-                              {theCase.caseNumber}
-                            </td>
-                            <td className="case-title-column">
-                              <span className="mobile-title">Case Title (Debtor):</span>
-                              {theCase.caseTitle}
-                            </td>
-                            <td
-                              className="filing-date"
-                              data-sort-value={theCase.sortableDateFiled}
-                              data-sort-active={true}
+                  {(unassignedCaseList as Array<Chapter15Node>).map(
+                    (theCase: Chapter15Node, idx: number) => {
+                      return (
+                        <tr key={idx}>
+                          <td className="case-number">
+                            <span className="mobile-title">Case Number:</span>
+                            {theCase.caseNumber}
+                          </td>
+                          <td className="case-title-column">
+                            <span className="mobile-title">Case Title (Debtor):</span>
+                            {theCase.caseTitle}
+                          </td>
+                          <td
+                            className="filing-date"
+                            data-sort-value={theCase.sortableDateFiled}
+                            data-sort-active={true}
+                          >
+                            <span className="mobile-title">Filing Date:</span>
+                            {theCase.dateFiled}
+                          </td>
+                          <td data-testid={`attorney-list-${idx}`} className="attorney-list">
+                            <span className="mobile-title">Assigned Attorney:</span>
+                            <ToggleModalButton
+                              className="case-assignment-modal-toggle"
+                              id={`assign-attorney-btn-${idx}`}
+                              buttonId={`${idx}`}
+                              toggleAction="open"
+                              modalId={`${modalId}`}
+                              modalRef={modalRef}
+                              onClick={() => onOpenModal(theCase, `assign-attorney-btn-${idx}`)}
                             >
-                              <span className="mobile-title">Filing Date:</span>
-                              {theCase.dateFiled}
-                            </td>
-                            <td data-testid={`attorney-list-${idx}`} className="attorney-list">
-                              <span className="mobile-title">Assigned Attorney:</span>
-                              <ToggleModalButton
-                                className="case-assignment-modal-toggle"
-                                id={`assign-attorney-btn-${idx}`}
-                                buttonId={`${idx}`}
-                                toggleAction="open"
-                                modalId={`${modalId}`}
-                                modalRef={modalRef}
-                                onClick={() => onOpenModal(theCase, `assign-attorney-btn-${idx}`)}
-                              >
-                                Assign
-                              </ToggleModalButton>
-                            </td>
-                          </tr>
-                        );
-                      },
-                    )}
+                              Assign
+                            </ToggleModalButton>
+                          </td>
+                        </tr>
+                      );
+                    },
+                  )}
                 </tbody>
               </table>
             )}
           </div>
 
           <div className="usa-table-container--scrollable" tabIndex={1}>
-            <table className="case-list usa-table usa-table--striped">
-              <caption>Assigned Cases</caption>
-              <thead>
-                <tr className="case-headings">
-                  <th scope="col" role="columnheader">
-                    Case Number
-                  </th>
-                  <th scope="col" role="columnheader">
-                    Case Title (Debtor)
-                  </th>
-                  <th
-                    data-sortable
-                    scope="col"
-                    role="columnheader"
-                    aria-sort="descending"
-                    aria-label="Filing Date, sortable column, currently sorted descending"
-                  >
-                    Filing Date
-                    <button
-                      tabIndex={0}
-                      className="usa-table__header__button"
-                      title="Click to sort by Filing Date in ascending order."
-                      disabled={true}
+            {assignedCaseList.length > 0 && (
+              <table className="case-list usa-table usa-table--striped">
+                <caption>Assigned Cases</caption>
+                <thead>
+                  <tr className="case-headings">
+                    <th scope="col" role="columnheader">
+                      Case Number
+                    </th>
+                    <th scope="col" role="columnheader">
+                      Case Title (Debtor)
+                    </th>
+                    <th
+                      data-sortable
+                      scope="col"
+                      role="columnheader"
+                      aria-sort="descending"
+                      aria-label="Filing Date, sortable column, currently sorted descending"
                     >
-                      <svg
-                        className="usa-icon"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
+                      Filing Date
+                      <button
+                        tabIndex={0}
+                        className="usa-table__header__button"
+                        title="Click to sort by Filing Date in ascending order."
+                        disabled={true}
                       >
-                        <g className="descending" fill="transparent">
-                          <path d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"></path>
-                        </g>
-                        <g className="ascending" fill="transparent">
-                          <path
-                            transform="rotate(180, 12, 12)"
-                            d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"
-                          ></path>
-                        </g>
-                        <g className="unsorted" fill="transparent">
-                          <polygon points="15.17 15 13 17.17 13 6.83 15.17 9 16.58 7.59 12 3 7.41 7.59 8.83 9 11 6.83 11 17.17 8.83 15 7.42 16.41 12 21 16.59 16.41 15.17 15"></polygon>
-                        </g>
-                      </svg>
-                    </button>
-                  </th>
-                  <th scope="col" role="columnheader">
-                    Assigned Attorney
-                  </th>
-                </tr>
-              </thead>
-              <tbody data-testid="assigned-table-body">
-                {assignedCaseList.length > 0 &&
-                  (assignedCaseList as Array<Chapter15Node>).map(
+                        <svg
+                          className="usa-icon"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                        >
+                          <g className="descending" fill="transparent">
+                            <path d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"></path>
+                          </g>
+                          <g className="ascending" fill="transparent">
+                            <path
+                              transform="rotate(180, 12, 12)"
+                              d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"
+                            ></path>
+                          </g>
+                          <g className="unsorted" fill="transparent">
+                            <polygon points="15.17 15 13 17.17 13 6.83 15.17 9 16.58 7.59 12 3 7.41 7.59 8.83 9 11 6.83 11 17.17 8.83 15 7.42 16.41 12 21 16.59 16.41 15.17 15"></polygon>
+                          </g>
+                        </svg>
+                      </button>
+                    </th>
+                    <th scope="col" role="columnheader">
+                      Assigned Attorney
+                    </th>
+                  </tr>
+                </thead>
+                <tbody data-testid="assigned-table-body">
+                  {(assignedCaseList as Array<Chapter15Node>).map(
                     (theCase: Chapter15Node, idx: number) => {
                       return (
                         <tr
@@ -366,8 +370,9 @@ export const CaseAssignment = () => {
                       );
                     },
                   )}
-              </tbody>
-            </table>
+                </tbody>
+              </table>
+            )}
           </div>
         </div>
         {attorneyList.length > 0 && (

--- a/user-interface/src/components/CaseAssignment.tsx
+++ b/user-interface/src/components/CaseAssignment.tsx
@@ -139,10 +139,8 @@ export const CaseAssignment = () => {
 
   // Fetch all cases from CAMS API
   useEffect(() => {
-    if (!isLoading) {
-      fetchCases();
-    }
-  }, [unassignedCaseList.length > 0, chapter]);
+    fetchCases();
+  }, [!isLoading, chapter]);
 
   // Fetch list of Attorney Names from CAMS API for display in the Create Assignment Modal
   useEffect(() => {
@@ -181,97 +179,99 @@ export const CaseAssignment = () => {
           <h1 data-testid="case-list-heading">{screenTitle}</h1>
           <h2 data-testid="case-list-subtitle">{subTitle}</h2>
           <div className="usa-table-container--scrollable" tabIndex={0}>
-            <table className="case-list usa-table usa-table--striped">
-              <caption>Unassigned Cases</caption>
-              <thead>
-                <tr className="case-headings">
-                  <th scope="col" role="columnheader">
-                    Case Number
-                  </th>
-                  <th scope="col" role="columnheader">
-                    Case Title (Debtor)
-                  </th>
-                  <th
-                    data-sortable
-                    scope="col"
-                    role="columnheader"
-                    aria-sort="descending"
-                    aria-label="Filing Date, sortable column, currently sorted descending"
-                  >
-                    Filing Date
-                    <button
-                      tabIndex={0}
-                      className="usa-table__header__button"
-                      title="Click to sort by Filing Date in ascending order."
-                      disabled={true}
+            {unassignedCaseList.length > 0 && (
+              <table className="case-list usa-table usa-table--striped">
+                <caption>Unassigned Cases</caption>
+                <thead>
+                  <tr className="case-headings">
+                    <th scope="col" role="columnheader">
+                      Case Number
+                    </th>
+                    <th scope="col" role="columnheader">
+                      Case Title (Debtor)
+                    </th>
+                    <th
+                      data-sortable
+                      scope="col"
+                      role="columnheader"
+                      aria-sort="descending"
+                      aria-label="Filing Date, sortable column, currently sorted descending"
                     >
-                      <svg
-                        className="usa-icon"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
+                      Filing Date
+                      <button
+                        tabIndex={0}
+                        className="usa-table__header__button"
+                        title="Click to sort by Filing Date in ascending order."
+                        disabled={true}
                       >
-                        <g className="descending" fill="transparent">
-                          <path d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"></path>
-                        </g>
-                        <g className="ascending" fill="transparent">
-                          <path
-                            transform="rotate(180, 12, 12)"
-                            d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"
-                          ></path>
-                        </g>
-                        <g className="unsorted" fill="transparent">
-                          <polygon points="15.17 15 13 17.17 13 6.83 15.17 9 16.58 7.59 12 3 7.41 7.59 8.83 9 11 6.83 11 17.17 8.83 15 7.42 16.41 12 21 16.59 16.41 15.17 15"></polygon>
-                        </g>
-                      </svg>
-                    </button>
-                  </th>
-                  <th scope="col" role="columnheader">
-                    Assigned Attorney
-                  </th>
-                </tr>
-              </thead>
-              <tbody data-testid="case-assignment-table-body">
-                {unassignedCaseList.length > 0 &&
-                  (unassignedCaseList as Array<Chapter15Node>).map(
-                    (theCase: Chapter15Node, idx: number) => {
-                      return (
-                        <tr key={idx}>
-                          <td className="case-number">
-                            <span className="mobile-title">Case Number:</span>
-                            {theCase.caseNumber}
-                          </td>
-                          <td className="case-title-column">
-                            <span className="mobile-title">Case Title (Debtor):</span>
-                            {theCase.caseTitle}
-                          </td>
-                          <td
-                            className="filing-date"
-                            data-sort-value={theCase.sortableDateFiled}
-                            data-sort-active={true}
-                          >
-                            <span className="mobile-title">Filing Date:</span>
-                            {theCase.dateFiled}
-                          </td>
-                          <td data-testid={`attorney-list-${idx}`} className="attorney-list">
-                            <span className="mobile-title">Assigned Attorney:</span>
-                            <ToggleModalButton
-                              className="case-assignment-modal-toggle"
-                              id={`assign-attorney-btn-${idx}`}
-                              buttonId={`${idx}`}
-                              toggleAction="open"
-                              modalId={`${modalId}`}
-                              modalRef={modalRef}
-                              onClick={() => onOpenModal(theCase, `assign-attorney-btn-${idx}`)}
+                        <svg
+                          className="usa-icon"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                        >
+                          <g className="descending" fill="transparent">
+                            <path d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"></path>
+                          </g>
+                          <g className="ascending" fill="transparent">
+                            <path
+                              transform="rotate(180, 12, 12)"
+                              d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"
+                            ></path>
+                          </g>
+                          <g className="unsorted" fill="transparent">
+                            <polygon points="15.17 15 13 17.17 13 6.83 15.17 9 16.58 7.59 12 3 7.41 7.59 8.83 9 11 6.83 11 17.17 8.83 15 7.42 16.41 12 21 16.59 16.41 15.17 15"></polygon>
+                          </g>
+                        </svg>
+                      </button>
+                    </th>
+                    <th scope="col" role="columnheader">
+                      Assigned Attorney
+                    </th>
+                  </tr>
+                </thead>
+                <tbody data-testid="unassigned-table-body">
+                  {unassignedCaseList.length > 0 &&
+                    (unassignedCaseList as Array<Chapter15Node>).map(
+                      (theCase: Chapter15Node, idx: number) => {
+                        return (
+                          <tr key={idx}>
+                            <td className="case-number">
+                              <span className="mobile-title">Case Number:</span>
+                              {theCase.caseNumber}
+                            </td>
+                            <td className="case-title-column">
+                              <span className="mobile-title">Case Title (Debtor):</span>
+                              {theCase.caseTitle}
+                            </td>
+                            <td
+                              className="filing-date"
+                              data-sort-value={theCase.sortableDateFiled}
+                              data-sort-active={true}
                             >
-                              Assign
-                            </ToggleModalButton>
-                          </td>
-                        </tr>
-                      );
-                    },
-                  )}
-              </tbody>
-            </table>
+                              <span className="mobile-title">Filing Date:</span>
+                              {theCase.dateFiled}
+                            </td>
+                            <td data-testid={`attorney-list-${idx}`} className="attorney-list">
+                              <span className="mobile-title">Assigned Attorney:</span>
+                              <ToggleModalButton
+                                className="case-assignment-modal-toggle"
+                                id={`assign-attorney-btn-${idx}`}
+                                buttonId={`${idx}`}
+                                toggleAction="open"
+                                modalId={`${modalId}`}
+                                modalRef={modalRef}
+                                onClick={() => onOpenModal(theCase, `assign-attorney-btn-${idx}`)}
+                              >
+                                Assign
+                              </ToggleModalButton>
+                            </td>
+                          </tr>
+                        );
+                      },
+                    )}
+                </tbody>
+              </table>
+            )}
           </div>
 
           <div className="usa-table-container--scrollable" tabIndex={1}>
@@ -324,7 +324,7 @@ export const CaseAssignment = () => {
                   </th>
                 </tr>
               </thead>
-              <tbody data-testid="case-assignment-table-body">
+              <tbody data-testid="assigned-table-body">
                 {assignedCaseList.length > 0 &&
                   (assignedCaseList as Array<Chapter15Node>).map(
                     (theCase: Chapter15Node, idx: number) => {


### PR DESCRIPTION
# Purpose

The purpose of this PR is to add functionality to hide the unassigned cases table when there are 0 unassigned cases

# Major Changes

- Addition of hide unassigned cases table functionality
- addition of test cases

# Testing/Validation

The app was run locally and assigned all unassigned cases, confirming the unassigned table is not visible.
