### PR TITLE
added evaluation against string car for deploy_flag

### DIFF
--- a/ops/scripts/pipeline/check-deploy-bicep.sh
+++ b/ops/scripts/pipeline/check-deploy-bicep.sh
@@ -24,7 +24,7 @@ else
     changes=$(git diff HEAD origin/main -- ./ops/cloud-deployment/ ./.github/workflows/continuous-deployment.yml)
 fi
 
-if [[ $changes != "" || $rg_response == "" || $deploy_flag == true  ]]; then
+if [[ $changes != "" || $rg_response == "" || $deploy_flag == true || $deploy_flag == "true" ]]; then #
     deployBicep=true
 fi
 


### PR DESCRIPTION
Jira ticket: CAMS-358

# Problem

Forcing bicep deployment on USTP with var does not evaluate correctly because it is a string vs a boolean variable

# Solution

added check for string against deployment boolean within check-deploy-bicep.sh

# Testing/Validation

Test on USTP side


