### PR TITLE
CAMS-122 bug fix with missing boolean value for main deployments

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -402,7 +402,7 @@ jobs:
           ./ops/scripts/pipeline/azure-deploy-rg.sh \
             --show-what-if \
             --file ./ops/cloud-deployment/lib/subscription/ustp-cams-rg.bicep \
-            --parameters 'databaseResourceGroupName=${{ secrets.AZURE_RG }} networkResourceGroupName=${{ steps.rgNetwork.outputs.out }} webappResourceGroupName=${{ steps.rgApp.outputs.out }} azSubscription=${{ secrets.AZURE_SUBSCRIPTION }} branchName=${{ github.ref_name }} branchHashId=${{ needs.build-info.outputs.environmentHash }} isBranchDeployment=${{ inputs.deployBranch }}' \
+            --parameters 'databaseResourceGroupName=${{ secrets.AZURE_RG }} networkResourceGroupName=${{ steps.rgNetwork.outputs.out }} webappResourceGroupName=${{ steps.rgApp.outputs.out }} azSubscription=${{ secrets.AZURE_SUBSCRIPTION }} branchName=${{ github.ref_name }} branchHashId=${{ needs.build-info.outputs.environmentHash }} isBranchDeployment=${{ inputs.deployBranch || false}}' \
             -l ${{ secrets.AZ_LOCATION }}
 
       - name: Deploy Azure resources


### PR DESCRIPTION
# Purpose

During main deployment, `input.isBranch` is a null value instead of the expected default of `false`

# Major Changes

- Set a default value within the GHA step

# Testing/Validation

Needs to be verified in main

# Notes
