### PR TITLE
CAMS-243 Fixed logic make DXTR petition and debtor type lookup resilient

### DIFF
--- a/backend/functions/attorneys/attorneys.function.ts
+++ b/backend/functions/attorneys/attorneys.function.ts
@@ -31,10 +31,10 @@ const httpTrigger: AzureFunction = async function (
     const attorneysList = await attorneysController.getAttorneyList({ officeId });
     functionContext.res = httpSuccess(attorneysList);
   } catch (originalError) {
-    let error = originalError;
-    if (!(error instanceof CamsError)) {
-      error = new UnknownError(MODULE_NAME, { originalError });
-    }
+    const error =
+      originalError instanceof CamsError
+        ? originalError
+        : new UnknownError(MODULE_NAME, { originalError });
     log.camsError(applicationContext, error);
     functionContext.res = httpError(error);
   }

--- a/backend/functions/case-assignments/case.assignment.function.ts
+++ b/backend/functions/case-assignments/case.assignment.function.ts
@@ -25,10 +25,10 @@ const httpTrigger: AzureFunction = async function (
     await handlePostMethod(applicationContext, caseId, listOfAttorneyNames, role);
     functionContext.res = applicationContext.res;
   } catch (originalError) {
-    let error = originalError;
-    if (!(error instanceof CamsError)) {
-      error = new UnknownError(MODULE_NAME, { originalError });
-    }
+    const error =
+      originalError instanceof CamsError
+        ? originalError
+        : new UnknownError(MODULE_NAME, { originalError });
     log.camsError(applicationContext, error);
     functionContext.res = httpError(error);
   }

--- a/backend/functions/cases/cases.function.ts
+++ b/backend/functions/cases/cases.function.ts
@@ -41,10 +41,10 @@ const httpTrigger: AzureFunction = async function (
 
     functionContext.res = httpSuccess(responseBody);
   } catch (originalError) {
-    let error = originalError;
-    if (!(error instanceof CamsError)) {
-      error = new UnknownError(MODULE_NAME, { originalError });
-    }
+    const error =
+      originalError instanceof CamsError
+        ? originalError
+        : new UnknownError(MODULE_NAME, { originalError });
     log.camsError(applicationContext, error);
     functionContext.res = httpError(error);
   }

--- a/backend/functions/lib/adapters/gateways/debtor-type-gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/debtor-type-gateway.test.ts
@@ -1,4 +1,3 @@
-import { CamsError } from '../../common-errors/cams-error';
 import { getDebtorTypeLabel } from './debtor-type-gateway';
 
 describe('Debtor Type Name gateway', () => {
@@ -6,13 +5,8 @@ describe('Debtor Type Name gateway', () => {
     const debtorTypeName = getDebtorTypeLabel('CB');
     expect(debtorTypeName).toEqual('Corporate Business');
   });
-  test('should throw an error for an invalid ID', () => {
-    const expectedException = new CamsError('DEBTOR-TYPE-NAME-GATEWAY', {
-      message: 'Cannot find debtor type name by ID',
-      data: { id: 'ZZ' },
-    });
-    expect(() => {
-      getDebtorTypeLabel('ZZ');
-    }).toThrow(expectedException);
+  test('should return an unknown label for an invalid ID', () => {
+    const debtorTypeName = getDebtorTypeLabel('ZZ');
+    expect(debtorTypeName).toEqual('Debtor type information is not available.');
   });
 });

--- a/backend/functions/lib/adapters/gateways/debtor-type-gateway.ts
+++ b/backend/functions/lib/adapters/gateways/debtor-type-gateway.ts
@@ -1,10 +1,3 @@
-import { CamsError } from '../../common-errors/cams-error';
-
-// TODO: This lookup may need to be migrated to a database at some point in the future.
-// This is a domain concern that we have not decided on where is the most appropriate place to keep outside of the gateway directory.
-
-const MODULE_NAME = 'DEBTOR-TYPE-NAME-GATEWAY';
-
 const debtorTypeLabelMap = new Map<string, string>([
   ['CB', 'Corporate Business'],
   ['FD', 'Foreign Debtor'],
@@ -17,8 +10,5 @@ const debtorTypeLabelMap = new Map<string, string>([
 
 export function getDebtorTypeLabel(id: string | undefined): string {
   if (debtorTypeLabelMap.has(id)) return debtorTypeLabelMap.get(id);
-  throw new CamsError(MODULE_NAME, {
-    message: 'Cannot find debtor type name by ID',
-    data: { id },
-  });
+  return 'Debtor type information is not available.';
 }

--- a/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -24,6 +24,8 @@ import {
   parseTransactionDate,
 } from './dxtr.gateway.helper';
 import { removeExtraSpaces } from '../../utils/string-helper';
+import { getDebtorTypeLabel } from '../debtor-type-gateway';
+import { getPetitionLabel } from '../petition-gateway';
 
 const MODULENAME = 'CASES-DXTR-GATEWAY';
 
@@ -566,9 +568,9 @@ export default class CasesDxtrGateway implements CasesInterface {
       `Transaction results received from DXTR:`,
       queryResult,
     );
-    const debtorTypeRecord = (queryResult.results as mssql.IResult<DxtrTransactionRecord>)
-      .recordset[0];
-    return parseDebtorType(debtorTypeRecord);
+    const resultset = (queryResult.results as mssql.IResult<DxtrTransactionRecord>).recordset;
+    const key = resultset.length ? parseDebtorType(resultset[0]) : 'UNKNOWN';
+    return getDebtorTypeLabel(key);
   }
 
   petitionLabelCallback(applicationContext: ApplicationContext, queryResult: QueryResults) {
@@ -578,9 +580,9 @@ export default class CasesDxtrGateway implements CasesInterface {
       `Transaction results received from DXTR:`,
       queryResult,
     );
-    const petitionTypeRecord = (queryResult.results as mssql.IResult<DxtrTransactionRecord>)
-      .recordset[0];
-    return parsePetitionType(petitionTypeRecord);
+    const resultset = (queryResult.results as mssql.IResult<DxtrTransactionRecord>).recordset;
+    const key = resultset.length ? parsePetitionType(resultset[0]) : 'UNKNOWN';
+    return getPetitionLabel(key);
   }
 
   caseDetailsQueryCallback(applicationContext: ApplicationContext, queryResult: QueryResults) {

--- a/backend/functions/lib/adapters/gateways/dxtr/dxtr.gateway.helper.test.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/dxtr.gateway.helper.test.ts
@@ -36,15 +36,15 @@ describe('DXTR Gateway Helper Tests', () => {
     const type1TransactionRecToTest = [
       [
         '1081201013220-10132            15CB               000000000000000000200117999992001179999920011799999200117VP000000                                 NNNNN',
-        'Corporate Business',
+        'CB',
       ],
       [
         '1081201013220-10132            15IB               000000000000000000200117999992001179999920011799999200117VP000000                                 NNNNN',
-        'Individual Business',
+        'IB',
       ],
       [
         '1081201013220-10132            15IC               000000000000000000200117999992001179999920011799999200117VP000000                                 NNNNN',
-        'Individual Consumer',
+        'IC',
       ],
     ];
 
@@ -59,48 +59,25 @@ describe('DXTR Gateway Helper Tests', () => {
         expect(parseDebtorType(transactionRecord)).toEqual(expected);
       },
     );
-
-    const negativeType1TransactionRecToTest = [
-      ['000000000000000000200117999992001179999920011799999200117VP000000'],
-      [
-        '1081201013220-10132            15AA               000000000000000000200117999992001179999920011799999200117VP000000                                 NNNNN',
-      ],
-    ];
-    test.each(negativeType1TransactionRecToTest)(
-      'should throw an error when a bad record is encountered',
-      (txRecord: string) => {
-        const transactionRecord: DxtrTransactionRecord = {
-          txCode: '1',
-          txRecord,
-        };
-        const expectedException = new CamsError('DEBTOR-TYPE-NAME-GATEWAY', {
-          message: 'Cannot find debtor type name by ID',
-        });
-
-        expect(() => {
-          parseDebtorType(transactionRecord);
-        }).toThrow(expectedException);
-      },
-    );
   });
 
   describe('parsePetitionType tests', () => {
     const petitionsToTest = [
       [
         '0000000000000-00000            00AA               000000000000000000000000000000000000000000000000000000000IP000000                                 NNNNN',
-        'Involuntary',
+        'IP',
       ],
       [
         '0000000000000-00000            00AA               000000000000000000000000000000000000000000000000000000000TI000000                                 NNNNN',
-        'Involuntary',
+        'TI',
       ],
       [
         '0000000000000-00000            00AA               000000000000000000000000000000000000000000000000000000000TV000000                                 NNNNN',
-        'Voluntary',
+        'TV',
       ],
       [
         '0000000000000-00000            00AA               000000000000000000000000000000000000000000000000000000000VP000000                                 NNNNN',
-        'Voluntary',
+        'VP',
       ],
     ];
 
@@ -113,29 +90,6 @@ describe('DXTR Gateway Helper Tests', () => {
         };
 
         expect(parsePetitionType(transactionRecord)).toEqual(expected);
-      },
-    );
-
-    const negativePetitionRecToTest = [
-      ['000000000000000000000000000000000000000000000000000000000VP000000'],
-      [
-        '0000000000000-00000            00AA               000000000000000000000000000000000000000000000000000000000ZZ000000                                 NNNNN',
-      ],
-    ];
-    test.each(negativePetitionRecToTest)(
-      'should throw an error when a bad record is encountered',
-      (txRecord: string) => {
-        const transactionRecord: DxtrTransactionRecord = {
-          txCode: '1',
-          txRecord,
-        };
-        const expectedException = new CamsError('PETITION-NAME-GATEWAY', {
-          message: 'Cannot find petition label by ID',
-        });
-
-        expect(() => {
-          parsePetitionType(transactionRecord);
-        }).toThrow(expectedException);
       },
     );
   });

--- a/backend/functions/lib/adapters/gateways/dxtr/dxtr.gateway.helper.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/dxtr.gateway.helper.ts
@@ -1,8 +1,6 @@
 import { DxtrTransactionRecord } from '../../types/cases';
 import { getDate } from '../../utils/date-helper';
 import { CamsError } from '../../../common-errors/cams-error';
-import { getDebtorTypeLabel } from '../debtor-type-gateway';
-import { getPetitionLabel } from '../petition-gateway';
 
 const MODULE_NAME = 'DXTR-GATEWAY-HELPER';
 
@@ -39,16 +37,16 @@ export function parseTransactionDate(record: DxtrTransactionRecord): Date {
 export function parseDebtorType(record: DxtrTransactionRecord): string {
   const codeLength = 2;
   const codeIndex = 33;
-  const debtorType = record.txRecord.slice(codeIndex, codeIndex + codeLength);
-  return getDebtorTypeLabel(debtorType);
+  const debtorTypeKey = record.txRecord.slice(codeIndex, codeIndex + codeLength);
+  return debtorTypeKey;
 }
 
 // 1081231056523-10565            15IB00-0000000     000000000000000000230411999992304119999923041110308230411VP000000                                 NNNNN
 export function parsePetitionType(record: DxtrTransactionRecord): string {
   const codeLength = 2;
   const codeIndex = 107;
-  const petition = record.txRecord.slice(codeIndex, codeIndex + codeLength);
-  return getPetitionLabel(petition);
+  const petitionKey = record.txRecord.slice(codeIndex, codeIndex + codeLength);
+  return petitionKey;
 }
 
 export function decomposeCaseId(caseId: string) {

--- a/backend/functions/lib/adapters/gateways/petition-gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/petition-gateway.test.ts
@@ -1,4 +1,3 @@
-import { CamsError } from '../../common-errors/cams-error';
 import { getPetitionLabel } from './petition-gateway';
 
 describe('Petition Type Label gateway', () => {
@@ -7,13 +6,8 @@ describe('Petition Type Label gateway', () => {
     expect(debtorTypeName).toEqual('Voluntary');
   });
 
-  test('should throw an error for an invalid ID', () => {
-    const expectedException = new CamsError('PETITION-GATEWAY', {
-      message: 'Cannot find petition label by ID',
-      data: { id: 'ZZ' },
-    });
-    expect(() => {
-      getPetitionLabel('ZZ');
-    }).toThrow(expectedException);
+  test('should return an unknown label for an invalid ID', () => {
+    const debtorTypeName = getPetitionLabel('ZZ');
+    expect(debtorTypeName).toEqual('');
   });
 });

--- a/backend/functions/lib/adapters/gateways/petition-gateway.ts
+++ b/backend/functions/lib/adapters/gateways/petition-gateway.ts
@@ -1,7 +1,3 @@
-import { CamsError } from '../../common-errors/cams-error';
-
-const MODULE_NAME = 'PETITION-GATEWAY';
-
 const petitionLabelMap = new Map<string, string>([
   ['IP', 'Involuntary'],
   ['TI', 'Involuntary'],
@@ -11,8 +7,5 @@ const petitionLabelMap = new Map<string, string>([
 
 export function getPetitionLabel(id: string | undefined): string {
   if (petitionLabelMap.has(id)) return petitionLabelMap.get(id);
-  throw new CamsError(MODULE_NAME, {
-    message: 'Cannot find petition label by ID',
-    data: { id },
-  });
+  return ''; // Unknown case.
 }


### PR DESCRIPTION
Jira ticket: CAMS-243

# Problem

Case detail lookup fail to show on case detail screen.

# Solution

Revised logic to not throw CamsError when a lookup key is not found in the label mappings
and instead return an 'unknown' label for a more graceful failure.

# Testing/Validation

Updated unit tests to handle lookup table misses.
