### PR TITLE
Add newline after mermaid language tag

### DIFF
--- a/architecture/export-architecture-diagrams.sh
+++ b/architecture/export-architecture-diagrams.sh
@@ -9,45 +9,45 @@ pushd architecture || exit
 ## CAMS System Context
 mermaid_file="./structurizr-SystemLandscape.mmd"
 {
-  printf "# CAMS System Context\n\n\`\`\`mermaid"
+  printf "# CAMS System Context\n\n\`\`\`mermaid\n"
   cat "$mermaid_file"
-  printf "\n\`\`\`"
+  printf "\n\`\`\`\n"
 } > temp_file.md
 mv temp_file.md ../docs/architecture/diagrams/cams-context.md
 
 ## CAMS Containers
 mermaid_file="./structurizr-CAMSContainers.mmd"
 {
-  printf "# CAMS Containers\n\n\`\`\`mermaid"
+  printf "# CAMS Containers\n\n\`\`\`mermaid\n"
   cat "$mermaid_file"
-  printf "\n\`\`\`"
+  printf "\n\`\`\`\n"
 } > temp_file.md
 mv temp_file.md ../docs/architecture/diagrams/cams-containers.md
 
 ## CAMS Functions API with Webapp
 mermaid_file="./structurizr-FunctionsAPIwithWebapp.mmd"
 {
-  printf "# CAMS Webapp with Functions API\n\n\`\`\`mermaid"
+  printf "# CAMS Webapp with Functions API\n\n\`\`\`mermaid\n"
   cat "$mermaid_file"
-  printf "\n\`\`\`"
+  printf "\n\`\`\`\n"
 } > temp_file.md
 mv temp_file.md ../docs/architecture/diagrams/cams-webapp-with-functions-api.md
 
 ## CAMS Webapp Components
 mermaid_file="./structurizr-CAMSWebapp.mmd"
 {
-  printf "# CAMS Webapp Components\n\n\`\`\`mermaid"
+  printf "# CAMS Webapp Components\n\n\`\`\`mermaid\n"
   cat "$mermaid_file"
-  printf "\n\`\`\`"
+  printf "\n\`\`\`\n"
 } > temp_file.md
 mv temp_file.md ../docs/architecture/diagrams/cams-webapp-components.md
 
 ## CAMS Functions API Components
 mermaid_file="./structurizr-FunctionsAPI.mmd"
 {
-  printf "# CAMS Functions API Components\n\n\`\`\`mermaid"
+  printf "# CAMS Functions API Components\n\n\`\`\`mermaid\n"
   cat "$mermaid_file"
-  printf "\n\`\`\`"
+  printf "\n\`\`\`\n"
 } > temp_file.md
 mv temp_file.md ../docs/architecture/diagrams/cams-functions-api-components.md
 

--- a/docs/architecture/diagrams/cams-containers.md
+++ b/docs/architecture/diagrams/cams-containers.md
@@ -1,9 +1,10 @@
 # CAMS Containers
 
-```mermaidgraph TB
+```mermaid
+graph TB
   linkStyle default fill:#ffffff
 
-  subgraph diagram [CAMS - Containers]
+  subgraph diagram ["CAMS - Containers"]
     style diagram fill:#ffffff,stroke:#ffffff
 
     1["<div style='font-weight: bold'>AUST</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Assistant United States<br />Trustee - manages a USTP<br />office</div>"]
@@ -16,10 +17,10 @@
     subgraph 4 [CAMS]
       style 4 fill:#ffffff,stroke:#0b4884,color:#0b4884
 
-      21("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
-      style 21 fill:#438dd5,stroke:#2e6295,color:#ffffff
-      22("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
+      22("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
       style 22 fill:#438dd5,stroke:#2e6295,color:#ffffff
+      23("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
+      style 23 fill:#438dd5,stroke:#2e6295,color:#ffffff
       5("<div style='font-weight: bold'>Webapp</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>The user interface for CAMS</div>")
       style 5 fill:#438dd5,stroke:#2e6295,color:#ffffff
       9("<div style='font-weight: bold'>API</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>An Azure Functions App<br />(Node.js)</div>")
@@ -30,7 +31,7 @@
     2-. "<div>Views bankruptcy cases</div><div style='font-size: 70%'></div>" .->5
     3-. "<div>Reviews, approves, and<br />rejects case events</div><div style='font-size: 70%'></div>" .->5
     5-. "<div>Reads and writes case data<br />and assignments</div><div style='font-size: 70%'></div>" .->9
-    9-. "<div>Reads and writes case<br />assignments, orders, cases,<br />etc.</div><div style='font-size: 70%'></div>" .->22
-    9-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->21
+    9-. "<div>Reads and writes case<br />assignments, orders, cases,<br />etc.</div><div style='font-size: 70%'></div>" .->23
+    9-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->22
   end
 ```

--- a/docs/architecture/diagrams/cams-context.md
+++ b/docs/architecture/diagrams/cams-context.md
@@ -1,9 +1,10 @@
 # CAMS System Context
 
-```mermaidgraph TB
+```mermaid
+graph TB
   linkStyle default fill:#ffffff
 
-  subgraph diagram [System Landscape]
+  subgraph diagram ["System Landscape"]
     style diagram fill:#ffffff,stroke:#ffffff
 
     1["<div style='font-weight: bold'>AUST</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Assistant United States<br />Trustee - manages a USTP<br />office</div>"]

--- a/docs/architecture/diagrams/cams-functions-api-components.md
+++ b/docs/architecture/diagrams/cams-functions-api-components.md
@@ -1,17 +1,18 @@
 # CAMS Functions API Components
 
-```mermaidgraph TB
+```mermaid
+graph TB
   linkStyle default fill:#ffffff
 
-  subgraph diagram [CAMS - API - Components]
+  subgraph diagram ["CAMS - API - Components"]
     style diagram fill:#ffffff,stroke:#ffffff
 
-    22("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
-    style 22 fill:#438dd5,stroke:#2e6295,color:#ffffff
     5("<div style='font-weight: bold'>Webapp</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>The user interface for CAMS</div>")
     style 5 fill:#438dd5,stroke:#2e6295,color:#ffffff
-    21("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
-    style 21 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    22("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
+    style 22 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    23("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
+    style 23 fill:#438dd5,stroke:#2e6295,color:#ffffff
 
     subgraph 9 [API]
       style 9 fill:#ffffff,stroke:#2e6295,color:#2e6295
@@ -38,6 +39,8 @@
       style 19 fill:#85bbf0,stroke:#5d82a8,color:#000000
       20("<div style='font-weight: bold'>Sync</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Creates events in CAMS based<br />on orders to transfer<br />transactions in DXTR</div>")
       style 20 fill:#85bbf0,stroke:#5d82a8,color:#000000
+      21("<div style='font-weight: bold'>Consolidations</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Consolidation Orders API</div>")
+      style 21 fill:#85bbf0,stroke:#5d82a8,color:#000000
     end
 
     5-. "<div>Reads and writes case data</div><div style='font-size: 70%'></div>" .->11
@@ -50,16 +53,18 @@
     5-. "<div>Reads case events</div><div style='font-size: 70%'></div>" .->17
     5-. "<div>Triggers order sync via HTTP</div><div style='font-size: 70%'></div>" .->18
     5-. "<div>Reads case summaries for data<br />verification</div><div style='font-size: 70%'></div>" .->19
-    11-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->21
-    11-. "<div>Reads case assignments</div><div style='font-size: 70%'></div>" .->22
-    12-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->22
-    13-. "<div>Reads case docket entries</div><div style='font-size: 70%'></div>" .->21
-    14-. "<div>Reads case audit logs</div><div style='font-size: 70%'></div>" .->22
-    15-. "<div>Reads case summaries</div><div style='font-size: 70%'></div>" .->21
-    16-. "<div>Reads USTP office information</div><div style='font-size: 70%'></div>" .->21
-    17-. "<div>Reads case events</div><div style='font-size: 70%'></div>" .->22
-    18-. "<div>Writes case audit logs</div><div style='font-size: 70%'></div>" .->22
-    19-. "<div>Reads case summaries matching<br />a case transfer event</div><div style='font-size: 70%'></div>" .->21
-    20-. "<div>Writes case audit logs</div><div style='font-size: 70%'></div>" .->22
+    5-. "<div>Reads and writes<br />consolidation order data</div><div style='font-size: 70%'></div>" .->21
+    11-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->22
+    11-. "<div>Reads case assignments</div><div style='font-size: 70%'></div>" .->23
+    21-. "<div>Reads and Writes<br />consolidations</div><div style='font-size: 70%'></div>" .->23
+    12-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->23
+    13-. "<div>Reads case docket entries</div><div style='font-size: 70%'></div>" .->22
+    14-. "<div>Reads case audit logs</div><div style='font-size: 70%'></div>" .->23
+    15-. "<div>Reads case summaries</div><div style='font-size: 70%'></div>" .->22
+    16-. "<div>Reads USTP office information</div><div style='font-size: 70%'></div>" .->22
+    17-. "<div>Reads case events</div><div style='font-size: 70%'></div>" .->23
+    18-. "<div>Writes case audit logs</div><div style='font-size: 70%'></div>" .->23
+    19-. "<div>Reads case summaries matching<br />a case transfer event</div><div style='font-size: 70%'></div>" .->22
+    20-. "<div>Writes case audit logs</div><div style='font-size: 70%'></div>" .->23
   end
 ```

--- a/docs/architecture/diagrams/cams-webapp-components.md
+++ b/docs/architecture/diagrams/cams-webapp-components.md
@@ -1,9 +1,10 @@
 # CAMS Webapp Components
 
-```mermaidgraph TB
+```mermaid
+graph TB
   linkStyle default fill:#ffffff
 
-  subgraph diagram [CAMS - Webapp - Components]
+  subgraph diagram ["CAMS - Webapp - Components"]
     style diagram fill:#ffffff,stroke:#ffffff
 
     1["<div style='font-weight: bold'>AUST</div><div style='font-size: 70%; margin-top: 0px'>[Person]</div><div style='font-size: 80%; margin-top:10px'>Assistant United States<br />Trustee - manages a USTP<br />office</div>"]

--- a/docs/architecture/diagrams/cams-webapp-with-functions-api.md
+++ b/docs/architecture/diagrams/cams-webapp-with-functions-api.md
@@ -1,17 +1,18 @@
 # CAMS Webapp with Functions API
 
-```mermaidgraph TB
+```mermaid
+graph TB
   linkStyle default fill:#ffffff
 
-  subgraph diagram [CAMS - API - Components]
+  subgraph diagram ["CAMS - API - Components"]
     style diagram fill:#ffffff,stroke:#ffffff
 
-    22("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
-    style 22 fill:#438dd5,stroke:#2e6295,color:#ffffff
     5("<div style='font-weight: bold'>Webapp</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>The user interface for CAMS</div>")
     style 5 fill:#438dd5,stroke:#2e6295,color:#ffffff
-    21("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
-    style 21 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    22("<div style='font-weight: bold'>DXTR DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>DXTR SQL Database</div>")
+    style 22 fill:#438dd5,stroke:#2e6295,color:#ffffff
+    23("<div style='font-weight: bold'>Cosmos DB</div><div style='font-size: 70%; margin-top: 0px'>[Container]</div><div style='font-size: 80%; margin-top:10px'>NoSQL Database</div>")
+    style 23 fill:#438dd5,stroke:#2e6295,color:#ffffff
 
     subgraph 9 [API]
       style 9 fill:#ffffff,stroke:#2e6295,color:#2e6295
@@ -38,6 +39,8 @@
       style 19 fill:#85bbf0,stroke:#5d82a8,color:#000000
       20("<div style='font-weight: bold'>Sync</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Creates events in CAMS based<br />on orders to transfer<br />transactions in DXTR</div>")
       style 20 fill:#85bbf0,stroke:#5d82a8,color:#000000
+      21("<div style='font-weight: bold'>Consolidations</div><div style='font-size: 70%; margin-top: 0px'>[Component]</div><div style='font-size: 80%; margin-top:10px'>Consolidation Orders API</div>")
+      style 21 fill:#85bbf0,stroke:#5d82a8,color:#000000
     end
 
     5-. "<div>Reads and writes case data</div><div style='font-size: 70%'></div>" .->11
@@ -50,16 +53,18 @@
     5-. "<div>Reads case events</div><div style='font-size: 70%'></div>" .->17
     5-. "<div>Triggers order sync via HTTP</div><div style='font-size: 70%'></div>" .->18
     5-. "<div>Reads case summaries for data<br />verification</div><div style='font-size: 70%'></div>" .->19
-    11-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->21
-    11-. "<div>Reads case assignments</div><div style='font-size: 70%'></div>" .->22
-    12-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->22
-    13-. "<div>Reads case docket entries</div><div style='font-size: 70%'></div>" .->21
-    14-. "<div>Reads case audit logs</div><div style='font-size: 70%'></div>" .->22
-    15-. "<div>Reads case summaries</div><div style='font-size: 70%'></div>" .->21
-    16-. "<div>Reads USTP office information</div><div style='font-size: 70%'></div>" .->21
-    17-. "<div>Reads case events</div><div style='font-size: 70%'></div>" .->22
-    18-. "<div>Writes case audit logs</div><div style='font-size: 70%'></div>" .->22
-    19-. "<div>Reads case summaries matching<br />a case transfer event</div><div style='font-size: 70%'></div>" .->21
-    20-. "<div>Writes case audit logs</div><div style='font-size: 70%'></div>" .->22
+    5-. "<div>Reads and writes<br />consolidation order data</div><div style='font-size: 70%'></div>" .->21
+    11-. "<div>Gets case data</div><div style='font-size: 70%'></div>" .->22
+    11-. "<div>Reads case assignments</div><div style='font-size: 70%'></div>" .->23
+    21-. "<div>Reads and Writes<br />consolidations</div><div style='font-size: 70%'></div>" .->23
+    12-. "<div>Reads and writes case<br />assignments</div><div style='font-size: 70%'></div>" .->23
+    13-. "<div>Reads case docket entries</div><div style='font-size: 70%'></div>" .->22
+    14-. "<div>Reads case audit logs</div><div style='font-size: 70%'></div>" .->23
+    15-. "<div>Reads case summaries</div><div style='font-size: 70%'></div>" .->22
+    16-. "<div>Reads USTP office information</div><div style='font-size: 70%'></div>" .->22
+    17-. "<div>Reads case events</div><div style='font-size: 70%'></div>" .->23
+    18-. "<div>Writes case audit logs</div><div style='font-size: 70%'></div>" .->23
+    19-. "<div>Reads case summaries matching<br />a case transfer event</div><div style='font-size: 70%'></div>" .->22
+    20-. "<div>Writes case audit logs</div><div style='font-size: 70%'></div>" .->23
   end
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,13 +47,12 @@
         ],
       }
     </script>
-    <script src="//unpkg.com/docsify-mermaid@2.0.0/dist/docsify-mermaid.js"></script>
     <script type="module">
       import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
-
-      mermaid.initialize({startOnLoad: true});
+      mermaid.initialize({ startOnLoad: true });
       window.mermaid = mermaid;
     </script>
+    <script src="//unpkg.com/docsify-mermaid@2.0.1/dist/docsify-mermaid.js"></script>
     <!-- Docsify v4 -->
     <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
   </body>


### PR DESCRIPTION
# Purpose

Our architecture diagrams were not being displayed properly.

# Major Changes

- Added a newline after the ```` ```mermaid ```` line
- Added a newline after the ```` ``` ```` line so that pre-commit doesn't have to add it (helps with developer's commit flow
- Updated the mermaid docs themselves
- Modified the Docsify html file a bit which was probably unnecessary, but does update the version of the mermaid plugin we're using

# Testing/Validation

Ran Docsify locally.

# Notes

While troubleshooting I found that we can use `homebrew` to install the `structurizr-cli` locally rather than needing to manually download the archived `structurizr.sh`. We could also potentially add this step to our GitHub Actions workflow and not need to worry about developers potentially having different versions of structurizr locally.

If you have the `structurizr-cli` installed through `homebrew` or some other method, you call it with `structurizr-cli` rather than `structurizr.sh` which would prompt a change to `architecture/export-architecture-diagrams.sh`.