### PR TITLE
CAMS-262 limit orders chapter region

### DIFF
--- a/backend/functions/lib/adapters/gateways/dxtr/orders.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/orders.dxtr.gateway.ts
@@ -57,12 +57,12 @@ export class DxtrOrdersGateway implements OrdersGateway {
   async _getOrders(context: ApplicationContext): Promise<Array<DxtrOrder>> {
     const input: DbTableFieldSpec[] = [];
 
-    // TODO: This filter will be applied to Cosmos order documents based on user context in the future.
+    // TODO: We need to consider whether we partially load cosmos by chapter. This has ongoing data handling concerns whether we load all or load partially.
     const chapters: string[] = ["'15'"];
     if (context.featureFlags['chapter-eleven-enabled']) chapters.push("'11'");
     if (context.featureFlags['chapter-twelve-enabled']) chapters.push("'12'");
 
-    // TODO: This temporarily limits the regions to region 2 for now. We need to discuss whether we copy orders from all regions into Cosmos on day one.
+    // TODO: This filter will be applied to Cosmos order documents based on user context in the future. This temporarily limits the regions to region 2 for now. We need to discuss whether we copy orders from all regions into Cosmos on day one.
     const regions: string[] = ["'02'"];
 
     const query = `

--- a/backend/functions/lib/adapters/gateways/dxtr/orders.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/orders.dxtr.gateway.ts
@@ -56,6 +56,15 @@ export class DxtrOrdersGateway implements OrdersGateway {
 
   async _getOrders(context: ApplicationContext): Promise<Array<DxtrOrder>> {
     const input: DbTableFieldSpec[] = [];
+
+    // TODO: This filter will be applied to Cosmos order documents based on user context in the future.
+    const chapters: string[] = ["'15'"];
+    if (context.featureFlags['chapter-eleven-enabled']) chapters.push("'11'");
+    if (context.featureFlags['chapter-twelve-enabled']) chapters.push("'12'");
+
+    // TODO: This temporarily limits the regions to region 2 for now. We need to discuss whether we copy orders from all regions into Cosmos on day one.
+    const regions: string[] = ["'02'"];
+
     const query = `
       SELECT TOP 20
         CS.CS_CASEID AS dxtrCaseId,
@@ -87,6 +96,8 @@ export class DxtrOrdersGateway implements OrdersGateway {
         ON CS.COURT_ID = O.COURT_ID
         AND CSD.OFFICE_CODE = O.OFFICE_CODE
       WHERE TX.TX_CODE = 'CTO'
+      AND CS.CS_CHAPTER IN (${chapters.join(',')})
+      AND G.REGION_ID IN (${regions.join(',')})
       ORDER BY TX.TX_DATE DESC
       `;
 


### PR DESCRIPTION
# Purpose

Temporarily limit order results in the USTP environment from DXTR to chapters enabled by feature flags from region 2.

# Major Changes

Added additional chapter and region predicates to the order SQL query.

# Testing/Validation

Added unit test to exercise the feature flag logic. Manually debugged the app to observe changes to the SQL statement.
