### PR TITLE
CAMS-140 Automate setting minimum TLS cipher suite

### DIFF
--- a/ops/cloud-deployment/frontend-webapp-deploy.bicep
+++ b/ops/cloud-deployment/frontend-webapp-deploy.bicep
@@ -279,6 +279,7 @@ resource webappConfig 'Microsoft.Web/sites/config@2022-09-01' = {
       }
     ]
     linuxFxVersion: linuxFxVersionMap['${appServiceRuntime}']
+    minTlsCipherSuite: 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
     appCommandLine: appCommandLine
   }
 }


### PR DESCRIPTION
# Purpose

Resolves the following CWE-757

# Major Changes

- Update bicep deployment to set min cipher for deployments using premium plans

# Testing/Validation

- Verify bicep deployment with Basic and Premium plan types

# Notes

- This Azure feature is still in Preview and is only available for premium plan types or higher.
