### PR TITLE
Remove richard morrissey

### DIFF
--- a/backend/functions/lib/testing/mock-data/attorneys.mock.ts
+++ b/backend/functions/lib/testing/mock-data/attorneys.mock.ts
@@ -36,13 +36,6 @@ const list = {
       office: 'Manhattan',
     },
     {
-      firstName: 'Richard',
-      middleName: 'C',
-      lastName: 'Morrissey',
-      generation: '',
-      office: 'Manhattan',
-    },
-    {
       firstName: 'Andrea',
       middleName: 'B',
       lastName: 'Schwartz',

--- a/backend/functions/lib/testing/mock-data/case-history.mock.ts
+++ b/backend/functions/lib/testing/mock-data/case-history.mock.ts
@@ -85,7 +85,7 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
       {
         documentType: 'ASSIGNMENT',
         caseId: '081-22-84687',
-        name: 'Richard C Morrissey',
+        name: 'Daniel Rudewicz',
         role: 'TrialAttorney',
         assignedOn: '2023-12-14T21:39:26.755Z',
         id: '7a6e1dba-4a27-4c59-85bb-919a6746a676',


### PR DESCRIPTION
# Purpose

Removing Richard C Morrissey from the Attorneys to reduce the risk of upsetting individuals when they are testing the application. 

# Major Changes

Removed Richard from the Attorney list. Changed a test that was assigning Richard.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.
