### PR TITLE
Fix contributing link in docsify

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,6 +3,6 @@
 - [Home](/)
 - [Running the Application](running.md)
 - [Operations](operations/README.md)
-- [Contributing](contributing.md)
+- [Contributing](contributing/README.md)
 - [Architecture](architecture/README.md)
 - [Troubleshooting](troubleshooting.md)


### PR DESCRIPTION
# Purpose

The link in the documentation to the contributing markdown was broken.

# Major Changes

Point to the new contributing directory for the contributing documentation.

# Testing/Validation

- Validated that the docs work as expected locally.
- [Deployed this branch](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/7006887038).
