### PR TITLE
CAMS-193: adds sast scan upload task to only run on main

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -141,7 +141,7 @@ jobs:
 
   sast-scan-and-upload:
     runs-on: ubuntu-latest
-    if: ((github.ref == 'refs/heads/main')
+    if: github.ref == 'refs/heads/main'
     
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -160,7 +160,8 @@ jobs:
           --account-key ${{ secrets.AZ_STOR_VERACODE_KEY }} \
           -c baseline \
           -n results-latest.json \
-          -f ./results-latest.json
+          -f ./results-latest.json \
+          --app-id ${{ secrets.VERACODE_APP_ID }}
 
       - name: pipeline-scan
         id: pipeline-scan

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -194,8 +194,7 @@ jobs:
           -bf results-latest.json \
           -jf results.json \
           -fjf filtered_results.json \
-          --file cams.zip \
-          --app_id ${{ secrets.VERACODE_APP_ID }}
+          --file cams.zip
 
       - name: Upload to storage account
         if: always()

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -175,7 +175,7 @@ jobs:
           -jf results.json \
           -fjf filtered_results.json \
           --file cams.zip \
-          --app-id ${{ secrets.VERACODE_APP_ID }}
+          --app_id ${{ secrets.VERACODE_APP_ID }}
 
       - name: Upload to storage account
         if: always()

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -160,8 +160,7 @@ jobs:
           --account-key ${{ secrets.AZ_STOR_VERACODE_KEY }} \
           -c baseline \
           -n results-latest.json \
-          -f ./results-latest.json \
-          --app-id ${{ secrets.VERACODE_APP_ID }}
+          -f ./results-latest.json
 
       - name: pipeline-scan
         id: pipeline-scan
@@ -175,7 +174,8 @@ jobs:
           -bf results-latest.json \
           -jf results.json \
           -fjf filtered_results.json \
-          --file cams.zip
+          --file cams.zip \
+          --app-id ${{ secrets.VERACODE_APP_ID }}
 
       - name: Upload to storage account
         if: always()

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -139,6 +139,26 @@ jobs:
       - name: Run pa11y Test
         run: ../ops/helper-scripts/accessibility-test.sh
 
+  sast-scan-and-upload:
+    runs-on: ubuntu-latest
+    # if: ((github.ref == 'refs/heads/main')
+    
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Package source code for scan
+        run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*"
+          
+      - name: Veracode Upload And Scan
+        uses: veracode/veracode-uploadandscan-action@0.2.6
+        with:
+          appname: 'CAMS'
+          createprofile: false
+          filepath: 'cams.zip'
+          vid: '${{ secrets.VERACODE_API_ID }}'
+          vkey: '${{ secrets.VERACODE_API_KEY }}'
+          criticality: 'Medium'
+
   security-sast-scan:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -141,7 +141,7 @@ jobs:
 
   sast-scan-and-upload:
     runs-on: ubuntu-latest
-    # if: ((github.ref == 'refs/heads/main')
+    if: ((github.ref == 'refs/heads/main')
     
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -142,13 +142,13 @@ jobs:
   sast-scan-and-upload:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Package source code for scan
         run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*"
-          
+
       - name: Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@0.2.6
         with:


### PR DESCRIPTION
# Purpose

Current SAST scan breaks build where appropriate, but does not upload results to Veracode. These changes will add another scan job that scans & uploads, but won't break build.

# Major Changes

* Add GitHub workflow job to run the scan & upload task
* Updated secrets to use service account

# Testing/Validation

See action [completed successfully here (when commented out `if github.ref =='refs/heads/main`)](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/6628569957) and that it [does not run when that is uncommented](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/6629259027).

Verified that scan results appeared in Veracode platform.

# Notes

May still want to have Veracode review our workflow to see if any optimizations could be achieved.
