### PR TITLE
Configure AppInsights to exclude request-id header for request sent t…

### DIFF
--- a/user-interface/src/ApplicationInsightsService.tsx
+++ b/user-interface/src/ApplicationInsightsService.tsx
@@ -17,6 +17,7 @@ const appInsights = new ApplicationInsights({
     enableRequestHeaderTracking: true,
     enableResponseHeaderTracking: true,
     enableDebug: true,
+    correlationHeaderExcludedDomains: ['launchdarkly.us'],
   },
 });
 


### PR DESCRIPTION
# Purpose

Received CORS issue related to header not allowed for header `request-id`. The header was coming from Application Insights instrumentation and needed to be excluded for request made to the domain launchdarkly.us

# Major Changes

- Update App Insights configuration

# Testing/Validation

- Able to recreate issue locally and verify fix

# Notes

