### PR TITLE
CAMS-263: Perform upsert for orders so we do not duplicate

### DIFF
--- a/backend/functions/lib/adapters/gateways/cosmos/cosmos.helper.test.ts
+++ b/backend/functions/lib/adapters/gateways/cosmos/cosmos.helper.test.ts
@@ -1,0 +1,29 @@
+import { ErrorResponse } from '@azure/cosmos';
+import { isCosmosErrorResponse, isPreExistingDocumentError } from './cosmos.helper';
+import { createPreExistingDocumentError } from '../../../testing/cosmos-errors';
+
+describe('Cosmos helpers', () => {
+  test('isCosmosErrorResponse: true', () => {
+    const error = new ErrorResponse('TEST');
+    const truth = isCosmosErrorResponse(error);
+    expect(truth).toBeTruthy();
+  });
+
+  test('isCosmosErrorResponse: false', () => {
+    const error = new Error('TEST');
+    const truth = isCosmosErrorResponse(error);
+    expect(truth).toBeFalsy();
+  });
+
+  test('isPreExistingDocumentError: true', () => {
+    const error = createPreExistingDocumentError();
+    const truth = isPreExistingDocumentError(error);
+    expect(truth).toBeTruthy();
+  });
+
+  test('isPreExistingDocumentError: false', () => {
+    const error = new Error('TEST');
+    const truth = isPreExistingDocumentError(error);
+    expect(truth).toBeFalsy();
+  });
+});

--- a/backend/functions/lib/adapters/gateways/cosmos/cosmos.helper.ts
+++ b/backend/functions/lib/adapters/gateways/cosmos/cosmos.helper.ts
@@ -1,0 +1,14 @@
+import { ErrorResponse } from '@azure/cosmos';
+
+export const ID_ALREADY_EXISTS = 'Entity with the specified id already exists in the system.';
+
+export function isCosmosErrorResponse(e): e is ErrorResponse {
+  return e instanceof ErrorResponse;
+}
+
+export function isPreExistingDocumentError(e: Error): boolean {
+  if (isCosmosErrorResponse(e)) {
+    return e.body.message.includes(ID_ALREADY_EXISTS);
+  }
+  return false;
+}

--- a/backend/functions/lib/adapters/gateways/orders.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/orders.cosmosdb.repository.test.ts
@@ -107,7 +107,7 @@ describe('Test case assignment cosmosdb repository tests', () => {
     };
     delete errorTestNewOrderData.id;
 
-    const mockRead = jest.spyOn(HumbleItems.prototype, 'create').mockImplementation(() => {
+    const mockRead = jest.spyOn(HumbleItems.prototype, 'upsert').mockImplementation(() => {
       throw new UnknownError('TEST_MODULE', { message: 'unknown error' });
     });
 
@@ -125,7 +125,7 @@ describe('Test case assignment cosmosdb repository tests', () => {
     delete testNewOrderData2.id;
     const ordersList = [testNewOrderData2];
 
-    const mockCreate = jest.spyOn(HumbleItems.prototype, 'create').mockImplementation(() => {
+    const mockCreate = jest.spyOn(HumbleItems.prototype, 'upsert').mockImplementation(() => {
       throw new AggregateAuthenticationError([
         new ForbiddenError('TEST_MODULE', { message: 'forbidden' }),
       ]);
@@ -159,7 +159,7 @@ describe('Test case assignment cosmosdb repository tests', () => {
     delete positiveTestNewOrderData2.id;
     const ordersList = [positiveTestNewOrderData1, positiveTestNewOrderData2];
 
-    const mockCreate = jest.spyOn(HumbleItems.prototype, 'create').mockImplementation(() => {
+    const mockCreate = jest.spyOn(HumbleItems.prototype, 'upsert').mockImplementation(() => {
       return;
     });
 
@@ -176,7 +176,7 @@ describe('Test case assignment cosmosdb repository tests', () => {
     );
     expect(fetchAll).toHaveBeenCalled();
 
-    const create = jest.spyOn(HumbleItems.prototype, 'create').mockImplementationOnce(() => {
+    const create = jest.spyOn(HumbleItems.prototype, 'upsert').mockImplementationOnce(() => {
       throw new AggregateAuthenticationError([], 'Mock AggregateAuthenticationError');
     });
     await expect(repository.putOrders(applicationContext, [testNewOrderData])).rejects.toThrow(

--- a/backend/functions/lib/testing/cosmos-errors.ts
+++ b/backend/functions/lib/testing/cosmos-errors.ts
@@ -1,0 +1,11 @@
+import { ErrorResponse } from '@azure/cosmos';
+import { ID_ALREADY_EXISTS } from '../adapters/gateways/cosmos/cosmos.helper';
+
+export function createPreExistingDocumentError() {
+  const error = new ErrorResponse(ID_ALREADY_EXISTS);
+  error.body = {
+    code: 'TEST',
+    message: ID_ALREADY_EXISTS,
+  };
+  return error;
+}

--- a/backend/functions/lib/testing/mock.cosmos-client-humble.ts
+++ b/backend/functions/lib/testing/mock.cosmos-client-humble.ts
@@ -53,6 +53,14 @@ export class HumbleItems<T> {
       id,
     };
   }
+  upsert(item: T) {
+    const id = crypto.randomUUID().toString();
+    this.container.map.set(id, item);
+    return {
+      ...item,
+      id,
+    };
+  }
   query(query: QueryOptions) {
     return new HumbleQuery(this, query);
   }

--- a/backend/functions/lib/testing/mock.cosmos-client-humble.ts
+++ b/backend/functions/lib/testing/mock.cosmos-client-humble.ts
@@ -54,7 +54,7 @@ export class HumbleItems<T> {
     };
   }
   upsert(item: T) {
-    const id = crypto.randomUUID().toString();
+    const id = item['id'] || crypto.randomUUID().toString();
     this.container.map.set(id, item);
     return {
       ...item,

--- a/backend/functions/lib/use-cases/orders/orders.model.ts
+++ b/backend/functions/lib/use-cases/orders/orders.model.ts
@@ -12,6 +12,7 @@ export type Order = CaseDocketEntry & {
   regionId: string;
   orderType: 'transfer';
   orderDate: string;
+  sequenceNumber: number;
   status: OrderStatus;
   newCaseId?: string;
   newCourtName?: string;


### PR DESCRIPTION
# Purpose

We do not want to create duplicate orders.

# Major Changes

- Replace the auto-generated id with a hash of full caseId and order sequenceNumber
- Perform an upsert instead of a create

# Testing/Validation

Ran the manual sync many times with the transaction id override set to 0 and validated that only one of each order existed afterward.
