### PR TITLE
CAMS-192 Include retry logic in curl commands invoked in deployment script.

### DIFF
--- a/ops/helper-scripts/az-app-deploy.sh
+++ b/ops/helper-scripts/az-app-deploy.sh
@@ -58,7 +58,7 @@ function on_exit() {
 trap on_exit EXIT
 
 # allow build agent access to execute deployment
-agentIp=$(curl -s https://api.ipify.org)
+agentIp=$(curl -s --retry 3 --retry-delay 30 --retry-all-errors https://api.ipify.org)
 ruleName="agent-${app_name:0:26}"
 az webapp config access-restriction add -g $app_rg -n $app_name --rule-name $ruleName --action Allow --ip-address $agentIp --priority 232 --scm-site true 1>/dev/null
 

--- a/ops/helper-scripts/az-func-deploy.sh
+++ b/ops/helper-scripts/az-func-deploy.sh
@@ -77,7 +77,7 @@ if [ ! -f "$artifact_path" ]; then
 fi
 
 # allow build agent access to execute deployment
-agentIp=$(curl -s https://api.ipify.org)
+agentIp=$(curl -s --retry 3 --retry-delay 30 --retry-all-errors https://api.ipify.org)
 az functionapp config access-restriction add -g $app_rg -n $app_name --rule-name $ruleName --action Allow --ip-address $agentIp --priority 232 --scm-site true 1>/dev/null
 
 # Construct and execute deployment command

--- a/ops/helper-scripts/dev-add-allowed-ip.sh
+++ b/ops/helper-scripts/dev-add-allowed-ip.sh
@@ -50,7 +50,7 @@ if [[ -z "${app_rg}" || -z "${stack_name}" || -z "${priority}" ]]; then
 fi
 
 if [[ -z "${ip}" ]]; then
-    agentIp=$(curl -s https://api.ipify.org)
+    agentIp=$(curl -s --retry 3 --retry-delay 30 --retry-all-errors https://api.ipify.org)
 else
     agentIp=${ip}
 fi


### PR DESCRIPTION
Jira ticket: CAMS-192

# Purpose

Noticed some failed deployment due to curl command that did not make successful request the first try.

# Major Changes

- Update deployment scripts that used curl command to include retry options

# Testing/Validation

- Verified snippet of command locally with options set. Spoof url to simulate unreachable service.

# Notes
