### PR TITLE
CAMS 322 remove unused vars from bicep

### DIFF
--- a/ops/cloud-deployment/ustp-cams-cosmos.bicep
+++ b/ops/cloud-deployment/ustp-cams-cosmos.bicep
@@ -156,5 +156,3 @@ module cosmosDiagnosticSetting './lib/app-insights/diagnostics-settings-cosmos.b
     containers
   ]
 }
-
-output cosmosDbManagedIdName string = cosmosDbUserManagedIdentity.outputs.name

--- a/ops/cloud-deployment/ustp-cams-cosmos.bicep
+++ b/ops/cloud-deployment/ustp-cams-cosmos.bicep
@@ -157,6 +157,4 @@ module cosmosDiagnosticSetting './lib/app-insights/diagnostics-settings-cosmos.b
   ]
 }
 
-output cosmosDbClientId string = cosmosDbUserManagedIdentity.outputs.clientId
-output cosmosDbPrincipalId string = cosmosDbUserManagedIdentity.outputs.principalId
 output cosmosDbManagedIdName string = cosmosDbUserManagedIdentity.outputs.name


### PR DESCRIPTION
# Purpose

removing unused output from bicep files 

# Major Changes

removed unused output from bicep file that was replaced 

# Testing/Validation

Deploy environment without the bicep file output

