### PR TITLE
Cams 300 reject order

### DIFF
--- a/backend/functions/lib/use-cases/orders/orders.model.ts
+++ b/backend/functions/lib/use-cases/orders/orders.model.ts
@@ -20,6 +20,7 @@ export type Order = CaseDocketEntry & {
   newDivisionCode?: string;
   newRegionId?: string;
   newRegionName?: string;
+  reason?: string;
 };
 
 export type OrderTransfer = {
@@ -33,6 +34,7 @@ export type OrderTransfer = {
   newRegionId: string;
   newRegionName: string;
   status: OrderStatus;
+  reason?: string;
 };
 
 export interface Transfer {

--- a/backend/functions/lib/use-cases/orders/orders.test.ts
+++ b/backend/functions/lib/use-cases/orders/orders.test.ts
@@ -44,6 +44,7 @@ describe('Orders use case', () => {
 
   test('should add transfer records for both cases when a transfer order is completed', async () => {
     const order: Order = { ...ORDERS[0] };
+    order.status = 'approved';
 
     const transferIn: TransferIn = {
       caseId: order.newCaseId,

--- a/backend/functions/lib/use-cases/orders/orders.ts
+++ b/backend/functions/lib/use-cases/orders/orders.ts
@@ -54,26 +54,29 @@ export class OrdersUseCase {
     await this.ordersRepo.updateOrder(context, id, data);
     const order = await this.ordersRepo.getOrder(context, id, data.caseId);
 
-    const transferIn: TransferIn = {
-      caseId: order.newCaseId,
-      otherCaseId: order.caseId,
-      divisionName: order.courtDivisionName,
-      courtName: order.courtName,
-      orderDate: order.orderDate,
-      documentType: 'TRANSFER_IN',
-    };
+    if (order.status === 'approved') {
+      const transferIn: TransferIn = {
+        caseId: order.newCaseId,
+        otherCaseId: order.caseId,
+        divisionName: order.courtDivisionName,
+        courtName: order.courtName,
+        orderDate: order.orderDate,
+        documentType: 'TRANSFER_IN',
+      };
 
-    const transferOut: TransferOut = {
-      caseId: order.caseId,
-      otherCaseId: order.newCaseId,
-      divisionName: order.newCourtDivisionName,
-      courtName: order.newCourtName,
-      orderDate: order.orderDate,
-      documentType: 'TRANSFER_OUT',
-    };
+      const transferOut: TransferOut = {
+        caseId: order.caseId,
+        otherCaseId: order.newCaseId,
+        divisionName: order.newCourtDivisionName,
+        courtName: order.newCourtName,
+        orderDate: order.orderDate,
+        documentType: 'TRANSFER_OUT',
+      };
 
-    await this.casesRepo.createTransferIn(context, transferIn);
-    await this.casesRepo.createTransferOut(context, transferOut);
+      await this.casesRepo.createTransferIn(context, transferIn);
+      await this.casesRepo.createTransferOut(context, transferOut);
+    }
+
     return id;
   }
 

--- a/user-interface/src/lib/models/api.ts
+++ b/user-interface/src/lib/models/api.ts
@@ -1,7 +1,7 @@
 import { httpGet, httpPatch, httpPost } from '../utils/http.adapter';
-import config from '../../configuration/apiConfiguration';
 import { ResponseData } from '../type-declarations/api';
 import { ObjectKeyVal } from '../type-declarations/basic';
+import config from '../../configuration/apiConfiguration';
 
 export default class Api {
   private static _host = `${config.protocol || 'https'}://${config.server}:${config.port}${
@@ -25,7 +25,7 @@ export default class Api {
     options?: ObjectKeyVal,
   ): Promise<ResponseData> {
     try {
-      const apiOptions = this.getQueryStringsToPassthrough(options ?? {});
+      const apiOptions = this.getQueryStringsToPassthrough(window.location.search, options);
       const pathStr = Api.createPath(path, apiOptions);
 
       const response = await httpPost({ url: Api._host + pathStr, body });
@@ -44,7 +44,7 @@ export default class Api {
 
   public static async list(path: string, options: ObjectKeyVal = {}): Promise<ResponseData> {
     try {
-      const apiOptions = this.getQueryStringsToPassthrough(options ?? {});
+      const apiOptions = this.getQueryStringsToPassthrough(window.location.search, options);
       const pathStr = Api.createPath(path, apiOptions);
       const response = await httpGet({ url: Api._host + pathStr });
 
@@ -65,7 +65,7 @@ export default class Api {
 
   public static async get(path: string, options?: ObjectKeyVal): Promise<ResponseData> {
     try {
-      const apiOptions = this.getQueryStringsToPassthrough(options ?? {});
+      const apiOptions = this.getQueryStringsToPassthrough(window.location.search, options);
       const pathStr = Api.createPath(path, apiOptions);
       const response = await httpGet({ url: Api._host + pathStr });
 
@@ -84,28 +84,13 @@ export default class Api {
     }
   }
 
-  public static getQueryStringsToPassthrough(options: ObjectKeyVal): ObjectKeyVal {
-    const queryParams = new URLSearchParams(window.location.search);
-
-    // Add to this list if there are query params that should be passed to backend api request
-    const params = ['x-ms-routing-name'];
-
-    params.forEach((key) => {
-      const value = queryParams.get(key);
-      if (value) {
-        options[key] = value;
-      }
-    });
-    return options;
-  }
-
   public static async patch(
     path: string,
     body: object,
     options?: ObjectKeyVal,
   ): Promise<ResponseData> {
     try {
-      const apiOptions = this.getQueryStringsToPassthrough(options ?? {});
+      const apiOptions = this.getQueryStringsToPassthrough(window.location.search, options);
       const pathStr = Api.createPath(path, apiOptions);
       const response = await httpPatch({ url: Api._host + pathStr, body });
 
@@ -119,5 +104,23 @@ export default class Api {
     } catch (e: unknown) {
       return Promise.reject(new Error(`500 Error - Server Error ${(e as Error).message}`));
     }
+  }
+
+  public static getQueryStringsToPassthrough(
+    search: string,
+    options: ObjectKeyVal = {},
+  ): ObjectKeyVal {
+    const queryParams = new URLSearchParams(search);
+
+    // Add to this list if there are query params that should be passed to backend api request
+    const params = ['x-ms-routing-name'];
+
+    params.forEach((key) => {
+      const value = queryParams.get(key);
+      if (value) {
+        options[key] = value;
+      }
+    });
+    return options;
   }
 }

--- a/user-interface/src/lib/type-declarations/chapter-15.d.ts
+++ b/user-interface/src/lib/type-declarations/chapter-15.d.ts
@@ -126,6 +126,7 @@ export type Order = CaseDocketEntry & {
   newCourtDivisionName?: string;
   newDivisionCode?: string;
   newRegionId?: string;
+  reason?: string;
 };
 
 export interface OrderResponseData extends ResponseData {
@@ -161,6 +162,7 @@ export interface OrderTransfer {
   newRegionId?: string;
   newRegionName?: string;
   status: OrderStatus;
+  reason?: string;
 }
 
 export interface OfficesResponseData extends ResponseData {

--- a/user-interface/src/review-orders/ReviewOrdersScreen.test.tsx
+++ b/user-interface/src/review-orders/ReviewOrdersScreen.test.tsx
@@ -153,7 +153,7 @@ describe('Review Orders screen', () => {
         expect(content).not.toBeVisible();
         expect(content?.textContent).toContain(order.summaryText);
         expect(content?.textContent).toContain(order.fullText);
-        if (order.status !== 'approved') {
+        if (order.status !== 'approved' && order.status !== 'rejected') {
           const form = screen.getByTestId(`order-form-${order.id}`);
           expect(form).toBeInTheDocument();
           const newCaseIdText = screen.getByTestId(`new-case-input-${order.id}`);

--- a/user-interface/src/review-orders/ReviewOrdersScreen.tsx
+++ b/user-interface/src/review-orders/ReviewOrdersScreen.tsx
@@ -96,11 +96,6 @@ export default function ReviewOrders() {
     alertRef.current?.show();
   }
 
-  function handleOrderRejection(alertDetails: AlertDetails) {
-    setReviewOrderAlert(alertDetails);
-    alertRef.current?.show();
-  }
-
   useEffect(() => {
     getOrders();
     getOffices();
@@ -134,7 +129,6 @@ export default function ReviewOrders() {
                     orderType={orderType}
                     statusType={statusType}
                     onOrderUpdate={handleOrderUpdate}
-                    onOrderRejection={handleOrderRejection}
                   ></TransferOrderAccordion>
                 );
               }) || <></>}

--- a/user-interface/src/review-orders/ReviewOrdersScreen.tsx
+++ b/user-interface/src/review-orders/ReviewOrdersScreen.tsx
@@ -96,6 +96,11 @@ export default function ReviewOrders() {
     alertRef.current?.show();
   }
 
+  function handleOrderRejection(alertDetails: AlertDetails) {
+    setReviewOrderAlert(alertDetails);
+    alertRef.current?.show();
+  }
+
   useEffect(() => {
     getOrders();
     getOffices();
@@ -129,6 +134,7 @@ export default function ReviewOrders() {
                     orderType={orderType}
                     statusType={statusType}
                     onOrderUpdate={handleOrderUpdate}
+                    onOrderRejection={handleOrderRejection}
                   ></TransferOrderAccordion>
                 );
               }) || <></>}

--- a/user-interface/src/review-orders/TransferOrderAccordion.scss
+++ b/user-interface/src/review-orders/TransferOrderAccordion.scss
@@ -24,4 +24,8 @@
   .button-bar {
     padding-top: 2rem;
   }
+  blockquote {
+    background: rgba(0,0,0,.05);
+    padding: 1rem;
+  }
 }

--- a/user-interface/src/review-orders/TransferOrderAccordion.scss
+++ b/user-interface/src/review-orders/TransferOrderAccordion.scss
@@ -21,4 +21,7 @@
       width: 100%;
     }
   }
+  .button-bar {
+    padding-top: 2rem;
+  }
 }

--- a/user-interface/src/review-orders/TransferOrderAccordion.test.tsx
+++ b/user-interface/src/review-orders/TransferOrderAccordion.test.tsx
@@ -6,9 +6,11 @@ import { BrowserRouter } from 'react-router-dom';
 import { formatDate } from '@/lib/utils/datetime';
 import { getCaseNumber } from '@/lib/utils/formatCaseNumber';
 import {
+  CaseSelection,
   TransferOrderAccordion,
   getOfficeList,
   isValidOrderTransfer,
+  validateNewCaseIdInput,
 } from './TransferOrderAccordion';
 
 vi.mock(
@@ -329,8 +331,65 @@ describe('TransferOrderAccordion', () => {
   });
 });
 
-// function buildChangeEvent(value: string): React.ChangeEvent<HTMLInputElement> {
-//   const element = new HTMLInputElement();
-//   element.value = value;
-//   return { target: element };
-// }
+describe('Test CaseSelection component', () => {
+  test('Should display message as expected using toCourt and fromCourt', async () => {
+    render(
+      <CaseSelection
+        fromCourt={{
+          region: '1',
+          courtDivisionName: 'Division Name 1',
+        }}
+        toCourt={{
+          region: '002',
+          courtDivisionName: 'Division Name 2',
+        }}
+      ></CaseSelection>,
+    );
+
+    expect(document.body).toHaveTextContent(
+      'USTP Office: transfer fromRegion 1 - Division Name 1toRegion 2 - Division Name 2',
+    );
+  });
+
+  test('Should properly display region as a non-numeric string when one is supplied', async () => {
+    render(
+      <CaseSelection
+        fromCourt={{
+          region: 'ABC',
+          courtDivisionName: 'Division Name 1',
+        }}
+        toCourt={{
+          region: 'BCD',
+          courtDivisionName: 'Division Name 2',
+        }}
+      ></CaseSelection>,
+    );
+
+    expect(document.body).toHaveTextContent(
+      'USTP Office: transfer fromRegion ABC - Division Name 1toRegion BCD - Division Name 2',
+    );
+  });
+});
+
+describe('Test validateNewCaseIdInput function', () => {
+  test('When supplied a valud with a length greater than 7, it should truncate value to 7 digits', async () => {
+    const testValue = '1234567890';
+    const resultValue = '12-34567';
+
+    const expectedResult = {
+      newCaseId: resultValue,
+      joinedInput: resultValue,
+    };
+
+    const testEvent = {
+      target: {
+        value: testValue,
+      },
+    };
+
+    const returnedValue = validateNewCaseIdInput(testEvent as React.ChangeEvent<HTMLInputElement>);
+    console.log(returnedValue);
+    console.log(expectedResult);
+    expect(returnedValue).toEqual(expectedResult);
+  });
+});

--- a/user-interface/src/review-orders/TransferOrderAccordion.tsx
+++ b/user-interface/src/review-orders/TransferOrderAccordion.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import DocketEntryDocumentList from '@/lib/components/DocketEntryDocumentList';
 import { Accordion } from '@/lib/components/uswds/Accordion';
@@ -14,6 +14,8 @@ import SearchableSelect, { SearchableSelectOption } from '@/lib/components/Searc
 import { AlertDetails } from '@/review-orders/ReviewOrdersScreen';
 import { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import './TransferOrderAccordion.scss';
+import Modal from '@/lib/components/uswds/modal/Modal';
+import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 
 export function getOrderTransferFromOrder(order: Order): OrderTransfer {
   const { id, caseId, status, newCaseId, sequenceNumber } = order;
@@ -65,6 +67,14 @@ export function validateNewCaseIdInput(ev: React.ChangeEvent<HTMLInputElement>) 
   return { newCaseId, joinedInput };
 }
 
+type OrderRejection = {
+  id: string;
+  rejectionMessage: string;
+  staleCaseId: string;
+  staleCourtName: string;
+  staleCourtDivisionName: string;
+};
+
 interface TransferOrderAccordionProps {
   order: Order;
   statusType: Map<string, string>;
@@ -72,6 +82,7 @@ interface TransferOrderAccordionProps {
   officesList: Array<OfficeDetails>;
   regionsMap: Map<string, string>;
   onOrderUpdate: (alertDetails: AlertDetails, order?: Order) => void;
+  onOrderRejection: (alertDetails: AlertDetails) => void;
   onExpand?: (id: string) => void;
   expandedId?: string;
 }
@@ -83,6 +94,9 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
   const courtSelectionRef = useRef<InputRef>(null);
   const caseIdRef = useRef<InputRef>(null);
   const approveButtonRef = useRef<ButtonRef>(null);
+
+  //const approveModalRef = useRef(null);
+  const rejectModalRef = useRef<ModalRefType>(null);
 
   const api = import.meta.env['CAMS_PA11Y'] === 'true' ? MockApi : Api;
 
@@ -118,6 +132,11 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
     updated.newCaseId = newCaseId;
     approveButtonRef.current?.disableButton(!isValidOrderTransfer(updated));
     setOrderTransfer(updated);
+  }
+
+  function rejectOrder(): void {
+    // open rejection modal
+    rejectModalRef.current?.show({});
   }
 
   function approveOrder(): void {
@@ -158,186 +177,231 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
     approveButtonRef.current?.disableButton(true);
   }
 
+  function approveOrderRejection(rejection: OrderRejection) {
+    const { id, rejectionMessage, staleCaseId, staleCourtName, staleCourtDivisionName } = rejection;
+
+    api
+      .patch(`/orders/${id}`, {
+        id,
+        rejectionMessage,
+        status: 'rejected',
+      })
+      .then(() => {
+        props.onOrderRejection({
+          message: `Transfer of case to ${getCaseNumber(staleCaseId)} in ${staleCourtName} (${staleCourtDivisionName}) was rejected.`,
+          type: UswdsAlertStyle.Success,
+          timeOut: 8,
+        });
+      })
+      .catch((reason) => {
+        // TODO: make the error message more meaningful
+        props.onOrderRejection({
+          message: reason.message,
+          type: UswdsAlertStyle.Error,
+          timeOut: 8,
+        });
+      });
+  }
+
   return (
-    <Accordion
-      key={order.id}
-      id={`order-list-${order.id}`}
-      expandedId={expandedId}
-      onExpand={onExpand}
-    >
-      <section
-        className="accordion-heading grid-row grid-gap-lg"
-        data-testid={`accordion-heading-${order.id}`}
+    <>
+      <Accordion
+        key={order.id}
+        id={`order-list-${order.id}`}
+        expandedId={expandedId}
+        onExpand={onExpand}
       >
-        <div
-          className="grid-col-1 case-id text-no-wrap"
-          aria-label={`Case ID ${getCaseNumber(order.caseId).split('').join(' ')}`}
+        <section
+          className="accordion-heading grid-row grid-gap-lg"
+          data-testid={`accordion-heading-${order.id}`}
         >
-          {getCaseNumber(order.caseId)}
-        </div>
-        <div
-          className="grid-col-4 case-title text-no-wrap"
-          aria-label={`Case title ${order.caseTitle}`}
-        >
-          {order.caseTitle}
-        </div>
-        <div
-          className="grid-col-1 order-date text-no-wrap"
-          title="Order date"
-          aria-label={`Order date ${formatDate(order.orderDate)}`}
-        >
-          {formatDate(order.orderDate)}
-        </div>
-        <div className="grid-col-2"></div>
-        <div className="grid-col-2 order-type text-no-wrap">
-          <span aria-label={`Order type ${orderType.get(order.orderType)}`}>
-            {orderType.get(order.orderType)}
-          </span>
-        </div>
-        <div className="grid-col-2 order-status text-no-wrap">
-          <span
-            className={order.status}
-            aria-label={`Order status ${statusType.get(order.status)}`}
+          <div
+            className="grid-col-1 case-id text-no-wrap"
+            aria-label={`Case ID ${getCaseNumber(order.caseId).split('').join(' ')}`}
           >
-            {statusType.get(order.status)}
-          </span>
-        </div>
-      </section>
-      <section className="accordion-content" data-testid={`accordion-content-${order.id}`}>
-        <div className="grid-row grid-gap-lg">
-          <div className="grid-col-1"></div>
-          <div className="order-legal-statement grid-col-10">
-            <Link
-              to={`/case-detail/${order.caseId}/court-docket?document=${order.documentNumber}`}
-              target="_blank"
-              title={`Open case ${order.caseId} docket in new window`}
-            >
-              {order.documentNumber && (
-                <span className="document-number">#{order.documentNumber} - </span>
-              )}
-              {formatDate(order.orderDate)} - {order.summaryText}
-            </Link>
-            <p tabIndex={0} className="measure-6">
-              {order.fullText}
-            </p>
-            {order.documents && <DocketEntryDocumentList documents={order.documents} />}
+            {getCaseNumber(order.caseId)}
           </div>
-          <div className="grid-col-1"></div>
-        </div>
-        {order.status === 'approved' && (
+          <div
+            className="grid-col-4 case-title text-no-wrap"
+            aria-label={`Case title ${order.caseTitle}`}
+          >
+            {order.caseTitle}
+          </div>
+          <div
+            className="grid-col-1 order-date text-no-wrap"
+            title="Order date"
+            aria-label={`Order date ${formatDate(order.orderDate)}`}
+          >
+            {formatDate(order.orderDate)}
+          </div>
+          <div className="grid-col-2"></div>
+          <div className="grid-col-2 order-type text-no-wrap">
+            <span aria-label={`Order type ${orderType.get(order.orderType)}`}>
+              {orderType.get(order.orderType)}
+            </span>
+          </div>
+          <div className="grid-col-2 order-status text-no-wrap">
+            <span
+              className={order.status}
+              aria-label={`Order status ${statusType.get(order.status)}`}
+            >
+              {statusType.get(order.status)}
+            </span>
+          </div>
+        </section>
+        <section className="accordion-content" data-testid={`accordion-content-${order.id}`}>
           <div className="grid-row grid-gap-lg">
             <div className="grid-col-1"></div>
-            <div className="transfer-text grid-col-10" tabIndex={0}>
-              Transferred
-              <span className="transfer-highlight__span">{getCaseNumber(order.caseId)}</span>
-              from
-              <span className="transfer-highlight__span">
-                {order.courtName} ({order.courtDivisionName})
-              </span>
-              to case ID
-              <span className="transfer-highlight__span">{getCaseNumber(order.newCaseId)}</span>
-              and court
-              <span className="transfer-highlight__span">
-                {order.newCourtName} ({order.newCourtDivisionName})
-              </span>
+            <div className="order-legal-statement grid-col-10">
+              <Link
+                to={`/case-detail/${order.caseId}/court-docket?document=${order.documentNumber}`}
+                target="_blank"
+                title={`Open case ${order.caseId} docket in new window`}
+              >
+                {order.documentNumber && (
+                  <span className="document-number">#{order.documentNumber} - </span>
+                )}
+                {formatDate(order.orderDate)} - {order.summaryText}
+              </Link>
+              <p tabIndex={0} className="measure-6">
+                {order.fullText}
+              </p>
+              {order.documents && <DocketEntryDocumentList documents={order.documents} />}
             </div>
             <div className="grid-col-1"></div>
           </div>
-        )}
-        {order.status !== 'approved' && (
-          <section className="order-form" data-testid={`order-form-${order.id}`}>
-            <div className="court-selection grid-row grid-gap-lg">
+          {order.status === 'approved' && (
+            <div className="grid-row grid-gap-lg">
               <div className="grid-col-1"></div>
-              <div className="transfer-from-to__div grid-col-10">
-                <div className="transfer-text" tabIndex={0}>
-                  Transfer
-                  <span className="transfer-highlight__span">{getCaseNumber(order.caseId)}</span>
-                  from
-                  <span className="transfer-highlight__span">
-                    {order.courtName} ({order.courtDivisionName})
-                  </span>
-                  to
-                </div>
-                <div className="form-row">
-                  <div className="select-container court-select-container">
-                    <label htmlFor={`court-selection-${order.id}`}>New Court</label>
-                    <div
-                      className="usa-combo-box"
-                      data-testid={`court-selection-usa-combo-box-${order.id}`}
-                    >
-                      <SearchableSelect
-                        id={`court-selection-${order.id}`}
-                        className="new-court__select"
-                        closeMenuOnSelect={true}
-                        label="Select new court"
-                        ref={courtSelectionRef}
-                        onChange={handleCourtSelection}
-                        options={getOfficeList(officesList)}
-                      />
+              <div className="transfer-text grid-col-10" tabIndex={0}>
+                Transferred
+                <span className="transfer-highlight__span">{getCaseNumber(order.caseId)}</span>
+                from
+                <span className="transfer-highlight__span">
+                  {order.courtName} ({order.courtDivisionName})
+                </span>
+                to case ID
+                <span className="transfer-highlight__span">{getCaseNumber(order.newCaseId)}</span>
+                and court
+                <span className="transfer-highlight__span">
+                  {order.newCourtName} ({order.newCourtDivisionName})
+                </span>
+              </div>
+              <div className="grid-col-1"></div>
+            </div>
+          )}
+          {order.status !== 'approved' && (
+            <section className="order-form" data-testid={`order-form-${order.id}`}>
+              <div className="court-selection grid-row grid-gap-lg">
+                <div className="grid-col-1"></div>
+                <div className="transfer-from-to__div grid-col-10">
+                  <div className="transfer-text" tabIndex={0}>
+                    Transfer
+                    <span className="transfer-highlight__span">{getCaseNumber(order.caseId)}</span>
+                    from
+                    <span className="transfer-highlight__span">
+                      {order.courtName} ({order.courtDivisionName})
+                    </span>
+                    to
+                  </div>
+                  <div className="form-row">
+                    <div className="select-container court-select-container">
+                      <label htmlFor={`court-selection-${order.id}`}>New Court</label>
+                      <div
+                        className="usa-combo-box"
+                        data-testid={`court-selection-usa-combo-box-${order.id}`}
+                      >
+                        <SearchableSelect
+                          id={`court-selection-${order.id}`}
+                          className="new-court__select"
+                          closeMenuOnSelect={true}
+                          label="Select new court"
+                          ref={courtSelectionRef}
+                          onChange={handleCourtSelection}
+                          options={getOfficeList(officesList)}
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div className="grid-col-1"></div>
-            </div>
-            {isCourtSelected(orderTransfer) && (
-              <div className="preview-results grid-row grid-gap-lg">
                 <div className="grid-col-1"></div>
-                <div className="grid-col-10">
-                  <span data-testid={`preview-description-${order.id}`}>
-                    <CaseSelection
-                      fromCourt={{
-                        region: order.regionId,
-                        courtDivisionName: order.courtDivisionName,
-                      }}
-                      toCourt={{
-                        region: orderTransfer.newRegionId || '',
-                        courtDivisionName: orderTransfer.newCourtDivisionName || '',
-                      }}
-                    ></CaseSelection>
-                  </span>
+              </div>
+              {isCourtSelected(orderTransfer) && (
+                <div className="preview-results grid-row grid-gap-lg">
+                  <div className="grid-col-1"></div>
+                  <div className="grid-col-10">
+                    <span data-testid={`preview-description-${order.id}`}>
+                      <CaseSelection
+                        fromCourt={{
+                          region: order.regionId,
+                          courtDivisionName: order.courtDivisionName,
+                        }}
+                        toCourt={{
+                          region: orderTransfer.newRegionId || '',
+                          courtDivisionName: orderTransfer.newCourtDivisionName || '',
+                        }}
+                      ></CaseSelection>
+                    </span>
+                  </div>
+                  <div className="grid-col-1"></div>
+                </div>
+              )}
+              <div className="case-selection grid-row grid-gap-lg">
+                <div className="grid-col-1"></div>
+                <div className="grid-col-4">
+                  <label htmlFor={`new-case-input-${order.id}`}>New Case</label>
+                  <div>
+                    <Input
+                      id={`new-case-input-${order.id}`}
+                      data-testid={`new-case-input-${order.id}`}
+                      className="usa-input"
+                      value={order.newCaseId || ''}
+                      onChange={handleCaseInputChange}
+                      aria-label="New case ID"
+                      ref={caseIdRef}
+                    />
+                  </div>
+                </div>
+                <div className="grid-col-6"></div>
+                <div className="grid-col-1"></div>
+              </div>
+              <div className="button-bar grid-row grid-gap-lg">
+                <div className="grid-col-1"></div>
+                <div className="grid-col-2">
+                  <Button onClick={rejectOrder} uswdsStyle={UswdsButtonStyle.Secondary}>
+                    Reject
+                  </Button>
+                </div>
+                <div className="grid-col-4"></div>
+                <div className="grid-col-2">
+                  <Button onClick={cancelUpdate} uswdsStyle={UswdsButtonStyle.Outline}>
+                    Cancel
+                  </Button>
+                </div>
+                <div className="grid-col-2">
+                  <Button onClick={approveOrder} disabled={true} ref={approveButtonRef}>
+                    Approve
+                  </Button>
                 </div>
                 <div className="grid-col-1"></div>
               </div>
-            )}
-            <div className="case-selection grid-row grid-gap-lg">
-              <div className="grid-col-1"></div>
-              <div className="grid-col-4">
-                <label htmlFor={`new-case-input-${order.id}`}>New Case</label>
-                <div>
-                  <Input
-                    id={`new-case-input-${order.id}`}
-                    data-testid={`new-case-input-${order.id}`}
-                    className="usa-input"
-                    value={order.newCaseId || ''}
-                    onChange={handleCaseInputChange}
-                    aria-label="New case ID"
-                    ref={caseIdRef}
-                  />
-                </div>
-              </div>
-              <div className="grid-col-6"></div>
-              <div className="grid-col-1"></div>
-            </div>
-            <div className="button-bar grid-row grid-gap-lg">
-              <div className="grid-col-1"></div>
-              <div className="grid-col-6"></div>
-              <div className="grid-col-2">
-                <Button onClick={cancelUpdate} uswdsStyle={UswdsButtonStyle.Outline}>
-                  Cancel
-                </Button>
-              </div>
-              <div className="grid-col-2">
-                <Button onClick={approveOrder} disabled={true} ref={approveButtonRef}>
-                  Approve
-                </Button>
-              </div>
-              <div className="grid-col-1"></div>
-            </div>
-          </section>
-        )}
-      </section>
-    </Accordion>
+              <RejectModal
+                ref={rejectModalRef}
+                id={order.id}
+                fromCaseId={order.caseId}
+                toCaseId={orderTransfer.newCaseId}
+                fromDivisionName={order.courtDivisionName}
+                toDivisionName={orderTransfer.newCourtDivisionName}
+                fromCourtName={order.courtName}
+                toCourtName={orderTransfer.newCourtName}
+                cancelCallback={cancelUpdate}
+                rejectCallback={approveOrderRejection}
+              ></RejectModal>
+            </section>
+          )}
+        </section>
+      </Accordion>
+    </>
   );
 }
 
@@ -352,7 +416,7 @@ interface CaseSelectionProps {
 }
 
 function CaseSelection(props: CaseSelectionProps) {
-  const { fromCourt, toCourt }: CaseSelectionProps = props;
+  const { fromCourt, toCourt } = props;
 
   return (
     <>
@@ -367,3 +431,119 @@ function CaseSelection(props: CaseSelectionProps) {
     </>
   );
 }
+
+interface RejectModalProps {
+  id: string;
+  fromCaseId: string;
+  toCaseId?: string;
+  fromDivisionName: string;
+  toDivisionName?: string;
+  fromCourtName: string;
+  toCourtName?: string;
+  cancelCallback: () => void;
+  rejectCallback: (rejection: OrderRejection) => void;
+}
+
+function RejectModalComponent(props: RejectModalProps, rejectModalRef: React.Ref<ModalRefType>) {
+  const {
+    id,
+    fromCaseId,
+    toCaseId,
+    fromDivisionName,
+    toDivisionName,
+    fromCourtName,
+    toCourtName,
+    cancelCallback,
+    rejectCallback,
+  }: RejectModalProps = props;
+
+  const modalRef = useRef<ModalRefType>(null);
+  const [rejectionMessage] = useState<string>('');
+
+  function approveReject() {
+    const rejectData: OrderRejection = {
+      id,
+      rejectionMessage,
+      staleCaseId: toCaseId ?? '',
+      staleCourtName: toCourtName ?? '',
+      staleCourtDivisionName: toDivisionName ?? '',
+    };
+
+    rejectCallback(rejectData);
+  }
+
+  const actionButtonGroup = {
+    modalId: `reject-modal-${id}`,
+    modalRef: modalRef,
+    submitButton: {
+      label: 'Reject',
+      onClick: approveReject,
+    },
+    cancelButton: {
+      label: 'Go back',
+      onClick: cancelCallback,
+    },
+  };
+
+  function show() {
+    if (modalRef.current?.show) {
+      modalRef.current?.show({});
+    }
+  }
+
+  function hide() {
+    if (modalRef.current?.hide) {
+      modalRef.current?.hide({});
+    }
+  }
+
+  useImperativeHandle(rejectModalRef, () => ({
+    show,
+    hide,
+  }));
+
+  return (
+    <Modal
+      ref={modalRef}
+      modalId={`reject-modal-${id}`}
+      className="reject-modal"
+      heading="Reject case transfer?"
+      content={
+        <>
+          This will stop the transfer of case
+          <span className="transfer-highlight__span">{getCaseNumber(fromCaseId)}</span>
+          in
+          <span className="transfer-highlight__span">
+            {fromCourtName} ({fromDivisionName})
+          </span>
+          {toCaseId && (
+            <>
+              to case
+              <span className="transfer-highlight__span">{toCaseId}</span>
+            </>
+          )}
+          {toCourtName && (
+            <>
+              in
+              <span className="transfer-highlight__span">
+                {toCourtName} ({toDivisionName})
+              </span>
+            </>
+          )}
+          .
+          <div>
+            <label className="usa-label">Reason for rejection</label>
+            <div>
+              <textarea className="rejection-reason-input usa-textarea">
+                {rejectionMessage}
+              </textarea>
+            </div>
+          </div>
+        </>
+      }
+      actionButtonGroup={actionButtonGroup}
+    ></Modal>
+  );
+}
+
+const RejectModal = forwardRef(RejectModalComponent);


### PR DESCRIPTION
# Purpose

User should be able to reject a transfer order by clicking on red Reject button.  Confirmation modal should display with an optional "Reason for rejection" field, which they can submit.

Orders screen should update indicating that the order was rejected and form should be unavailable on the order in the accordion.

# Major Changes

Added user interface elements, button, modal, etc.
Also added a confirmation modal for Approval process.

# Testing/Validation

Tests have been updated to ensure that coverage stays above 90%.


