### PR TITLE
CAMS-209 Add USTP region ID to case details

### DIFF
--- a/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
@@ -19,6 +19,7 @@ function generateTestCase(overlay = {}) {
     dxtrId: '123',
     courtId: '567',
     chapter: '15',
+    regionId: '02',
   };
   return {
     ...defaultReturn,

--- a/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -149,16 +149,18 @@ export default class CasesDxtrGateway implements CasesInterface {
     });
 
     const CASE_DETAIL_QUERY = `select
-        CS_DIV+'-'+CASE_ID as caseId,
-        CS_SHORT_TITLE as caseTitle,
-        FORMAT(CS_DATE_FILED, 'MM-dd-yyyy') as dateFiled,
-        CS_CASEID as dxtrId,
-        CS_CHAPTER as chapter,
-        COURT_ID as courtId,
-        TRIM(CONCAT(JD_FIRST_NAME, ' ', JD_MIDDLE_NAME, ' ', JD_LAST_NAME)) as judgeName
-        FROM [dbo].[AO_CS]
-        WHERE CASE_ID = @dxtrCaseId
-        AND CS_DIV = @courtDiv`;
+        cs.CS_DIV+'-'+cs.CASE_ID as caseId,
+        cs.CS_SHORT_TITLE as caseTitle,
+        FORMAT(cs.CS_DATE_FILED, 'MM-dd-yyyy') as dateFiled,
+        cs.CS_CASEID as dxtrId,
+        cs.CS_CHAPTER as chapter,
+        cs.COURT_ID as courtId,
+        TRIM(CONCAT(cs.JD_FIRST_NAME, ' ', cs.JD_MIDDLE_NAME, ' ', cs.JD_LAST_NAME)) as judgeName,
+        grp_des.REGION_ID as regionId
+        FROM [dbo].[AO_CS] AS cs
+        JOIN [dbo].[AO_GRP_DES] AS grp_des ON cs.GRP_DES = grp_des.GRP_DES
+        WHERE cs.CASE_ID = @dxtrCaseId
+        AND cs.CS_DIV = @courtDiv`;
 
     const queryResult: QueryResults = await executeQuery(
       applicationContext,

--- a/backend/functions/lib/adapters/types/cases.d.ts
+++ b/backend/functions/lib/adapters/types/cases.d.ts
@@ -46,6 +46,7 @@ export interface CaseDetailInterface {
   reopenedDate?: string;
   dxtrId?: string;
   courtId?: string;
+  regionId?: string;
   assignments?: string[];
   judgeName?: string;
   debtor?: Party;

--- a/backend/functions/lib/testing/mock-data/cases.mock.json
+++ b/backend/functions/lib/testing/mock-data/cases.mock.json
@@ -1,6 +1,7 @@
 [
   {
     "caseId": "081-11-06541",
+    "regionId": "02",
     "caseTitle": "Crawford, Turner and Garrett",
     "chapter": "15",
     "dateFiled": "2011-05-20T11:59:00.0000000",
@@ -9,6 +10,7 @@
   },
   {
     "caseId": "081-14-03544",
+    "regionId": "02",
     "caseTitle": "Ali-Cruz",
     "chapter": "15",
     "dateFiled": "2014-04-23T11:59:00.0000000",
@@ -17,6 +19,7 @@
   },
   {
     "caseId": "081-18-00235",
+    "regionId": "02",
     "caseTitle": "Daniels LLC",
     "chapter": "15",
     "dateFiled": "2018-11-16T11:59:00.0000000",
@@ -25,6 +28,7 @@
   },
   {
     "caseId": "081-15-42623",
+    "regionId": "02",
     "caseTitle": "Gonzalez, Clark and Kelley",
     "chapter": "15",
     "dateFiled": "2015-05-18T11:59:00.0000000",
@@ -33,6 +37,7 @@
   },
   {
     "caseId": "081-06-00243",
+    "regionId": "02",
     "caseTitle": "Wilson-Sheppard",
     "chapter": "15",
     "dateFiled": "2006-05-12T11:59:00.0000000",
@@ -41,6 +46,7 @@
   },
   {
     "caseId": "081-10-00351",
+    "regionId": "02",
     "caseTitle": "Taylor Inc",
     "chapter": "15",
     "dateFiled": "2010-02-16T11:59:00.0000000",
@@ -49,6 +55,7 @@
   },
   {
     "caseId": "081-15-39572",
+    "regionId": "02",
     "caseTitle": "Holmes, Koch and Knight",
     "chapter": "15",
     "dateFiled": "2015-10-16T11:59:00.0000000",
@@ -57,6 +64,7 @@
   },
   {
     "caseId": "081-19-02355",
+    "regionId": "02",
     "caseTitle": "Allen-Sandoval",
     "chapter": "15",
     "dateFiled": "2019-04-18T11:59:00.0000000",
@@ -65,6 +73,7 @@
   },
   {
     "caseId": "081-19-02365",
+    "regionId": "02",
     "caseTitle": "Valentine, Miller and Beck",
     "chapter": "15",
     "dateFiled": "2019-04-18T11:59:00.0000000",
@@ -73,6 +82,7 @@
   },
   {
     "caseId": "081-22-23587",
+    "regionId": "02",
     "caseTitle": "Mccarthy Group",
     "chapter": "15",
     "dateFiled": "2022-10-31T11:59:00.0000000",

--- a/dev-tools/test-data/domain/court.ts
+++ b/dev-tools/test-data/domain/court.ts
@@ -13,6 +13,8 @@ export interface Group {
 export interface Court {
   id: string;
   group: Group;
+  county: string;
+  div: string;
 }
 
 export function toDbRecords(input: Court | Array<Court>): DatabaseRecords {

--- a/dev-tools/test-data/domain/court.ts
+++ b/dev-tools/test-data/domain/court.ts
@@ -1,0 +1,24 @@
+import { DatabaseRecords, emptyDatabaseRecords } from '../tables/common';
+
+export interface Region {
+  id: string;
+  name: string;
+}
+
+export interface Group {
+  id: string;
+  region: Region;
+}
+
+export interface Court {
+  id: string;
+  group: Group;
+}
+
+export function toDbRecords(input: Court | Array<Court>): DatabaseRecords {
+  const dbRecords = emptyDatabaseRecords();
+  const courts = input instanceof Array ? input : [input];
+  // TODO: Implement
+  console.log(courts);
+  return dbRecords;
+}

--- a/dev-tools/test-data/fixtures/courts.ts
+++ b/dev-tools/test-data/fixtures/courts.ts
@@ -1,0 +1,16 @@
+import { Court } from '../domain/court';
+
+export const courts: Array<Court> = [
+  {
+    county: 'NEW YORK-NY',
+    id: '0208',
+    group: {
+      id: 'NY',
+      region: {
+        id: '02',
+        name: 'NEW YORK',
+      },
+    },
+    div: '081',
+  },
+];

--- a/dev-tools/test-data/fixtures/lib/common.ts
+++ b/dev-tools/test-data/fixtures/lib/common.ts
@@ -2,6 +2,7 @@ import { Faker, fakerEN_GB, fakerEN_US, fakerES_MX } from '@faker-js/faker';
 import { concatenateName, randomInt, randomTruth } from '../../utility';
 import { BCase, BCaseParty, DebtorAttorney, Judge } from '../../domain/bcase';
 import { Chapter } from '../../types';
+import { Court } from '../../domain/court';
 
 const DEFAULT_CHAPTER: Chapter = '15';
 
@@ -34,6 +35,7 @@ export interface CreateCaseOptions {
   judges?: Array<Judge>;
   attorneys?: Array<DebtorAttorney>;
   isCompany?: boolean;
+  courts?: Array<Court>;
 }
 
 export function createCases(caseCount: number, options: CreateCaseOptions): Array<BCase> {

--- a/dev-tools/test-data/fixtures/lib/common.ts
+++ b/dev-tools/test-data/fixtures/lib/common.ts
@@ -3,6 +3,7 @@ import { concatenateName, randomInt, randomTruth } from '../../utility';
 import { BCase, BCaseParty, DebtorAttorney, Judge } from '../../domain/bcase';
 import { Chapter } from '../../types';
 import { Court } from '../../domain/court';
+import { courts } from '../courts';
 
 const DEFAULT_CHAPTER: Chapter = '15';
 
@@ -48,10 +49,11 @@ export function createCases(caseCount: number, options: CreateCaseOptions): Arra
 
 export function createCase(options: CreateCaseOptions = {}): BCase {
   // TODO: Make these options / externalize them.
-  const county = 'NEW YORK-NY';
-  const courtId = '0208';
-  const group = 'NY';
-  const div = '081';
+  const court = courts[0];
+  const county = court.county;
+  const courtId = court.id;
+  const group = court.group.id;
+  const div = court.div;
   const reopenCode = '1';
 
   const isCompany = options.isCompany === undefined ? randomTruth() : options.isCompany;

--- a/dev-tools/test-data/tables/AO_GRP_DES.ts
+++ b/dev-tools/test-data/tables/AO_GRP_DES.ts
@@ -1,0 +1,28 @@
+import { ColumnNames, TableRecordHelper } from '../types';
+import { toSqlInsertStatements } from '../utility';
+
+export const AO_GRP_DES_TableName = 'AO_GRP_DES';
+export const AO_GRP_DES_InsertableColumnNames: ColumnNames = ['GRP_DES', 'REGION_ID'];
+export const AO_GRP_DES_ColumnNames: ColumnNames = [...AO_GRP_DES_InsertableColumnNames];
+export interface AO_GRP_DES_RecordProps {
+  GRP_DES: string;
+  REGION_ID: string;
+}
+export class AO_GRP_DES_Record implements TableRecordHelper {
+  GRP_DES: string = '';
+  REGION_ID: string = '';
+
+  constructor(props: AO_GRP_DES_RecordProps) {
+    Object.assign(this, props);
+  }
+  validate(): void {
+    /// TODO: implement this schema validation
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  toInsertableArray(): any[] {
+    return [this.GRP_DES, this.REGION_ID];
+  }
+}
+export function toAoGrpDesInsertStatements(records: Array<AO_GRP_DES_Record>): string[] {
+  return toSqlInsertStatements(AO_GRP_DES_TableName, AO_GRP_DES_InsertableColumnNames, records);
+}

--- a/dev-tools/test-data/tables/AO_REGION.ts
+++ b/dev-tools/test-data/tables/AO_REGION.ts
@@ -1,0 +1,28 @@
+import { ColumnNames, TableRecordHelper } from '../types';
+import { toSqlInsertStatements } from '../utility';
+
+export const AO_REGION_TableName = 'AO_REGION';
+export const AO_REGION_InsertableColumnNames: ColumnNames = ['REGION_ID', 'REGION_NAME'];
+export const AO_REGION_ColumnNames: ColumnNames = [...AO_REGION_InsertableColumnNames];
+export interface AO_REGION_RecordProps {
+  REGION_ID: string;
+  REGION_NAME: string;
+}
+export class AO_REGION_Record implements TableRecordHelper {
+  REGION_ID: string = '';
+  REGION_NAME: string = '';
+
+  constructor(props: AO_REGION_RecordProps) {
+    Object.assign(this, props);
+  }
+  validate(): void {
+    /// TODO: implement this schema validation
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  toInsertableArray(): any[] {
+    return [this.REGION_ID, this.REGION_NAME];
+  }
+}
+export function toAoRegionInsertStatements(records: Array<AO_REGION_Record>): string[] {
+  return toSqlInsertStatements(AO_REGION_TableName, AO_REGION_InsertableColumnNames, records);
+}

--- a/dev-tools/test-data/tables/common.ts
+++ b/dev-tools/test-data/tables/common.ts
@@ -1,20 +1,26 @@
-import { AO_CS_Record } from './AO_CS';
-import { AO_TX_Record } from './AO_TX';
-import { AO_PY_Record } from './AO_PY';
 import { AO_AT_Record } from './AO_AT';
+import { AO_CS_Record } from './AO_CS';
+import { AO_GRP_DES_Record } from './AO_GRP_DES';
+import { AO_PY_Record } from './AO_PY';
+import { AO_REGION_Record } from './AO_REGION';
+import { AO_TX_Record } from './AO_TX';
 
 export type DatabaseRecords = {
   AO_AT: Array<AO_AT_Record>;
   AO_CS: Array<AO_CS_Record>;
+  AO_GRP_DES: Array<AO_GRP_DES_Record>;
   AO_TX: Array<AO_TX_Record>;
   AO_PY: Array<AO_PY_Record>;
+  AO_REGION: Array<AO_REGION_Record>;
 };
 
 export function emptyDatabaseRecords(): DatabaseRecords {
   return {
     AO_AT: [],
     AO_CS: [],
-    AO_TX: [],
+    AO_GRP_DES: [],
     AO_PY: [],
+    AO_REGION: [],
+    AO_TX: [],
   };
 }

--- a/user-interface/src/components/CaseDetail.scss
+++ b/user-interface/src/components/CaseDetail.scss
@@ -17,11 +17,6 @@
       }
       .case-card-list {
         .case-card {
-          ul.usa-list {
-            .unassigned-placeholder {
-              padding-left: 0.5rem;
-            }
-          }
           .case-detail-item-name {
             padding-right: 0.5rem;
           }

--- a/user-interface/src/components/CaseDetail.test.tsx
+++ b/user-interface/src/components/CaseDetail.test.tsx
@@ -35,6 +35,7 @@ describe('Case Detail screen tests', () => {
     const testCaseDetail: CaseDetailType = {
       caseId: caseId,
       chapter: '15',
+      regionId: '02',
       caseTitle: 'The Beach Boys',
       dateFiled: '01-04-1962',
       judgeName: rickBHartName,
@@ -78,6 +79,9 @@ describe('Case Detail screen tests', () => {
         const chapter = screen.getByTestId('case-chapter');
         expect(chapter.innerHTML).toEqual('Chapter 15');
 
+        const region = screen.getByTestId('case-detail-region-id');
+        expect(region.innerHTML).toEqual('Region 2');
+
         const assigneeMap = new Map<string, string>();
         const assigneeElements = document.querySelectorAll(
           '.assigned-staff-list .individual-assignee',
@@ -118,6 +122,46 @@ describe('Case Detail screen tests', () => {
       { timeout: 5000 },
     );
   }, 20000);
+
+  const regionTestCases = [
+    ['02', 'Region 2'],
+    ['10', 'Region 10'],
+  ];
+
+  test.each(regionTestCases)(
+    'should display the reformatted region ID',
+    async (regionId: MaybeString, expectedRegionId: string) => {
+      const testCaseDetail: CaseDetailType = {
+        caseId: caseId,
+        chapter: '15',
+        regionId,
+        caseTitle: 'The Beach Boys',
+        dateFiled: '01-04-1962',
+        judgeName: rickBHartName,
+        closedDate: '01-08-1963',
+        dismissedDate: '01-08-1964',
+        assignments: [brianWilsonName, carlWilsonName],
+        debtor: {
+          name: 'Roger Rabbit',
+        },
+        debtorAttorney,
+      };
+      render(
+        <BrowserRouter>
+          <CaseDetail caseDetail={testCaseDetail} />
+        </BrowserRouter>,
+      );
+
+      await waitFor(
+        async () => {
+          const region = screen.getByTestId('case-detail-region-id');
+          expect(region.innerHTML).toEqual(expectedRegionId);
+        },
+        { timeout: 5000 },
+      );
+    },
+    20000,
+  );
 
   const debtorAddressTestCases = [
     [undefined, undefined, undefined, undefined],
@@ -486,7 +530,9 @@ describe('Case Detail screen tests', () => {
         },
         debtorAttorney: expectedAttorney,
       };
-      const expectedLink = `mailto:${expectedAttorney.email}?subject=${testCaseDetail.caseId} - ${testCaseDetail.caseTitle}`;
+      const expectedLink = `mailto:${expectedAttorney.email}?subject=${getCaseNumber(
+        testCaseDetail.caseId,
+      )} - ${testCaseDetail.caseTitle}`;
       render(
         <BrowserRouter>
           <CaseDetail caseDetail={testCaseDetail} />

--- a/user-interface/src/components/CaseDetail.tsx
+++ b/user-interface/src/components/CaseDetail.tsx
@@ -115,6 +115,11 @@ export const CaseDetail = (props: CaseDetailProps) => {
               <div className="assigned-staff-information padding-bottom-4 case-card">
                 <h3>Assigned Staff</h3>
                 <div className="assigned-staff-list">
+                  {caseDetail.regionId && (
+                    <div className="case-detail-region-id" data-testid="case-detail-region-id">
+                      Region {caseDetail.regionId.replace(/^0*/, '')}
+                    </div>
+                  )}
                   <ul className="usa-list usa-list--unstyled">
                     {caseDetail.assignments?.length > 0 &&
                       (caseDetail.assignments as Array<string>)?.map(
@@ -192,7 +197,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
                 </div>
               </div>
               <div className="debtor-counsel-information padding-bottom-4 case-card">
-                <h3>Debtor Counsel</h3>
+                <h3>Debtor&apos;s Counsel</h3>
                 {caseDetail.debtorAttorney && (
                   <>
                     <div
@@ -249,7 +254,11 @@ export const CaseDetail = (props: CaseDetailProps) => {
                           aria-label="debtor counsel email"
                         >
                           <a
-                            href={`mailto:${caseDetail.debtorAttorney.email}?subject=${caseDetail.caseId} - ${caseDetail.caseTitle}`}
+                            href={`mailto:${
+                              caseDetail.debtorAttorney.email
+                            }?subject=${getCaseNumber(caseDetail.caseId)} - ${
+                              caseDetail.caseTitle
+                            }`}
                           >
                             {caseDetail.debtorAttorney.email}
                           </a>

--- a/user-interface/src/models/chapter15-mock.api.cases.ts
+++ b/user-interface/src/models/chapter15-mock.api.cases.ts
@@ -49,6 +49,7 @@ export default class Chapter15MockApi extends Api {
   static caseDetails = {
     caseId: '101-23-12345',
     chapter: '15',
+    regionId: '02',
     caseTitle: 'Débora Arden Coronado Nazario III',
     dateFiled: '02-15-2023',
     judgeName: 'Meyer Steven',

--- a/user-interface/src/type-declarations/chapter-15.d.ts
+++ b/user-interface/src/type-declarations/chapter-15.d.ts
@@ -36,6 +36,7 @@ interface CaseDetailType {
   closedDate?: string;
   dismissedDate?: string;
   reopenedDate?: string;
+  regionId?: string;
   assignments: string[];
   debtor: Debtor;
   debtorAttorney?: DebtorAttorney;


### PR DESCRIPTION
# Purpose

Add region ID to case detail screen.

# Major Changes

Modified case detail query against DXTR database to join on AO_GRP_DES to return REGION_ID.
Modified case detail screen to show the region ID.
Reformatted the region ID to remove leading zeros which are present in the database.

# Testing/Validation

Added unit tests in API to confirm region ID is returned from DXTR gateway.
Added unit tests in UI to confirm the presence of the region ID and that it is properly formatted on screen.
