### PR TITLE
CAMS-246 view case header while scrolling

### DIFF
--- a/user-interface/src/App.tsx
+++ b/user-interface/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
   const bodyElement = document.querySelector('.App');
 
   function documentScroll(ev: React.UIEvent<HTMLElement>) {
+    console.log((ev.currentTarget as Element).scrollTop);
     if ((ev.currentTarget as Element).scrollTop > 100) {
       setAppClasses('App header-scrolled-out');
       setScrollBtnClass('show');
@@ -35,7 +36,7 @@ function App() {
       }}
       appInsights={reactPlugin}
     >
-      <div className={appClasses} onScroll={documentScroll}>
+      <div className={appClasses} onScroll={documentScroll} data-testid="app-component-test-id">
         <HeaderNavBar />
         <div className="body">
           <Routes>

--- a/user-interface/src/App.tsx
+++ b/user-interface/src/App.tsx
@@ -18,7 +18,6 @@ function App() {
   const bodyElement = document.querySelector('.App');
 
   function documentScroll(ev: React.UIEvent<HTMLElement>) {
-    console.log((ev.currentTarget as Element).scrollTop);
     if ((ev.currentTarget as Element).scrollTop > 100) {
       setAppClasses('App header-scrolled-out');
       setScrollBtnClass('show');

--- a/user-interface/src/case-detail/CaseDetailScreen.scss
+++ b/user-interface/src/case-detail/CaseDetailScreen.scss
@@ -1,15 +1,6 @@
 .App {
   .body {
     .case-detail {
-      .back-button {
-        display: inline-block;
-        padding-top: 2rem;
-        padding-bottom: 2.5rem;
-        svg {
-          margin-right: 0.5rem;
-          vertical-align: text-bottom;
-        }
-      }
       .case-card-list {
         .case-card {
           .case-detail-item-name {

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -29,6 +29,7 @@ function showReopenDate(reOpenDate: string | undefined, closedDate: string | und
   }
   return false;
 }
+
 export const CaseDetail = (props: CaseDetailProps) => {
   const { caseId } = useParams();
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -1,5 +1,5 @@
 import './CaseDetailScreen.scss';
-import { lazy, Suspense, useState, useEffect } from 'react';
+import { lazy, Suspense, useState, useEffect, useRef } from 'react';
 import { Route, useParams, useLocation, Outlet, Routes } from 'react-router-dom';
 import Api from '../lib/models/api';
 import MockApi from '../lib/models/chapter15-mock.api.cases';
@@ -10,6 +10,7 @@ import {
   Chapter15CaseDocketResponseData,
 } from '@/lib/type-declarations/chapter-15';
 import { mapNavState } from './panels/CaseDetailNavigation';
+import { CaseDetailNavigationRef } from './panels/CaseDetailNavigation.d';
 const LoadingIndicator = lazy(() => import('@/lib/components/LoadingIndicator'));
 const CaseDetailHeader = lazy(() => import('./panels/CaseDetailHeader'));
 const CaseDetailBasicInfo = lazy(() => import('./panels/CaseDetailBasicInfo'));
@@ -36,6 +37,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
   const api = import.meta.env['CAMS_PA11Y'] === 'true' ? MockApi : Api;
   const [caseBasicInfo, setCaseBasicInfo] = useState<CaseDetailType>();
   const [caseDocketEntries, setCaseDocketEntries] = useState<CaseDocketEntry[]>();
+  const navRef = useRef<CaseDetailNavigationRef>(null);
   const location = useLocation();
 
   const navState = mapNavState(location.pathname);
@@ -77,11 +79,19 @@ export const CaseDetail = (props: CaseDetailProps) => {
       <div className="case-detail">
         {isLoading && (
           <>
-            <CaseDetailHeader isLoading={isLoading} caseId={caseId} />
+            <CaseDetailHeader
+              isLoading={isLoading}
+              navigationRef={navRef as React.RefObject<CaseDetailNavigationRef>}
+              caseId={caseId}
+            />
             <div className="grid-row grid-gap-lg">
               <div className="grid-col-1"></div>
               <div className="grid-col-2">
-                <CaseDetailNavigation caseId={caseId} initiallySelectedNavLink={navState} />
+                <CaseDetailNavigation
+                  caseId={caseId}
+                  initiallySelectedNavLink={navState}
+                  ref={navRef}
+                />
               </div>
               <div className="grid-col-8">
                 <LoadingIndicator />
@@ -96,11 +106,16 @@ export const CaseDetail = (props: CaseDetailProps) => {
               isLoading={false}
               caseId={caseBasicInfo.caseId}
               caseDetail={caseBasicInfo}
+              navigationRef={navRef as React.RefObject<CaseDetailNavigationRef>}
             />
             <div className="grid-row grid-gap-lg">
               <div className="grid-col-1"></div>
               <div className="grid-col-2">
-                <CaseDetailNavigation caseId={caseId} initiallySelectedNavLink={navState} />
+                <CaseDetailNavigation
+                  caseId={caseId}
+                  initiallySelectedNavLink={navState}
+                  ref={navRef}
+                />
               </div>
               <div className="grid-col-6">
                 <Suspense fallback={<LoadingIndicator />}>

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.scss
@@ -1,0 +1,16 @@
+.case-detail-header {
+  .sub-headers {
+    position: relative;
+    top: auto;
+    background-color: transparent;
+  }
+  .sub-headers.fixed {
+    position: fixed;
+    width: 100%;
+    margin: 0;
+    top: 0;
+    background-color: #fefefe;
+    border: 1px solid #f0f0f0;
+    z-index: 10;
+  }
+}

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.scss
@@ -1,16 +1,42 @@
 .case-detail-header {
-  .sub-headers {
-    position: relative;
-    top: auto;
-    background-color: transparent;
+  position: relative;
+  top: auto;
+  background-color: transparent;
+
+  .back-button {
+    display: inline-block;
+    padding-top: 2rem;
+    padding-bottom: 2.5rem;
+    svg {
+      margin-right: 0.5rem;
+      vertical-align: text-bottom;
+    }
   }
-  .sub-headers.fixed {
-    position: fixed;
-    width: 100%;
+}
+
+.case-detail-header.fixed {
+  position: fixed;
+  width: 100%;
+  margin: 0;
+  top: 0;
+  background-color: #fefefe;
+  border: 1px solid #f0f0f0;
+  z-index: 10;
+  box-shadow: 0px 1px 5px #ddd;
+  padding-bottom: 1rem;
+
+  a.back-button {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+  h3 {
     margin: 0;
-    top: 0;
-    background-color: #fefefe;
-    border: 1px solid #f0f0f0;
-    z-index: 10;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
+}
+
+.spacer-fixer {
+  margin-top: 125px;
 }

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.test.tsx
@@ -1,7 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import CaseDetailHeader from './CaseDetailHeader';
 import { CaseDetailType } from '@/lib/type-declarations/chapter-15';
+import { CaseDetailNavigationRef } from './CaseDetailNavigation.d';
+import CaseDetail from '../CaseDetailScreen';
+import React from 'react';
 
 describe('Case Detail Header tests', () => {
   const testCaseDetail: CaseDetailType = {
@@ -29,12 +32,14 @@ describe('Case Detail Header tests', () => {
   };
 
   test('should render loading info when isLoading is true', () => {
+    const navRef = React.createRef<CaseDetailNavigationRef>();
     render(
       <BrowserRouter>
         <CaseDetailHeader
           caseDetail={testCaseDetail}
           isLoading={true}
           caseId={testCaseDetail.caseId}
+          navigationRef={navRef}
         />
       </BrowserRouter>,
     );
@@ -47,12 +52,14 @@ describe('Case Detail Header tests', () => {
   });
 
   test('should render case detail info when isLoading is false', () => {
+    const navRef = React.createRef<CaseDetailNavigationRef>();
     render(
       <BrowserRouter>
         <CaseDetailHeader
           caseDetail={testCaseDetail}
           isLoading={false}
           caseId={testCaseDetail.caseId}
+          navigationRef={navRef}
         />
       </BrowserRouter>,
     );
@@ -64,5 +71,87 @@ describe('Case Detail Header tests', () => {
     expect(isLoadingH1).toContainHTML('The Beach Boys');
     expect(isFinishedH2).toBeInTheDocument();
     expect(caseChapter.innerHTML).toEqual('Voluntary Chapter&nbsp;15');
+  });
+
+  test('should fix header in place when screen is scrolled and header hits the top of the screen', async () => {
+    const testCaseDetail: CaseDetailType = {
+      caseId: '000-11-22222',
+      chapter: '15',
+      regionId: '02',
+      officeName: 'New York',
+      caseTitle: 'The Beach Boys',
+      dateFiled: '01-04-1962',
+      judgeName: 'Ms. Judge',
+      courtName: 'Court of Law',
+      courtDivisionName: 'Manhattan',
+      debtorTypeLabel: 'Corporate Business',
+      petitionLabel: 'Voluntary',
+      closedDate: '01-08-1963',
+      dismissedDate: '01-08-1964',
+      assignments: ['Mr. Frank', 'Ms. Jane'],
+      debtor: {
+        name: 'Roger Rabbit',
+        address1: '123 Rabbithole Lane',
+        address2: '',
+        address3: '',
+        cityStateZipCountry: 'Redondo Beach CA 90111 USA',
+      },
+      debtorAttorney: {
+        name: 'Jane Doe',
+        address1: 'Somewhere nice',
+        cityStateZipCountry: 'where its sunny all the time',
+        phone: '111-555-1234',
+      },
+    };
+
+    render(
+      <BrowserRouter>
+        <div className="App" data-testid="app-component-test-id">
+          <header
+            className="cams-header usa-header-usa-header--basic"
+            style={{ minHeight: '100px', height: '100px' }}
+          ></header>
+          <CaseDetail caseDetail={testCaseDetail} />
+          <div style={{ minHeight: '2000px', height: '2000px' }}></div>
+        </div>
+      </BrowserRouter>,
+    );
+
+    const app = await screen.findByTestId('app-component-test-id');
+    await waitFor(
+      async () => {
+        const title = await screen.findByTestId('case-detail-heading');
+        expect(title.innerHTML).toEqual('The Beach Boys');
+      },
+      { timeout: 1000 },
+    );
+
+    const initialHeader = await screen.findByTestId('case-detail-header');
+    expect(initialHeader).toBeInTheDocument();
+
+    /*
+    await act(async () => {
+      await fireEvent.scroll(app, { target: { scrollY: 98 } });
+    });
+    */
+    await fireEvent.scroll(app as Element, { target: { scrollTop: 98 } });
+
+    const semiScrolledHeader = await screen.findByTestId('case-detail-header');
+    expect(semiScrolledHeader).not.toHaveClass('fixed');
+
+    /*
+    await act(async () => {
+      fireEvent.scroll(app, { target: { scrollY: 1000 } });
+    });
+    */
+    await fireEvent.scroll(app as Element, { target: { scrollTop: 1000 } });
+
+    await waitFor(
+      async () => {
+        const fixedHeader = await screen.findByTestId('case-detail-fixed-header');
+        expect(fixedHeader).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
   });
 });

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
@@ -26,10 +26,7 @@ export default function CaseDetailHeader(props: CaseDetailHeaderProps) {
     if (camsHeader) {
       const caseDetailHeader = document.querySelector('.case-detail-header.fixed');
       const caseDetailH1 = document.querySelector('.case-detail-header h1');
-      console.log('TOP POSITION OF H1 ', caseDetailH1?.getBoundingClientRect().top);
-      console.log('case detail Header section', caseDetailHeader);
       if (caseDetailH1 && caseDetailH1.getBoundingClientRect().top < 0) {
-        console.log('Header should now be fixed', caseDetailH1?.getBoundingClientRect().top);
         fix();
         props.navigationRef.current?.fix();
       } else if (

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
@@ -1,7 +1,9 @@
+import './CaseDetailHeader.scss';
 import { Link } from 'react-router-dom';
 import Icon from '@/lib/components/uswds/Icon';
 import { getCaseNumber } from '@/lib/utils/formatCaseNumber';
 import { CaseDetailType } from '@/lib/type-declarations/chapter-15';
+import { useEffect } from 'react';
 
 export interface CaseDetailHeaderProps {
   isLoading: boolean;
@@ -13,6 +15,21 @@ export default function CaseDetailHeader(props: CaseDetailHeaderProps) {
   const courtInformation = `${props.caseDetail?.courtName} - ${props.caseDetail?.courtDivisionName}`;
   // u00A0 is a non-breaking space. Using &nbsp; in the string literal does not display correctly.
   const chapterInformation = `${props.caseDetail?.petitionLabel} Chapter\u00A0${props.caseDetail?.chapter}`;
+
+  useEffect(() => {
+    const caseH1 = document.querySelector('.case-detail-header h1');
+    const caseSubHeaders = document.querySelector('.case-detail-header .sub-headers');
+    if (caseH1 && caseSubHeaders) {
+      window.addEventListener('scroll', () => {
+        if (caseH1.getBoundingClientRect().bottom <= 20) {
+          if (!caseSubHeaders.classList.contains('fixed')) caseSubHeaders.classList.add('fixed');
+        } else {
+          if (caseSubHeaders.classList.contains('fixed')) caseSubHeaders.classList.remove('fixed');
+        }
+      });
+    }
+  }, [props.isLoading == false]);
+
   return (
     <div className="case-detail-header">
       <div className="grid-row grid-gap-lg">
@@ -50,7 +67,7 @@ export default function CaseDetailHeader(props: CaseDetailHeaderProps) {
       )}
 
       {!props.isLoading && (
-        <div className="grid-row grid-gap-lg" data-testid="h2-with-case-info">
+        <div className="grid-row grid-gap-lg sub-headers" data-testid="h2-with-case-info">
           <div className="grid-col-1"></div>
           <div className="grid-col-2">
             <h2 className="case-number text-no-wrap" title="Case Number">

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
@@ -4,93 +4,166 @@ import Icon from '@/lib/components/uswds/Icon';
 import { getCaseNumber } from '@/lib/utils/formatCaseNumber';
 import { CaseDetailType } from '@/lib/type-declarations/chapter-15';
 import { useEffect } from 'react';
+import useFixedPosition from '@/lib/hooks/UseFixedPosition';
+import { CaseDetailNavigationRef } from './CaseDetailNavigation.d';
 
 export interface CaseDetailHeaderProps {
   isLoading: boolean;
   caseId: string | undefined;
+  navigationRef: React.RefObject<CaseDetailNavigationRef>;
   caseDetail?: CaseDetailType;
 }
 
 export default function CaseDetailHeader(props: CaseDetailHeaderProps) {
+  const { isFixed, fix, loosen } = useFixedPosition();
   const courtInformation = `${props.caseDetail?.courtName} - ${props.caseDetail?.courtDivisionName}`;
   // u00A0 is a non-breaking space. Using &nbsp; in the string literal does not display correctly.
   const chapterInformation = `${props.caseDetail?.petitionLabel} Chapter\u00A0${props.caseDetail?.chapter}`;
+  const appEl = document.querySelector('.App');
+  const camsHeader = document.querySelector('.cams-header');
+
+  const modifyHeader = () => {
+    if (camsHeader) {
+      const caseDetailHeader = document.querySelector('.case-detail-header.fixed');
+      const caseDetailH1 = document.querySelector('.case-detail-header h1');
+      if (caseDetailH1 && caseDetailH1.getBoundingClientRect().top < 0) {
+        fix();
+        props.navigationRef.current?.fix();
+      } else if (
+        caseDetailHeader &&
+        camsHeader.getBoundingClientRect().bottom > caseDetailHeader.getBoundingClientRect().bottom
+      ) {
+        loosen();
+        props.navigationRef.current?.loosen();
+      }
+    }
+  };
 
   useEffect(() => {
-    const caseH1 = document.querySelector('.case-detail-header h1');
-    const caseSubHeaders = document.querySelector('.case-detail-header .sub-headers');
-    if (caseH1 && caseSubHeaders) {
-      window.addEventListener('scroll', () => {
-        if (caseH1.getBoundingClientRect().bottom <= 20) {
-          if (!caseSubHeaders.classList.contains('fixed')) caseSubHeaders.classList.add('fixed');
-        } else {
-          if (caseSubHeaders.classList.contains('fixed')) caseSubHeaders.classList.remove('fixed');
-        }
-      });
+    if (!props.isLoading && appEl && camsHeader) {
+      appEl.addEventListener('scroll', modifyHeader);
     }
   }, [props.isLoading == false]);
 
   return (
-    <div className="case-detail-header">
-      <div className="grid-row grid-gap-lg">
-        <div className="grid-col-1"></div>
-        <div className="grid-col-10">
-          <Link className="back-button" to="/case-assignment">
-            <Icon name="arrow_back"></Icon>
-            Back to Case List
-          </Link>
-        </div>
-        <div className="grid-col-1"></div>
-      </div>
-
-      <div className="grid-row grid-gap-lg">
-        <div className="grid-col-1"></div>
-        <div className="grid-col-10">
-          <h1 data-testid="case-detail-heading">
-            {props.isLoading && <>Loading Case Details...</>}
-            {!props.isLoading && props.caseDetail?.caseTitle}
-          </h1>
-        </div>
-        <div className="grid-col-1"></div>
-      </div>
-
-      {props.isLoading && (
-        <div className="grid-row grid-gap-lg" data-testid="loading-h2">
-          <div className="grid-col-1"></div>
-          <div className="grid-col-10">
-            <h2 className="case-number text-no-wrap" title="Case Number">
-              {getCaseNumber(props.caseId)}
-            </h2>
+    <>
+      {isFixed && (
+        <>
+          <div className="case-detail-header fixed">
+            <div className="grid-row grid-gap-lg">
+              <div className="grid-col-1"></div>
+              <div className="grid-col-10">
+                <Link className="back-button" to="/case-assignment">
+                  <Icon name="arrow_back"></Icon>
+                  Back to Case List
+                </Link>
+              </div>
+            </div>
+            <div className="grid-row grid-gap-lg">
+              <div className="grid-col-1"></div>
+              <div className="grid-col-4">
+                <h3
+                  data-testid="case-detail-heading"
+                  title={`Case Title: ${props.caseDetail?.caseTitle}`}
+                >
+                  {props.caseDetail?.caseTitle}
+                </h3>
+              </div>
+              <div className="grid-col-1">
+                <h3
+                  className="case-number text-no-wrap"
+                  title={`Case Number: ${getCaseNumber(props.caseId)}`}
+                >
+                  {getCaseNumber(props.caseId)}
+                </h3>
+              </div>
+              <div className="grid-col-3">
+                <h3
+                  className="court-name"
+                  title={`Court Name and District: ${courtInformation}`}
+                  data-testid="court-name-and-district"
+                >
+                  {courtInformation}
+                </h3>
+              </div>
+              <div className="grid-col-2">
+                <h3
+                  className="case-chapter"
+                  title={`Case Chapter: ${chapterInformation}`}
+                  data-testid="case-chapter"
+                >
+                  {chapterInformation}
+                </h3>
+              </div>
+              <div className="grid-col-1"></div>
+            </div>
           </div>
-          <div className="grid-col-1"></div>
+          <div className="spacer-fixer"></div>
+        </>
+      )}
+      {!isFixed && (
+        <div className="case-detail-header">
+          <div className="grid-row grid-gap-lg">
+            <div className="grid-col-1"></div>
+            <div className="grid-col-10">
+              <Link className="back-button" to="/case-assignment">
+                <Icon name="arrow_back"></Icon>
+                Back to Case List
+              </Link>
+            </div>
+            <div className="grid-col-1"></div>
+          </div>
+
+          <div className="grid-row grid-gap-lg">
+            <div className="grid-col-1"></div>
+            <div className="grid-col-10">
+              <h1 data-testid="case-detail-heading">
+                {props.isLoading && <>Loading Case Details...</>}
+                {!props.isLoading && props.caseDetail?.caseTitle}
+              </h1>
+            </div>
+            <div className="grid-col-1"></div>
+          </div>
+
+          {props.isLoading && (
+            <div className="grid-row grid-gap-lg" data-testid="loading-h2">
+              <div className="grid-col-1"></div>
+              <div className="grid-col-10">
+                <h2 className="case-number text-no-wrap" title="Case Number">
+                  {getCaseNumber(props.caseId)}
+                </h2>
+              </div>
+              <div className="grid-col-1"></div>
+            </div>
+          )}
+
+          {!props.isLoading && (
+            <div className="grid-row grid-gap-lg" data-testid="h2-with-case-info">
+              <div className="grid-col-1"></div>
+              <div className="grid-col-2">
+                <h2 className="case-number text-no-wrap" title="Case Number">
+                  {getCaseNumber(props.caseId)}
+                </h2>
+              </div>
+              <div className="grid-col-5">
+                <h2
+                  className="court-name"
+                  title="Court Name and District"
+                  data-testid="court-name-and-district"
+                >
+                  {courtInformation}
+                </h2>
+              </div>
+              <div className="grid-col-3">
+                <h2 className="case-chapter" title="Case Chapter" data-testid="case-chapter">
+                  {chapterInformation}
+                </h2>
+              </div>
+              <div className="grid-col-1"></div>
+            </div>
+          )}
         </div>
       )}
-
-      {!props.isLoading && (
-        <div className="grid-row grid-gap-lg sub-headers" data-testid="h2-with-case-info">
-          <div className="grid-col-1"></div>
-          <div className="grid-col-2">
-            <h2 className="case-number text-no-wrap" title="Case Number">
-              {getCaseNumber(props.caseId)}
-            </h2>
-          </div>
-          <div className="grid-col-5">
-            <h2
-              className="court-name"
-              title="Court Name and Distrct"
-              data-testid="court-name-and-district"
-            >
-              {courtInformation}
-            </h2>
-          </div>
-          <div className="grid-col-3">
-            <h2 className="case-chapter" title="Case Chapter" data-testid="case-chapter">
-              {chapterInformation}
-            </h2>
-          </div>
-          <div className="grid-col-1"></div>
-        </div>
-      )}
-    </div>
+    </>
   );
 }

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
@@ -26,7 +26,10 @@ export default function CaseDetailHeader(props: CaseDetailHeaderProps) {
     if (camsHeader) {
       const caseDetailHeader = document.querySelector('.case-detail-header.fixed');
       const caseDetailH1 = document.querySelector('.case-detail-header h1');
+      console.log('TOP POSITION OF H1 ', caseDetailH1?.getBoundingClientRect().top);
+      console.log('case detail Header section', caseDetailHeader);
       if (caseDetailH1 && caseDetailH1.getBoundingClientRect().top < 0) {
+        console.log('Header should now be fixed', caseDetailH1?.getBoundingClientRect().top);
         fix();
         props.navigationRef.current?.fix();
       } else if (
@@ -49,7 +52,7 @@ export default function CaseDetailHeader(props: CaseDetailHeaderProps) {
     <>
       {isFixed && (
         <>
-          <div className="case-detail-header fixed">
+          <div className="case-detail-header fixed" data-testid="case-detail-fixed-header">
             <div className="grid-row grid-gap-lg">
               <div className="grid-col-1"></div>
               <div className="grid-col-10">
@@ -102,7 +105,7 @@ export default function CaseDetailHeader(props: CaseDetailHeaderProps) {
         </>
       )}
       {!isFixed && (
-        <div className="case-detail-header">
+        <div className="case-detail-header" data-testid="case-detail-header">
           <div className="grid-row grid-gap-lg">
             <div className="grid-col-1"></div>
             <div className="grid-col-10">

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.d.ts
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.d.ts
@@ -1,0 +1,4 @@
+export interface CaseDetailNavigationRef {
+  fix: () => void;
+  loosen: () => void;
+}

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.scss
@@ -1,0 +1,4 @@
+.case-details-navigation.fixed {
+  position: fixed;
+  top: 125px;
+}

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import CaseDetailNavigation, { NavState, mapNavState, setCurrentNav } from './CaseDetailNavigation';
 import { BrowserRouter } from 'react-router-dom';
+import { CaseDetailNavigationRef } from './CaseDetailNavigation.d';
+import React from 'react';
 
 describe('Navigation tests', () => {
   const activeNavClass = 'usa-current';
@@ -41,5 +43,30 @@ describe('Navigation tests', () => {
     const result = mapNavState('case-detail/1234/court-docket/');
 
     expect(result).toEqual(NavState.COURT_DOCKET);
+  });
+
+  test('should render with css class name of "case-details-navigation fixed" when ref.fix() is called and "case-details-navigation" when ref.loosen() is called', async () => {
+    const navRef = React.createRef<CaseDetailNavigationRef>();
+    render(
+      <BrowserRouter>
+        <CaseDetailNavigation
+          caseId="12345"
+          initiallySelectedNavLink={NavState.BASIC_INFO}
+          ref={navRef}
+        />
+      </BrowserRouter>,
+    );
+
+    const navigation = document.querySelector('.case-details-navigation');
+
+    navRef.current?.fix();
+    await waitFor(async () => {
+      expect(navigation).toHaveClass('fixed');
+    });
+
+    navRef.current?.loosen();
+    await waitFor(async () => {
+      expect(navigation).not.toHaveClass('fixed');
+    });
   });
 });

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import './CaseDetailNavigation.scss';
+import { useImperativeHandle, useState, forwardRef } from 'react';
 import { Link } from 'react-router-dom';
+import { CaseDetailNavigationRef } from './CaseDetailNavigation.d';
 
 export function mapNavState(path: string) {
   const cleanPath = path.replace(/\/$/, '').split('/');
@@ -25,15 +27,21 @@ export function setCurrentNav(activeNav: NavState, stateToCheck: NavState): stri
   return activeNav === stateToCheck ? 'usa-current' : '';
 }
 
-export default function CaseDetailNavigation({
-  caseId,
-  initiallySelectedNavLink,
-}: CaseDetailNavigationProps) {
+function CaseDetailNavigationComponent(
+  { caseId, initiallySelectedNavLink }: CaseDetailNavigationProps,
+  ref: React.Ref<CaseDetailNavigationRef>,
+) {
   const [activeNav, setActiveNav] = useState<NavState>(initiallySelectedNavLink);
+  const [navClassName, setNavClassName] = useState<string>('');
+
+  useImperativeHandle(ref, () => ({
+    fix: () => setNavClassName('fixed'),
+    loosen: () => setNavClassName(''),
+  }));
 
   return (
     <>
-      <nav aria-label="Side navigation">
+      <nav className={`case-details-navigation ${navClassName}`} aria-label="Side navigation">
         <ul className="usa-sidenav">
           <li className="usa-sidenav__item">
             <Link
@@ -60,3 +68,7 @@ export default function CaseDetailNavigation({
     </>
   );
 }
+
+const CaseDetailNavigation = forwardRef(CaseDetailNavigationComponent);
+
+export default CaseDetailNavigation;

--- a/user-interface/src/lib/hooks/UseFixedPosition.ts
+++ b/user-interface/src/lib/hooks/UseFixedPosition.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+export default function useFixedPosition() {
+  const [isFixed, setIsFixed] = useState(false);
+
+  const loosen = () => {
+    setIsFixed(false);
+  };
+
+  const fix = () => {
+    setIsFixed(true);
+  };
+
+  return {
+    isFixed,
+    loosen,
+    fix,
+  };
+}


### PR DESCRIPTION

# Purpose

Case Details Screen header, which contains the Case Title, number, location, and chapter number and type, should become fixed to the top of the screen whenever the screen is scrolled to the point where the header touches the top of the browser window.

Likewise the Case Detail Navigation menu at the left should become fixed.

The header and navigation should then go back to normal once the screen is scrolled down enough for the BLUE app header peaks out under the Case Details Screen Header.

# Major Changes

A lot... ?  Handling for screen manipulation via useEffect and watching scroll events to either render a new component to replace one on screen, or add css classes to components.  The animation and style changes are handled in SCSS files.

# Testing/Validation

Testing was added to ensure that components were properly replaced and/or css classes were properly added and removed after scrolling to various points on the screen.

# Notes

In the tests, we had to override getBoundingClientRect() for various elements, due to jsdom not updating the information properly.
