### PR TITLE
CAMS-270: Changed button label in modal to Approve

### DIFF
--- a/user-interface/src/data-verification/ConsolidationOrderModal.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderModal.tsx
@@ -64,7 +64,7 @@ function ConsolidationOrderModalComponent(
     modalId: `confirmation-modal-${id}`,
     modalRef: modalRef,
     submitButton: {
-      label: options.heading,
+      label: 'Approve',
       onClick: () => {
         onConfirm(
           options.status,


### PR DESCRIPTION
# Purpose

Change modal button label to 'Approve' temporarily until we create the second screen for the modal.

# Major Changes

verbiage

