### PR TITLE
corrected typo in APPI connection string

### DIFF
--- a/ops/cloud-deployment/frontend-webapp-deploy.bicep
+++ b/ops/cloud-deployment/frontend-webapp-deploy.bicep
@@ -257,7 +257,7 @@ var applicationSettings = concat([
       value: '~2'
     }
     {
-      name: 'APPlICATIONINSIGHTS_CONNECTION_STRING'
+      name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
       value: appInsights.outputs.connectionString
     }
   ] : []


### PR DESCRIPTION
# Purpose

Ensure application insights is configured correctly for USTP and correct typo in APPLICATIONINSIGHTS_CONNECTION_STRING within frontend deployment

# Major Changes

correct typo in APPLICATIONINSIGHTS_CONNECTION_STRING within frontend deployment

# Testing/Validation

Validated logs coming through on our side and the USTP side

# Notes

Future improvement, we might need to change the threshold on alerts so we do not get them as frequently when we do not need to address them.
