### PR TITLE
CAMS-257 get cases with documents

### DIFF
--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -9,5 +9,6 @@ export interface FeatureFlagSet {
 
 export const defaultFeatureFlags: FeatureFlagSet = {
   'chapter-twelve-enabled': false,
+  'chapter-eleven-enabled': false,
   'docket-search-enabled': true,
 };

--- a/user-interface/src/case-assignment/AssignAttorneyModal.tsx
+++ b/user-interface/src/case-assignment/AssignAttorneyModal.tsx
@@ -9,7 +9,10 @@ import { Attorney, AttorneyInfo } from '@/lib/type-declarations/attorneys';
 import Api from '../lib/models/api';
 import { ModalRefType } from '../lib/components/uswds/modal/modal-refs';
 import { getCaseNumber } from '@/lib/utils/formatCaseNumber';
-import useFeatureFlags, { CHAPTER_TWELVE_ENABLED } from '../lib/hooks/UseFeatureFlags';
+import useFeatureFlags, {
+  CHAPTER_ELEVEN_ENABLED,
+  CHAPTER_TWELVE_ENABLED,
+} from '../lib/hooks/UseFeatureFlags';
 import { getFullName } from '@common/name-helper';
 
 export interface AssignAttorneyModalProps {
@@ -44,7 +47,9 @@ function AssignAttorneyModalComponent(
     </>
   );
   const chapterTwelveEnabled = flags[CHAPTER_TWELVE_ENABLED];
-  const caseLoadLabel = chapterTwelveEnabled ? 'Case Load' : 'Chapter 15 Cases';
+  const chapterElevenEnabled = flags[CHAPTER_ELEVEN_ENABLED];
+  const caseLoadLabel =
+    chapterTwelveEnabled || chapterElevenEnabled ? 'Case Load' : 'Chapter 15 Cases';
 
   const [initialDocumentBodyStyle, setInitialDocumentBodyStyle] = useState<string>('');
   const [checkListValues, setCheckListValues] = useState<string[]>([]);

--- a/user-interface/src/case-assignment/CaseAssignmentScreen.test.tsx
+++ b/user-interface/src/case-assignment/CaseAssignmentScreen.test.tsx
@@ -240,6 +240,13 @@ describe('CaseAssignment Component Tests', () => {
                 dateFiled: '2023-04-14',
                 assignments: [],
               },
+              {
+                caseId: '081-23-44455',
+                chapter: '11',
+                caseTitle: 'Foo Bar',
+                dateFiled: '2023-04-14',
+                assignments: [],
+              },
             ],
           },
         });
@@ -254,7 +261,7 @@ describe('CaseAssignment Component Tests', () => {
     await waitFor(() => {
       const unassignedTableBody = screen.getAllByTestId('unassigned-table-body');
       const unassignedData = unassignedTableBody[0].querySelectorAll('tr');
-      expect(unassignedData).toHaveLength(2);
+      expect(unassignedData).toHaveLength(3);
       const assignedTableBody = screen.getAllByTestId('assigned-table-body');
       const assignedData = assignedTableBody[0].querySelectorAll('tr');
       expect(assignedData).toHaveLength(2);
@@ -631,13 +638,11 @@ describe('CaseAssignment Component Tests', () => {
       await waitFor(() => {
         const screenTitle = screen.getByTestId('case-list-heading');
         expect(screenTitle).toBeInTheDocument();
-        expect(screenTitle.innerHTML).toEqual('Chapter 15 Bankruptcy Cases');
+        expect(screenTitle.innerHTML).toEqual('Bankruptcy Cases');
       });
     });
 
-    test('should contain chapter column when true', async () => {
-      vi.spyOn(FeatureFlags, 'default').mockReturnValue({ 'chapter-twelve-enabled': true });
-
+    test('should display correct chapter number', async () => {
       render(
         <BrowserRouter>
           <CaseAssignment />
@@ -651,37 +656,18 @@ describe('CaseAssignment Component Tests', () => {
           expect(e.innerHTML).toEqual('Chapter');
         }
 
-        const unassignedTableData = screen.getByTestId('081-23-44460-chapter');
-        expect(unassignedTableData).toBeInTheDocument();
-        expect(unassignedTableData.innerHTML).toContain('12');
+        const chapterElevenTableData = screen.getByTestId('081-23-44455-chapter');
+        expect(chapterElevenTableData).toBeInTheDocument();
+        expect(chapterElevenTableData.innerHTML).toContain('11');
 
-        const assignedTableData = screen.getByTestId('081-23-44461-chapter');
-        expect(assignedTableData).toBeInTheDocument();
-        expect(assignedTableData.innerHTML).toContain('15');
+        const chapterTwelveTableData = screen.getByTestId('081-23-44460-chapter');
+        expect(chapterTwelveTableData).toBeInTheDocument();
+        expect(chapterTwelveTableData.innerHTML).toContain('12');
+
+        const chapterFifteenTableData = screen.getByTestId('081-23-44461-chapter');
+        expect(chapterFifteenTableData).toBeInTheDocument();
+        expect(chapterFifteenTableData.innerHTML).toContain('15');
       });
-    });
-
-    test('should not contain chapter column when false', async () => {
-      vi.spyOn(FeatureFlags, 'default').mockReturnValue({ 'chapter-twelve-enabled': false });
-
-      render(
-        <BrowserRouter>
-          <CaseAssignment />
-        </BrowserRouter>,
-      );
-
-      await waitFor(() => {
-        const unassignedTable = screen.getByTestId('unassigned-table');
-        expect(unassignedTable).toBeInTheDocument();
-      });
-
-      expect(screen.queryByTestId('chapter-table-header')).not.toBeInTheDocument();
-
-      const unassignedTableData = screen.queryByTestId('081-23-44460-chapter');
-      expect(unassignedTableData).not.toBeInTheDocument();
-
-      const assignedTableData = screen.queryByTestId('081-23-44461-chapter');
-      expect(assignedTableData).not.toBeInTheDocument();
     });
   });
 });

--- a/user-interface/src/case-assignment/CaseAssignmentScreen.tsx
+++ b/user-interface/src/case-assignment/CaseAssignmentScreen.tsx
@@ -3,14 +3,13 @@ import { useState, useEffect, useRef } from 'react';
 import Api from '../lib/models/api';
 import { Chapter15Type, Chapter15CaseListResponseData } from '@/lib/type-declarations/chapter-15';
 import MockApi from '../lib/models/chapter15-mock.api.cases';
-import { ToggleModalButton } from '../lib/components/uswds/modal/ToggleModalButton';
+import { ToggleModalButton } from '@/lib/components/uswds/modal/ToggleModalButton';
 import AssignAttorneyModal, { CallBackProps } from './AssignAttorneyModal';
-import { ModalRefType } from '../lib/components/uswds/modal/modal-refs';
+import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 import Alert, { AlertRefType, UswdsAlertStyle } from '../lib/components/uswds/Alert';
 import AttorneysApi from '../lib/models/attorneys-api';
 import { Attorney } from '@/lib/type-declarations/attorneys';
 import { getCaseNumber } from '@/lib/utils/formatCaseNumber';
-import useFeatureFlags, { CHAPTER_TWELVE_ENABLED } from '../lib/hooks/UseFeatureFlags';
 
 const modalId = 'assign-attorney-modal';
 
@@ -21,12 +20,10 @@ interface Chapter15Node extends Chapter15Type {
 const TABLE_TRANSFER_TIMEOUT = 10;
 
 export const CaseAssignment = () => {
-  const flags = useFeatureFlags();
   const modalRef = useRef<ModalRefType>(null);
   const alertRef = useRef<AlertRefType>(null);
   const api = import.meta.env['CAMS_PA11Y'] === 'true' ? MockApi : Api;
-  const chapterTwelveEnabled = flags[CHAPTER_TWELVE_ENABLED];
-  const screenTitle = chapterTwelveEnabled ? 'Bankruptcy Cases' : 'Chapter 15 Bankruptcy Cases';
+  const screenTitle = 'Bankruptcy Cases';
   const regionId = 2;
   const officeName = 'Manhattan';
   const subTitle = `Region ${regionId} (${officeName} Office)`;
@@ -208,11 +205,9 @@ export const CaseAssignment = () => {
                           <th scope="col" role="columnheader">
                             Case Number
                           </th>
-                          {chapterTwelveEnabled && (
-                            <th scope="col" role="columnheader" data-testid="chapter-table-header">
-                              Chapter
-                            </th>
-                          )}
+                          <th scope="col" role="columnheader" data-testid="chapter-table-header">
+                            Chapter
+                          </th>
                           <th scope="col" role="columnheader">
                             Case Title (Debtor)
                           </th>
@@ -266,12 +261,10 @@ export const CaseAssignment = () => {
                                     {getCaseNumber(theCase.caseId)}
                                   </a>
                                 </td>
-                                {chapterTwelveEnabled && (
-                                  <td className="chapter" data-testid={`${theCase.caseId}-chapter`}>
-                                    <span className="mobile-title">Chapter:</span>
-                                    {theCase.chapter}
-                                  </td>
-                                )}
+                                <td className="chapter" data-testid={`${theCase.caseId}-chapter`}>
+                                  <span className="mobile-title">Chapter:</span>
+                                  {theCase.chapter}
+                                </td>
                                 <td className="case-title-column">
                                   <span className="mobile-title">Case Title (Debtor):</span>
                                   {theCase.caseTitle}
@@ -314,11 +307,9 @@ export const CaseAssignment = () => {
                           <th scope="col" role="columnheader">
                             Case Number
                           </th>
-                          {chapterTwelveEnabled && (
-                            <th scope="col" role="columnheader" data-testid="chapter-table-header">
-                              Chapter
-                            </th>
-                          )}
+                          <th scope="col" role="columnheader" data-testid="chapter-table-header">
+                            Chapter
+                          </th>
                           <th scope="col" role="columnheader">
                             Case Title (Debtor)
                           </th>
@@ -379,12 +370,10 @@ export const CaseAssignment = () => {
                                     {getCaseNumber(theCase.caseId)}
                                   </a>
                                 </td>
-                                {chapterTwelveEnabled && (
-                                  <td className="chapter" data-testid={`${theCase.caseId}-chapter`}>
-                                    <span className="mobile-title">Chapter:</span>
-                                    {theCase.chapter}
-                                  </td>
-                                )}
+                                <td className="chapter" data-testid={`${theCase.caseId}-chapter`}>
+                                  <span className="mobile-title">Chapter:</span>
+                                  {theCase.chapter}
+                                </td>
                                 <td className="case-title-column">
                                   <span className="mobile-title">Case Title (Debtor):</span>
                                   {theCase.caseTitle}

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -2,6 +2,7 @@ import { useFlags } from 'launchdarkly-react-client-sdk';
 import config from '@/configuration/featureFlagConfiguration';
 import { defaultFeatureFlags, FeatureFlagSet } from '@common/feature-flags';
 
+export const CHAPTER_ELEVEN_ENABLED = 'chapter-eleven-enabled';
 export const CHAPTER_TWELVE_ENABLED = 'chapter-twelve-enabled';
 export const DOCKET_SEARCH_ENABLED = 'docket-search-enabled';
 

--- a/user-interface/src/lib/models/chapter15-mock.api.cases.ts
+++ b/user-interface/src/lib/models/chapter15-mock.api.cases.ts
@@ -48,6 +48,11 @@ export default class Chapter15MockApi extends Api {
       caseTitle: 'Marilyn Lang and Rudy Bryant',
       dateFiled: '01-04-2023',
     },
+    {
+      caseId: '101-23-44455',
+      caseTitle: 'Justin Long and Michael Cera',
+      dateFiled: '02-07-2023',
+    },
   ];
 
   static caseDocketEntries: CaseDocketEntry[] = [


### PR DESCRIPTION
# Purpose

For demo purposes, we wanted the cases displayed in the Case Assignment screen to be more likely to have viewable documents. 

# Major Changes

- Adds a feature flag to enable chapter 11. When set, we retrieve the top 10 chapter 11 results in addition to chapter 15 (and chapter 12 if it is enabled).
- Modifies the query to get the case list to order by filed date, newest first.
- Case Assignment screen no longer changes based on feature flags (the Assign Attorney modal still does)

# Testing/Validation

- Updated automated tests.
- Modified some Flexion data to reflect some chapter 11 data when enabled.
- Deployed to USTP environment and validated view.
