### PR TITLE
CAMS-254 Re-enable pa11y tests. Fix side nav styling.

### DIFF
--- a/user-interface/.pa11yci
+++ b/user-interface/.pa11yci
@@ -19,6 +19,22 @@
     },
     "http://localhost:3000/case-detail/101-23-44461",
     {
+      "url": "http://localhost:3000/case-detail/101-23-44461/court-docket",
+      "actions": [
+        "wait for element [id='searchable-docket'] to be visible",
+        "set field #basic-search-field to Motion",
+        "set field #basic-search-field to joint",
+        "set field #document-number-search-field to 10000",
+        "clear field #document-number-search-field",
+        "click element .cams-multi-select"
+      ],
+      "timeout": 20000,
+      "viewport": {
+        "width": 1280,
+        "height": 2048
+      }
+    },
+    {
       "url": "http://localhost:3000/case-detail/123-12-12345/court-docket",
       "actions": [
         "wait for element [data-testid='alert-container'] to be visible"

--- a/user-interface/src/case-detail/CaseDetailScreen.scss
+++ b/user-interface/src/case-detail/CaseDetailScreen.scss
@@ -1,3 +1,4 @@
+@import '../styles/theme.scss';
 .App {
   .body {
     .case-detail {
@@ -33,9 +34,12 @@
           margin-bottom: 0.5rem;
         }
       }
-      .left-navigation-pane-container.fixed {
+      .case-details-navigation.fixed {
         position: fixed;
-        top: 125px;
+        top: 85px;
+        padding-top: 40px;
+        z-index: 10;
+        background: $cams-theme-background;
       }
     }
   }

--- a/user-interface/src/case-detail/CaseDetailScreen.scss
+++ b/user-interface/src/case-detail/CaseDetailScreen.scss
@@ -34,13 +34,6 @@
           margin-bottom: 0.5rem;
         }
       }
-      .case-details-navigation.fixed {
-        position: fixed;
-        top: 85px;
-        padding-top: 40px;
-        z-index: 10;
-        background: $cams-theme-background;
-      }
     }
   }
 }

--- a/user-interface/src/case-detail/CaseDetailScreen.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.test.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import { describe } from 'vitest';
-import { render, waitFor, screen, queryByTestId, fireEvent } from '@testing-library/react';
+import { render, waitFor, screen, queryByTestId } from '@testing-library/react';
 import { CaseDetail, docketSorterClosure } from './CaseDetailScreen';
 import { getCaseNumber } from '@/lib/utils/formatCaseNumber';
 import {
@@ -672,77 +672,6 @@ describe('Case Detail screen tests', () => {
       expect(caseDocketLink).toHaveClass('usa-current');
     },
   );
-
-  describe('Fixed navigation area', () => {
-    const testCaseDetail: CaseDetailType = {
-      caseId: '080-01-12345',
-      chapter: '15',
-      officeName: 'Redondo Beach',
-      caseTitle: 'The Beach Boys',
-      dateFiled: '01-04-1962',
-      judgeName: 'some judge',
-      debtorTypeLabel: 'Corporate Business',
-      petitionLabel: 'Voluntary Petition',
-      closedDate: '01-08-1963',
-      dismissedDate: '01-08-1964',
-      assignments: [],
-      debtor: {
-        name: 'Roger Rabbit',
-      },
-      debtorAttorney: {
-        name: 'Jane Doe',
-        address1: '123 Rabbithole Lane',
-        cityStateZipCountry: 'Ciudad Obregón GR 25443, MX',
-        phone: '234-123-1234',
-      },
-    };
-
-    test('should fix when scrolled at top of viewport', async () => {
-      render(
-        <BrowserRouter>
-          <div className="App" data-testid="app-component-test-id">
-            <header
-              className="cams-header usa-header-usa-header--basic"
-              style={{ minHeight: '100px', height: '100px' }}
-              data-testid="cams-header-test-id"
-            ></header>
-            <CaseDetail caseDetail={testCaseDetail} />
-            <div style={{ minHeight: '2000px', height: '2000px' }}></div>
-          </div>
-        </BrowserRouter>,
-      );
-
-      const app = await screen.findByTestId('app-component-test-id');
-
-      await waitFor(() => {
-        const pane = document.querySelector('.left-navigation-pane-container');
-        expect(pane).toBeInTheDocument();
-        expect(pane).not.toHaveClass('fixed');
-      });
-
-      const paneBeforeBreak = document.querySelector('.left-navigation-pane-container');
-      expect(paneBeforeBreak).toBeInTheDocument();
-
-      window.HTMLElement.prototype.getBoundingClientRect = () =>
-        ({
-          top: 2,
-        }) as DOMRect;
-      fireEvent.scroll(app as Element, { target: { scrollTop: 98 } });
-
-      expect(paneBeforeBreak).toBeInTheDocument();
-      expect(paneBeforeBreak).not.toHaveClass('fixed');
-
-      window.HTMLElement.prototype.getBoundingClientRect = () =>
-        ({
-          top: -175,
-        }) as DOMRect;
-      fireEvent.scroll(app as Element, { target: { scrollTop: 275 } });
-
-      const paneAfterBreak = document.querySelector('.case-details-navigation');
-      expect(paneAfterBreak).toBeInTheDocument();
-      expect(paneAfterBreak).toHaveClass('fixed');
-    });
-  });
 
   describe('Docket entry sorter', () => {
     const left: CaseDocketEntry = {

--- a/user-interface/src/case-detail/CaseDetailScreen.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.test.tsx
@@ -738,7 +738,7 @@ describe('Case Detail screen tests', () => {
         }) as DOMRect;
       fireEvent.scroll(app as Element, { target: { scrollTop: 275 } });
 
-      const paneAfterBreak = document.querySelector('.left-navigation-pane-container');
+      const paneAfterBreak = document.querySelector('.case-details-navigation');
       expect(paneAfterBreak).toBeInTheDocument();
       expect(paneAfterBreak).toHaveClass('fixed');
     });

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -1,5 +1,5 @@
 import './CaseDetailScreen.scss';
-import { lazy, Suspense, useState, useEffect, useRef, useImperativeHandle } from 'react';
+import { lazy, Suspense, useState, useEffect, useRef } from 'react';
 import { Route, useParams, useLocation, Outlet, Routes } from 'react-router-dom';
 import Api from '../lib/models/api';
 import MockApi from '../lib/models/chapter15-mock.api.cases';
@@ -181,7 +181,6 @@ export const CaseDetail = (props: CaseDetailProps) => {
   const leftNavContainerRef = useRef<CaseDetailScrollPanelRef>(null);
 
   const location = useLocation();
-  const [navigationFixed, setNavigationFixed] = useState<string>('');
   const [navState, setNavState] = useState<number>(mapNavState(location.pathname));
   const [selectedDateRange, setSelectedDateRange] = useState<DateRange>({});
   const [dateRangeBounds, setDateRangeBounds] = useState<DateRange>({});
@@ -285,11 +284,6 @@ export const CaseDetail = (props: CaseDetailProps) => {
     }
   }, [location]);
 
-  useImperativeHandle(leftNavContainerRef, () => ({
-    fix: () => setNavigationFixed('grid-col-2 fixed'),
-    loosen: () => setNavigationFixed(''),
-  }));
-
   const { filteredDocketEntries, alertOptions } = applySortAndFilters(caseDocketEntries, {
     searchInDocketText,
     selectedFacets,
@@ -332,11 +326,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
               <div id="left-gutter" className="grid-col-1"></div>
               <div className="grid-col-2">
                 <div className={'left-navigation-pane-container'}>
-                  <CaseDetailNavigation
-                    caseId={caseId}
-                    initiallySelectedNavLink={navState}
-                    className={navigationFixed}
-                  />
+                  <CaseDetailNavigation caseId={caseId} initiallySelectedNavLink={navState} />
                   {hasDocketEntries && navState === NavState.COURT_DOCKET && (
                     <div
                       className={`filter-and-search padding-y-4`}
@@ -380,6 +370,28 @@ export const CaseDetail = (props: CaseDetailProps) => {
                           />
                         </div>
                       </div>
+                      {filterFeature && (
+                        <div className="docket-summary-facets form-field">
+                          <label>Filter by Summary</label>
+                          <MultiSelect
+                            options={getSummaryFacetList(caseDocketSummaryFacets)}
+                            closeMenuOnSelect={false}
+                            onChange={handleSelectedFacet}
+                            label="Filter by Summary"
+                          ></MultiSelect>
+                        </div>
+                      )}
+                      <div className="in-docket-search form-field" data-testid="docket-date-range">
+                        <DateRangePicker
+                          id="docket-date-range"
+                          startDateLabel="Docket Entries from"
+                          endDateLabel="To"
+                          onStartDateChange={handleStartDateChange}
+                          onEndDateChange={handleEndDateChange}
+                          minDate={dateRangeBounds.start}
+                          maxDate={dateRangeBounds.end}
+                        ></DateRangePicker>
+                      </div>
                       <div
                         className="in-docket-search form-field"
                         data-testid="docket-number-search"
@@ -404,28 +416,6 @@ export const CaseDetail = (props: CaseDetailProps) => {
                           />
                         </div>
                       </div>
-                      <div className="in-docket-search form-field" data-testid="docket-date-range">
-                        <DateRangePicker
-                          id="docket-date-range"
-                          startDateLabel="Docket Entries from"
-                          endDateLabel="To"
-                          onStartDateChange={handleStartDateChange}
-                          onEndDateChange={handleEndDateChange}
-                          minDate={dateRangeBounds.start}
-                          maxDate={dateRangeBounds.end}
-                        ></DateRangePicker>
-                      </div>
-                      {filterFeature && (
-                        <div className="docket-summary-facets form-field">
-                          <label>Filter by Summary</label>
-                          <MultiSelect
-                            options={getSummaryFacetList(caseDocketSummaryFacets)}
-                            closeMenuOnSelect={false}
-                            onChange={handleSelectedFacet}
-                            label="Filter by Summary"
-                          ></MultiSelect>
-                        </div>
-                      )}
                     </div>
                   )}
                 </div>

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -45,9 +45,13 @@ export function findDocketLimits(docket: CaseDocket): DocketLimits {
   const firstEntryWithDocument = docket.find((entry) => {
     return !!entry.documentNumber;
   });
-  const lastEntryWithDocument = docket.findLast((entry) => {
-    return !!entry.documentNumber;
-  });
+  let lastEntryWithDocument = undefined;
+  for (let i = docket.length - 1; i >= 0; i--) {
+    if (docket[i].documentNumber) {
+      lastEntryWithDocument = docket[i];
+      break;
+    }
+  }
 
   documentRange.first = firstEntryWithDocument?.documentNumber || 0;
   documentRange.last = lastEntryWithDocument?.documentNumber || 0;
@@ -177,7 +181,7 @@ export const CaseDetail = (props: CaseDetailProps) => {
   const leftNavContainerRef = useRef<CaseDetailScrollPanelRef>(null);
 
   const location = useLocation();
-  const [leftNavContainerFixed, setLeftNavContainerFixed] = useState<string>('');
+  const [navigationFixed, setNavigationFixed] = useState<string>('');
   const [navState, setNavState] = useState<number>(mapNavState(location.pathname));
   const [selectedDateRange, setSelectedDateRange] = useState<DateRange>({});
   const [dateRangeBounds, setDateRangeBounds] = useState<DateRange>({});
@@ -282,8 +286,8 @@ export const CaseDetail = (props: CaseDetailProps) => {
   }, [location]);
 
   useImperativeHandle(leftNavContainerRef, () => ({
-    fix: () => setLeftNavContainerFixed('grid-col-2 fixed'),
-    loosen: () => setLeftNavContainerFixed(''),
+    fix: () => setNavigationFixed('grid-col-2 fixed'),
+    loosen: () => setNavigationFixed(''),
   }));
 
   const { filteredDocketEntries, alertOptions } = applySortAndFilters(caseDocketEntries, {
@@ -327,8 +331,12 @@ export const CaseDetail = (props: CaseDetailProps) => {
             <div className="grid-row grid-gap-lg">
               <div id="left-gutter" className="grid-col-1"></div>
               <div className="grid-col-2">
-                <div className={'left-navigation-pane-container ' + leftNavContainerFixed}>
-                  <CaseDetailNavigation caseId={caseId} initiallySelectedNavLink={navState} />
+                <div className={'left-navigation-pane-container'}>
+                  <CaseDetailNavigation
+                    caseId={caseId}
+                    initiallySelectedNavLink={navState}
+                    className={navigationFixed}
+                  />
                   {hasDocketEntries && navState === NavState.COURT_DOCKET && (
                     <div
                       className={`filter-and-search padding-y-4`}

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.scss
@@ -21,7 +21,7 @@
   top: 0;
   background-color: #fefefe;
   border: 1px solid #f0f0f0;
-  z-index: 10;
+  z-index: 20;
   box-shadow: 0px 1px 5px #ddd;
   padding-bottom: 1rem;
 

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
@@ -14,6 +14,7 @@ export function mapNavState(path: string) {
 export interface CaseDetailNavigationProps {
   caseId: string | undefined;
   initiallySelectedNavLink: NavState;
+  className?: string;
 }
 
 export enum NavState {
@@ -28,12 +29,13 @@ export function setCurrentNav(activeNav: NavState, stateToCheck: NavState): stri
 function CaseDetailNavigationComponent({
   caseId,
   initiallySelectedNavLink,
+  className,
 }: CaseDetailNavigationProps) {
   const [activeNav, setActiveNav] = useState<NavState>(initiallySelectedNavLink);
 
   return (
     <>
-      <nav className="case-details-navigation" aria-label="Side navigation">
+      <nav className={`case-details-navigation ${className ?? ''}`} aria-label="Side navigation">
         <ul className="usa-sidenav">
           <li className="usa-sidenav__item">
             <Link

--- a/user-interface/src/lib/components/uswds/DateRangePicker.scss
+++ b/user-interface/src/lib/components/uswds/DateRangePicker.scss
@@ -1,0 +1,9 @@
+.cams-date-picker {
+    .usa-form-group:nth-child(1) {
+        margin-top: 0;
+
+        .usa-label:nth-child(1) {
+            margin-top: 0;
+        }
+    }
+}

--- a/user-interface/src/lib/components/uswds/DateRangePicker.tsx
+++ b/user-interface/src/lib/components/uswds/DateRangePicker.tsx
@@ -1,3 +1,4 @@
+import './DateRangePicker.scss';
 import { useState } from 'react';
 
 export interface DateRange {
@@ -36,7 +37,7 @@ export default function DateRangePicker(props: DateRangePickerProps) {
   return (
     <div
       id={id}
-      className="usa-date-range-picker"
+      className="usa-date-range-picker cams-date-picker"
       data-min-date={props.minDate}
       data-max-date={props.maxDate}
     >

--- a/user-interface/src/styles/theme.scss
+++ b/user-interface/src/styles/theme.scss
@@ -1,0 +1,1 @@
+$cams-theme-background: white;


### PR DESCRIPTION
# Purpose

Re-enable pa11y tests. Fix side nav styling.

# Major Changes

* Refactored logic using Array.prototype.findLast
* Re-enabled case docket pa11y test
* Modified styling of docket search components to slip beneath side navigation.

# Testing/Validation

Visually verified style changes. Ran pa11y tests to confirm re-enabled test worked. Existing unit test for bounds function proved the refactor did not change the output of the function.
