### PR TITLE
CAMS-219 display docket record

### DIFF
--- a/user-interface/.pa11yci
+++ b/user-interface/.pa11yci
@@ -17,7 +17,8 @@
       ],
       "timeout": 20000
     },
-    "http://localhost:3000/case-detail/101-23-44461"
+    "http://localhost:3000/case-detail/101-23-44461",
+    "http://localhost:3000/case-detail/101-23-44461/court-docket"
   ],
   "standard": "WCAG2AA"
 }

--- a/user-interface/src/case-detail/panels/CaseDetailBasicInfo.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailBasicInfo.tsx
@@ -3,12 +3,12 @@ import { CaseDetailType } from '@/lib/type-declarations/chapter-15';
 
 const informationUnavailable = 'Information is not available at this time.';
 
-export interface CaseDetailContentProps {
+export interface CaseDetailBasicInfoProps {
   caseDetail?: CaseDetailType;
   showReopenDate: boolean;
 }
 
-export default function CaseDetailContent(props: CaseDetailContentProps) {
+export default function CaseDetailBasicInfo(props: CaseDetailBasicInfoProps) {
   if (!props.caseDetail) {
     return <></>;
   } else {

--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.scss
@@ -1,0 +1,13 @@
+#case-detail-court-docket-panel {
+  .docket-entry {
+    padding-bottom: 2rem;
+
+    h3 {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    .docket-content {
+      line-height: 24px;
+    }
+  }
+}

--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import CaseDetailCourtDocket from '@/case-detail/panels/CaseDetailCourtDocket';
+
+describe('court docket panel tests', () => {
+  test('should render loading info when isLoading is true', () => {
+    render(
+      <BrowserRouter>
+        <CaseDetailCourtDocket caseId="081-12-12345" docketEntries={undefined} />
+      </BrowserRouter>,
+    );
+
+    const isLoading = screen.getByTestId('loading-indicator');
+
+    expect(isLoading).toBeInTheDocument();
+  });
+
+  test('should render docket entries when provided', () => {
+    const docketEntries = [
+      {
+        sequenceNumber: 2,
+        documentNumber: 1,
+        dateFiled: '2023-05-07T00:00:00.0000000',
+        summaryText: 'Add Judge',
+        fullText: 'Docket entry number 1.',
+      },
+      {
+        sequenceNumber: 3,
+        dateFiled: '2023-05-07T00:00:00.0000000',
+        summaryText: 'Add Judge',
+        fullText: 'Docket entry number 2.',
+      },
+    ];
+    render(
+      <BrowserRouter>
+        <CaseDetailCourtDocket caseId="081-12-12345" docketEntries={docketEntries} />
+      </BrowserRouter>,
+    );
+
+    const isLoading = screen.queryByTestId('loading-indicator');
+    expect(isLoading).not.toBeInTheDocument();
+
+    const docketEntry1 = screen.getByTestId('docket-entry-0');
+    const docketEntry2 = screen.getByTestId('docket-entry-1');
+    expect(docketEntry1).toBeInTheDocument();
+    expect(docketEntry2).toBeInTheDocument();
+
+    const docketEntry1Number = screen.getByTestId('docket-entry-0-number');
+    expect(docketEntry1Number.innerHTML).toEqual(docketEntries[0].documentNumber?.toString());
+    const docketEntry1Header = screen.getByTestId('docket-entry-0-header');
+    expect(docketEntry1Header.innerHTML).toEqual(
+      docketEntries[0].dateFiled + ' - ' + docketEntries[0].summaryText,
+    );
+    const docketEntry1Text = screen.getByTestId('docket-entry-0-text');
+    expect(docketEntry1Text.innerHTML).toEqual(docketEntries[0].fullText);
+
+    const docketEntry2Number = screen.getByTestId('docket-entry-1-number');
+    expect(docketEntry2Number.innerHTML).toEqual('');
+  });
+});

--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.tsx
@@ -1,3 +1,47 @@
-export default function CaseDetailCourtDocket() {
-  return <div>Court Docket</div>;
+import './CaseDetailCourtDocket.scss';
+import LoadingIndicator from '@/lib/components/LoadingIndicator';
+import { CaseDocketEntry } from '@/lib/type-declarations/chapter-15';
+import { useEffect, useState } from 'react';
+
+export interface CaseDetailCourtDocketProps {
+  caseId: string | undefined;
+  docketEntries?: CaseDocketEntry[];
+}
+
+export default function CaseDetailCourtDocket(props: CaseDetailCourtDocketProps) {
+  const { docketEntries } = props;
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setIsLoading(!docketEntries);
+  }, [docketEntries]);
+
+  return (
+    <div id="case-detail-court-docket-panel">
+      {isLoading && <LoadingIndicator />}
+      {!isLoading &&
+        docketEntries &&
+        (docketEntries as Array<CaseDocketEntry>)?.map(
+          (docketEntry: CaseDocketEntry, idx: number) => {
+            return (
+              <div
+                className="grid-row grid-gap-lg docket-entry"
+                key={idx}
+                data-testid={`docket-entry-${idx}`}
+              >
+                <div className="grid-col-1" data-testid={`docket-entry-${idx}-number`}>
+                  {docketEntry.documentNumber ? <h3>{docketEntry.documentNumber}</h3> : ''}
+                </div>
+                <div className="grid-col-11 docket-content">
+                  <div data-testid={`docket-entry-${idx}-header`}>
+                    {docketEntry.dateFiled} - {docketEntry.summaryText}
+                  </div>
+                  <div data-testid={`docket-entry-${idx}-text`}>{docketEntry.fullText}</div>
+                </div>
+              </div>
+            );
+          },
+        )}
+    </div>
+  );
 }

--- a/user-interface/src/lib/components/uswds/Alert.tsx
+++ b/user-interface/src/lib/components/uswds/Alert.tsx
@@ -59,8 +59,8 @@ function AlertComponent(props: AlertProps, ref: React.Ref<AlertRefType>) {
           isVisible === IsVisible.True
             ? 'usa-alert__visible'
             : isVisible === IsVisible.False
-              ? 'usa-alert__hidden'
-              : 'usa-alert__unset'
+            ? 'usa-alert__hidden'
+            : 'usa-alert__unset'
         }`}
         role={props.role}
         data-testid={`alert`}

--- a/user-interface/src/lib/components/uswds/Alert.tsx
+++ b/user-interface/src/lib/components/uswds/Alert.tsx
@@ -59,8 +59,8 @@ function AlertComponent(props: AlertProps, ref: React.Ref<AlertRefType>) {
           isVisible === IsVisible.True
             ? 'usa-alert__visible'
             : isVisible === IsVisible.False
-            ? 'usa-alert__hidden'
-            : 'usa-alert__unset'
+              ? 'usa-alert__hidden'
+              : 'usa-alert__unset'
         }`}
         role={props.role}
         data-testid={`alert`}

--- a/user-interface/src/lib/type-declarations/chapter-15.d.ts
+++ b/user-interface/src/lib/type-declarations/chapter-15.d.ts
@@ -47,6 +47,13 @@ interface CaseDetailType {
   petitionLabel: string;
 }
 
+export interface CaseDocketEntry {
+  sequenceNumber: number;
+  documentNumber?: number;
+  dateFiled: string;
+  summaryText: string;
+  fullText: string;
+}
 export interface Chapter15CaseListResponseData extends ResponseData {
   body: {
     caseList: Array<object>;


### PR DESCRIPTION
# Purpose

Display Docket Entries in the Case Detail screen court docket panel.

# Major Changes

* Court Docket screen added to Pa11y.
* Updated CaseDetailScreen.tsx to support Court Docket entries and renamed the basic info component from CaseDetailContents to CaseDetailBasicInfo (or something like that)
* Populated Court Docket screen according to the Figma
* Wrote tests

# Testing/Validation

Coverage is above 90%

