### PR TITLE
CAMS-255: Fix label for document-number-search-field

### DIFF
--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -320,7 +320,9 @@ export const CaseDetail = (props: CaseDetailProps) => {
                         data-testid="docket-number-search"
                       >
                         <div className="usa-search usa-search--small">
-                          <label htmlFor="search-by-document-number">Go to Document Number</label>
+                          <label htmlFor="document-number-search-field">
+                            Go to Document Number
+                          </label>
                           <IconInput
                             pattern="^[0-9]*$"
                             inputmode="numeric"


### PR DESCRIPTION
# Purpose

Screen readers were not reading the label for the document number filter.

# Major Changes

Set the `htmlFor` correctly (i.e. the `id` of the input, not the `name`).

# Testing/Validation

Ran a screen reader locally and validated that the label is now read.