### PR TITLE
CAMS-270: Added step to order transfer pa11y test

### DIFF
--- a/user-interface/.pa11yci
+++ b/user-interface/.pa11yci
@@ -42,8 +42,9 @@
       "url": "http://localhost:3000/data-verification/",
       "actions": [
         "wait for element [data-testid='data-verification-screen'] to be visible",
-        "click element div.approved",
-        "click element div.rejected",
+        "click element div.filter.approved",
+        "click element div.filter.rejected",
+        "click element div.filter.consolidation",
         "click element [data-testid='accordion-button-order-list-guid-0']",
         "click element #buttonSuggestedCases",
         "click element [data-testid='suggested-cases-radio-0']",


### PR DESCRIPTION

# Purpose

This should hopefully fix the failed pa11y test.

# Major Changes

Added a click on the Consolidations filter to turn consolidations off during the Pa11y test.  We're expecting only 3 transfer orders and nothing else on screen.

# Testing/Validation

Tests seem to be passing now.
