### PR TITLE
CAMS-345 Fix modified slot resource script to deal with main deployment error

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -538,7 +538,8 @@ jobs:
             --kvIdName ${{ secrets.AZ_KV_APP_CONFIG_MANAGED_ID }} \
             --sqlIdName ${{ secrets.AZ_SQL_IDENTITY_NAME }} \
             --cosmosIdName ${{ steps.set-deploy-params.outputs.cosmosDbManagedIdName }} \
-            --branchHashId ${{ needs.build-info.outputs.environmentHash }} \
+            --branchHashId ${{ needs.build-info.outputs.environmentHash || 'DOES_NOT_EXIST' }} \
+            --databaseName ${{ secrets.AZ_COSMOS_DATABASE_NAME }} \
             --storageAccName ${slotStorageAccountName:0:24}
 
   deploy-webapp:
@@ -870,7 +871,13 @@ jobs:
           az webapp traffic-routing clear --name ${{ env.webappName }} -g ${{ steps.rgApp.outputs.out }}
   swap-nodeapi-deployment-slot:
     runs-on: ubuntu-latest
-    needs: [build-info, deploy-webapp-slot, deploy-service-slot, execute-e2e-test-pre-swap]
+    needs:
+      [
+        build-info,
+        deploy-webapp-slot,
+        deploy-service-slot,
+        execute-e2e-test-pre-swap,
+      ]
     environment: ${{ needs.build-info.outputs.environment }}
     env:
       apiName: ${{ needs.build-info.outputs.apiName }}
@@ -893,7 +900,8 @@ jobs:
 
   smoke-test-application-post-swap:
     runs-on: ubuntu-latest
-    needs: [build-info, swap-nodeapi-deployment-slot, swap-webapp-deployment-slot]
+    needs:
+      [build-info, swap-nodeapi-deployment-slot, swap-webapp-deployment-slot]
     environment: ${{ needs.build-info.outputs.environment }}
     env:
       stackName: ${{ needs.build-info.outputs.stackName }}


### PR DESCRIPTION
Jira ticket: CAMS-345

# Problem

Failing CICD pipeline related to provisioning slot resources. New --branchId flag requires non-empty string value.

# Solution

- Pass non-empty string for `--branchId` for main deployment

# Testing/Validation

- Needs to verified once merged to main

# Other Changes


