### PR TITLE
CAMS-230: Finish 12 column grid transition

### DIFF
--- a/backend/functions/lib/adapters/gateways/cases.local.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/cases.local.gateway.ts
@@ -62,6 +62,12 @@ export class CasesLocalGateway implements CasesInterface {
       caseDetail.debtor = debtors.get(caseDetail.caseId);
       caseDetail.debtorAttorney = debtorAttorneys.get(caseDetail.caseId);
       caseDetail.judgeName = 'Bob Seger';
+      caseDetail.courtDivision = '081';
+      caseDetail.courtDivisionName = 'Manhattan';
+      caseDetail.courtName = 'Southern District of New York';
+      caseDetail.regionId = '02';
+      caseDetail.debtorTypeLabel = 'Corporate Debtor';
+      caseDetail.petitionLabel = 'Voluntary Petition';
     } catch (err) {
       log.error(
         applicationContext,

--- a/user-interface/src/components/CaseAssignment.scss
+++ b/user-interface/src/components/CaseAssignment.scss
@@ -3,9 +3,7 @@
 
 .case-assignment {
   .usa-table-container--scrollable .usa-table.case-list {
-    width: 83.3%;
-    max-width: 2000px;
-    margin: 0 auto;
+    width: 100%;
   }
 
   table.case-list {
@@ -63,7 +61,7 @@
 
 @media screen and (width < 1000px) {
   .case-assignment.case-list {
-    width: 95%;
+    width: 100%;
 
     table.case-list {
       margin: 0;

--- a/user-interface/src/components/CaseAssignment.tsx
+++ b/user-interface/src/components/CaseAssignment.tsx
@@ -182,82 +182,228 @@ export const CaseAssignment = () => {
           ref={alertRef}
           timeout={assignmentAlert.timeOut}
         />
-        <h1 data-testid="case-list-heading">{screenTitle}</h1>
-        <h2 data-testid="case-list-subtitle">{subTitle}</h2>
-        {isLoading && <p data-testid="loading-indicator">Loading...</p>}
-        {caseListLoadError && (
-          <div>
-            We are having trouble reviewing case information at this time. Please refresh your
-            browser.
+        <div className="grid-row">
+          <div className="grid-col-1"></div>
+          <div className="grid-col-10">
+            <h1 data-testid="case-list-heading">{screenTitle}</h1>
+          </div>
+          <div className="grid-col-1"></div>
+        </div>
+
+        <div className="grid-row">
+          <div className="grid-col-1"></div>
+          <div className="grid-col-10">
+            <h2 data-testid="case-list-subtitle">{subTitle}</h2>
+          </div>
+          <div className="grid-col-1"></div>
+        </div>
+
+        {isLoading && (
+          <div className="grid-row">
+            <div className="grid-col-1"></div>
+            <div className="grid-col-10">
+              <p data-testid="loading-indicator">Loading...</p>
+            </div>
+            <div className="grid-col-1"></div>
           </div>
         )}
+
+        {caseListLoadError && (
+          <div className="grid-row">
+            <div className="grid-col-1"></div>
+            <div className="grid-col-10">
+              <div>
+                We are having trouble reviewing case information at this time. Please refresh your
+                browser.
+              </div>
+            </div>
+            <div className="grid-col-1"></div>
+          </div>
+        )}
+
         {!isLoading && (
-          <>
-            {unassignedCaseList.length > 0 && (
-              <div className="usa-table-container--scrollable" tabIndex={0}>
-                <table
-                  className="case-list usa-table usa-table--striped"
-                  data-testid="unassigned-table"
-                >
-                  <caption>Unassigned Cases</caption>
-                  <thead>
-                    <tr className="case-headings">
-                      <th scope="col" role="columnheader">
-                        Case Number
-                      </th>
-                      {chapterTwelveEnabled && (
-                        <th scope="col" role="columnheader" data-testid="chapter-table-header">
-                          Chapter
+          <div className="grid-row">
+            <div className="grid-col-1"></div>
+            <div className="grid-col-10">
+              {unassignedCaseList.length > 0 && (
+                <div className="usa-table-container--scrollable" tabIndex={0}>
+                  <table
+                    className="case-list usa-table usa-table--striped"
+                    data-testid="unassigned-table"
+                  >
+                    <caption>Unassigned Cases</caption>
+                    <thead>
+                      <tr className="case-headings">
+                        <th scope="col" role="columnheader">
+                          Case Number
                         </th>
-                      )}
-                      <th scope="col" role="columnheader">
-                        Case Title (Debtor)
-                      </th>
-                      <th
-                        data-sortable
-                        scope="col"
-                        role="columnheader"
-                        aria-sort="descending"
-                        aria-label="Filing Date, sortable column, currently sorted descending"
-                      >
-                        Filing Date
-                        <button
-                          tabIndex={0}
-                          className="usa-table__header__button"
-                          title="Click to sort by Filing Date in ascending order."
-                          disabled={true}
+                        {chapterTwelveEnabled && (
+                          <th scope="col" role="columnheader" data-testid="chapter-table-header">
+                            Chapter
+                          </th>
+                        )}
+                        <th scope="col" role="columnheader">
+                          Case Title (Debtor)
+                        </th>
+                        <th
+                          data-sortable
+                          scope="col"
+                          role="columnheader"
+                          aria-sort="descending"
+                          aria-label="Filing Date, sortable column, currently sorted descending"
                         >
-                          <svg
-                            className="usa-icon"
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 24 24"
+                          Filing Date
+                          <button
+                            tabIndex={0}
+                            className="usa-table__header__button"
+                            title="Click to sort by Filing Date in ascending order."
+                            disabled={true}
                           >
-                            <g className="descending" fill="transparent">
-                              <path d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"></path>
-                            </g>
-                            <g className="ascending" fill="transparent">
-                              <path
-                                transform="rotate(180, 12, 12)"
-                                d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"
-                              ></path>
-                            </g>
-                            <g className="unsorted" fill="transparent">
-                              <polygon points="15.17 15 13 17.17 13 6.83 15.17 9 16.58 7.59 12 3 7.41 7.59 8.83 9 11 6.83 11 17.17 8.83 15 7.42 16.41 12 21 16.59 16.41 15.17 15"></polygon>
-                            </g>
-                          </svg>
-                        </button>
-                      </th>
-                      <th scope="col" role="columnheader">
-                        Assign Attorney
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody data-testid="unassigned-table-body">
-                    {(unassignedCaseList as Array<Chapter15Node>).map(
-                      (theCase: Chapter15Node, idx: number) => {
-                        return (
-                          <>
-                            <tr key={idx}>
+                            <svg
+                              className="usa-icon"
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 24 24"
+                            >
+                              <g className="descending" fill="transparent">
+                                <path d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"></path>
+                              </g>
+                              <g className="ascending" fill="transparent">
+                                <path
+                                  transform="rotate(180, 12, 12)"
+                                  d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"
+                                ></path>
+                              </g>
+                              <g className="unsorted" fill="transparent">
+                                <polygon points="15.17 15 13 17.17 13 6.83 15.17 9 16.58 7.59 12 3 7.41 7.59 8.83 9 11 6.83 11 17.17 8.83 15 7.42 16.41 12 21 16.59 16.41 15.17 15"></polygon>
+                              </g>
+                            </svg>
+                          </button>
+                        </th>
+                        <th scope="col" role="columnheader">
+                          Assign Attorney
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody data-testid="unassigned-table-body">
+                      {(unassignedCaseList as Array<Chapter15Node>).map(
+                        (theCase: Chapter15Node, idx: number) => {
+                          return (
+                            <>
+                              <tr key={idx}>
+                                <td className="case-number">
+                                  <span className="mobile-title">Case Number:</span>
+                                  <a className="usa-link" href={`/case-detail/${theCase.caseId}`}>
+                                    {getCaseNumber(theCase.caseId)}
+                                  </a>
+                                </td>
+                                {chapterTwelveEnabled && (
+                                  <td className="chapter" data-testid={`${theCase.caseId}-chapter`}>
+                                    <span className="mobile-title">Chapter:</span>
+                                    {theCase.chapter}
+                                  </td>
+                                )}
+                                <td className="case-title-column">
+                                  <span className="mobile-title">Case Title (Debtor):</span>
+                                  {theCase.caseTitle}
+                                </td>
+                                <td
+                                  className="filing-date"
+                                  data-sort-value={theCase.sortableDateFiled}
+                                  data-sort-active={true}
+                                >
+                                  <span className="mobile-title">Filing Date:</span>
+                                  {theCase.dateFiled}
+                                </td>
+                                <td data-testid={`attorney-list-${idx}`} className="attorney-list">
+                                  <span className="mobile-title">Assigned Attorney:</span>
+                                  <ToggleModalButton
+                                    className="case-assignment-modal-toggle"
+                                    buttonIndex={`${idx}`}
+                                    toggleAction="open"
+                                    modalId={`${modalId}`}
+                                    modalRef={modalRef}
+                                    onClick={() => onOpenModal(theCase)}
+                                  >
+                                    Assign
+                                  </ToggleModalButton>
+                                </td>
+                              </tr>
+                            </>
+                          );
+                        },
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+              {assignedCaseList.length > 0 && (
+                <div className="usa-table-container--scrollable" tabIndex={0}>
+                  <table className="case-list usa-table usa-table--striped">
+                    <caption>Assigned Cases</caption>
+                    <thead>
+                      <tr className="case-headings">
+                        <th scope="col" role="columnheader">
+                          Case Number
+                        </th>
+                        {chapterTwelveEnabled && (
+                          <th scope="col" role="columnheader" data-testid="chapter-table-header">
+                            Chapter
+                          </th>
+                        )}
+                        <th scope="col" role="columnheader">
+                          Case Title (Debtor)
+                        </th>
+                        <th
+                          data-sortable
+                          scope="col"
+                          role="columnheader"
+                          aria-sort="descending"
+                          aria-label="Filing Date, sortable column, currently sorted descending"
+                        >
+                          Filing Date
+                          <button
+                            tabIndex={0}
+                            className="usa-table__header__button"
+                            title="Click to sort by Filing Date in ascending order."
+                            disabled={true}
+                          >
+                            <svg
+                              className="usa-icon"
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 24 24"
+                            >
+                              <g className="descending" fill="transparent">
+                                <path d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"></path>
+                              </g>
+                              <g className="ascending" fill="transparent">
+                                <path
+                                  transform="rotate(180, 12, 12)"
+                                  d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"
+                                ></path>
+                              </g>
+                              <g className="unsorted" fill="transparent">
+                                <polygon points="15.17 15 13 17.17 13 6.83 15.17 9 16.58 7.59 12 3 7.41 7.59 8.83 9 11 6.83 11 17.17 8.83 15 7.42 16.41 12 21 16.59 16.41 15.17 15"></polygon>
+                              </g>
+                            </svg>
+                          </button>
+                        </th>
+                        <th scope="col" role="columnheader">
+                          Assigned Attorney
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody data-testid="assigned-table-body">
+                      {(assignedCaseList as Array<Chapter15Node>).map(
+                        (theCase: Chapter15Node, idx: number) => {
+                          return (
+                            <tr
+                              key={idx}
+                              className={
+                                theCase.caseId === inTableTransferMode
+                                  ? 'in-table-transfer-mode'
+                                  : ''
+                              }
+                            >
                               <td className="case-number">
                                 <span className="mobile-title">Case Number:</span>
                                 <a className="usa-link" href={`/case-detail/${theCase.caseId}`}>
@@ -284,134 +430,24 @@ export const CaseAssignment = () => {
                               </td>
                               <td data-testid={`attorney-list-${idx}`} className="attorney-list">
                                 <span className="mobile-title">Assigned Attorney:</span>
-                                <ToggleModalButton
-                                  className="case-assignment-modal-toggle"
-                                  buttonIndex={`${idx}`}
-                                  toggleAction="open"
-                                  modalId={`${modalId}`}
-                                  modalRef={modalRef}
-                                  onClick={() => onOpenModal(theCase)}
-                                >
-                                  Assign
-                                </ToggleModalButton>
+                                {theCase.assignments?.map((attorney, key: number) => (
+                                  <div key={key}>
+                                    {attorney}
+                                    <br />
+                                  </div>
+                                ))}
                               </td>
                             </tr>
-                          </>
-                        );
-                      },
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            )}
-            {assignedCaseList.length > 0 && (
-              <div className="usa-table-container--scrollable" tabIndex={0}>
-                <table className="case-list usa-table usa-table--striped">
-                  <caption>Assigned Cases</caption>
-                  <thead>
-                    <tr className="case-headings">
-                      <th scope="col" role="columnheader">
-                        Case Number
-                      </th>
-                      {chapterTwelveEnabled && (
-                        <th scope="col" role="columnheader" data-testid="chapter-table-header">
-                          Chapter
-                        </th>
+                          );
+                        },
                       )}
-                      <th scope="col" role="columnheader">
-                        Case Title (Debtor)
-                      </th>
-                      <th
-                        data-sortable
-                        scope="col"
-                        role="columnheader"
-                        aria-sort="descending"
-                        aria-label="Filing Date, sortable column, currently sorted descending"
-                      >
-                        Filing Date
-                        <button
-                          tabIndex={0}
-                          className="usa-table__header__button"
-                          title="Click to sort by Filing Date in ascending order."
-                          disabled={true}
-                        >
-                          <svg
-                            className="usa-icon"
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 24 24"
-                          >
-                            <g className="descending" fill="transparent">
-                              <path d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"></path>
-                            </g>
-                            <g className="ascending" fill="transparent">
-                              <path
-                                transform="rotate(180, 12, 12)"
-                                d="M17 17L15.59 15.59L12.9999 18.17V2H10.9999V18.17L8.41 15.58L7 17L11.9999 22L17 17Z"
-                              ></path>
-                            </g>
-                            <g className="unsorted" fill="transparent">
-                              <polygon points="15.17 15 13 17.17 13 6.83 15.17 9 16.58 7.59 12 3 7.41 7.59 8.83 9 11 6.83 11 17.17 8.83 15 7.42 16.41 12 21 16.59 16.41 15.17 15"></polygon>
-                            </g>
-                          </svg>
-                        </button>
-                      </th>
-                      <th scope="col" role="columnheader">
-                        Assigned Attorney
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody data-testid="assigned-table-body">
-                    {(assignedCaseList as Array<Chapter15Node>).map(
-                      (theCase: Chapter15Node, idx: number) => {
-                        return (
-                          <tr
-                            key={idx}
-                            className={
-                              theCase.caseId === inTableTransferMode ? 'in-table-transfer-mode' : ''
-                            }
-                          >
-                            <td className="case-number">
-                              <span className="mobile-title">Case Number:</span>
-                              <a className="usa-link" href={`/case-detail/${theCase.caseId}`}>
-                                {getCaseNumber(theCase.caseId)}
-                              </a>
-                            </td>
-                            {chapterTwelveEnabled && (
-                              <td className="chapter" data-testid={`${theCase.caseId}-chapter`}>
-                                <span className="mobile-title">Chapter:</span>
-                                {theCase.chapter}
-                              </td>
-                            )}
-                            <td className="case-title-column">
-                              <span className="mobile-title">Case Title (Debtor):</span>
-                              {theCase.caseTitle}
-                            </td>
-                            <td
-                              className="filing-date"
-                              data-sort-value={theCase.sortableDateFiled}
-                              data-sort-active={true}
-                            >
-                              <span className="mobile-title">Filing Date:</span>
-                              {theCase.dateFiled}
-                            </td>
-                            <td data-testid={`attorney-list-${idx}`} className="attorney-list">
-                              <span className="mobile-title">Assigned Attorney:</span>
-                              {theCase.assignments?.map((attorney, key: number) => (
-                                <div key={key}>
-                                  {attorney}
-                                  <br />
-                                </div>
-                              ))}
-                            </td>
-                          </tr>
-                        );
-                      },
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </>
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+            <div className="grid-col-1"></div>
+          </div>
         )}
       </div>
       {attorneyList.length > 0 && (

--- a/user-interface/src/components/CaseDetail.tsx
+++ b/user-interface/src/components/CaseDetail.tsx
@@ -47,38 +47,68 @@ export const CaseDetail = (props: CaseDetailProps) => {
   if (isLoading) {
     return (
       <div className="case-detail">
-        <Link className="back-button" to="/case-assignment">
-          <Icon name="arrow_back"></Icon>
-          Back to Case List
-        </Link>
-
-        <h1 data-testid="case-detail-heading">Loading Case Details...</h1>
-        <h2>
-          <span className="case-number" title="Case Number">
-            {getCaseNumber(caseId)}
-          </span>
-        </h2>
-        <p data-testid="loading-indicator">Loading...</p>
+        <div className="grid-row">
+          <div className="grid-col-1"></div>
+          <div className="grid-col-10">
+            <Link className="back-button" to="/case-assignment">
+              <Icon name="arrow_back"></Icon>
+              Back to Case List
+            </Link>
+          </div>
+          <div className="grid-col-1"></div>
+        </div>
+        <div className="grid-row">
+          <div className="grid-col-1"></div>
+          <div className="grid-col-10">
+            <h1 data-testid="case-detail-heading">Loading Case Details...</h1>
+          </div>
+          <div className="grid-col-1"></div>
+        </div>
+        <div className="grid-row">
+          <div className="grid-col-1"></div>
+          <div className="grid-col-10">
+            <h2>
+              <span className="case-number" title="Case Number">
+                {getCaseNumber(caseId)}
+              </span>
+            </h2>
+          </div>
+          <div className="grid-col-1"></div>
+        </div>
+        <div className="case-detail">
+          <div className="grid-row">
+            <div className="grid-col-1"></div>
+            <div className="grid-col-10">
+              <p data-testid="loading-indicator">Loading...</p>
+            </div>
+          </div>
+          <div className="grid-col-1"></div>
+        </div>
       </div>
     );
   } else {
     return (
       caseDetail && (
-        <div className="case-detail grid-container">
+        <div className="case-detail">
           <div className="grid-row">
-            <div className="grid-col-12">
+            <div className="grid-col-1"></div>
+            <div className="grid-col-10">
               <Link className="back-button" to="/case-assignment">
                 <Icon name="arrow_back"></Icon>
                 Back to Case List
               </Link>
             </div>
+            <div className="grid-col-1"></div>
           </div>
           <div className="grid-row">
-            <div className="grid-col-12">
+            <div className="grid-col-1"></div>
+            <div className="grid-col-10">
               <h1 data-testid="case-detail-heading">{caseDetail.caseTitle}</h1>
             </div>
+            <div className="grid-col-1"></div>
           </div>
           <div className="grid-row">
+            <div className="grid-col-1"></div>
             <div className="grid-col-2">
               <h2>
                 <span className="case-number" title="Case Number">
@@ -86,7 +116,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
                 </span>
               </h2>
             </div>
-            <div className="grid-col-8">
+            <div className="grid-col-6">
               <h2>
                 <span
                   className="court-name"
@@ -104,10 +134,12 @@ export const CaseDetail = (props: CaseDetailProps) => {
                 </span>
               </h2>
             </div>
+            <div className="grid-col-1"></div>
           </div>
           <div className="grid-row">
+            <div className="grid-col-1"></div>
             <div className="grid-col-2"></div>
-            <div className="grid-col-8">
+            <div className="grid-col-6">
               <div className="case-card-list">
                 <div className="date-information padding-bottom-4 case-card">
                   <h3>Dates</h3>
@@ -345,6 +377,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
               </div>
             </div>
             <div className="grid-col-2"></div>
+            <div className="grid-col-1"></div>
           </div>
         </div>
       )


### PR DESCRIPTION
# Purpose

Only the case details screen after data was loaded was utilizing the 12 column grid and we wanted everything to do so.

# Major Changes

- Add grid to case assignment screen during loading and after the list is displayed
- Add grid to case detail screen during loading
- Make case details take up the entirety of the 12 columns (with 1 column empty on either side)

# Testing/Validation

Validated that the screens look correct at various sizes of the browser.

# Other

- Added local gateway data to the backend

# Future Work

Responsiveness is not fully defined yet. We need to know what effect break points should have on the display.
