### PR TITLE
CAMS-250 null summary bug

### DIFF
--- a/backend/functions/lib/adapters/gateways/dxtr/case-docket.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/case-docket.dxtr.gateway.ts
@@ -32,8 +32,8 @@ export class DxtrCaseDocketGateway implements CaseDocketGateway {
       D.DE_SEQNO as sequenceNumber,
       D.DE_DOCUMENT_NUM as documentNumber,
       FORMAT(D.DE_DATE_FILED, 'MM-dd-yyyy') as dateFiled,
-      D.DO_SUMMARY_TEXT as summaryText,
-      D.DT_TEXT as fullText
+      ISNULL(D.DO_SUMMARY_TEXT, 'SUMMARY NOT AVAILABLE') as summaryText,
+      ISNULL(D.DT_TEXT, 'TEXT NOT AVAILABLE') as fullText
     FROM AO_DE AS D
     JOIN AO_CS AS C ON C.CS_CASEID=D.CS_CASEID AND C.COURT_ID=D.COURT_ID
     WHERE C.CS_DIV=@courtDiv AND C.CASE_ID=@dxtrCaseId


### PR DESCRIPTION
# Problem

The case docket screen does not render when a summary text is null in the docket

# Solution

Added null checks in the SQL to ensure text is always returned from the API.

# Testing/Validation

Added the data integrity issue to a case in the Flexion DXTR database to reproduce the error then tested to ensure the page renders as expected.
