### PR TITLE
CAMS-146 Add retry to webapp code deploy job

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -443,11 +443,15 @@ jobs:
           in: ${{ needs.build-info.outputs.azResourceGrpAppEncrypted }}
 
       - name: Deploy to Azure WebApp
-        run: |
-          ./ops/scripts/pipeline/az-app-deploy.sh \
-          --src ./${{ needs.build-info.outputs.webappName }}.tar \
-          -g ${{ steps.rgApp.outputs.out }} \
-          -n ${{ needs.build-info.outputs.webappName }}
+        uses: nick-fields/retry@2
+        with:
+          timeout_minutes: 10 # Expect deployment to take no longer than 10 minutes
+          max_attempts: 2
+          command: |
+            ./ops/scripts/pipeline/az-app-deploy.sh \
+            --src ./${{ needs.build-info.outputs.webappName }}.tar \
+            -g ${{ steps.rgApp.outputs.out }} \
+            -n ${{ needs.build-info.outputs.webappName }}
 
   deploy-service:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -443,7 +443,7 @@ jobs:
           in: ${{ needs.build-info.outputs.azResourceGrpAppEncrypted }}
 
       - name: Deploy to Azure WebApp
-        uses: nick-fields/retry@2
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10 # Expect deployment to take no longer than 10 minutes
           max_attempts: 2


### PR DESCRIPTION
# Purpose

Intermittent failure sometimes occur during deployment that is not related to recent changes. In most cases, retrying will work the second time but this requires manual intervention.

# Major Changes
- Automate retry of webapp code deployment in an event of a failure

# Testing/Validation

- Verified that retry implementation works, see following [run](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/7136112398/job/19434284171)

# Notes

New GHA action added. See following actions, https://github.com/nick-fields/retry
