### PR TITLE
CAMS-262 fix tests

### DIFF
--- a/user-interface/src/App.test.tsx
+++ b/user-interface/src/App.test.tsx
@@ -11,13 +11,19 @@ describe('App', () => {
     );
 
     const app = document.querySelector('.App');
-    expect(app).not.toHaveClass('header-scrolled-out');
+    await waitFor(() => {
+      expect(app).not.toHaveClass('header-scrolled-out');
+    });
 
     fireEvent.scroll(app as Element, { target: { scrollTop: 101 } });
-    expect(app).toHaveClass('header-scrolled-out');
+    await waitFor(() => {
+      expect(app).toHaveClass('header-scrolled-out');
+    });
 
     fireEvent.scroll(app as Element, { target: { scrollTop: 90 } });
-    expect(app).not.toHaveClass('header-scrolled-out');
+    await waitFor(() => {
+      expect(app).not.toHaveClass('header-scrolled-out');
+    });
   });
 
   test('should display scroll button when screen is scrolled beyond 100px', async () => {
@@ -33,12 +39,17 @@ describe('App', () => {
     expect(scrollToTopBtn).not.toHaveClass('show');
 
     fireEvent.scroll(app as Element, { target: { scrollTop: 101 } });
-    expect(scrollToTopBtn).toHaveClass('show');
+    await waitFor(() => {
+      expect(scrollToTopBtn).toHaveClass('show');
+    });
 
     fireEvent.scroll(app as Element, { target: { scrollTop: 90 } });
-    expect(scrollToTopBtn).not.toHaveClass('show');
+    await waitFor(() => {
+      expect(scrollToTopBtn).not.toHaveClass('show');
+    });
   });
 
+  /*
   test('should scroll to top when scroll-to-top button is clicked', async () => {
     render(
       <BrowserRouter>
@@ -49,17 +60,24 @@ describe('App', () => {
     const app = document.querySelector('.App');
     const scrollToTopBtn = document.querySelector('.scroll-to-top-button');
 
-    expect((app as Element).scrollTop).toEqual(0);
-    expect(scrollToTopBtn).not.toHaveClass('show');
+    await waitFor(() => {
+      expect((app as Element).scrollTop).toEqual(0);
+      expect(scrollToTopBtn).not.toHaveClass('show');
+    });
 
     fireEvent.scroll(app as Element, { target: { scrollTop: 101 } });
-    expect((app as Element).scrollTop).toEqual(101);
+    await waitFor(() => {
+      expect((app as Element).scrollTop).toEqual(101);
+    });
 
     fireEvent.click(scrollToTopBtn as Element);
-    expect((app as Element).scrollTop).toEqual(0);
+    await waitFor(() => {
+      expect((app as Element).scrollTop).toEqual(0);
+    });
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(scrollToTopBtn).not.toHaveClass('show');
     });
   });
+  */
 });

--- a/user-interface/src/App.test.tsx
+++ b/user-interface/src/App.test.tsx
@@ -49,7 +49,6 @@ describe('App', () => {
     });
   });
 
-  /*
   test('should scroll to top when scroll-to-top button is clicked', async () => {
     render(
       <BrowserRouter>
@@ -79,5 +78,4 @@ describe('App', () => {
       expect(scrollToTopBtn).not.toHaveClass('show');
     });
   });
-  */
 });

--- a/user-interface/src/App.tsx
+++ b/user-interface/src/App.tsx
@@ -37,7 +37,12 @@ function App() {
       }}
       appInsights={reactPlugin}
     >
-      <div className={appClasses} onScroll={documentScroll} data-testid="app-component-test-id">
+      <div
+        id="app-root"
+        className={appClasses}
+        onScroll={documentScroll}
+        data-testid="app-component-test-id"
+      >
         <Header />
         <div className="body">
           <Routes>

--- a/user-interface/src/App.tsx
+++ b/user-interface/src/App.tsx
@@ -32,8 +32,7 @@ function App() {
 
   return (
     <AppInsightsErrorBoundary
-      onError={(e) => {
-        console.log(e);
+      onError={(_error) => {
         return <h1>Something Went Wrong</h1>;
       }}
       appInsights={reactPlugin}
@@ -48,7 +47,11 @@ function App() {
             <Route path="/review-orders" element={<ReviewOrders />}></Route>
             <Route path="*" element={<NotFound />}></Route>
           </Routes>
-          <ScrollToTopButton className={scrollBtnClass} target={bodyElement} />
+          <ScrollToTopButton
+            className={scrollBtnClass}
+            target={bodyElement}
+            data-testid="scroll-to-top-button"
+          />
         </div>
       </div>
     </AppInsightsErrorBoundary>

--- a/user-interface/src/case-assignment/AssignAttorneyModal.test.tsx
+++ b/user-interface/src/case-assignment/AssignAttorneyModal.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import AssignAttorneyModal, { AssignAttorneyModalRefType } from './AssignAttorneyModal';
 import React from 'react';
@@ -60,43 +60,43 @@ describe('Test Assign Attorney Modal Component', () => {
     const modal = screen.getByTestId(`modal-${modalId}`);
     const submitButton = screen.getByTestId('toggle-modal-button-submit');
 
-    act(() => {
-      fireEvent.click(button);
-    });
+    fireEvent.click(button);
 
-    expect(modal).toHaveClass('is-visible');
-    expect(submitButton).toBeDisabled();
+    await waitFor(() => {
+      expect(modal).toHaveClass('is-visible');
+      expect(submitButton).toBeDisabled();
+    });
 
     const checkbox1 = screen.getByTestId('checkbox-1-checkbox');
     const checkbox2 = screen.getByTestId('checkbox-2-checkbox');
 
-    act(() => {
-      fireEvent.click(checkbox1);
+    fireEvent.click(checkbox1);
+
+    await waitFor(() => {
+      expect(checkbox1).toBeChecked();
+      expect(submitButton).toBeEnabled();
     });
 
-    expect(checkbox1).toBeChecked();
-    expect(submitButton).toBeEnabled();
+    fireEvent.click(checkbox2);
 
-    act(() => {
-      fireEvent.click(checkbox2);
+    await waitFor(() => {
+      expect(checkbox2).toBeChecked();
+      expect(submitButton).toBeEnabled();
     });
 
-    expect(checkbox2).toBeChecked();
-    expect(submitButton).toBeEnabled();
+    fireEvent.click(checkbox1);
 
-    act(() => {
-      fireEvent.click(checkbox1);
+    await waitFor(() => {
+      expect(checkbox1).not.toBeChecked();
+      expect(submitButton).toBeEnabled();
     });
 
-    expect(checkbox1).not.toBeChecked();
-    expect(submitButton).toBeEnabled();
+    fireEvent.click(checkbox2);
 
-    act(() => {
-      fireEvent.click(checkbox2);
+    await waitFor(() => {
+      expect(checkbox2).not.toBeChecked();
+      expect(submitButton).toBeDisabled();
     });
-
-    expect(checkbox2).not.toBeChecked();
-    expect(submitButton).toBeDisabled();
   });
 
   test('Should call POST with list of attorneys when assign button is clicked.', async () => {
@@ -141,36 +141,35 @@ describe('Test Assign Attorney Modal Component', () => {
     const modal = screen.getByTestId(`modal-${modalId}`);
 
     const submitButton = screen.getByTestId('toggle-modal-button-submit');
-    act(() => {
-      fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(modal).toHaveClass('is-visible');
     });
 
-    expect(modal).toHaveClass('is-visible');
     const checkbox1 = screen.getByTestId('checkbox-1-checkbox');
     const checkbox2 = screen.getByTestId('checkbox-2-checkbox');
-
     const checkbox3 = screen.getByTestId('checkbox-3-checkbox');
-    act(() => {
-      fireEvent.click(checkbox1);
-      fireEvent.click(checkbox2);
-      fireEvent.click(checkbox3);
-    });
 
-    act(() => {
-      fireEvent.click(submitButton);
+    fireEvent.click(checkbox1);
+    fireEvent.click(checkbox2);
+    fireEvent.click(checkbox3);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith(
+        '/case-assignments',
+        expect.objectContaining({
+          attorneyList: expect.arrayContaining([
+            getFullName(mark),
+            getFullName(shara),
+            getFullName(brian),
+          ]),
+          caseId: '123',
+          role: 'TrialAttorney',
+        }),
+      );
     });
-    expect(postSpy).toHaveBeenCalledWith(
-      '/case-assignments',
-      expect.objectContaining({
-        attorneyList: expect.arrayContaining([
-          getFullName(mark),
-          getFullName(shara),
-          getFullName(brian),
-        ]),
-        caseId: '123',
-        role: 'TrialAttorney',
-      }),
-    );
   });
 
   describe('Feature flag chapter-twelve-enabled', () => {
@@ -204,16 +203,16 @@ describe('Test Assign Attorney Modal Component', () => {
       const button = screen.getByTestId('toggle-modal-button');
       const modal = screen.getByTestId(`modal-${modalId}`);
 
-      act(() => {
-        fireEvent.click(button);
-      });
+      fireEvent.click(button);
 
       const expectedLabel = 'Case Load';
 
-      expect(modal).toHaveClass('is-visible');
-      const caseLoadLabel = screen.getByTestId(caseLoadLabelTestId);
-      expect(caseLoadLabel).toBeInTheDocument();
-      expect(caseLoadLabel.innerHTML).toEqual(expectedLabel);
+      await waitFor(() => {
+        expect(modal).toHaveClass('is-visible');
+        const caseLoadLabel = screen.getByTestId(caseLoadLabelTestId);
+        expect(caseLoadLabel).toBeInTheDocument();
+        expect(caseLoadLabel.innerHTML).toEqual(expectedLabel);
+      });
 
       const caseLoadTableLabel = screen.getByTestId(caseLoadTableHeaderTestId);
       expect(caseLoadTableLabel).toBeInTheDocument();
@@ -244,16 +243,16 @@ describe('Test Assign Attorney Modal Component', () => {
       const button = screen.getByTestId('toggle-modal-button');
       const modal = screen.getByTestId(`modal-${modalId}`);
 
-      act(() => {
-        fireEvent.click(button);
-      });
+      fireEvent.click(button);
 
       const expectedLabel = 'Chapter 15 Cases';
 
-      expect(modal).toHaveClass('is-visible');
-      const caseLoadLabel = screen.getByTestId(caseLoadLabelTestId);
-      expect(caseLoadLabel).toBeInTheDocument();
-      expect(caseLoadLabel.innerHTML).toEqual(expectedLabel);
+      await waitFor(() => {
+        expect(modal).toHaveClass('is-visible');
+        const caseLoadLabel = screen.getByTestId(caseLoadLabelTestId);
+        expect(caseLoadLabel).toBeInTheDocument();
+        expect(caseLoadLabel.innerHTML).toEqual(expectedLabel);
+      });
 
       const caseLoadTableLabel = screen.getByTestId(caseLoadTableHeaderTestId);
       expect(caseLoadTableLabel).toBeInTheDocument();

--- a/user-interface/src/case-assignment/CaseAssignmentScreen.test.tsx
+++ b/user-interface/src/case-assignment/CaseAssignmentScreen.test.tsx
@@ -407,9 +407,7 @@ describe('CaseAssignment Component Tests', () => {
       { timeout: 1000 },
     ).then(() => {
       passedExpects++;
-      act(() => {
-        fireEvent.click(assignButton);
-      });
+      fireEvent.click(assignButton);
     });
     await sleep(100);
 
@@ -425,15 +423,11 @@ describe('CaseAssignment Component Tests', () => {
     const checkbox1 = screen.getByTestId('checkbox-1-checkbox');
     const checkbox2 = screen.getByTestId('checkbox-2-checkbox');
 
-    act(() => {
-      fireEvent.click(checkbox1);
-      fireEvent.click(checkbox2);
-    });
+    fireEvent.click(checkbox1);
+    fireEvent.click(checkbox2);
 
     const submitButton = screen.getByTestId('toggle-modal-button-submit');
-    act(() => {
-      fireEvent.click(submitButton);
-    });
+    fireEvent.click(submitButton);
     await sleep(100);
 
     const alert = screen.getByTestId('alert');
@@ -565,9 +559,7 @@ describe('CaseAssignment Component Tests', () => {
       { timeout: 1000 },
     ).then(() => {
       passedExpects++;
-      act(() => {
-        fireEvent.click(assignButton);
-      });
+      fireEvent.click(assignButton);
     });
     await sleep(100);
 
@@ -583,15 +575,11 @@ describe('CaseAssignment Component Tests', () => {
     const checkbox1 = screen.getByTestId('checkbox-1-checkbox');
     const checkbox2 = screen.getByTestId('checkbox-2-checkbox');
 
-    act(() => {
-      fireEvent.click(checkbox1);
-      fireEvent.click(checkbox2);
-    });
+    fireEvent.click(checkbox1);
+    fireEvent.click(checkbox2);
 
     const submitButton = screen.getByTestId('toggle-modal-button-submit');
-    act(() => {
-      fireEvent.click(submitButton);
-    });
+    fireEvent.click(submitButton);
 
     const attorneyList = await screen.getByTestId('attorney-list-1');
 

--- a/user-interface/src/case-detail/CaseDetailScreenSortAndFilter.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreenSortAndFilter.test.tsx
@@ -1,5 +1,5 @@
 import { describe } from 'vitest';
-import { render, waitFor, screen, fireEvent, act, within } from '@testing-library/react';
+import { render, waitFor, screen, fireEvent, within } from '@testing-library/react';
 import CaseDetail, {
   applySortAndFilters,
   findDocketLimits,
@@ -90,8 +90,6 @@ describe('Case Detail sort, search, and filter tests', () => {
         </MemoryRouter>,
       );
 
-      let basicInfoLink;
-      let docketEntryLink;
       const sortButtonId = 'docket-entry-sort';
       let sortButton: HTMLElement | null;
       const searchInputId = 'docket-entry-search';
@@ -102,20 +100,22 @@ describe('Case Detail sort, search, and filter tests', () => {
         expect(sortButton).not.toBeInTheDocument();
         searchInput = screen.queryByTestId(searchInputId);
         expect(searchInput).not.toBeInTheDocument();
+        const docketEntryLink = screen.getByTestId('court-docket-link');
+        expect(docketEntryLink).toBeInTheDocument();
       });
 
+      const docketEntryLink = screen.getByTestId('court-docket-link');
+      fireEvent.click(docketEntryLink as Element);
       await waitFor(() => {
-        docketEntryLink = screen.getByTestId('court-docket-link');
-        fireEvent.click(docketEntryLink as Element);
         sortButton = screen.queryByTestId(sortButtonId);
         expect(sortButton).toBeInTheDocument();
         searchInput = screen.queryByTestId(searchInputId);
         expect(searchInput).toBeInTheDocument();
       });
 
+      const basicInfoLink = screen.getByTestId('basic-info-link');
+      fireEvent.click(basicInfoLink as Element);
       await waitFor(() => {
-        basicInfoLink = screen.getByTestId('basic-info-link');
-        fireEvent.click(basicInfoLink as Element);
         sortButton = screen.queryByTestId(sortButtonId);
         expect(sortButton).not.toBeInTheDocument();
         searchInput = screen.queryByTestId(searchInputId);
@@ -153,9 +153,9 @@ describe('Case Detail sort, search, and filter tests', () => {
         expect(searchInput).toBeInTheDocument();
       });
 
+      const basicInfoLink = screen.getByTestId('basic-info-link');
+      fireEvent.click(basicInfoLink as Element);
       await waitFor(() => {
-        const basicInfoLink = screen.getByTestId('basic-info-link');
-        fireEvent.click(basicInfoLink as Element);
         sortButton = screen.queryByTestId(sortButtonId);
         expect(sortButton).not.toBeInTheDocument();
         searchInput = screen.queryByTestId(searchInputId);
@@ -179,8 +179,6 @@ describe('Case Detail sort, search, and filter tests', () => {
         </MemoryRouter>,
       );
 
-      let basicInfoLink;
-      let docketEntryLink;
       const filterSelectClass = '.docket-summary-facets';
       let filterSelectElement: HTMLElement | null;
 
@@ -189,16 +187,16 @@ describe('Case Detail sort, search, and filter tests', () => {
         expect(filterSelectElement).not.toBeInTheDocument();
       });
 
+      const docketEntryLink = screen.getByTestId('court-docket-link');
+      fireEvent.click(docketEntryLink as Element);
       await waitFor(() => {
-        docketEntryLink = screen.getByTestId('court-docket-link');
-        fireEvent.click(docketEntryLink as Element);
         filterSelectElement = document.querySelector(filterSelectClass);
         expect(filterSelectElement).toBeInTheDocument();
       });
 
+      const basicInfoLink = screen.getByTestId('basic-info-link');
+      fireEvent.click(basicInfoLink as Element);
       await waitFor(() => {
-        basicInfoLink = screen.getByTestId('basic-info-link');
-        fireEvent.click(basicInfoLink as Element);
         filterSelectElement = document.querySelector(filterSelectClass);
         expect(filterSelectElement).not.toBeInTheDocument();
       });
@@ -230,9 +228,9 @@ describe('Case Detail sort, search, and filter tests', () => {
         expect(filterSelectElement).toBeInTheDocument();
       });
 
+      const basicInfoLink = screen.getByTestId('basic-info-link');
+      fireEvent.click(basicInfoLink as Element);
       await waitFor(() => {
-        const basicInfoLink = screen.getByTestId('basic-info-link');
-        fireEvent.click(basicInfoLink as Element);
         filterSelectElement = document.querySelector(filterSelectClass);
         expect(filterSelectElement).not.toBeInTheDocument();
       });
@@ -429,11 +427,9 @@ describe('Case Detail sort, search, and filter tests', () => {
       );
 
       let dateRangePicker;
-      let docketEntryLink;
+      const docketEntryLink = screen.getByTestId('court-docket-link');
+      fireEvent.click(docketEntryLink as Element);
       await waitFor(() => {
-        docketEntryLink = screen.getByTestId('court-docket-link');
-        fireEvent.click(docketEntryLink as Element);
-
         const docketListBefore = screen.getByTestId('searchable-docket');
         expect(docketListBefore.children.length).toEqual(testCaseDocketEntries.length);
         dateRangePicker = screen.queryByTestId('docket-date-range');
@@ -442,10 +438,9 @@ describe('Case Detail sort, search, and filter tests', () => {
 
         const docNumberInput = screen.getByTestId('document-number-search-field');
         expect(docNumberInput).toBeInTheDocument();
-        act(() => {
-          fireEvent.change(docNumberInput, { target: { value: '1' } });
-        });
       });
+      const docNumberInput = screen.getByTestId('document-number-search-field');
+      fireEvent.change(docNumberInput, { target: { value: '1' } });
 
       const docketListAfter = screen.getByTestId('searchable-docket');
       expect(docketListAfter.children.length).toEqual(1);
@@ -468,20 +463,19 @@ describe('Case Detail sort, search, and filter tests', () => {
       );
 
       let dateRangePicker;
-      let docketEntryLink;
+      const docketEntryLink = screen.getByTestId('court-docket-link');
+      fireEvent.click(docketEntryLink as Element);
       await waitFor(() => {
-        docketEntryLink = screen.getByTestId('court-docket-link');
-        fireEvent.click(docketEntryLink as Element);
-
         dateRangePicker = screen.queryByTestId('docket-date-range');
         expect(dateRangePicker).toBeInTheDocument();
 
         const docNumberInput = screen.getByTestId('document-number-search-field');
         expect(docNumberInput).toBeInTheDocument();
-        act(() => {
-          fireEvent.change(docNumberInput, { target: { value: '100' } });
-        });
+      });
 
+      const docNumberInput = screen.getByTestId('document-number-search-field');
+      fireEvent.change(docNumberInput, { target: { value: '100' } });
+      await waitFor(() => {
         const alertMessage = screen.getByTestId('alert-message');
         expect(alertMessage).toHaveTextContent(
           'The document number you entered is not found in the docket.',
@@ -506,11 +500,9 @@ describe('Case Detail sort, search, and filter tests', () => {
       );
 
       let dateRangePicker;
-      let docketEntryLink;
+      const docketEntryLink = screen.getByTestId('court-docket-link');
+      fireEvent.click(docketEntryLink as Element);
       await waitFor(() => {
-        docketEntryLink = screen.getByTestId('court-docket-link');
-        fireEvent.click(docketEntryLink as Element);
-
         const docketListBefore = screen.getByTestId('searchable-docket');
         expect(docketListBefore.children.length).toEqual(testCaseDocketEntries.length);
         dateRangePicker = screen.queryByTestId('docket-date-range');
@@ -519,12 +511,11 @@ describe('Case Detail sort, search, and filter tests', () => {
 
         const docNumberInput = screen.getByTestId('document-number-search-field');
         expect(docNumberInput).toBeInTheDocument();
-
-        act(() => {
-          fireEvent.change(docNumberInput, { target: { value: '1' } });
-          fireEvent.change(docNumberInput, { target: { value: '' } });
-        });
       });
+
+      const docNumberInput = screen.getByTestId('document-number-search-field');
+      fireEvent.change(docNumberInput, { target: { value: '1' } });
+      fireEvent.change(docNumberInput, { target: { value: '' } });
 
       const docketListAfter = screen.getByTestId('searchable-docket');
       expect(docketListAfter.children.length).toEqual(testCaseDocketEntries.length);
@@ -549,11 +540,9 @@ describe('Case Detail sort, search, and filter tests', () => {
       );
 
       let dateRangePicker;
-      let docketEntryLink;
+      const docketEntryLink = screen.getByTestId('court-docket-link');
+      fireEvent.click(docketEntryLink as Element);
       await waitFor(() => {
-        docketEntryLink = screen.getByTestId('court-docket-link');
-        fireEvent.click(docketEntryLink as Element);
-
         const docketListBefore = screen.getByTestId('searchable-docket');
         expect(docketListBefore.children.length).toEqual(testCaseDocketEntries.length);
         dateRangePicker = screen.queryByTestId('docket-date-range');
@@ -562,10 +551,10 @@ describe('Case Detail sort, search, and filter tests', () => {
 
         const startDateText = screen.getByTestId('docket-date-range-date-start');
         expect(startDateText).toBeInTheDocument();
-        act(() => {
-          fireEvent.change(startDateText, { target: { value: '2023-07-01' } });
-        });
       });
+
+      const startDateText = screen.getByTestId('docket-date-range-date-start');
+      fireEvent.change(startDateText, { target: { value: '2023-07-01' } });
 
       const docketListAfter = screen.getByTestId('searchable-docket');
       expect(docketListAfter.children.length).toEqual(2);
@@ -588,12 +577,10 @@ describe('Case Detail sort, search, and filter tests', () => {
       );
 
       let dateRangePicker;
-      let docketEntryLink;
 
+      const docketEntryLink = screen.getByTestId('court-docket-link');
+      fireEvent.click(docketEntryLink as Element);
       await waitFor(() => {
-        docketEntryLink = screen.getByTestId('court-docket-link');
-        fireEvent.click(docketEntryLink as Element);
-
         const docketListBefore = screen.getByTestId('searchable-docket');
         expect(docketListBefore.children.length).toEqual(testCaseDocketEntries.length);
         dateRangePicker = screen.queryByTestId('docket-date-range');
@@ -602,10 +589,9 @@ describe('Case Detail sort, search, and filter tests', () => {
 
         const endDateText = screen.getByTestId('docket-date-range-date-end');
         expect(endDateText).toBeInTheDocument();
-        act(() => {
-          fireEvent.change(endDateText, { target: { value: '2023-07-01' } });
-        });
       });
+      const endDateText = screen.getByTestId('docket-date-range-date-end');
+      fireEvent.change(endDateText, { target: { value: '2023-07-01' } });
 
       const docketListAfter = screen.getByTestId('searchable-docket');
       expect(docketListAfter.children.length).toEqual(2);
@@ -629,15 +615,14 @@ describe('Case Detail sort, search, and filter tests', () => {
         </MemoryRouter>,
       );
 
-      let docketEntryLink;
       let sortButton;
 
       sortButton = screen.queryByTestId('docket-entry-sort');
       expect(sortButton).not.toBeInTheDocument();
 
+      const docketEntryLink = screen.getByTestId('court-docket-link');
+      fireEvent.click(docketEntryLink as Element);
       await waitFor(() => {
-        docketEntryLink = screen.getByTestId('court-docket-link');
-        fireEvent.click(docketEntryLink as Element);
         sortButton = screen.queryByTestId('docket-entry-sort');
         expect(sortButton).toBeInTheDocument();
 
@@ -670,24 +655,18 @@ describe('Case Detail sort, search, and filter tests', () => {
       const caseDetailScreen = screen.getByTestId('case-detail');
       expect(caseDetailScreen).toBeInTheDocument();
 
-      act(() => {
-        fireEvent.change(searchInput, { target: { value: 'abc' } });
-        fireEvent.change(startDateText, { target: { value: '2023-07-01' } });
-        fireEvent.change(endDateText, { target: { value: '2023-011-01' } });
-        fireEvent.change(docNumberSearchInput, { target: { value: '1' } });
-        fireEvent.change(docketFacetInput, {
-          target: { value: testCaseDocketEntries[0].summaryText },
-        });
+      fireEvent.change(searchInput, { target: { value: 'abc' } });
+      fireEvent.change(startDateText, { target: { value: '2023-07-01' } });
+      fireEvent.change(endDateText, { target: { value: '2023-011-01' } });
+      fireEvent.change(docNumberSearchInput, { target: { value: '1' } });
+      fireEvent.change(docketFacetInput, {
+        target: { value: testCaseDocketEntries[0].summaryText },
       });
 
       const docketListAfterInput = screen.getByTestId('searchable-docket');
       expect(docketListAfterInput.children.length).toEqual(1);
 
-      await waitFor(() => {
-        act(() => {
-          fireEvent.click(clearFiltersButton as Element);
-        });
-      });
+      fireEvent.click(clearFiltersButton as Element);
 
       const docketListAfterClear = screen.getByTestId('searchable-docket');
       expect(docketListAfterClear.children.length).toEqual(testCaseDocketEntries.length);

--- a/user-interface/src/lib/components/ScrollToTopButton.tsx
+++ b/user-interface/src/lib/components/ScrollToTopButton.tsx
@@ -10,7 +10,12 @@ export interface ScrollToTopButtonProps {
 export default function ScrollToTopButton(props: ScrollToTopButtonProps) {
   function scrollElement(el: Element | null) {
     if (el) {
-      el.scrollTop = 0;
+      const appRoot = document.getElementById('app-root');
+      if (appRoot) {
+        appRoot.scrollTop = 0;
+        const scrollEvent = new CustomEvent('scroll');
+        appRoot.dispatchEvent(scrollEvent);
+      }
     }
   }
 

--- a/user-interface/src/lib/components/uswds/Checkbox.test.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import Checkbox from './Checkbox';
@@ -20,9 +20,7 @@ describe('Test Checkbox component', async () => {
     );
 
     const checkbox = screen.getByTestId('checkbox-checkbox123');
-    act(() => {
-      fireEvent.click(checkbox);
-    });
+    fireEvent.click(checkbox);
     expect(checkboxOnClick).toHaveBeenCalled();
   });
 });

--- a/user-interface/src/lib/components/uswds/DateRangePicker.test.tsx
+++ b/user-interface/src/lib/components/uswds/DateRangePicker.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import DateRangePicker from './DateRangePicker';
 
 describe('Test DateRangePicker component', async () => {
@@ -20,16 +20,13 @@ describe('Test DateRangePicker component', async () => {
 
     const startDateText = screen.getByTestId('date-picker-date-start');
     expect(startDateText).toBeInTheDocument();
-    act(() => {
-      fireEvent.change(startDateText, { target: { value: '2020-01-01' } });
-    });
+
+    fireEvent.change(startDateText, { target: { value: '2020-01-01' } });
     expect(mockHandlerStart).toHaveBeenCalled();
 
     const endDateText = screen.getByTestId('date-picker-date-end');
     expect(endDateText).toBeInTheDocument();
-    act(() => {
-      fireEvent.change(endDateText, { target: { value: '2020-01-01' } });
-    });
+    fireEvent.change(endDateText, { target: { value: '2020-01-01' } });
     expect(mockHandlerEnd).toHaveBeenCalled();
   });
 
@@ -72,34 +69,26 @@ describe('Test DateRangePicker component', async () => {
     expect(startDateText).toHaveAttribute('max', '01/01/2035');
     expect(endDateText).toHaveAttribute('min', '01/01/2020');
 
-    act(() => {
-      fireEvent.change(startDateText, { target: { value: '2022-05-01' } });
-    });
+    fireEvent.change(startDateText, { target: { value: '2022-05-01' } });
 
     startDateText = screen.getByTestId('date-picker-date-start');
     endDateText = screen.getByTestId('date-picker-date-end');
     expect(startDateText).toHaveAttribute('max', '01/01/2035');
     expect(endDateText).toHaveAttribute('min', '2022-05-01');
 
-    act(() => {
-      fireEvent.change(endDateText, { target: { value: '2025-07-01' } });
-    });
+    fireEvent.change(endDateText, { target: { value: '2025-07-01' } });
 
     startDateText = screen.getByTestId('date-picker-date-start');
     endDateText = screen.getByTestId('date-picker-date-end');
     expect(startDateText).toHaveAttribute('max', '2025-07-01');
     expect(endDateText).toHaveAttribute('min', '2022-05-01');
 
-    act(() => {
-      fireEvent.change(startDateText, { target: { value: '' } });
-    });
+    fireEvent.change(startDateText, { target: { value: '' } });
 
     expect(startDateText).toHaveAttribute('max', '2025-07-01');
     expect(endDateText).toHaveAttribute('min', '01/01/2020');
 
-    act(() => {
-      fireEvent.change(endDateText, { target: { value: '' } });
-    });
+    fireEvent.change(endDateText, { target: { value: '' } });
 
     expect(startDateText).toHaveAttribute('max', '01/01/2035');
     expect(endDateText).toHaveAttribute('min', '01/01/2020');

--- a/user-interface/src/lib/components/uswds/Header.test.tsx
+++ b/user-interface/src/lib/components/uswds/Header.test.tsx
@@ -102,9 +102,7 @@ describe('Header', () => {
     );
 
     const linkToClick = await screen.findByTestId('header-review-orders-link');
-    await waitFor(() => {
-      fireEvent.click(linkToClick);
-    });
+    fireEvent.click(linkToClick);
 
     const casesLink = await screen.findByTestId('header-cases-link');
     expect(casesLink).toBeInTheDocument();

--- a/user-interface/src/lib/components/uswds/modal/Modal.test.tsx
+++ b/user-interface/src/lib/components/uswds/modal/Modal.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { ToggleModalButton } from './ToggleModalButton';
@@ -60,9 +60,7 @@ describe('Test Modal component', () => {
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(button);
-    });
+    fireEvent.click(button);
 
     expect(modal).toHaveClass('is-visible');
     expect(modal).not.toHaveClass('is-hidden');
@@ -76,15 +74,11 @@ describe('Test Modal component', () => {
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(button);
-    });
+    fireEvent.click(button);
 
     expect(modal).toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.keyDown(modal, { key: 'Escape', code: 'Escape' });
-    });
+    fireEvent.keyDown(modal, { key: 'Escape', code: 'Escape' });
 
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
@@ -98,16 +92,12 @@ describe('Test Modal component', () => {
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(openButton);
-    });
+    fireEvent.click(openButton);
 
     expect(modal).toHaveClass('is-visible');
 
     const closeButton = screen.getByTestId(`modal-x-button-${modalId}`);
-    act(() => {
-      fireEvent.click(closeButton);
-    });
+    fireEvent.click(closeButton);
 
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
@@ -121,16 +111,12 @@ describe('Test Modal component', () => {
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(openButton);
-    });
+    fireEvent.click(openButton);
 
     expect(modal).toHaveClass('is-visible');
 
     const overlay = screen.getByTestId(`modal-overlay-${modalId}`);
-    act(() => {
-      fireEvent.click(overlay);
-    });
+    fireEvent.click(overlay);
 
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
@@ -144,16 +130,12 @@ describe('Test Modal component', () => {
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(openButton);
-    });
+    fireEvent.click(openButton);
 
     expect(modal).toHaveClass('is-visible');
 
     const cancelButton = screen.getByTestId(`toggle-modal-button-cancel`);
-    act(() => {
-      fireEvent.click(cancelButton);
-    });
+    fireEvent.click(cancelButton);
 
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
@@ -167,15 +149,11 @@ describe('Test Modal component', () => {
     const submitButton = screen.getByTestId('toggle-modal-button-submit');
     const modal = screen.getByTestId(`modal-${modalId}`);
 
-    act(() => {
-      fireEvent.click(openButton);
-    });
+    fireEvent.click(openButton);
 
     expect(modal).toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(submitButton);
-    });
+    fireEvent.click(submitButton);
 
     expect(submitButtonOnClick).toHaveBeenCalled();
   });
@@ -184,9 +162,7 @@ describe('Test Modal component', () => {
     const button = screen.getByTestId('toggle-modal-button-open-test');
     const modalContent = screen.getByTestId(`modal-content-${modalId}`);
 
-    act(() => {
-      fireEvent.click(button);
-    });
+    fireEvent.click(button);
 
     expect(onOpenModal).toHaveBeenCalled();
     expect(modalContent).toHaveFocus();
@@ -237,15 +213,11 @@ describe('Test Modal component with force action', () => {
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(button);
-    });
+    fireEvent.click(button);
 
     expect(modal).toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.keyDown(modal, { key: 'Escape', code: 'Escape' });
-    });
+    fireEvent.keyDown(modal, { key: 'Escape', code: 'Escape' });
 
     expect(modal).not.toHaveClass('is-hidden');
     expect(modal).toHaveClass('is-visible');
@@ -257,9 +229,7 @@ describe('Test Modal component with force action', () => {
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(openButton);
-    });
+    fireEvent.click(openButton);
 
     expect(modal).toHaveClass('is-visible');
 
@@ -278,16 +248,12 @@ describe('Test Modal component with force action', () => {
     expect(modal).toHaveClass('is-hidden');
     expect(modal).not.toHaveClass('is-visible');
 
-    act(() => {
-      fireEvent.click(openButton);
-    });
+    fireEvent.click(openButton);
 
     expect(modal).toHaveClass('is-visible');
 
     const overlay = screen.getByTestId(`modal-overlay-${modalId}`);
-    act(() => {
-      fireEvent.click(overlay);
-    });
+    fireEvent.click(overlay);
 
     expect(modal).not.toHaveClass('is-hidden');
     expect(modal).toHaveClass('is-visible');

--- a/user-interface/src/review-orders/ReviewOrdersScreen.test.tsx
+++ b/user-interface/src/review-orders/ReviewOrdersScreen.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Chapter15MockApi from '@/lib/models/chapter15-mock.api.cases';
 import { OfficeDetails, OrderResponseData } from '@/lib/type-declarations/chapter-15';
 import ReviewOrders, { officeSorter } from './ReviewOrdersScreen';
@@ -173,10 +173,8 @@ describe('Review Orders screen', () => {
       expect(content).not.toBeVisible();
     });
 
-    act(() => {
-      const heading = screen.getByTestId(`accordion-heading-${idx}`);
-      if (heading) fireEvent.click(heading);
-    });
+    const heading = screen.getByTestId(`accordion-heading-${idx}`);
+    if (heading) fireEvent.click(heading);
 
     await waitFor(async () => {
       const content = screen.getByTestId(`accordion-content-${idx}`);
@@ -200,10 +198,8 @@ describe('Review Orders screen', () => {
       expect(content).not.toBeVisible();
     });
 
-    act(() => {
-      const heading = screen.getByTestId(`accordion-heading-${idx}`);
-      if (heading) fireEvent.click(heading);
-    });
+    const heading = screen.getByTestId(`accordion-heading-${idx}`);
+    if (heading) fireEvent.click(heading);
 
     await waitFor(async () => {
       const content = screen.getByTestId(`accordion-content-${idx}`);
@@ -211,14 +207,12 @@ describe('Review Orders screen', () => {
       expect(content).toBeVisible();
     });
 
-    act(() => {
-      const selection = screen.getByTestId(`court-selection-${idx}`);
-      expect(selection).toBeInTheDocument();
-      if (selection) {
-        fireEvent.click(selection);
-        fireEvent.change(selection, { target: { value: '001' } });
-      }
-    });
+    const selection = screen.getByTestId(`court-selection-${idx}`);
+    expect(selection).toBeInTheDocument();
+    if (selection) {
+      fireEvent.click(selection);
+      fireEvent.change(selection, { target: { value: '001' } });
+    }
 
     await waitFor(async () => {
       const preview = screen.getByTestId(`preview-description-${idx}`);
@@ -245,10 +239,8 @@ describe('Review Orders screen', () => {
       expect(content).not.toBeVisible();
     });
 
-    act(() => {
-      const heading = screen.getByTestId(`accordion-heading-${idx}`);
-      if (heading) fireEvent.click(heading);
-    });
+    const heading = screen.getByTestId(`accordion-heading-${idx}`);
+    if (heading) fireEvent.click(heading);
 
     await waitFor(async () => {
       const content = screen.getByTestId(`accordion-content-${idx}`);
@@ -256,14 +248,12 @@ describe('Review Orders screen', () => {
       expect(content).toBeVisible();
     });
 
-    act(() => {
-      const selection = screen.getByTestId(`court-selection-${idx}`);
-      expect(selection).toBeInTheDocument();
-      if (selection) {
-        fireEvent.click(selection);
-        fireEvent.change(selection, { target: { value: '001' } });
-      }
-    });
+    const selection = screen.getByTestId(`court-selection-${idx}`);
+    expect(selection).toBeInTheDocument();
+    if (selection) {
+      fireEvent.click(selection);
+      fireEvent.change(selection, { target: { value: '001' } });
+    }
 
     await waitFor(async () => {
       const preview = screen.getByTestId(`preview-description-${idx}`);
@@ -274,14 +264,11 @@ describe('Review Orders screen', () => {
       );
     });
 
-    act(() => {
-      const selection = screen.getByTestId(`court-selection-${idx}`);
-      expect(selection).toBeInTheDocument();
-      if (selection) {
-        fireEvent.click(selection);
-        fireEvent.change(selection, { target: { value: '' } });
-      }
-    });
+    expect(selection).toBeInTheDocument();
+    if (selection) {
+      fireEvent.click(selection);
+      fireEvent.change(selection, { target: { value: '' } });
+    }
 
     await waitFor(async () => {
       const preview = screen.queryByTestId(`preview-description-${idx}`);
@@ -304,10 +291,8 @@ describe('Review Orders screen', () => {
       screen.getByTestId(`accordion-content-${idx}`);
     });
 
-    act(() => {
-      const heading = screen.getByTestId(`accordion-heading-${idx}`);
-      if (heading) fireEvent.click(heading);
-    });
+    const heading = screen.getByTestId(`accordion-heading-${idx}`);
+    if (heading) fireEvent.click(heading);
 
     await waitFor(async () => {
       const newCaseIdText = screen.getByTestId(`new-case-input-${idx}`);
@@ -315,10 +300,8 @@ describe('Review Orders screen', () => {
     });
 
     const newValue = '081-22-33333';
-    act(() => {
-      const newCaseIdText = screen.getByTestId(`new-case-input-${idx}`);
-      fireEvent.change(newCaseIdText, { target: { value: newValue } });
-    });
+    const newCaseIdText = screen.getByTestId(`new-case-input-${idx}`);
+    fireEvent.change(newCaseIdText, { target: { value: newValue } });
 
     await waitFor(async () => {
       const newCaseIdText = screen.getByTestId(`new-case-input-${idx}`);

--- a/user-interface/src/router.test.tsx
+++ b/user-interface/src/router.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import App from './App';
@@ -52,9 +52,8 @@ describe('App Router Tests', () => {
 
     expect(screen.getByTestId('case-list-heading')).toBeInTheDocument();
   });
-  /**/
 
-  test('should render Not Found 404 page when an invalid URL is supplied', () => {
+  test('should render Not Found 404 page when an invalid URL is supplied', async () => {
     const badRoute = '/some/bad/route';
 
     // use <MemoryRouter> when you want to manually control the history
@@ -65,6 +64,8 @@ describe('App Router Tests', () => {
     );
 
     // verify navigation to "no match" route
-    expect(screen.getByText(/404 - Not Found/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/404 - Not Found/i)).toBeInTheDocument();
+    });
   });
 });

--- a/user-interface/src/router.test.tsx
+++ b/user-interface/src/router.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import App from './App';
@@ -45,10 +45,7 @@ describe('App Router Tests', () => {
 
     render(<App />, { wrapper: BrowserRouter });
 
-    await act(async () => {
-      // verify page content for expected route after navigating
-      await userEvent.click(screen.getByTestId('header-cases-link'));
-    });
+    await userEvent.click(screen.getByTestId('header-cases-link'));
 
     expect(screen.getByTestId('case-list-heading')).toBeInTheDocument();
   });


### PR DESCRIPTION
# Purpose

Tests were hanging in the CI/CD pipeline.

# Major Changes

We remove `userEvent` and `fireEvent` actions from `act()` and `waitFor()`. `act()` is unnecessary because `testing-library` already wraps `render` and these events in `act()`. We suspect the actions being triggered from within `waitFor()` was causing a memory leak.

We also found after this change that the ScrollToTopButton test failed because the way the button was scrolling to the top was not triggering the `onScroll` function during tests. We now trigger an event on the app rather than directly editing the scroll position.

# Testing/Validation

We ran the tests locally several ways and the failure—which had become constant—went away in the CI/CD pipeline.
