### PR TITLE
CAMS-158 added scrolling to modal to prevent Assign button from dissa…

### DIFF
--- a/user-interface/src/App.scss
+++ b/user-interface/src/App.scss
@@ -52,6 +52,9 @@
     color: #61dafb;
   }
 
+  #assign-attorney-modal-overlay.usa-modal-overlay{
+    overflow-y: scroll;
+  }
 }
 
 @media screen and (max-width: 800px) {


### PR DESCRIPTION
# Purpose

The Assign button on the Assign Attorney Modal disappeared when the user was zoomed in within the browser. This change allows the user to scroll down to the assign button within the modal.

# Major Changes

added scrolling to assign Attorney modal

# Testing/Validation

ran locally, opened assign attorney modal, zoomed in until assign button disappeared, verified accessibility to the button.
