### PR TITLE
CAMS-269 Fix grid layout for transfer accordian buttons

### DIFF
--- a/user-interface/src/App.scss
+++ b/user-interface/src/App.scss
@@ -70,6 +70,11 @@ body {
   }
 }
 
+.float-right {
+  display: flex;
+  justify-content: right;
+}
+
 @media screen and (max-width: 800px) {
   .App {
     .body {

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -269,7 +269,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
 
             <div className="button-bar grid-row grid-gap-lg">
               <div className="grid-col-1"></div>
-              <div className="grid-col-2">
+              <div className="grid-col-5">
                 <Button
                   id={`accordion-reject-button-${order.id}`}
                   onClick={() =>
@@ -285,8 +285,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
                   Reject
                 </Button>
               </div>
-              <div className="grid-col-6"></div>
-              <div className="grid-col-2 text-no-wrap">
+              <div className="grid-col-5 text-no-wrap float-right">
                 <Button
                   id={`accordion-cancel-button-${order.id}`}
                   onClick={cancelUpdate}

--- a/user-interface/src/data-verification/TransferOrderAccordion.scss
+++ b/user-interface/src/data-verification/TransferOrderAccordion.scss
@@ -1,4 +1,8 @@
 .accordion-content {
+  div.align-right {
+    text-align: right; // aligns content in div to the right
+  }
+
   .transfer-text {
     padding: 1rem 0;
     font-size: 1.25rem;

--- a/user-interface/src/data-verification/TransferOrderAccordion.scss
+++ b/user-interface/src/data-verification/TransferOrderAccordion.scss
@@ -1,8 +1,4 @@
 .accordion-content {
-  div.align-right {
-    text-align: right; // aligns content in div to the right
-  }
-
   .transfer-text {
     padding: 1rem 0;
     font-size: 1.25rem;

--- a/user-interface/src/data-verification/TransferOrderAccordion.tsx
+++ b/user-interface/src/data-verification/TransferOrderAccordion.tsx
@@ -701,7 +701,7 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
                       Reject
                     </Button>
                   </div>
-                  <div className="grid-col-5 text-no-wrap align-right">
+                  <div className="grid-col-5 text-no-wrap float-right">
                     <Button
                       id={`accordion-cancel-button-${order.id}`}
                       onClick={cancelUpdate}

--- a/user-interface/src/data-verification/TransferOrderAccordion.tsx
+++ b/user-interface/src/data-verification/TransferOrderAccordion.tsx
@@ -692,7 +692,7 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
                 )}
                 <div className="button-bar grid-row grid-gap-lg">
                   <div className="grid-col-1"></div>
-                  <div className="grid-col-2">
+                  <div className="grid-col-5">
                     <Button
                       id={`accordion-reject-button-${order.id}`}
                       onClick={() => confirmationModalRef.current?.show({ status: 'rejected' })}
@@ -701,8 +701,7 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
                       Reject
                     </Button>
                   </div>
-                  <div className="grid-col-6"></div>
-                  <div className="grid-col-2 text-no-wrap">
+                  <div className="grid-col-5 text-no-wrap align-right">
                     <Button
                       id={`accordion-cancel-button-${order.id}`}
                       onClick={cancelUpdate}


### PR DESCRIPTION
# Purpose

Noticed issue with how the `Cancel` and `Approve` buttons get overlay during implementation of test using Cypress. The right gutter column overlay the Approve button and prevented it being clicked by the test framework.

# Major Changes

- Modified the grid layout

# Testing/Validation

- Manual inspection
- Confirm passing Cypress test after change

# Notes


