### PR TITLE
Add debtor address to the case detail screen

### DIFF
--- a/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
@@ -173,7 +173,15 @@ describe('Test DXTR Gateway', () => {
     const mockQueryParties: QueryResults = {
       success: true,
       results: {
-        recordset: [{ partyName: 'John Q. Smith' }],
+        recordset: [
+          {
+            name: 'John Q. Smith',
+            address1: '123 Main St',
+            address2: 'Apt 17',
+            address3: '',
+            address4: 'Queens NY 12345 USA',
+          },
+        ],
       },
       message: '',
     };
@@ -207,7 +215,13 @@ describe('Test DXTR Gateway', () => {
     expect(actualResult.closedDate).toEqual(closedDate);
     expect(actualResult.dismissedDate).toEqual(dismissedDate);
     expect(actualResult.reopenedDate).toEqual(reopenedDate);
-    expect(actualResult.debtorName).toEqual('John Q. Smith');
+    expect(actualResult.debtor).toEqual({
+      name: 'John Q. Smith',
+      address1: '123 Main St',
+      address2: 'Apt 17',
+      address3: '',
+      address4: 'Queens NY 12345 USA',
+    });
   });
 
   test('should call executeQuery with the expected properties for a case', async () => {
@@ -349,6 +363,54 @@ describe('Test DXTR Gateway', () => {
       await testCasesDxtrGateway.getCases(appContext, {});
       expect(querySpy.mock.calls[0][2]).not.toContain('UNION ALL');
       expect(querySpy.mock.calls[0][2]).not.toContain("CS_CHAPTER = '12'");
+    });
+  });
+
+  describe('partyQueryCallback', () => {
+    test('should return null when no results are returned', async () => {
+      const queryResult: QueryResults = {
+        success: true,
+        results: {
+          recordset: [],
+        },
+        message: '',
+      };
+
+      const testCasesDxtrGateway: CasesDxtrGateway = new CasesDxtrGateway();
+
+      const party = await testCasesDxtrGateway.partyQueryCallback(appContext, queryResult);
+
+      expect(party).toBeNull();
+    });
+
+    test('should return expected address fields', async () => {
+      const queryResult: QueryResults = {
+        success: true,
+        results: {
+          recordset: [
+            {
+              name: 'John Q. Smith',
+              address1: '123 Main St',
+              address2: 'Apt 17',
+              address3: '',
+              address4: 'Queens NY 12345 USA',
+            },
+          ],
+        },
+        message: '',
+      };
+
+      const testCasesDxtrGateway: CasesDxtrGateway = new CasesDxtrGateway();
+
+      const party = await testCasesDxtrGateway.partyQueryCallback(appContext, queryResult);
+      //store object as constant
+      expect(party).toEqual({
+        name: 'John Q. Smith',
+        address1: '123 Main St',
+        address2: 'Apt 17',
+        address3: '',
+        address4: 'Queens NY 12345 USA',
+      });
     });
   });
 });

--- a/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -1,21 +1,30 @@
 import { CasesInterface } from '../../../use-cases/cases.interface';
 import { ApplicationContext } from '../../types/basic';
-import { CaseDetailInterface, DxtrPartyRecord, DxtrTransactionRecord } from '../../types/cases';
 import {
-  getDate,
+  CaseDetailInterface,
+  Debtor,
+  DxtrPartyRecord,
+  DxtrTransactionRecord,
+  TransactionDates,
+} from '../../types/cases';
+import {
   getMonthDayYearStringFromDate,
   getYearMonthDayStringFromDate,
+  sortDates,
 } from '../../utils/date-helper';
 import { executeQuery } from '../../utils/database';
 import { DbTableFieldSpec, QueryResults } from '../../types/database';
 import * as mssql from 'mssql';
 import log from '../../services/logger.service';
-import { CamsError } from '../../../common-errors/cams-error';
 import { handleQueryResult } from '../gateway-helper';
+import { parseTransactionDate } from './dxtr.gateway.helper';
 
 const MODULENAME = 'CASES-DXTR-GATEWAY';
 
 const MANHATTAN_GROUP_DESIGNATOR = 'NY';
+const closedByCourtTxCode = 'CBC';
+const dismissedByCourtTxCode = 'CDC';
+const reopenedDate = 'OCO';
 
 function sqlSelectList(top: string, chapter: string) {
   // THIS SETS US UP FOR SQL INJECTION IF WE EVER ACCEPT top OR chapter FROM USER INPUT.
@@ -42,24 +51,20 @@ export default class CasesDxtrGateway implements CasesInterface {
 
     const bCase = await this.queryCase(context, courtDiv, dxtrCaseId);
 
-    const { closedDates, dismissedDates, reopenedDates } = await this.queryTransactions(
-      context,
-      bCase.dxtrId,
-      bCase.courtId,
-    );
-    if (closedDates.length > 0) {
-      bCase.closedDate = getMonthDayYearStringFromDate(closedDates[0]);
+    const transactionDates = await this.queryTransactions(context, bCase.dxtrId, bCase.courtId);
+    if (transactionDates.closedDates.length > 0) {
+      bCase.closedDate = getMonthDayYearStringFromDate(transactionDates.closedDates[0]);
     }
 
-    if (dismissedDates.length > 0) {
-      bCase.dismissedDate = getMonthDayYearStringFromDate(dismissedDates[0]);
+    if (transactionDates.dismissedDates.length > 0) {
+      bCase.dismissedDate = getMonthDayYearStringFromDate(transactionDates.dismissedDates[0]);
     }
 
-    if (reopenedDates.length > 0) {
-      bCase.reopenedDate = getMonthDayYearStringFromDate(reopenedDates[0]);
+    if (transactionDates.reopenedDates.length > 0) {
+      bCase.reopenedDate = getMonthDayYearStringFromDate(transactionDates.reopenedDates[0]);
     }
 
-    bCase.debtorName = await this.queryParties(context, bCase.dxtrId, bCase.courtId);
+    bCase.debtor = await this.queryParties(context, bCase.dxtrId, bCase.courtId);
 
     return bCase;
   }
@@ -101,14 +106,14 @@ export default class CasesDxtrGateway implements CasesInterface {
       input,
     );
 
-    if (queryResult.success) {
-      log.debug(context, MODULENAME, `Results received from DXTR `, queryResult);
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (queryResult.results as mssql.IResult<any>).recordset;
-    } else {
-      throw new CamsError(MODULENAME, { message: queryResult.message });
-    }
+    return Promise.resolve(
+      handleQueryResult<CaseDetailInterface[]>(
+        context,
+        queryResult,
+        MODULENAME,
+        this.casesQueryCallback,
+      ),
+    );
   }
 
   private async queryCase(
@@ -149,20 +154,21 @@ export default class CasesDxtrGateway implements CasesInterface {
       input,
     );
 
-    if (queryResult.success) {
-      log.debug(context, MODULENAME, `Case results received from DXTR:`, queryResult);
-
-      return (queryResult.results as mssql.IResult<CaseDetailInterface>).recordset[0];
-    } else {
-      throw new CamsError(MODULENAME, { message: queryResult.message });
-    }
+    return Promise.resolve(
+      handleQueryResult<CaseDetailInterface>(
+        context,
+        queryResult,
+        MODULENAME,
+        this.caseDetailsQueryCallback,
+      ),
+    );
   }
 
   private async queryTransactions(
     context: ApplicationContext,
     dxtrId: string,
     courtId: string,
-  ): Promise<{ closedDates: Date[]; dismissedDates: Date[]; reopenedDates: Date[] }> {
+  ): Promise<TransactionDates> {
     const input: DbTableFieldSpec[] = [];
 
     input.push({
@@ -177,23 +183,17 @@ export default class CasesDxtrGateway implements CasesInterface {
       value: courtId,
     });
 
-    const closedByCourtTxCode = 'CBC';
-
     input.push({
       name: 'closedByCourtTxCode',
       type: mssql.VarChar,
       value: closedByCourtTxCode,
     });
 
-    const dismissedByCourtTxCode = 'CDC';
-
     input.push({
       name: 'dismissedByCourtTxCode',
       type: mssql.VarChar,
       value: dismissedByCourtTxCode,
     });
-
-    const reopenedDate = 'OCO';
 
     input.push({
       name: 'reopenedDate',
@@ -216,78 +216,21 @@ export default class CasesDxtrGateway implements CasesInterface {
       input,
     );
 
-    const closedDates: Date[] = [];
-    const dismissedDates: Date[] = [];
-    const reopenedDates: Date[] = [];
-
-    function parseTransactionDate(record: DxtrTransactionRecord): Date {
-      const transactionYearStart = 19;
-      const transactionDateYear = record.txRecord.slice(
-        transactionYearStart,
-        transactionYearStart + 2,
-      );
-
-      const transactionMonthStart = 21;
-      const transactionDateMonth = record.txRecord.slice(
-        transactionMonthStart,
-        transactionMonthStart + 2,
-      );
-
-      const transactionDayStart = 23;
-      const transactionDateDay = record.txRecord.slice(
-        transactionDayStart,
-        transactionDayStart + 2,
-      );
-
-      // `new Date()` uses a base year of 1900, so we add 2000 to the 2-digit year
-      const baseYear = 2000;
-      return getDate(
-        parseInt(transactionDateYear) + baseYear,
-        parseInt(transactionDateMonth),
-        parseInt(transactionDateDay),
-      );
-    }
-
-    if (queryResult.success) {
-      log.debug(context, MODULENAME, `Transaction results received from DXTR:`, queryResult);
-      (queryResult.results as mssql.IResult<DxtrTransactionRecord>).recordset.forEach((record) => {
-        const transactionDate = parseTransactionDate(record);
-
-        if (record.txCode === closedByCourtTxCode) {
-          closedDates.push(transactionDate);
-        } else if (record.txCode === dismissedByCourtTxCode) {
-          dismissedDates.push(transactionDate);
-        } else {
-          reopenedDates.push(transactionDate);
-        }
-      });
-
-      closedDates.sort((a: Date, b: Date) => {
-        // sort in order of newest to oldest
-        return b.valueOf() - a.valueOf();
-      });
-
-      dismissedDates.sort((a: Date, b: Date) => {
-        // sort in order of newest to oldest
-        return b.valueOf() - a.valueOf();
-      });
-
-      reopenedDates.sort((a: Date, b: Date) => {
-        // sort in order of newest to oldest
-        return b.valueOf() - a.valueOf();
-      });
-
-      return { closedDates, dismissedDates, reopenedDates };
-    } else {
-      throw new CamsError(MODULENAME, { message: queryResult.message });
-    }
+    return Promise.resolve(
+      handleQueryResult<TransactionDates>(
+        context,
+        queryResult,
+        MODULENAME,
+        this.transactionQueryCallback,
+      ),
+    );
   }
 
   private async queryParties(
     context: ApplicationContext,
     dxtrId: string,
     courtId: string,
-  ): Promise<string> {
+  ): Promise<Debtor> {
     const debtorPartyCode = 'db';
     const input: DbTableFieldSpec[] = [];
 
@@ -309,6 +252,8 @@ export default class CasesDxtrGateway implements CasesInterface {
       value: debtorPartyCode,
     });
 
+    //update query to include address
+
     const query = `SELECT
         TRIM(CONCAT(
           PY_FIRST_NAME,
@@ -318,7 +263,19 @@ export default class CasesDxtrGateway implements CasesInterface {
           PY_LAST_NAME,
           ' ',
           PY_GENERATION
-        )) as partyName
+        )) as name,
+        PY_ADDRESS1 as address1,
+        PY_ADDRESS2 as address2,
+        PY_ADDRESS3 as address3,
+        TRIM(CONCAT(
+          PY_CITY,
+          ' ',
+          PY_STATE,
+          ' ',
+          PY_ZIP,
+          ' ',
+          PY_COUNTRY
+        )) as address4
       FROM [dbo].[AO_PY]
       WHERE
         CS_CASEID = @dxtrId AND
@@ -334,16 +291,58 @@ export default class CasesDxtrGateway implements CasesInterface {
     );
 
     return Promise.resolve(
-      handleQueryResult<string>(context, queryResult, MODULENAME, this.partyQueryCallback),
+      handleQueryResult<DxtrPartyRecord>(context, queryResult, MODULENAME, this.partyQueryCallback),
     );
   }
 
-  private partyQueryCallback(context: ApplicationContext, queryResult: QueryResults) {
-    let partyName = '';
+  partyQueryCallback(context: ApplicationContext, queryResult: QueryResults) {
+    let debtor: Debtor;
     log.debug(context, MODULENAME, `Party results received from DXTR:`, queryResult);
+
     (queryResult.results as mssql.IResult<DxtrPartyRecord>).recordset.forEach((record) => {
-      partyName = record.partyName;
+      debtor = { name: record.name };
+      debtor.address1 = record.address1;
+      debtor.address2 = record.address2;
+      debtor.address3 = record.address3;
+      debtor.address4 = record.address4?.replace(new RegExp(/\s+/), ' ');
     });
-    return partyName;
+    return debtor || null;
+  }
+
+  transactionQueryCallback(context: ApplicationContext, queryResult: QueryResults) {
+    const closedDates: Date[] = [];
+    const dismissedDates: Date[] = [];
+    const reopenedDates: Date[] = [];
+    log.debug(context, MODULENAME, `Transaction results received from DXTR:`, queryResult);
+    (queryResult.results as mssql.IResult<DxtrTransactionRecord>).recordset.forEach((record) => {
+      const transactionDate = parseTransactionDate(record);
+
+      if (record.txCode === closedByCourtTxCode) {
+        closedDates.push(transactionDate);
+      } else if (record.txCode === dismissedByCourtTxCode) {
+        dismissedDates.push(transactionDate);
+      } else {
+        reopenedDates.push(transactionDate);
+      }
+    });
+
+    sortDates(closedDates);
+    sortDates(dismissedDates);
+    sortDates(reopenedDates);
+
+    return { closedDates, dismissedDates, reopenedDates } as TransactionDates;
+  }
+
+  caseDetailsQueryCallback(context: ApplicationContext, queryResult: QueryResults) {
+    log.debug(context, MODULENAME, `Case results received from DXTR:`, queryResult);
+
+    return (queryResult.results as mssql.IResult<CaseDetailInterface>).recordset[0];
+  }
+
+  casesQueryCallback(context: ApplicationContext, queryResult: QueryResults) {
+    log.debug(context, MODULENAME, `Results received from DXTR `, queryResult);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (queryResult.results as mssql.IResult<CaseDetailInterface[]>).recordset;
   }
 }

--- a/backend/functions/lib/adapters/gateways/dxtr/dxtr.gateway.helper.test.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/dxtr.gateway.helper.test.ts
@@ -1,0 +1,33 @@
+import { parseTransactionDate } from './dxtr.gateway.helper';
+import { CamsError } from '../../../common-errors/cams-error';
+
+describe('DXTR Gateway Helper Tests', () => {
+  describe('parseTransactionDate tests', () => {
+    test('should return January 1st 2023', async () => {
+      const record = { txRecord: 'zzzzzzzzzzzzzzzzzzz230101zzzzzzzzzzzz', txCode: 'OCO' };
+      const actual = parseTransactionDate(record).valueOf();
+      const expected = Date.parse('2023-01-01T00:00:00');
+      expect(actual).toEqual(expected);
+    });
+
+    test('should return December 31st 2055', () => {
+      const record = { txRecord: 'zzzzzzzzzzzzzzzzzzz551231zzzzzzzzzzzz', txCode: 'OCO' };
+      const actual = parseTransactionDate(record).valueOf();
+      const expected = Date.parse('2055-12-31T00:00:00');
+      expect(actual).toEqual(expected);
+    });
+
+    test('should throw if date string contains any non-numeric characters', async () => {
+      // The following expect highlights why each character in the string must be individually parsed.
+      expect(parseInt('5f')).toEqual(5);
+      const record = { txRecord: 'zzzzzzzzzzzzzzzzzzzAF1231zzzzzzzzzzzz', txCode: 'OCO' };
+      expect(() => {
+        parseTransactionDate(record);
+      }).toThrow(
+        new CamsError('', {
+          message: 'The transaction contains non-numeric characters in the date string.',
+        }),
+      );
+    });
+  });
+});

--- a/backend/functions/lib/adapters/gateways/dxtr/dxtr.gateway.helper.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/dxtr.gateway.helper.ts
@@ -1,0 +1,32 @@
+import { DxtrTransactionRecord } from '../../types/cases';
+import { getDate } from '../../utils/date-helper';
+import { CamsError } from '../../../common-errors/cams-error';
+
+const MODULE_NAME = 'DXTR-GATEWAY-HELPER';
+
+export function parseTransactionDate(record: DxtrTransactionRecord): Date {
+  const dateStringStart = 19;
+  const dateStringEnd = dateStringStart + 6;
+  const dateStringChars = Array.from(record.txRecord.slice(dateStringStart, dateStringEnd));
+  dateStringChars.forEach((char) => {
+    if (isNaN(parseInt(char))) {
+      throw new CamsError(MODULE_NAME, {
+        status: 500,
+        message: 'The transaction contains non-numeric characters in the date string.',
+        data: record,
+      });
+    }
+  });
+
+  const transactionDateYear = dateStringChars[0] + dateStringChars[1];
+  const transactionDateMonth = dateStringChars[2] + dateStringChars[3];
+  const transactionDateDay = dateStringChars[4] + dateStringChars[5];
+
+  // `new Date()` uses a base year of 1900, so we add 2000 to the 2-digit year
+  const baseYear = 2000;
+  return getDate(
+    parseInt(transactionDateYear) + baseYear,
+    parseInt(transactionDateMonth),
+    parseInt(transactionDateDay),
+  );
+}

--- a/backend/functions/lib/adapters/types/cases.d.ts
+++ b/backend/functions/lib/adapters/types/cases.d.ts
@@ -1,8 +1,6 @@
-import { ObjectKeyVal } from './basic';
-
 // TODO: make this implement the IRecordSet<any> interface
 export interface CaseListRecordSet {
-  caseList: ObjectKeyVal[];
+  caseList: CaseDetailInterface[];
   initialized?: boolean;
 }
 
@@ -21,7 +19,15 @@ export interface CaseDetailsDbResult {
   };
 }
 
-export interface CaseDetailInterface extends ObjectKeyVal {
+export interface Debtor {
+  name: string;
+  address1?: string;
+  address2?: string;
+  address3?: string;
+  address4?: string;
+}
+
+export interface CaseDetailInterface {
   caseId: string;
   chapter: string;
   caseTitle: string;
@@ -33,6 +39,7 @@ export interface CaseDetailInterface extends ObjectKeyVal {
   courtId?: string;
   assignments?: string[];
   judgeName?: string;
+  debtor?: Debtor;
 }
 
 export interface DxtrTransactionRecord {
@@ -41,5 +48,15 @@ export interface DxtrTransactionRecord {
 }
 
 export interface DxtrPartyRecord {
-  partyName: string;
+  name: string;
+  address1?: string;
+  address2?: string;
+  address3?: string;
+  address4?: string;
+}
+
+export interface TransactionDates {
+  closedDates?: Date[];
+  dismissedDates?: Date[];
+  reopenedDates?: Date[];
 }

--- a/backend/functions/lib/adapters/utils/date-helper.test.ts
+++ b/backend/functions/lib/adapters/utils/date-helper.test.ts
@@ -4,6 +4,7 @@ import {
   calculateDifferenceInMonths,
   getYearMonthDayStringFromDate,
   getMonthDayYearStringFromDate,
+  sortDates,
 } from './date-helper';
 
 describe('date-helper tests', () => {
@@ -209,6 +210,34 @@ describe('date-helper tests', () => {
   describe('getMonthDayYearStringFromDate tests', () => {
     test('should convert Jan 1, 2023 to 01-01-2023', async () => {
       expect(getMonthDayYearStringFromDate(new Date(2023, 0, 1))).toEqual('01-01-2023');
+    });
+  });
+
+  describe('sortDates tests', () => {
+    test('should properly sort dates in chronological order', async () => {
+      const date1 = getDate(2000, 3, 27);
+      const date2 = getDate(1995, 3, 30);
+      const date3 = getDate(2040, 1, 14);
+      const dates = [date1, date2, date3];
+      const sorted = [date2, date1, date3];
+
+      sortDates(dates, 'chronological');
+      expect(dates).toEqual(sorted);
+    });
+
+    test('should properly sort dates in reverse chronological order', async () => {
+      const date1 = getDate(2000, 3, 27);
+      const date2 = getDate(1995, 3, 30);
+      const date3 = getDate(2040, 1, 14);
+      const datesWithParameter = [date1, date2, date3];
+      const datesWithDefault = [date1, date2, date3];
+      const sorted = [date3, date1, date2];
+
+      sortDates(datesWithParameter, 'reverse');
+      expect(datesWithParameter).toEqual(sorted);
+
+      sortDates(datesWithDefault);
+      expect(datesWithDefault).toEqual(sorted);
     });
   });
 });

--- a/backend/functions/lib/adapters/utils/date-helper.ts
+++ b/backend/functions/lib/adapters/utils/date-helper.ts
@@ -55,3 +55,13 @@ function padDateElement(value: number) {
   if (value < 10) return '0' + value;
   return value.toString();
 }
+
+export function sortDates(dates: Date[], order: 'chronological' | 'reverse' = 'reverse') {
+  dates.sort((a: Date, b: Date) => {
+    if (order === 'chronological') {
+      return a.valueOf() - b.valueOf();
+    } else {
+      return b.valueOf() - a.valueOf();
+    }
+  });
+}

--- a/backend/functions/lib/common-errors/cams-error.ts
+++ b/backend/functions/lib/common-errors/cams-error.ts
@@ -4,12 +4,15 @@ export interface CamsErrorOptions {
   status?: number;
   message?: string;
   originalError?: Error;
+  // TODO: I'm a bit concerned about data being an object. Maybe it should be a string?
+  data?: object;
 }
 
 export class CamsError extends Error {
   status: number;
   module: string;
   originalError?: Error;
+  data?: object;
 
   constructor(module: string, options: CamsErrorOptions = {}) {
     super();
@@ -17,5 +20,6 @@ export class CamsError extends Error {
     this.status = options.status ?? INTERNAL_SERVER_ERROR;
     this.module = module;
     this.originalError = options.originalError;
+    this.data = options.data;
   }
 }

--- a/backend/functions/lib/use-cases/case-management.test.ts
+++ b/backend/functions/lib/use-cases/case-management.test.ts
@@ -254,13 +254,13 @@ describe('Case detail tests', () => {
     const appContext = await applicationContextCreator(functionContext);
     const caseId = caseIdWithAssignments;
     const dateFiled = '2018-11-16';
-    const dateClosed = '2019-06-21';
+    const closedDate = '2019-06-21';
     const assignments = [attorneyJaneSmith, attorneyJoeNobel];
     const caseDetail = {
       caseId: caseId,
       caseTitle: 'Daniels LLC',
       dateFiled,
-      dateClosed,
+      closedDate,
       assignments: [],
       dxtrId: '12345',
       courtId: '0208',
@@ -276,7 +276,7 @@ describe('Case detail tests', () => {
 
     expect(actualCaseDetail.body.caseDetails.caseId).toEqual(caseId);
     expect(actualCaseDetail.body.caseDetails.dateFiled).toEqual(dateFiled);
-    expect(actualCaseDetail.body.caseDetails.dateClosed).toEqual(dateClosed);
+    expect(actualCaseDetail.body.caseDetails.closedDate).toEqual(closedDate);
     expect(actualCaseDetail.body.caseDetails.assignments).toEqual(assignments);
   });
 });

--- a/backend/functions/lib/use-cases/case-management.ts
+++ b/backend/functions/lib/use-cases/case-management.ts
@@ -1,4 +1,4 @@
-import { ApplicationContext, ObjectKeyVal } from '../adapters/types/basic';
+import { ApplicationContext } from '../adapters/types/basic';
 import {
   CaseDetailsDbResult,
   CaseListDbResult,
@@ -40,7 +40,7 @@ export class CaseManagement {
         message: '',
         count: cases?.length,
         body: {
-          caseList: cases as ObjectKeyVal[],
+          caseList: cases as CaseDetailInterface[],
         },
       };
     } catch (e) {

--- a/user-interface/src/components/CaseDetail.scss
+++ b/user-interface/src/components/CaseDetail.scss
@@ -40,7 +40,7 @@
       .case-detail-judge-name {
         padding-left: 0.5rem;
       }
-      .debtor-name {
+      .debtor-information > div {
         padding-left: 0.5rem;
       }
     }

--- a/user-interface/src/components/CaseDetail.tsx
+++ b/user-interface/src/components/CaseDetail.tsx
@@ -141,9 +141,19 @@ export const CaseDetail = (props: CaseDetailProps) => {
               </div>
               <div className="debtor-information padding-bottom-4 case-card">
                 <h3>Debtor</h3>
-                <span className="debtor-name" data-testid="case-detail-debtor-name">
-                  {caseDetail.debtorName}
-                </span>
+                <div data-testid="case-detail-debtor-name">{caseDetail.debtor.name}</div>
+                {caseDetail.debtor.address1 && (
+                  <div data-testid="case-detail-debtor-address1">{caseDetail.debtor.address1}</div>
+                )}
+                {caseDetail.debtor.address2 && (
+                  <div data-testid="case-detail-debtor-address2">{caseDetail.debtor.address2}</div>
+                )}
+                {caseDetail.debtor.address3 && (
+                  <div data-testid="case-detail-debtor-address3">{caseDetail.debtor.address3}</div>
+                )}
+                {caseDetail.debtor.address4 && (
+                  <div data-testid="case-detail-debtor-address4">{caseDetail.debtor.address4}</div>
+                )}
               </div>
             </div>
           </div>

--- a/user-interface/src/type-declarations/chapter-15.d.ts
+++ b/user-interface/src/type-declarations/chapter-15.d.ts
@@ -8,6 +8,14 @@ export interface Chapter15Type {
   assignments?: string[];
 }
 
+export interface Debtor {
+  name: string;
+  address1?: string;
+  address2?: string;
+  address3?: string;
+  address4?: string;
+}
+
 interface CaseDetailType {
   caseId: string;
   chapter: string;
@@ -18,7 +26,7 @@ interface CaseDetailType {
   dismissedDate?: string;
   reopenedDate?: string;
   assignments: string[];
-  debtorName: string;
+  debtor: Debtor;
 }
 
 export interface Chapter15CaseListResponseData extends ResponseData {


### PR DESCRIPTION
We add retrieval of the debtor address and display it on the case detail
 screen. We also refactor some of the cases.dxtr.gateway.ts functions
to make them easier to test atomically and increase branch coverage.

Jira ticket: CAMS-182
# Purpose

Adds the debtor address to the case details screen.

# Major Changes

- Retrieve debtor address from the party table in DXTR
- Display the debtor address on the case details screen
- Extract transaction date parsing into a DXTR gateway helper file
- Extract date sorting into the date helper
- Extract handling of success or failure from SQL server into the gateway helper

# Testing/Validation

- Increased branch coverage and used test-driven development to drive our changes
- Validated running locally against Flexion DXTR instance
