### PR TITLE
CAMS-47: Set the case assignment screen as the home screen

### DIFF
--- a/user-interface/src/components/Home.tsx
+++ b/user-interface/src/components/Home.tsx
@@ -1,7 +1,12 @@
 import './Home.scss';
+import { CaseAssignment } from './CaseAssignment';
 
 function Home() {
-  return <div className="home"></div>;
+  return (
+    <div className="home">
+      <CaseAssignment />
+    </div>
+  );
 }
 
 export default Home;


### PR DESCRIPTION
# Purpose

Set the home view to be the case assignment screen.

# Major Changes

Add the CaseAssignment component to the Home component.

# Testing/Validation

Ran frontend locally, validated that the Case Assignment screen is displayed as the home page.
