### PR TITLE
CAMS-332 Fix RangeError on docket search

### DIFF
--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.tsx
@@ -31,7 +31,7 @@ export default function CaseDetailCourtDocket(props: CaseDetailCourtDocketProps)
 
   const [alertOptions, setAlertOptions] = useState<AlertOptions | null>(null);
 
-  const minSearchTextSize = 3;
+  const MINIMUM_SEARCH_CHARACTERS = 3;
 
   useEffect(() => {
     if (!props.isDocketLoading) {
@@ -48,25 +48,25 @@ export default function CaseDetailCourtDocket(props: CaseDetailCourtDocketProps)
         alertRef.current?.show();
       } else {
         alertRef.current?.hide();
-        if (props.searchString && props.searchString.length >= minSearchTextSize) {
-          try {
-            handleHighlight(window, document, 'searchable-docket', props.searchString);
-          } catch (e) {
-            // TODO CAMS-332 There might not be a need to handle this. May be okay to just ignore.
-          }
-        }
+        handleHighlight(
+          window,
+          document,
+          'searchable-docket',
+          props.searchString,
+          MINIMUM_SEARCH_CHARACTERS,
+        );
       }
     }
   }, [docketEntries]);
 
   useEffect(() => {
-    if (props.searchString && props.searchString.length >= minSearchTextSize) {
-      try {
-        handleHighlight(window, document, 'searchable-docket', props.searchString);
-      } catch (e) {
-        // TODO CAMS-332 There might not be a need to handle this. May be okay to just ignore.
-      }
-    }
+    handleHighlight(
+      window,
+      document,
+      'searchable-docket',
+      props.searchString,
+      MINIMUM_SEARCH_CHARACTERS,
+    );
   }, [props.searchString]);
 
   return (

--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.tsx
@@ -31,6 +31,8 @@ export default function CaseDetailCourtDocket(props: CaseDetailCourtDocketProps)
 
   const [alertOptions, setAlertOptions] = useState<AlertOptions | null>(null);
 
+  const minSearchTextSize = 3;
+
   useEffect(() => {
     if (!props.isDocketLoading) {
       if (!hasDocketEntries) {
@@ -46,15 +48,25 @@ export default function CaseDetailCourtDocket(props: CaseDetailCourtDocketProps)
         alertRef.current?.show();
       } else {
         alertRef.current?.hide();
-        if (props.searchString) {
-          handleHighlight(window, document, 'searchable-docket', props.searchString);
+        if (props.searchString && props.searchString.length >= minSearchTextSize) {
+          try {
+            handleHighlight(window, document, 'searchable-docket', props.searchString);
+          } catch (e) {
+            // TODO CAMS-332 There might not be a need to handle this. May be okay to just ignore.
+          }
         }
       }
     }
   }, [docketEntries]);
 
   useEffect(() => {
-    handleHighlight(window, document, 'searchable-docket', props.searchString);
+    if (props.searchString && props.searchString.length >= minSearchTextSize) {
+      try {
+        handleHighlight(window, document, 'searchable-docket', props.searchString);
+      } catch (e) {
+        // TODO CAMS-332 There might not be a need to handle this. May be okay to just ignore.
+      }
+    }
   }, [props.searchString]);
 
   return (

--- a/user-interface/src/lib/components/IconInput.tsx
+++ b/user-interface/src/lib/components/IconInput.tsx
@@ -22,10 +22,10 @@ export interface IconInputProps {
 
 function IconInputComponent(props: IconInputProps, ref: React.Ref<InputRef>) {
   //condition for check for title to style tooltip
-  const [inputValue, setInputValue] = useState<string | null>(null);
+  const [inputValue, setInputValue] = useState<string>('');
 
   function handleOnChange(ev: React.ChangeEvent<HTMLInputElement>) {
-    setInputValue(ev.target.value);
+    setInputValue(ev.target.value ?? '');
     if (props.onChange) {
       props.onChange(ev);
     }

--- a/user-interface/src/lib/utils/highlight-api.ts
+++ b/user-interface/src/lib/utils/highlight-api.ts
@@ -5,36 +5,36 @@ export function handleHighlight(
   _document: Document,
   elementId: string,
   searchString: string,
+  minSearchStringLength: number = 1,
 ) {
-  // See https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear#browser_compatibility
-  const browserApi = _window as unknown as WindowExperimental;
+  try {
+    // See https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear#browser_compatibility
+    const browserApi = _window as unknown as WindowExperimental;
 
-  // API is not supported in this browser.
-  if (!browserApi.CSS.highlights) return;
+    // API is not supported in this browser.
+    if (!browserApi.CSS.highlights) return;
 
-  // Clear all highlighting if we don't have a search string.
-  if (!searchString.length) {
-    browserApi.CSS.highlights.clear();
-    return;
-  }
+    // Clear all highlighting if we don't have a search string.
+    if (searchString.length < minSearchStringLength) {
+      browserApi.CSS.highlights.clear();
+      return;
+    }
 
-  // Apply highlighting to the docket nodes.
-  const docketNode = _document.getElementById(elementId);
-  if (!docketNode) return;
+    // Apply highlighting to the docket nodes.
+    const docketNode = _document.getElementById(elementId);
+    if (!docketNode) return;
 
-  const treeWalker = _document.createTreeWalker(docketNode, NodeFilter.SHOW_TEXT);
-  const allTextNodes = [];
-  let currentNode = treeWalker.nextNode();
-  while (currentNode) {
-    allTextNodes.push(currentNode);
-    currentNode = treeWalker.nextNode();
-  }
+    const treeWalker = _document.createTreeWalker(docketNode, NodeFilter.SHOW_TEXT);
+    const allTextNodes = [];
+    let currentNode = treeWalker.nextNode();
+    while (currentNode) {
+      allTextNodes.push(currentNode);
+      currentNode = treeWalker.nextNode();
+    }
 
-  const ranges = allTextNodes
-    .map((el) => {
-      return { el, text: el.textContent?.toLowerCase() || '' };
-    })
-    .map(({ text, el }) => {
+    const ranges = allTextNodes.reduce((accumulator, el) => {
+      const text = el.textContent?.toLowerCase() ?? '';
+
       const indices = [];
       let startPos = 0;
       while (startPos < text.length) {
@@ -44,17 +44,22 @@ export function handleHighlight(
         startPos = index + searchString.length;
       }
 
-      return indices.map((index) => {
+      const innerRanges = indices.map((index) => {
         const range = new Range();
         range.setStart(el, index);
         range.setEnd(el, index + searchString.length);
         return range;
       });
-    });
+      if (innerRanges.length) accumulator.push(...innerRanges);
+      return accumulator;
+    }, [] as Range[]);
 
-  // TypeScript does not ship experimental browser type definitions which are being used here.
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const searchResultsHighlight = new Highlight(...ranges.flat());
-  browserApi.CSS.highlights.set('search-results', searchResultsHighlight);
+    // TypeScript does not ship experimental browser type definitions which are being used here.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const searchResultsHighlight = new Highlight(...ranges.flat());
+    browserApi.CSS.highlights.set('search-results', searchResultsHighlight);
+  } catch {
+    // We want to silently fail and not crash the browser.
+  }
 }


### PR DESCRIPTION
# Purpose

Application crashed when entering in value for docket search in case details view for cases with large number of docket entries. Investigation shows approximately 9k+ docket entries for this particular case and webapp throws a **RangeError** when invoking `handleHighlight`

# Major Changes

- Catch error to prevent application to break
- Set a min limit before invoking handleHighlight
- Resolve warning related to IconInput

# Testing/Validation

- Seed database with large number of dockets for case id 96-45961 in test database and confirm that problem can be recreated
- Manually verify fix in deployed webapp 

# Notes

- Noticed degraded performance with entering text into the search field for cases with large number of dockets. Min search text size is set to 3. This should alleviate the webapp from crashing and a way to improve on this with this fix is to increase the min text size.

