### PR TITLE
CAMS-319 veracode fix pipeline scan

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -196,7 +196,7 @@ jobs:
           --account-name ${{ secrets.AZ_STOR_VERACODE_NAME }} \
           --account-key ${{ secrets.AZ_STOR_VERACODE_KEY }} \
           -c baseline \
-          -n results-latest.json \
+          -n results-branch-test.json \
           -f ./results-latest.json
 
       - name: Download veracode policy file

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -211,7 +211,7 @@ jobs:
           -bf results-latest.json \
           -jf results.json \
           -fjf filtered_results.json \
-          --fail_on_severity="Very High, High, Medium" \
+          --fail_on_severity="High, Medium" \
           --file cams.zip
 
       - name: Upload to storage account

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -225,7 +225,6 @@ jobs:
           -jf results.json \
           -fjf filtered_results.json \
           -pf Veracode_Medium_+_SCA_+_OWASP.json \
-          --fail_on_severity="Medium" \
           --file cams.zip
 
       - name: Upload to storage account

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -211,7 +211,7 @@ jobs:
           -bf results-latest.json \
           -jf results.json \
           -fjf filtered_results.json \
-          --fail_on_severity="High, Medium" \
+          --fail_on_severity="Medium" \
           --file cams.zip
 
       - name: Upload to storage account

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Package source code for scan
-        run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*"
+        run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*" -i "./common/*"
 
       - name: Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@0.2.6

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -221,7 +221,7 @@ jobs:
           -jf results.json \
           -fjf filtered_results.json \
           -pf Veracode_Medium_+_SCA_+_OWASP.json \
-          --fail_on_severity "Very High,High,Medium"
+          --fail_on_severity "Very High,High,Medium" \
           --file cams.zip
 
       - name: Upload to storage account

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -190,35 +190,31 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
 
+      - name: Fetch pipeline-scan tool
+        run: |
+          curl -sSO https://downloads.veracode.com/securityscan/pipeline-scan-LATEST.zip
+          unzip -o pipeline-scan-LATEST.zip
+          java -jar pipeline-scan.jar --version
+
       - name: Download baseline file
         run: |
           az storage blob download \
           --account-name ${{ secrets.AZ_STOR_VERACODE_NAME }} \
           --account-key ${{ secrets.AZ_STOR_VERACODE_KEY }} \
           -c baseline \
-          -n results-branch-test.json \
+          -n results-latest.json \
           -f ./results-latest.json
 
-      - name: Download veracode policy file
+      - name: Download Veracode policy file
         run: |
-          curl -sSO https://downloads.veracode.com/securityscan/pipeline-scan-LATEST.zip
-          unzip -o pipeline-scan-LATEST.zip
           java -jar pipeline-scan.jar \
           -vid ${{ secrets.VERACODE_API_ID }} \
           -vkey ${{ secrets.VERACODE_API_KEY }} \
-          --request_policy="Veracode Medium + SCA + OWASP"
+          --request_policy="${{ secrets.VERACODE_SAST_POLICY }}"
 
-          ls
-
-      - name: pipeline-scan
+      - name: Execute pipeline-scan
         id: pipeline-scan
         run: |
-          ls -l
-
-          curl -sSO https://downloads.veracode.com/securityscan/pipeline-scan-LATEST.zip
-          unzip -o pipeline-scan-LATEST.zip
-          java -jar pipeline-scan.jar --version
-
           java -jar pipeline-scan.jar \
           -vid ${{ secrets.VERACODE_API_ID }} -vkey ${{ secrets.VERACODE_API_KEY }} \
           -bf results-latest.json \

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -211,6 +211,7 @@ jobs:
           -bf results-latest.json \
           -jf results.json \
           -fjf filtered_results.json \
+          --fail_on_severity="Very High, High, Medium" \
           --file cams.zip
 
       - name: Upload to storage account

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -221,6 +221,7 @@ jobs:
           -jf results.json \
           -fjf filtered_results.json \
           -pf Veracode_Medium_+_SCA_+_OWASP.json \
+          --fail_on_severity "Very High,High,Medium"
           --file cams.zip
 
       - name: Upload to storage account

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -213,6 +213,8 @@ jobs:
       - name: pipeline-scan
         id: pipeline-scan
         run: |
+          ls -l
+
           curl -sSO https://downloads.veracode.com/securityscan/pipeline-scan-LATEST.zip
           unzip -o pipeline-scan-LATEST.zip
           java -jar pipeline-scan.jar --version
@@ -222,6 +224,7 @@ jobs:
           -bf results-latest.json \
           -jf results.json \
           -fjf filtered_results.json \
+          -pf Veracode_Medium_+_SCA_+_OWASP.json \
           --fail_on_severity="Medium" \
           --file cams.zip
 

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -199,6 +199,17 @@ jobs:
           -n results-latest.json \
           -f ./results-latest.json
 
+      - name: Download veracode policy file
+        run: |
+          curl -sSO https://downloads.veracode.com/securityscan/pipeline-scan-LATEST.zip
+          unzip -o pipeline-scan-LATEST.zip
+          java -jar pipeline-scan.jar \
+          -vid ${{ secrets.VERACODE_API_ID }} \
+          -vkey ${{ secrets.VERACODE_API_KEY }} \
+          --request_policy="Veracode Medium + SCA + OWASP"
+
+          ls
+
       - name: pipeline-scan
         id: pipeline-scan
         run: |

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -221,7 +221,6 @@ jobs:
           -jf results.json \
           -fjf filtered_results.json \
           -pf Veracode_Medium_+_SCA_+_OWASP.json \
-          --fail_on_severity "Very High,High,Medium" \
           --file cams.zip
 
       - name: Upload to storage account

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Package source code for scan
-        run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*"
+        run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*" -i "./common/*"
 
       - uses: azure/login@v1
         with:


### PR DESCRIPTION
# Purpose

Investigate and fix pipeline scan execution in CI pipeline. On findings that are equal and above a Medium, the pipeline should fail.

# Major Changes

- Update SAST scan to leverage a Veracode policy
- Include the common module as part of the scan

# Testing/Validation

- Confirm usage of Veracode policy
- Verify that pipeline fails for medium findings with the application of the policy

# Notes


