### PR TITLE
CAMS-345 Fix for missing branch hash id for main CICD deployment

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -688,7 +688,7 @@ jobs:
 
           if [[ $webStatusCode = "200" && $apiStatusCode = "200" ]]; then
             echo "Print api healthcheck response"
-            curl https://${{ inputs.apiName }}.azurewebsites${{ inputs.azureHostnameSuffix }}/api/healthcheck?x-ms-routing-name=${{ inputs.slotName }}
+            curl https://${{ env.apiName }}.azurewebsites${{ vars.AZ_HOSTNAME_SUFFIX }}/api/healthcheck?x-ms-routing-name=${{ env.slotName }}
             exit 0
           else
             echo "Health check error. Response codes webStatusCode=$webStatusCode apiStatusCode=$apiStatusCode"

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -491,7 +491,7 @@ jobs:
             --analyticsWorkspaceId ${{ secrets.AZ_ANALYTICS_WORKSPACE_ID }} \
             --actionGroupResourceGroup ${{ secrets.AZ_ANALYTICS_RG }} \
             --actionGroupName ${{ secrets.AZ_ACTION_GROUP_NAME }} \
-            --branchHashId ${{ needs.build-info.outputs.environmentHash }}
+            --branchHashId ${{ needs.build-info.outputs.environmentHash || 'DOES_NOT_EXIST' }}
 
       - name: Check deployment and set params
         id: set-deploy-params


### PR DESCRIPTION
# Purpose

Fix deployment failure related to empty string passed to database deployment script. This only occurs on main branch.

# Major Changes

- Pass expected non-empty string to script
- Update smoke test

# Testing/Validation

- Successful Deploy database step in branch deployment 

# Notes

Need to verify in main branch CICD workflow
