### PR TITLE
Cams 193 contain tab within modal

### DIFF
--- a/user-interface/src/components/AssignAttorneyModal.tsx
+++ b/user-interface/src/components/AssignAttorneyModal.tsx
@@ -188,7 +188,7 @@ function AssignAttorneyModalComponent(
               {caseLoadLabel}
             </label>
           </div>
-          <div className="usa-table-container--scrollable" tabIndex={0} ref={tableContainer}>
+          <div className="usa-table-container--scrollable" ref={tableContainer}>
             <table className="attorney-list">
               <thead>
                 <tr>

--- a/user-interface/src/components/uswds/modal/Modal.test.tsx
+++ b/user-interface/src/components/uswds/modal/Modal.test.tsx
@@ -43,7 +43,7 @@ describe('Test Modal component', () => {
               modalId={modalId}
               ref={modalRef}
               heading={'Test Heading'}
-              content={<button data-testid="test-content-button">Test Content</button>}
+              content={'Test Content'}
               actionButtonGroup={actionButtonGroup}
               onClose={closeModal}
               onOpen={onOpenModal}
@@ -191,30 +191,6 @@ describe('Test Modal component', () => {
     expect(onOpenModal).toHaveBeenCalled();
     expect(modalContent).toHaveFocus();
   });
-
-  /*
-  test('should focus on modal shell when tabbing past close button (in upper right of modal)', async () => {
-    const openButton = screen.getByTestId('toggle-modal-button-open-test');
-    const modalContent = screen.getByTestId(`modal-content-${modalId}`);
-    const closeButton = screen.getByTestId(`modal-x-button-${modalId}`);
-    const testContentButton = screen.getByTestId('test-content-button');
-
-    act(() => {
-      fireEvent.click(openButton);
-    });
-
-    expect(onOpenModal).toHaveBeenCalled();
-    expect(modalContent).toHaveFocus();
-
-    act(() => {
-      fireEvent.click(testContentButton);
-    });
-    expect(testContentButton).toHaveFocus();
-
-    fireEvent.keyDown(closeButton, { key: 'Tab', code: 'Tab', charCode: 9 });
-    expect(modalContent).toHaveFocus();
-  });
-*/
 });
 
 describe('Test Modal component with force action', () => {

--- a/user-interface/src/components/uswds/modal/Modal.test.tsx
+++ b/user-interface/src/components/uswds/modal/Modal.test.tsx
@@ -6,7 +6,7 @@ import Modal from './Modal';
 import { ModalRefType } from './modal-refs';
 
 describe('Test Modal component', () => {
-  const modalId = 'assign-attorney-modal';
+  const modalId = 'test-modal';
   const onOpenModal = vi.fn();
   const closeModal = vi.fn();
   const submitButtonOnClick = vi.fn();
@@ -43,7 +43,7 @@ describe('Test Modal component', () => {
               modalId={modalId}
               ref={modalRef}
               heading={'Test Heading'}
-              content={'Test Content'}
+              content={<button data-testid="test-content-button">Test Content</button>}
               actionButtonGroup={actionButtonGroup}
               onClose={closeModal}
               onOpen={onOpenModal}
@@ -191,10 +191,34 @@ describe('Test Modal component', () => {
     expect(onOpenModal).toHaveBeenCalled();
     expect(modalContent).toHaveFocus();
   });
+
+  /*
+  test('should focus on modal shell when tabbing past close button (in upper right of modal)', async () => {
+    const openButton = screen.getByTestId('toggle-modal-button-open-test');
+    const modalContent = screen.getByTestId(`modal-content-${modalId}`);
+    const closeButton = screen.getByTestId(`modal-x-button-${modalId}`);
+    const testContentButton = screen.getByTestId('test-content-button');
+
+    act(() => {
+      fireEvent.click(openButton);
+    });
+
+    expect(onOpenModal).toHaveBeenCalled();
+    expect(modalContent).toHaveFocus();
+
+    act(() => {
+      fireEvent.click(testContentButton);
+    });
+    expect(testContentButton).toHaveFocus();
+
+    fireEvent.keyDown(closeButton, { key: 'Tab', code: 'Tab', charCode: 9 });
+    expect(modalContent).toHaveFocus();
+  });
+*/
 });
 
 describe('Test Modal component with force action', () => {
-  const modalId = 'assign-attorney-modal';
+  const modalId = 'test-modal';
   beforeEach(() => {
     const modalRef = React.createRef<ModalRefType>();
     const actionButtonGroup = {

--- a/user-interface/src/components/uswds/modal/Modal.tsx
+++ b/user-interface/src/components/uswds/modal/Modal.tsx
@@ -60,7 +60,7 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
     setKeyboardAccessible(100000);
   }
 
-  const closeButtonKeyDown = (ev: React.KeyboardEvent<HTMLButtonElement>) => {
+  const handleTab = (ev: React.KeyboardEvent<HTMLButtonElement>) => {
     if (
       ev.key == 'Tab' &&
       !ev.shiftKey &&
@@ -72,7 +72,7 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
     }
   };
 
-  const modalShellKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleShiftTab = (ev: React.KeyboardEvent<HTMLDivElement>) => {
     const elementEquivalency =
       (ev.target as Element).id === `${props.modalId}-description` ||
       (ev.target as Element).id === `${props.modalId}`;
@@ -152,7 +152,7 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
           {...data}
           tabIndex={keyboardAccessible}
           ref={modalShellRef}
-          onKeyDown={modalShellKeyDown}
+          onKeyDown={handleShiftTab}
           data-testid={`modal-content-${props.modalId}`}
         >
           <div className="usa-modal__content">
@@ -196,7 +196,7 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
                 data-close-modal
                 onClick={close}
                 data-testid={`modal-x-button-${props.modalId}`}
-                onKeyDown={closeButtonKeyDown}
+                onKeyDown={handleTab}
               >
                 <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
                   <use xlinkHref={closeIcon}></use>

--- a/user-interface/src/components/uswds/modal/Modal.tsx
+++ b/user-interface/src/components/uswds/modal/Modal.tsx
@@ -73,12 +73,10 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
   };
 
   const modalShellKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
-    if (
-      ev.key == 'Tab' &&
-      ev.shiftKey &&
-      isVisible &&
-      (ev.target as Element).id === `${props.modalId}-description`
-    ) {
+    const elementEquivalency =
+      (ev.target as Element).id === `${props.modalId}-description` ||
+      (ev.target as Element).id === `${props.modalId}`;
+    if (ev.key == 'Tab' && ev.shiftKey && isVisible && elementEquivalency) {
       ev.preventDefault();
       const button = document.querySelector('.usa-button.usa-modal__close');
       if (button) {
@@ -86,7 +84,6 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
       }
     }
   };
-
   function submitBtnClick(e: React.MouseEvent<HTMLButtonElement>) {
     if (props.actionButtonGroup.submitButton.onClick) {
       props.actionButtonGroup.submitButton.onClick(e);

--- a/user-interface/src/components/uswds/modal/Modal.tsx
+++ b/user-interface/src/components/uswds/modal/Modal.tsx
@@ -37,22 +37,54 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
     data['data-force-action'] = true;
   }
 
-  const handleKeyDown = (e: KeyboardEvent) => {
+  const handleKeyDown = (ev: KeyboardEvent) => {
     if (!props.forceAction) {
-      if (e.key === 'Escape') {
-        close(e);
+      if (ev.key === 'Escape') {
+        close(ev);
       }
     }
   };
 
   useGlobalKeyDown(handleKeyDown, { forceAction: !!props.forceAction });
 
-  const close = (e: MouseEvent | React.MouseEvent | KeyboardEvent | React.KeyboardEvent) => {
+  const close = (ev: MouseEvent | React.MouseEvent | KeyboardEvent | React.KeyboardEvent) => {
+    closeModal();
+    ev.preventDefault();
+  };
+
+  function closeModal() {
     hide();
     if (props.onClose) {
       props.onClose();
     }
-    e.preventDefault();
+    setKeyboardAccessible(100000);
+  }
+
+  const closeButtonKeyDown = (ev: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (
+      ev.key == 'Tab' &&
+      !ev.shiftKey &&
+      isVisible &&
+      (ev.target as Element).classList.contains('usa-modal__close')
+    ) {
+      ev.preventDefault();
+      modalShellRef?.current?.focus();
+    }
+  };
+
+  const modalShellKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      ev.key == 'Tab' &&
+      ev.shiftKey &&
+      isVisible &&
+      (ev.target as Element).classList.contains('usa-table-container--scrollable')
+    ) {
+      ev.preventDefault();
+      const button = document.querySelector('.usa-button.usa-modal__close');
+      if (button) {
+        (button as HTMLElement).focus();
+      }
+    }
   };
 
   function submitBtnClick(e: React.MouseEvent<HTMLButtonElement>) {
@@ -85,12 +117,8 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
     show();
   }
 
-  function hideModal() {
-    setKeyboardAccessible(100000);
-  }
-
   useImperativeHandle(ref, () => ({
-    hide: hideModal,
+    hide: closeModal,
     show: showModal,
     buttons: submitCancelButtonGroupRef,
   }));
@@ -127,6 +155,7 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
           {...data}
           tabIndex={keyboardAccessible}
           ref={modalShellRef}
+          onKeyDown={modalShellKeyDown}
           data-testid={`modal-content-${props.modalId}`}
         >
           <div className="usa-modal__content">
@@ -168,6 +197,7 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
                 data-close-modal
                 onClick={close}
                 data-testid={`modal-x-button-${props.modalId}`}
+                onKeyDown={closeButtonKeyDown}
               >
                 <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
                   <use xlinkHref={closeIcon}></use>

--- a/user-interface/src/components/uswds/modal/Modal.tsx
+++ b/user-interface/src/components/uswds/modal/Modal.tsx
@@ -77,7 +77,7 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
       ev.key == 'Tab' &&
       ev.shiftKey &&
       isVisible &&
-      (ev.target as Element).classList.contains('usa-table-container--scrollable')
+      (ev.target as Element).id === `${props.modalId}-description`
     ) {
       ev.preventDefault();
       const button = document.querySelector('.usa-button.usa-modal__close');
@@ -164,7 +164,9 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
                 {props.heading}
               </h2>
               <div className="usa-prose">
-                <section id={props.modalId + '-description'}>{props.content}</section>
+                <section id={props.modalId + '-description'} tabIndex={0}>
+                  {props.content}
+                </section>
               </div>
               <div className="usa-modal__footer">
                 <SubmitCancelButtonGroup


### PR DESCRIPTION
# Purpose

Fix accessibility issue with tabbing out of the modal going back to the document.  

# Major Changes

We added event handlers to the modal close button and the modal body container that cause the tab stops to loop back to the first or last element in the modal, while the modal is open.

# Testing/Validation

Test coverage is already above 90%, barely. 

Testing has proven difficult for this... yet again.  It seems the testing libraries don't handle tabbing and focus events properly or at all in their jestdom.  I began a test, but it needs work to get it to pass.  I'm not sure we'll be able to successfully test these changes in this branch.