### PR TITLE
Cams 169 get dismissed date

### DIFF
--- a/backend/functions/lib/adapters/gateways/cases.dxtr.gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/cases.dxtr.gateway.test.ts
@@ -144,9 +144,15 @@ describe('Test DXTR Gateway', () => {
     const transactions = [
       {
         txRecord: 'zzzzzzzzzzzzzzzzzzz230830zzzzzzzzzzzz',
+        txCode: 'CBC',
       },
       {
         txRecord: 'zzzzzzzzzzzzzzzzzzz231031zzzzzzzzzzzz',
+        txCode: 'CBC',
+      },
+      {
+        txRecord: 'zzzzzzzzzzzzzzzzzzz231031zzzzzzzzzzzz',
+        txCode: 'CDC',
       },
     ];
 

--- a/backend/functions/lib/adapters/types/cases.d.ts
+++ b/backend/functions/lib/adapters/types/cases.d.ts
@@ -26,6 +26,7 @@ export interface Chapter15CaseInterface extends ObjectKeyVal {
   caseTitle: string;
   dateFiled: string;
   closedDate?: string;
+  dismissedDate?: string;
   dxtrId?: string;
   courtId?: string;
   assignments: string[];
@@ -33,4 +34,5 @@ export interface Chapter15CaseInterface extends ObjectKeyVal {
 
 export interface DxtrTransactionRecord {
   txRecord: string;
+  txCode: string;
 }

--- a/user-interface/src/components/CaseDetail-test-without-dismiss-date.test.tsx
+++ b/user-interface/src/components/CaseDetail-test-without-dismiss-date.test.tsx
@@ -1,18 +1,22 @@
 import { describe, vi } from 'vitest';
-import { render, waitFor, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import {
+  render,
+  waitFor,
+  screen,
+  waitForElementToBeRemoved,
+  queryByTestId,
+} from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { store } from '../store/store';
 import { CaseDetail } from './CaseDetail';
-import { getCaseNumber } from '../utils/formatCaseNumber';
 
 const sleep = (milliseconds: number) =>
   new Promise((callback) => setTimeout(callback, milliseconds));
 
-const caseId = '101-23-12345';
+const caseId = '101-23-54321';
 const brianWilsonName = 'Brian Wilson';
 const carlWilsonName = 'Carl Wilson';
-const trialAttorneyRole = 'Trial Attorney';
 describe('Case Detail screen tests', () => {
   beforeEach(() => {
     vi.stubEnv('CAMS_PA11Y', 'true');
@@ -31,7 +35,6 @@ describe('Case Detail screen tests', () => {
                   caseTitle: 'The Beach Boys',
                   dateFiled: '01-04-1962',
                   closedDate: '01-08-1963',
-                  dismissedDate: '01-08-1964',
                   assignments: [brianWilsonName, carlWilsonName],
                 },
               },
@@ -42,7 +45,8 @@ describe('Case Detail screen tests', () => {
     });
   });
 
-  test('should display case title, case number, dates, and assignees for the case', async () => {
+  test('should not display case dismissed date if not supplied in api response', async () => {
+    vi.stubEnv('CAMS_PA11Y', 'true');
     vi.mock('react-router-dom', async () => {
       const actual = (await vi.importActual('react-router-dom')) as object;
       return {
@@ -68,33 +72,12 @@ describe('Case Detail screen tests', () => {
 
     await waitFor(
       async () => {
-        const title = screen.getByTestId('case-detail-heading');
-        expect(title.innerHTML).toEqual('The Beach Boys');
-        const caseNumber = document.querySelector('.case-number');
-        expect(caseNumber?.innerHTML).toEqual(getCaseNumber(caseId));
+        // const title = screen.getByTestId('[data-testid="case-detail-heading"]');
+        // expect(title).not.toBeUn
 
-        const dateFiled = screen.getByTestId('case-detail-filed-date');
-        expect(dateFiled.innerHTML).toEqual('01-04-1962');
-
-        const closedDate = screen.getByTestId('case-detail-closed-date');
-        expect(closedDate.innerHTML).toEqual('01-08-1963');
-
-        const dismissedDate = screen.getByTestId('case-detail-dismissed-date');
-        expect(dismissedDate.innerHTML).toEqual('01-08-1964');
-
-        const assigneeMap = new Map<string, string>();
-        const assigneeElements = document.querySelectorAll(
-          '.assigned-staff-list .individual-assignee',
-        );
-        assigneeElements?.forEach((assignee) => {
-          const name = assignee.querySelector('.assignee-name')?.innerHTML;
-          const role = assignee.querySelector('.assignee-role')?.innerHTML;
-          if (name && role) {
-            assigneeMap.set(name, role);
-          }
-        });
-        expect(assigneeMap.get(`${brianWilsonName}`)).toEqual(trialAttorneyRole);
-        expect(assigneeMap.get(`${carlWilsonName}`)).toEqual(trialAttorneyRole);
+        // const dismissedDate = document.querySelector('[data-testid="case-detail-dismissed-date"]');
+        // expect(dismissedDate.innerHTML).toEqual('01-08-1964');
+        expect(queryByTestId(document.body, 'case-detail-dismissed-date')).not.toBeInTheDocument();
       },
       { timeout: 5000 },
     );

--- a/user-interface/src/components/CaseDetail.test.tsx
+++ b/user-interface/src/components/CaseDetail.test.tsx
@@ -33,6 +33,7 @@ describe('Case Detail screen tests', () => {
                   caseTitle: 'The Beach Boys',
                   dateFiled: '01-04-1962',
                   closedDate: '01-08-1963',
+                  dismissedDate: '01-08-1964',
                   assignments: [brianWilsonName, carlWilsonName],
                 },
               },
@@ -78,9 +79,13 @@ describe('Case Detail screen tests', () => {
         expect(caseNumber?.innerHTML).toEqual(getCaseNumber(caseId));
 
         const dateFiled = screen.getByTestId('case-detail-filed-date');
-        const closedDate = screen.getByTestId('case-detail-closed-date');
         expect(dateFiled.innerHTML).toEqual('01-04-1962');
+
+        const closedDate = screen.getByTestId('case-detail-closed-date');
         expect(closedDate.innerHTML).toEqual('01-08-1963');
+
+        const dismissedDate = screen.getByTestId('case-detail-dismissed-date');
+        expect(dismissedDate.innerHTML).toEqual('01-08-1964');
 
         const assigneeMap = new Map<string, string>();
         const assigneeElements = document.querySelectorAll(

--- a/user-interface/src/components/CaseDetail.tsx
+++ b/user-interface/src/components/CaseDetail.tsx
@@ -71,6 +71,15 @@ export const CaseDetail = () => {
                         {caseDetail.closedDate}
                       </span>
                     </li>
+                    <li>
+                      <span className="case-detail-item-name">Dismissed by court:</span>
+                      <span
+                        data-testid="case-detail-dismissed-date"
+                        className="case-detail-item-value"
+                      >
+                        {caseDetail.dismissedDate}
+                      </span>
+                    </li>
                   </ul>
                 </div>
               </div>

--- a/user-interface/src/components/CaseDetail.tsx
+++ b/user-interface/src/components/CaseDetail.tsx
@@ -71,15 +71,17 @@ export const CaseDetail = () => {
                         {caseDetail.closedDate}
                       </span>
                     </li>
-                    <li>
-                      <span className="case-detail-item-name">Dismissed by court:</span>
-                      <span
-                        data-testid="case-detail-dismissed-date"
-                        className="case-detail-item-value"
-                      >
-                        {caseDetail.dismissedDate}
-                      </span>
-                    </li>
+                    {caseDetail.dismissedDate && (
+                      <li>
+                        <span className="case-detail-item-name">Dismissed by court:</span>
+                        <span
+                          data-testid="case-detail-dismissed-date"
+                          className="case-detail-item-value"
+                        >
+                          {caseDetail.dismissedDate}
+                        </span>
+                      </li>
+                    )}
                   </ul>
                 </div>
               </div>

--- a/user-interface/src/type-declarations/chapter-15.d.ts
+++ b/user-interface/src/type-declarations/chapter-15.d.ts
@@ -12,6 +12,7 @@ interface CaseDetailType {
   caseTitle: string;
   dateFiled: string;
   closedDate: string;
+  dismissedDate: string;
   assignments: string[];
 }
 


### PR DESCRIPTION
# Purpose

Get Dismissed date to display on case details screen.

# Major Changes

Added Dismissed Date to both the back and and front end.  On Front end, if no case dismissed date is returned from the back end, then it will not be displayed.

# Testing/Validation

Testing coverage requirements met.