### PR TITLE
CAMS-146: frontend deployment retry

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -441,7 +441,7 @@ jobs:
           --src ./${{ needs.build-info.outputs.webappName }}.tar \
           -g ${{ steps.rgApp.outputs.out }} \
           -n ${{ needs.build-info.outputs.webappName }}
-      - name: Deploy to Azure WebApp
+      - name: Retry Deploy to Azure WebApp
         if: steps.deploy-webapp-step.outcome != 'success'
         run: |
           ./ops/scripts/pipeline/az-app-deploy.sh \

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -339,12 +339,13 @@ jobs:
     needs: [build-info, build-service, build-frontend]
     if: always() && needs.build-frontend != 'success'
     steps:
+      - uses: actions/checkout@v3
       - name: Rerun failed jobs in current workflow
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "Got to retry"
-          gh run rerun ${{github.run_id}} --failed
+          gh run rerun ${{ github.run_id }} --failed
   deploy:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -272,13 +272,6 @@ jobs:
           node-version: 18.17.1
           cache: "npm"
           cache-dependency-path: user-interface/package-lock.json
-      - name: fail build
-        continue-on-error: true
-        id: failbuild
-        run: exit 1
-      - name: retry build
-        id: build2
-        run: echo "in retry"
       - name: Execute Build
         run: |
           pushd ../common
@@ -293,10 +286,6 @@ jobs:
           export CAMS_APPLICATIONINSIGHTS_CONNECTION_STRING="${{ secrets.AZ_APPINSIGHTS_WEBAPP_CONNECTION_STRING }}"
           export CAMS_FEATURE_FLAG_CLIENT_ID="${{ secrets.LD_DEVELOPMENT_CLIENT_ID }}"
           npm run build --if-present
-
-      - name: fail build
-        id: failbuild2
-        run: exit 1
       - name: Execute Coverage
         run: |
           CI=true npm run coverage
@@ -338,20 +327,6 @@ jobs:
           name: ${{ needs.build-info.outputs.apiName }}-build
           path: backend/functions/${{ needs.build-info.outputs.apiName }}.zip
           if-no-files-found: error
-  rerun-failed-build:
-    runs-on: ubuntu-latest
-    needs: [build-info, build-service, build-frontend]
-    if: failure() && needs.build-frontend != 'success'
-    steps:
-      - uses: actions/checkout@v3
-      - name: get current dir
-        run: pwd
-      - name: Rerun failed jobs in current workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "Got to retry"
-          gh run rerun ${{ github.run_id }} --failed
   deploy:
     runs-on: ubuntu-latest
     needs:
@@ -528,13 +503,6 @@ jobs:
           COSMOS_MANAGED_IDENTITY=${{ needs.deploy.outputs.cosmosDbClientId }}" \
           --identities "${{ needs.deploy.outputs.cosmosDbPrincipalId }}" \
           --identitiesResourceGroup ${{ secrets.AZURE_RG }}
-  # rerun-failed-deploy:
-  #   runs-on: ubuntu-latest
-  #   needs: [build-info, deploy, deploy-webapp, deploy-service]
-  #   if: failure() && needs.deploy-webapp.result != 'success' || failure() && needs.deploy-service.result != 'success'
-  #   steps:
-  #     - name: Rerun failed jobs in current workflow
-  #       run: gh run rerun ${{github.run_id}} --failed
   smoke-test-application:
     runs-on: ubuntu-latest
     needs: [build-info, deploy-webapp, deploy-service]

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -337,10 +337,12 @@ jobs:
   rerun-failed-build:
     runs-on: ubuntu-latest
     needs: [build-info, build-service, build-frontend]
-    if: failure() && needs.build-frontend != 'success' || failure() && needs.build-service.result != 'success'
+    if: failure() && needs.build-frontend != 'success'
     steps:
       - name: Rerun failed jobs in current workflow
-        run: gh run rerun ${{github.run_id}} --failed
+        run: |
+          echo "Got to retry"
+          gh run rerun ${{github.run_id}} --failed
   deploy:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -260,11 +260,9 @@ jobs:
     defaults:
       run:
         working-directory: user-interface
-
     runs-on: ubuntu-latest
     needs: [build-info]
     environment: ${{ needs.build-info.outputs.environment }}
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 
@@ -274,7 +272,12 @@ jobs:
           node-version: 18.17.1
           cache: "npm"
           cache-dependency-path: user-interface/package-lock.json
-
+      - name: fail build
+        id: build
+        run: exit 1
+      # - name: retry build
+      #   id: build2
+      #   run: echo "in retry"
       - name: Execute Build
         run: |
           pushd ../common
@@ -293,9 +296,6 @@ jobs:
       - name: Execute Coverage
         run: |
           CI=true npm run coverage
-      - name: fail build
-        id: build
-        run: exit 1
       - name: Package
         run: |
           mkdir artifacts
@@ -337,7 +337,7 @@ jobs:
   rerun-failed-build:
     runs-on: ubuntu-latest
     needs: [build-info, build-service, build-frontend]
-    if: always() && needs.build-frontend != 'success'
+    if: failure() && needs.build-frontend != 'success'
     steps:
       - uses: actions/checkout@v3
       - name: Rerun failed jobs in current workflow
@@ -453,6 +453,15 @@ jobs:
           in: ${{ needs.build-info.outputs.azResourceGrpAppEncrypted }}
 
       - name: Deploy to Azure WebApp
+        id: deploy-webapp-step
+        continue-on-error: true
+        run: |
+          ./ops/scripts/pipeline/az-app-deploy.sh \
+          --src ./${{ needs.build-info.outputs.webappName }}.tar \
+          -g ${{ steps.rgApp.outputs.out }} \
+          -n ${{ needs.build-info.outputs.webappName }}
+      - name: Deploy to Azure WebApp
+        if: steps.deploy-webapp-step.outcome != 'success'
         run: |
           ./ops/scripts/pipeline/az-app-deploy.sh \
           --src ./${{ needs.build-info.outputs.webappName }}.tar \
@@ -496,13 +505,13 @@ jobs:
           COSMOS_MANAGED_IDENTITY=${{ needs.deploy.outputs.cosmosDbClientId }}" \
           --identities "${{ needs.deploy.outputs.cosmosDbPrincipalId }}" \
           --identitiesResourceGroup ${{ secrets.AZURE_RG }}
-  rerun-failed-deploy:
-    runs-on: ubuntu-latest
-    needs: [build-info, deploy, deploy-webapp, deploy-service]
-    if: always() && needs.deploy-webapp.result != 'success' || always() && needs.deploy-service.result != 'success'
-    steps:
-      - name: Rerun failed jobs in current workflow
-        run: gh run rerun ${{github.run_id}} --failed
+  # rerun-failed-deploy:
+  #   runs-on: ubuntu-latest
+  #   needs: [build-info, deploy, deploy-webapp, deploy-service]
+  #   if: always() && needs.deploy-webapp.result != 'success' || always() && needs.deploy-service.result != 'success'
+  #   steps:
+  #     - name: Rerun failed jobs in current workflow
+  #       run: gh run rerun ${{github.run_id}} --failed
   smoke-test-application:
     runs-on: ubuntu-latest
     needs: [build-info, deploy-webapp, deploy-service]

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     environment: ${{ needs.build-info.outputs.environment }}
-
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 
@@ -295,11 +295,7 @@ jobs:
           CI=true npm run coverage
       - name: fail build
         id: build
-        continue-on-error: true
         run: exit 1
-      - name: Retry frontend build
-        if: steps.build.outcome=='failure'
-        run: echo "Made it here"
       - name: Package
         run: |
           mkdir artifacts
@@ -310,14 +306,6 @@ jobs:
           name: ${{ needs.build-info.outputs.webappName }}-build
           path: user-interface/artifacts/
           if-no-files-found: error
-  rerun-failed-webapp-build:
-    runs-on: ubuntu-latest
-    needs: [build-info, build-frontend]
-    if: needs.build-frontend.result != 'success'
-    steps:
-      - name: Rerun failed jobs in current workflow
-        run: gh run rerun ${{github.run_id}} --failed
-
   build-service:
     defaults:
       run:
@@ -337,7 +325,6 @@ jobs:
       - name: Execute Coverage
         run: |
           npm run coverage
-
       - name: Package Application
         run: OUT=${{ needs.build-info.outputs.apiName }} npm run pack
 
@@ -347,7 +334,13 @@ jobs:
           name: ${{ needs.build-info.outputs.apiName }}-build
           path: backend/functions/${{ needs.build-info.outputs.apiName }}.zip
           if-no-files-found: error
-
+  rerun-failed-build:
+    runs-on: ubuntu-latest
+    needs: [build-info, build-service, build-frontend]
+    if: failure() && needs.build-frontend != 'success' || failure() && needs.build-service.result != 'success'
+    steps:
+      - name: Rerun failed jobs in current workflow
+        run: gh run rerun ${{github.run_id}} --failed
   deploy:
     runs-on: ubuntu-latest
     needs:
@@ -455,19 +448,11 @@ jobs:
           in: ${{ needs.build-info.outputs.azResourceGrpAppEncrypted }}
 
       - name: Deploy to Azure WebApp
-        run: exit 1
-        # run: |
-        #   ./ops/scripts/pipeline/az-app-deploy.sh \
-        #   --src ./${{ needs.build-info.outputs.webappName }}.tar \
-        #   -g ${{ steps.rgApp.outputs.out }} \
-        #   -n ${{ needs.build-info.outputs.webappName }}
-  # rerun-failed-webapp-deploy:
-  #   runs-on: ubuntu-latest
-  #   needs: [build-info, deploy, deploy-webapp]
-  #   if: needs.deploy-webapp.result == 'failed'
-  #   steps:
-  #     - name: Rerun failed jobs in current workflow
-  #       run: gh run rerun ${{github.run_id}} --failed
+        run: |
+          ./ops/scripts/pipeline/az-app-deploy.sh \
+          --src ./${{ needs.build-info.outputs.webappName }}.tar \
+          -g ${{ steps.rgApp.outputs.out }} \
+          -n ${{ needs.build-info.outputs.webappName }}
   deploy-service:
     runs-on: ubuntu-latest
     needs: [build-info, deploy]
@@ -506,7 +491,13 @@ jobs:
           COSMOS_MANAGED_IDENTITY=${{ needs.deploy.outputs.cosmosDbClientId }}" \
           --identities "${{ needs.deploy.outputs.cosmosDbPrincipalId }}" \
           --identitiesResourceGroup ${{ secrets.AZURE_RG }}
-
+  rerun-failed-deploy:
+    runs-on: ubuntu-latest
+    needs: [build-info, deploy, deploy-webapp, deploy-service]
+    if: failure() && needs.deploy-webapp.result != 'success' || failure() && needs.deploy-service.result != 'success'
+    steps:
+      - name: Rerun failed jobs in current workflow
+        run: gh run rerun ${{github.run_id}} --failed
   smoke-test-application:
     runs-on: ubuntu-latest
     needs: [build-info, deploy-webapp, deploy-service]

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     environment: ${{ needs.build-info.outputs.environment }}
-    # continue-on-error: true
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 
@@ -499,7 +499,7 @@ jobs:
   rerun-failed-deploy:
     runs-on: ubuntu-latest
     needs: [build-info, deploy, deploy-webapp, deploy-service]
-    if: al() && needs.deploy-webapp.result != 'success' || failure() && needs.deploy-service.result != 'success'
+    if: always() && needs.deploy-webapp.result != 'success' || always() && needs.deploy-service.result != 'success'
     steps:
       - name: Rerun failed jobs in current workflow
         run: gh run rerun ${{github.run_id}} --failed

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -444,6 +444,7 @@ jobs:
       - name: Retry Deploy to Azure WebApp
         if: steps.deploy-webapp-step.outcome != 'success'
         run: |
+          sleep 30s &&
           ./ops/scripts/pipeline/az-app-deploy.sh \
           --src ./${{ needs.build-info.outputs.webappName }}.tar \
           -g ${{ steps.rgApp.outputs.out }} \
@@ -491,6 +492,7 @@ jobs:
       - name: Retry Deploy Azure Functions backend
         if: steps.deploy-backend-step.outcome != 'success'
         run: |
+          sleep 30s &&
           ./ops/scripts/pipeline/az-func-deploy.sh \
           -g ${{ steps.rgApp.outputs.out }} \
           -n ${{ needs.build-info.outputs.apiName }} \

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -273,11 +273,12 @@ jobs:
           cache: "npm"
           cache-dependency-path: user-interface/package-lock.json
       - name: fail build
-        id: build
+        continue-on-error: true
+        id: failbuild
         run: exit 1
-      # - name: retry build
-      #   id: build2
-      #   run: echo "in retry"
+      - name: retry build
+        id: build2
+        run: echo "in retry"
       - name: Execute Build
         run: |
           pushd ../common
@@ -293,6 +294,9 @@ jobs:
           export CAMS_FEATURE_FLAG_CLIENT_ID="${{ secrets.LD_DEVELOPMENT_CLIENT_ID }}"
           npm run build --if-present
 
+      - name: fail build
+        id: failbuild2
+        run: exit 1
       - name: Execute Coverage
         run: |
           CI=true npm run coverage

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-info]
     environment: ${{ needs.build-info.outputs.environment }}
-    continue-on-error: true
+    # continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 
@@ -498,7 +498,7 @@ jobs:
   rerun-failed-deploy:
     runs-on: ubuntu-latest
     needs: [build-info, deploy, deploy-webapp, deploy-service]
-    if: failure() && needs.deploy-webapp.result != 'success' || failure() && needs.deploy-service.result != 'success'
+    if: al() && needs.deploy-webapp.result != 'success' || failure() && needs.deploy-service.result != 'success'
     steps:
       - name: Rerun failed jobs in current workflow
         run: gh run rerun ${{github.run_id}} --failed

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -293,18 +293,25 @@ jobs:
       - name: Execute Coverage
         run: |
           CI=true npm run coverage
-
+      - name: fail build
+        run: exit 1
       - name: Package
         run: |
           mkdir artifacts
           tar -cvf artifacts/${{ needs.build-info.outputs.webappName }}.tar ./build
-
       - name: Upload Frontend Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ needs.build-info.outputs.webappName }}-build
           path: user-interface/artifacts/
           if-no-files-found: error
+  rerun-failed-webapp-build:
+    runs-on: ubuntu-latest
+    needs: [build-info, build-frontend]
+    if: needs.build-frontend.result != 'success'
+    steps:
+      - name: Rerun failed jobs in current workflow
+        run: gh run rerun ${{github.run_id}} --failed
 
   build-service:
     defaults:
@@ -443,12 +450,19 @@ jobs:
           in: ${{ needs.build-info.outputs.azResourceGrpAppEncrypted }}
 
       - name: Deploy to Azure WebApp
-        run: |
-          ./ops/scripts/pipeline/az-app-deploy.sh \
-          --src ./${{ needs.build-info.outputs.webappName }}.tar \
-          -g ${{ steps.rgApp.outputs.out }} \
-          -n ${{ needs.build-info.outputs.webappName }}
-
+        run: exit 1
+        # run: |
+        #   ./ops/scripts/pipeline/az-app-deploy.sh \
+        #   --src ./${{ needs.build-info.outputs.webappName }}.tar \
+        #   -g ${{ steps.rgApp.outputs.out }} \
+        #   -n ${{ needs.build-info.outputs.webappName }}
+  # rerun-failed-webapp-deploy:
+  #   runs-on: ubuntu-latest
+  #   needs: [build-info, deploy, deploy-webapp]
+  #   if: needs.deploy-webapp.result == 'failed'
+  #   steps:
+  #     - name: Rerun failed jobs in current workflow
+  #       run: gh run rerun ${{github.run_id}} --failed
   deploy-service:
     runs-on: ubuntu-latest
     needs: [build-info, deploy]

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -340,6 +340,8 @@ jobs:
     if: always() && needs.build-frontend != 'success'
     steps:
       - name: Rerun failed jobs in current workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Got to retry"
           gh run rerun ${{github.run_id}} --failed

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -294,7 +294,12 @@ jobs:
         run: |
           CI=true npm run coverage
       - name: fail build
+        id: build
+        continue-on-error: true
         run: exit 1
+      - name: Retry frontend build
+        if: steps.build.outcome=='failure'
+        run: echo "Made it here"
       - name: Package
         run: |
           mkdir artifacts

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -344,6 +344,8 @@ jobs:
     if: failure() && needs.build-frontend != 'success'
     steps:
       - uses: actions/checkout@v3
+      - name: get current dir
+        run: pwd
       - name: Rerun failed jobs in current workflow
         env:
           GH_TOKEN: ${{ github.token }}
@@ -496,6 +498,23 @@ jobs:
           in: ${{ needs.build-info.outputs.azResourceGrpAppEncrypted }}
 
       - name: Deploy Azure Functions backend
+        continue-on-error: true
+        id: deploy-backend-step
+        run: |
+          ./ops/scripts/pipeline/az-func-deploy.sh \
+          -g ${{ steps.rgApp.outputs.out }} \
+          -n ${{ needs.build-info.outputs.apiName }} \
+          --src ./${{ needs.build-info.outputs.apiName }}.zip \
+          --kvName ${{ secrets.AZ_KV_APP_CONFIG_NAME }} \
+          --kvSettings "MSSQL_HOST MSSQL_DATABASE_DXTR MSSQL_CLIENT_ID MSSQL_ENCRYPT MSSQL_TRUST_UNSIGNED_CERT FEATURE_FLAG_SDK_KEY" \
+          --settings "STARTING_MONTH=${{ vars.STARTING_MONTH }} \
+          COSMOS_ENDPOINT=https://${{ secrets.AZ_COSMOS_ACCOUNT_NAME }}.documents.azure.us:443/ \
+          COSMOS_DATABASE_NAME=${{ secrets.AZ_COSMOS_DATABASE_NAME }} \
+          COSMOS_MANAGED_IDENTITY=${{ needs.deploy.outputs.cosmosDbClientId }}" \
+          --identities "${{ needs.deploy.outputs.cosmosDbPrincipalId }}" \
+          --identitiesResourceGroup ${{ secrets.AZURE_RG }}
+      - name: Retry Deploy Azure Functions backend
+        if: steps.deploy-backend-step.outcome != 'success'
         run: |
           ./ops/scripts/pipeline/az-func-deploy.sh \
           -g ${{ steps.rgApp.outputs.out }} \
@@ -512,7 +531,7 @@ jobs:
   # rerun-failed-deploy:
   #   runs-on: ubuntu-latest
   #   needs: [build-info, deploy, deploy-webapp, deploy-service]
-  #   if: always() && needs.deploy-webapp.result != 'success' || always() && needs.deploy-service.result != 'success'
+  #   if: failure() && needs.deploy-webapp.result != 'success' || failure() && needs.deploy-service.result != 'success'
   #   steps:
   #     - name: Rerun failed jobs in current workflow
   #       run: gh run rerun ${{github.run_id}} --failed

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -337,7 +337,7 @@ jobs:
   rerun-failed-build:
     runs-on: ubuntu-latest
     needs: [build-info, build-service, build-frontend]
-    if: failure() && needs.build-frontend != 'success'
+    if: always() && needs.build-frontend != 'success'
     steps:
       - name: Rerun failed jobs in current workflow
         run: |

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -444,7 +444,7 @@ jobs:
       - name: Retry Deploy to Azure WebApp
         if: steps.deploy-webapp-step.outcome != 'success'
         run: |
-          sleep 30s &&
+          sleep 30 &&
           ./ops/scripts/pipeline/az-app-deploy.sh \
           --src ./${{ needs.build-info.outputs.webappName }}.tar \
           -g ${{ steps.rgApp.outputs.out }} \
@@ -492,7 +492,7 @@ jobs:
       - name: Retry Deploy Azure Functions backend
         if: steps.deploy-backend-step.outcome != 'success'
         run: |
-          sleep 30s &&
+          sleep 30 &&
           ./ops/scripts/pipeline/az-func-deploy.sh \
           -g ${{ steps.rgApp.outputs.out }} \
           -n ${{ needs.build-info.outputs.apiName }} \


### PR DESCRIPTION
# Purpose

Add logic to retry deployment steps when they fail for webapp or function deployment

# Major Changes

- addition of steps to run retries when deploying frontend or backend components fails

# Testing/Validation

- ran workflow and tested logic
- deployed app environment to allow testing on an active environment

# Notes

We also have the option of using a separate github job that:
- runs on job failure
- runs **gh run rerun RUN_ID --failed**
            -- runs only failed jobs


