### PR TITLE
VER-10 Set X-Frame-Options response header

### DIFF
--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -28,4 +28,7 @@ server {
         access_log off;
         log_not_found off;
     }
+
+    # Security headers
+    add_header X-Frame-Options "DENY";
 }


### PR DESCRIPTION
# Problem

See issue VER-10 for details

# Solution

Set `X-Frame-Options` response header to `DENY`

# Testing/Validation

- Checked issued resolved with header updates via securityheaders.com using both latest Chrome and Edge browser
- Deployed branch updates to new environment and verified with Veracode DAST scanning.

# Other Changes
