### PR TITLE
CAMS-259: Add state variable for tracking docket api call

### DIFF
--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -101,6 +101,7 @@ export function getSummaryFacetList(facets: CaseDocketSummaryFacets) {
 export const CaseDetail = (props: CaseDetailProps) => {
   const { caseId } = useParams();
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isDocketLoading, setIsDocketLoading] = useState<boolean>(false);
   const api = import.meta.env['CAMS_PA11Y'] === 'true' ? MockApi : Api;
   const [caseBasicInfo, setCaseBasicInfo] = useState<CaseDetailType>();
   const [caseDocketEntries, setCaseDocketEntries] = useState<CaseDocketEntry[]>();
@@ -132,6 +133,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
   };
 
   const fetchCaseDocketEntries = async () => {
+    setIsDocketLoading(true);
     api
       .get(`/cases/${caseId}/docket`, {})
       .then((data) => {
@@ -142,6 +144,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
           new Map(),
         );
         setCaseDocketSummaryFacets(facets);
+        setIsDocketLoading(false);
       })
       .catch(() => {
         setCaseDocketEntries([]);
@@ -325,7 +328,8 @@ export const CaseDetail = (props: CaseDetailProps) => {
                             sortDirection,
                           })}
                           searchString={searchString}
-                          hasDocketEntries={caseDocketEntries && caseDocketEntries?.length > 1}
+                          hasDocketEntries={!!caseDocketEntries && caseDocketEntries?.length > 1}
+                          isDocketLoading={isDocketLoading}
                         />
                       }
                     />

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -148,6 +148,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
       })
       .catch(() => {
         setCaseDocketEntries([]);
+        setIsDocketLoading(false);
       });
   };
 

--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.test.tsx
@@ -39,10 +39,16 @@ describe('court docket panel tests', () => {
   ];
   const firstIndex = 0;
 
-  test('should render loading info when isLoading is true', () => {
+  test('should render loading info when isDocketLoading is true', () => {
     render(
       <BrowserRouter>
-        <CaseDetailCourtDocket caseId="081-12-12345" docketEntries={undefined} searchString="" />
+        <CaseDetailCourtDocket
+          caseId="081-12-12345"
+          docketEntries={undefined}
+          searchString=""
+          hasDocketEntries={false}
+          isDocketLoading={true}
+        />
       </BrowserRouter>,
     );
 
@@ -60,6 +66,7 @@ describe('court docket panel tests', () => {
           docketEntries={docketEntries}
           searchString=""
           hasDocketEntries={true}
+          isDocketLoading={false}
         />
       </BrowserRouter>,
     );
@@ -141,6 +148,7 @@ describe('court docket panel tests', () => {
             docketEntries={[]}
             searchString=""
             hasDocketEntries={false}
+            isDocketLoading={false}
           />
         </BrowserRouter>,
       );
@@ -161,6 +169,7 @@ describe('court docket panel tests', () => {
             docketEntries={docketEntries}
             searchString=""
             hasDocketEntries={true}
+            isDocketLoading={false}
           />
         </BrowserRouter>,
       );

--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import LoadingIndicator from '@/lib/components/LoadingIndicator';
 import {
   CaseDocketEntry,
@@ -16,7 +16,8 @@ export interface CaseDetailCourtDocketProps {
   caseId?: string;
   docketEntries?: CaseDocketEntry[];
   searchString: string;
-  hasDocketEntries?: boolean;
+  hasDocketEntries: boolean;
+  isDocketLoading: boolean;
 }
 
 export function fileSizeDescription(fileSize: number): string {
@@ -49,12 +50,10 @@ export function generateDocketFilenameDisplay(linkInfo: CaseDocketEntryDocument)
 export default function CaseDetailCourtDocket(props: CaseDetailCourtDocketProps) {
   const { docketEntries, hasDocketEntries } = props;
   // TODO: Replace use of useEffect for handling loading with useTransition
-  const [isLoading, setIsLoading] = useState(true);
   const alertRef = useRef<AlertRefType>(null);
 
   useEffect(() => {
-    setIsLoading(!docketEntries);
-    if (!hasDocketEntries) {
+    if (!props.isDocketLoading && !hasDocketEntries) {
       alertRef.current?.show(true);
     }
   }, [docketEntries]);
@@ -66,8 +65,8 @@ export default function CaseDetailCourtDocket(props: CaseDetailCourtDocketProps)
   return (
     <div id="case-detail-court-docket-panel">
       <div id="searchable-docket" data-testid="searchable-docket">
-        {isLoading && <LoadingIndicator />}
-        {!isLoading &&
+        {props.isDocketLoading && <LoadingIndicator />}
+        {!props.isDocketLoading &&
           hasDocketEntries &&
           docketEntries?.map((docketEntry: CaseDocketEntry, idx: number) => {
             return (


### PR DESCRIPTION
Jira ticket: CAMS-259

# Problem

When a case has a large number of docket entries and the call to get the docket record takes sufficiently longer than the call to get basic info, we were momentarily displaying the alert as if the case had no docket entries.

# Solution

When calculating `hasDocketEntries` for the docket panel, we passed `false` if the array did not exist yet. We could have passed true until it existed and then calculate it based on length, but we preferred to use an `isDocketLoading` state variable to be passed in the properties as well. 

# Testing/Validation

- Updated automated tests
- Triggered the error by temporarily adding a long wait to the call to docket
  - Validated that behavior was as observed in USTP environment
  - Validated that after the changes, no alert was displayed if docket entries exist, but is displayed if they do not
