### PR TITLE
CAMS-301 Reject consolidation

### DIFF
--- a/backend/functions/cases/cases.function.ts
+++ b/backend/functions/cases/cases.function.ts
@@ -23,12 +23,10 @@ const httpTrigger: AzureFunction = async function (
   const casesController = new CasesController(applicationContext);
 
   // Process request message
-  const caseId = casesRequest?.params?.caseId;
-
   try {
     let responseBody: CaseDetailsDbResult | CaseListDbResult;
 
-    if (caseId) {
+    if (casesRequest.params.caseId && casesRequest.params.caseId) {
       // return case details
       responseBody = await casesController.getCaseDetails({
         caseId: casesRequest.params.caseId,

--- a/backend/functions/lib/use-cases/orders/orders.test.ts
+++ b/backend/functions/lib/use-cases/orders/orders.test.ts
@@ -16,6 +16,7 @@ import { OrderSyncState } from '../gateways.types';
 import { CamsError } from '../../common-errors/cams-error';
 import {
   ConsolidationOrderActionApproval,
+  getCaseSummaryFromConsolidationOrderCase,
   getCaseSummaryFromTransferOrder,
   TransferOrder,
   TransferOrderAction,
@@ -334,10 +335,9 @@ describe('Orders use case', () => {
       status: 'pending',
       childCases: [],
     };
-    const childCaseSummaries = newConsolidation.childCases.map((bCase) => {
-      const { docketEntries: _docketEntries, ...bCaseSummary } = bCase;
-      return bCaseSummary;
-    });
+    const childCaseSummaries = newConsolidation.childCases.map((bCase) =>
+      getCaseSummaryFromConsolidationOrderCase(bCase),
+    );
     const leadCaseAfter: ConsolidationOrderSummary = {
       status: 'approved',
       childCases: childCaseSummaries,
@@ -440,10 +440,9 @@ describe('Orders use case', () => {
       status: 'pending',
       childCases: [],
     };
-    const childCaseSummaries = approvedConsolidation.childCases.map((bCase) => {
-      const { docketEntries: _docketEntries, ...bCaseSummary } = bCase;
-      return bCaseSummary;
-    });
+    const childCaseSummaries = approvedConsolidation.childCases.map((bCase) =>
+      getCaseSummaryFromConsolidationOrderCase(bCase),
+    );
     const leadCaseAfter: ConsolidationOrderSummary = {
       status: 'approved',
       childCases: [childCaseSummaries[0]],

--- a/backend/functions/lib/use-cases/orders/orders.ts
+++ b/backend/functions/lib/use-cases/orders/orders.ts
@@ -342,7 +342,7 @@ export class OrdersUseCase {
     response.push(createdConsolidation);
 
     for (const childCase of newConsolidation.childCases) {
-      if (childCase.caseId !== leadCase.caseId) {
+      if (!leadCase || childCase.caseId !== leadCase.caseId) {
         const caseHistory = await this.buildHistory(context, childCase, status, [], leadCase);
         await this.casesRepo.createCaseHistory(context, caseHistory);
       }

--- a/common/src/cams/orders.ts
+++ b/common/src/cams/orders.ts
@@ -7,7 +7,6 @@ export type ConsolidationType = 'administrative' | 'substantive';
 
 export type ConsolidationOrderActionRejection = ConsolidationOrder & {
   rejectedCases: Array<string>;
-  leadCase: undefined;
 };
 
 export type ConsolidationOrderActionApproval = ConsolidationOrder & {

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -12,5 +12,4 @@ export const defaultFeatureFlags: FeatureFlagSet = {
   'chapter-eleven-enabled': true,
   'transfer-orders-enabled': true,
   'consolidations-enabled': true,
-  'consolidations-add-case': true,
 };

--- a/dev-tools/cosmos-records/delete-orders.ts
+++ b/dev-tools/cosmos-records/delete-orders.ts
@@ -13,6 +13,4 @@ export default function deleteOrders() {
   deleteDocuments('consolidations', 'consolidationId', 'SELECT * FROM c');
 }
 
-if (require.main === module) {
-  deleteOrders();
-}
+deleteOrders();

--- a/dev-tools/cosmos-records/sync-orders.ts
+++ b/dev-tools/cosmos-records/sync-orders.ts
@@ -23,6 +23,4 @@ export function syncOrders() {
     .catch((error) => console.log('Unable to sync orders. Reason:', error.message, error));
 }
 
-if (require.main === module) {
-  syncOrders();
-}
+syncOrders();

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -414,7 +414,9 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
           >
             <div className="grid-row grid-gap-lg consolidation-text">
               <div className="grid-col-1"></div>
-              <div className="grid-col-10">Consolidation for the following cases is rejected.</div>
+              <div className="grid-col-10">
+                Consolidation order is rejected for the following cases.
+              </div>
               <div className="grid-col-1"></div>
             </div>
             <div className="grid-row grid-gap-lg">

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -96,7 +96,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
           const assignmentsResponse = await api.get(`/case-assignments/${bCase.caseId}`);
           bCase.attorneyAssignments = (assignmentsResponse as CaseAssignmentResponseData).body;
         } catch {
-          // The case assignments are not critical to perform the consolidation. Catch any error
+          // The child case assignments are not critical to perform the consolidation. Catch any error
           // and don't set the attorney assignment for this specific case.
         }
       }
@@ -111,19 +111,15 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     setSelectedCases([]);
   }
 
-  function confirmAction({
-    status,
-    leadCaseSummary,
-    consolidationType,
-  }: ConfirmActionResults): void {
-    if (status === 'approved') {
+  function confirmAction(action: ConfirmActionResults): void {
+    if (action.status === 'approved') {
       const data: ConsolidationOrderActionApproval = {
         ...order,
-        consolidationType,
+        consolidationType: action.consolidationType,
         approvedCases: selectedCases
           .map((bCase) => bCase.caseId)
-          .filter((caseId) => caseId !== leadCaseSummary.caseId),
-        leadCase: leadCaseSummary,
+          .filter((caseId) => caseId !== action.leadCaseSummary.caseId),
+        leadCase: action.leadCaseSummary,
       };
 
       api
@@ -302,8 +298,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
                       cases: order.childCases.map((c) => c),
                     })
                   }
-                  disabled={true}
-                  //Disabled until we get to story CAMS-301
                   uswdsStyle={UswdsButtonStyle.Secondary}
                 >
                   Reject

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -415,8 +415,15 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
             <div className="grid-row grid-gap-lg consolidation-text">
               <div className="grid-col-1"></div>
               <div className="grid-col-10">
-                Consolidation order is rejected for the following cases.
-                {order.reason && <p>&quot;{order.reason}&quot;</p>}
+                Rejected the consolidation of the cases below
+                {order.reason && order.reason.length && (
+                  <>
+                    {' '}
+                    for the following reason:
+                    <blockquote>{order.reason}</blockquote>
+                  </>
+                )}
+                {!order.reason && <>.</>}
               </div>
               <div className="grid-col-1"></div>
             </div>

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -2,7 +2,7 @@ import { Accordion } from '@/lib/components/uswds/Accordion';
 import { formatDate } from '@/lib/utils/datetime';
 import { AlertDetails } from '@/data-verification/DataVerificationScreen';
 import { CaseTable, CaseTableImperative } from './CaseTable';
-import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ConsolidationCaseTable } from './ConsolidationCasesTable';
 import './TransferOrderAccordion.scss';
 import {
@@ -12,17 +12,12 @@ import {
   ConsolidationOrderCase,
 } from '@common/cams/orders';
 import Button, { ButtonRef, UswdsButtonStyle } from '@/lib/components/uswds/Button';
-import SearchableSelect, { SearchableSelectOption } from '@/lib/components/SearchableSelect';
-import { InputRef } from '@/lib/type-declarations/input-fields';
-import { getOfficeList } from './dataVerificationHelper';
 import { OfficeDetails } from '@common/cams/courts';
-import Input from '@/lib/components/uswds/Input';
 import {
   ConsolidationOrderModal,
   ConfirmationModalImperative,
   ConfirmActionResults,
 } from '@/data-verification/ConsolidationOrderModal';
-import useFeatureFlags, { CONSOLIDATIONS_ADD_CASE_ENABLED } from '@/lib/hooks/UseFeatureFlags';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { getCaseNumber } from '@/lib/utils/formatCaseNumber';
 import { CaseNumber } from '@/lib/components/CaseNumber';
@@ -53,11 +48,8 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
   const [order, setOrder] = useState<ConsolidationOrder>(props.order);
   const [selectedCases, setSelectedCases] = useState<Array<ConsolidationOrderCase>>([]);
   const [isAssignmentLoaded, setIsAssignmentLoaded] = useState<boolean>(false);
-  const courtSelectionRef = useRef<InputRef>(null);
-  const caseIdRef = useRef<InputRef>(null);
   const confirmationModalRef = useRef<ConfirmationModalImperative>(null);
   const approveButtonRef = useRef<ButtonRef>(null);
-  const featureFlags = useFeatureFlags();
 
   const api = useApi();
 
@@ -77,13 +69,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     }
   }
 
-  function handleAddNewCaseDivisionCode(_newValue: SearchableSelectOption): void {
-    throw new Error('Function not implemented.');
-  }
-
-  function handleAddNewCaseNumber(_ev: ChangeEvent<HTMLInputElement>): void {
-    throw new Error('Function not implemented.');
-  }
   function setOrderWithAssignments(order: ConsolidationOrder) {
     setOrder({ ...order });
   }
@@ -263,70 +248,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
               </div>
               <div className="grid-col-1"></div>
             </div>
-
-            {featureFlags[CONSOLIDATIONS_ADD_CASE_ENABLED] && (
-              <>
-                <div className="grid-row grid-gap-lg">
-                  <div className="grid-col-1"></div>
-                  <div className="grid-col-10">
-                    <h3>Add Case</h3>
-                  </div>
-                  <div className="grid-col-1"></div>
-                </div>
-
-                <div className="court-selection grid-row grid-gap-lg">
-                  <div className="grid-col-1"></div>
-                  <div className="grid-col-10">
-                    <div className="form-row">
-                      <div className="select-container court-select-container">
-                        <label htmlFor={`court-selection-${order.id}`}>Court</label>
-                        <div
-                          className="usa-combo-box"
-                          data-testid={`court-selection-usa-combo-box-${order.id}`}
-                        >
-                          <SearchableSelect
-                            id={`court-selection-${order.id}`}
-                            data-testid={`court-selection-${order.id}`}
-                            className="new-court__select"
-                            closeMenuOnSelect={true}
-                            label="Select new court"
-                            ref={courtSelectionRef}
-                            onChange={handleAddNewCaseDivisionCode}
-                            //getOfficeList might need pulled into its own file
-                            options={getOfficeList(officesList)}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="grid-col-1"></div>
-                </div>
-
-                <div className="case-selection grid-row grid-gap-lg">
-                  <div className="grid-col-1"></div>
-
-                  <div className="grid-col-10">
-                    <div className="form-row">
-                      <div>
-                        <label htmlFor={`new-case-input-${order.id}`}>Case Number</label>
-                        <div>
-                          <Input
-                            id={`new-case-input-${order.id}`}
-                            data-testid={`new-case-input-${order.id}`}
-                            className="usa-input"
-                            value=""
-                            onChange={handleAddNewCaseNumber}
-                            aria-label="New case ID"
-                            ref={caseIdRef}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="grid-col-1"></div>
-                </div>
-              </>
-            )}
 
             <div className="button-bar grid-row grid-gap-lg">
               <div className="grid-col-1"></div>

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -50,16 +50,9 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
   const [isAssignmentLoaded, setIsAssignmentLoaded] = useState<boolean>(false);
   const confirmationModalRef = useRef<ConfirmationModalImperative>(null);
   const approveButtonRef = useRef<ButtonRef>(null);
+  const rejectButtonRef = useRef<ButtonRef>(null);
 
   const api = useApi();
-
-  useEffect(() => {
-    if (selectedCases.length == 0) {
-      approveButtonRef.current?.disableButton(true);
-    } else {
-      approveButtonRef.current?.disableButton(false);
-    }
-  }, [selectedCases]);
 
   function handleIncludeCase(bCase: ConsolidationOrderCase) {
     if (selectedCases.includes(bCase)) {
@@ -93,7 +86,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
 
   function clearInputs(): void {
     caseTable.current?.clearSelection();
-    approveButtonRef.current?.disableButton(true);
+    disableButtons(true);
     setSelectedCases([]);
   }
 
@@ -171,6 +164,15 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
         });
     }
   }
+
+  function disableButtons(disable: boolean) {
+    approveButtonRef.current?.disableButton(disable);
+    rejectButtonRef.current?.disableButton(disable);
+  }
+
+  useEffect(() => {
+    disableButtons(selectedCases.length === 0);
+  }, [selectedCases]);
 
   return (
     <Accordion
@@ -257,10 +259,11 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
                   onClick={() =>
                     confirmationModalRef.current?.show({
                       status: 'rejected',
-                      cases: order.childCases.map((c) => c),
+                      cases: selectedCases,
                     })
                   }
                   uswdsStyle={UswdsButtonStyle.Secondary}
+                  ref={rejectButtonRef}
                 >
                   Reject
                 </Button>

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -416,6 +416,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
               <div className="grid-col-1"></div>
               <div className="grid-col-10">
                 Consolidation order is rejected for the following cases.
+                {order.reason && <p>&quot;{order.reason}&quot;</p>}
               </div>
               <div className="grid-col-1"></div>
             </div>

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -407,6 +407,28 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
             </div>
           </section>
         )}
+        {order.status === 'rejected' && (
+          <section
+            className="accordion-content order-form"
+            data-testid={`accordion-content-${order.id}`}
+          >
+            <div className="grid-row grid-gap-lg consolidation-text">
+              <div className="grid-col-1"></div>
+              <div className="grid-col-10">Consolidation for the following cases is rejected.</div>
+              <div className="grid-col-1"></div>
+            </div>
+            <div className="grid-row grid-gap-lg">
+              <div className="grid-col-1"></div>
+              <div className="grid-col-10">
+                <CaseTable
+                  id={`order-${order.id}-child-cases`}
+                  cases={order.childCases}
+                ></CaseTable>
+              </div>
+              <div className="grid-col-1"></div>
+            </div>
+          </section>
+        )}
       </>
     </Accordion>
   );

--- a/user-interface/src/data-verification/ConsolidationOrderModal.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderModal.test.tsx
@@ -72,13 +72,13 @@ describe('ConsolidationOrderModalComponent', () => {
     await waitFor(() => {
       ref.current?.show({ status: 'rejected', cases });
     });
-
+    screen.debug();
     // Check heading
     const heading = document.querySelector('.usa-modal__heading');
     expect(heading).toHaveTextContent('Reject Case Consolidation?');
 
     // Check case Ids
-    const caseIdDiv = screen.queryByTestId(`confirm-modal-${id}-caseIds`);
+    const caseIdDiv = screen.queryByTestId(`modal-case-list-container`);
     expect(caseIdDiv).toBeInTheDocument();
     cases.forEach((bCase) => {
       expect(caseIdDiv).toHaveTextContent(getCaseNumber(bCase.caseId));

--- a/user-interface/src/data-verification/ConsolidationOrderModal.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderModal.test.tsx
@@ -63,29 +63,55 @@ describe('ConsolidationOrderModalComponent', () => {
     vitest.clearAllMocks();
   });
 
-  test('should show rejection modal', async () => {
+  test('should allow user to reject a consolidation', async () => {
     const id = 'test';
     const cases = MockData.buildArray(MockData.getCaseSummary, 2);
 
+    const onConfirmSpy = vitest.fn();
+    const onCancelSpy = vitest.fn();
+
     // Render and activate the modal.
-    const ref = renderModalWithProps({ id });
+    const ref = renderModalWithProps({ id, onConfirm: onConfirmSpy, onCancel: onCancelSpy });
     await waitFor(() => {
       ref.current?.show({ status: 'rejected', cases });
     });
-    screen.debug();
+
     // Check heading
     const heading = document.querySelector('.usa-modal__heading');
     expect(heading).toHaveTextContent('Reject Case Consolidation?');
 
     // Check case Ids
-    const caseIdDiv = screen.queryByTestId(`modal-case-list-container`);
-    expect(caseIdDiv).toBeInTheDocument();
+    const caseIdDiv = screen.getByTestId(`modal-case-list-container`);
     cases.forEach((bCase) => {
       expect(caseIdDiv).toHaveTextContent(getCaseNumber(bCase.caseId));
     });
+
+    const rejectionReasonText = screen.getByTestId(`rejection-reason-input-${id}`);
+    expect(rejectionReasonText).toBeVisible();
+    expect(rejectionReasonText).not.toBeDisabled();
+    const rejectionTextValue = 'This is a test';
+    fireEvent.change(rejectionReasonText, { target: { value: rejectionTextValue } });
+
+    const rejectButton = screen.getByTestId(`button-${id}-submit-button`);
+    expect(rejectButton).toBeVisible();
+    expect(rejectButton).not.toBeDisabled();
+    fireEvent.click(rejectButton!);
+    expect(onConfirmSpy).toHaveBeenCalledWith({
+      status: 'rejected',
+      rejectionReason: rejectionTextValue,
+    });
+
+    await waitFor(() => {
+      ref.current?.show({ status: 'rejected', cases });
+    });
+    const cancelButton = screen.getByTestId(`button-${id}-cancel-button`);
+    expect(cancelButton).toBeVisible();
+    expect(cancelButton).not.toBeDisabled();
+    fireEvent.click(cancelButton!);
+    expect(onCancelSpy).toHaveBeenCalled();
   });
 
-  test('should show approved modal and allow user to submit modal after completing form', async () => {
+  test('should allow user to approve a consolidation', async () => {
     const id = 'test';
     const childCases = MockData.buildArray(MockData.getCaseSummary, 2);
     const courts = MockData.getOffices().slice(0, 3);
@@ -146,6 +172,9 @@ describe('ConsolidationOrderModalComponent', () => {
     const leadCaseNumber = getCaseNumber(childCases[0].caseId);
     const caseNumberInput = findCaseNumberInputInModal(id);
     await waitFor(() => {
+      enterCaseNumberInModal(caseNumberInput, '12-');
+    });
+    await waitFor(() => {
       enterCaseNumberInModal(caseNumberInput, leadCaseNumber);
     });
 
@@ -177,6 +206,95 @@ describe('ConsolidationOrderModalComponent', () => {
       leadCaseSummary: leadCase,
       consolidationType: 'substantive',
     });
+
+    await waitFor(() => {
+      ref.current?.show({ status: 'approved', cases: childCases });
+    });
+    const cancelButton = screen.getByTestId(`button-${id}-cancel-button`);
+    expect(cancelButton).toBeVisible();
+    expect(cancelButton).not.toBeDisabled();
+    fireEvent.click(cancelButton!);
+    expect(onCancelSpy).toHaveBeenCalled();
+  });
+
+  test('should show an error if the lead case does not exist', async () => {
+    const id = 'test';
+    const childCases = MockData.buildArray(MockData.getCaseSummary, 2);
+    const courts = MockData.getOffices().slice(0, 3);
+
+    // Render and activate the modal.
+    const ref = renderModalWithProps({ id, courts });
+    await waitFor(() => {
+      ref.current?.show({ status: 'approved', cases: childCases });
+    });
+
+    const continueButton = screen.getByTestId(`button-${id}-submit-button`);
+    expect(continueButton).toBeDisabled();
+
+    const radioSubstantiveClickTarget = screen.queryByTestId(
+      `radio-substantive-${id}-click-target`,
+    );
+    fireEvent.click(radioSubstantiveClickTarget!);
+
+    // Select lead case court.
+    selectItemInMockSelect(`lead-case-court`, 1);
+
+    let errorMessage;
+    const leadCaseNumber = '11-11111';
+    const caseNumberInput = findCaseNumberInputInModal(id);
+
+    vitest.spyOn(Chapter15MockApi, 'get').mockRejectedValueOnce(new Error('404 Error'));
+
+    // Test the 404 case.
+    await waitFor(() => {
+      enterCaseNumberInModal(caseNumberInput, leadCaseNumber);
+    });
+    await waitFor(() => {
+      errorMessage = screen.queryByTestId('alert-message');
+    });
+    expect(errorMessage).toBeInTheDocument();
+    expect(errorMessage).toHaveTextContent('Lead case not found.');
+    expect(continueButton).toBeDisabled();
+  });
+
+  test('should show an error if the lead case cannot be verified', async () => {
+    const id = 'test';
+    const childCases = MockData.buildArray(MockData.getCaseSummary, 2);
+    const courts = MockData.getOffices().slice(0, 3);
+
+    // Render and activate the modal.
+    const ref = renderModalWithProps({ id, courts });
+    await waitFor(() => {
+      ref.current?.show({ status: 'approved', cases: childCases });
+    });
+
+    const continueButton = screen.getByTestId(`button-${id}-submit-button`);
+    expect(continueButton).toBeDisabled();
+
+    const radioSubstantiveClickTarget = screen.queryByTestId(
+      `radio-substantive-${id}-click-target`,
+    );
+    fireEvent.click(radioSubstantiveClickTarget!);
+
+    // Select lead case court.
+    selectItemInMockSelect(`lead-case-court`, 1);
+
+    let errorMessage;
+    const leadCaseNumber = '11-11111';
+    const caseNumberInput = findCaseNumberInputInModal(id);
+
+    vitest.spyOn(Chapter15MockApi, 'get').mockRejectedValueOnce(new Error('500 Error'));
+
+    // Test error other than 404.
+    await waitFor(() => {
+      enterCaseNumberInModal(caseNumberInput, leadCaseNumber);
+    });
+    await waitFor(() => {
+      errorMessage = screen.queryByTestId('alert-message');
+    });
+    expect(errorMessage).toBeInTheDocument();
+    expect(errorMessage).toHaveTextContent('Cannot verify lead case number.');
+    expect(continueButton).toBeDisabled();
   });
 
   test('should call onCancel callback when cancel button is clicked', async () => {

--- a/user-interface/src/data-verification/ConsolidationOrderModal.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderModal.tsx
@@ -309,7 +309,11 @@ function ConsolidationOrderModalComponent(
         <div data-testid="modal-rejection-notice-container">
           The following cases will not be consolidated
         </div>
-        <div className="modal-case-list-container" style={{ maxHeight: childCasesDivHeight }}>
+        <div
+          data-testid="modal-case-list-container"
+          className="modal-case-list-container"
+          style={{ maxHeight: childCasesDivHeight }}
+        >
           <ul className="usa-list--unstyled modal-case-list">
             {cases.map((bCase) => (
               <li key={bCase.caseId}>
@@ -415,7 +419,11 @@ function ConsolidationOrderModalComponent(
           This will confirm the{' '}
           <span className="text-bold">{consolidationTypeMap.get(consolidationType!)}</span> of
         </div>
-        <div className="modal-case-list-container" style={{ maxHeight: childCasesDivHeight }}>
+        <div
+          data-testid="modal-case-list-container"
+          className="modal-case-list-container"
+          style={{ maxHeight: childCasesDivHeight }}
+        >
           <ul className="usa-list--unstyled modal-case-list">
             {cases.map((bCase) => (
               <li key={bCase.caseId}>

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -6,7 +6,6 @@ export const CHAPTER_ELEVEN_ENABLED = 'chapter-eleven-enabled';
 export const CHAPTER_TWELVE_ENABLED = 'chapter-twelve-enabled';
 export const TRANSFER_ORDERS_ENABLED = 'transfer-orders-enabled';
 export const CONSOLIDATIONS_ENABLED = 'consolidations-enabled';
-export const CONSOLIDATIONS_ADD_CASE_ENABLED = 'consolidations-add-case';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();


### PR DESCRIPTION
# Purpose

Reject a consolidation order.

# Major Changes

* Enable the rejection button in the consolidation order accordion
* Render the rejection modal
* Call the rejection endpoint from the UI
* Update the order buffer in the UI
* Update status on the consolidation order in Cosmos

# Testing/Validation

* Confirm documents are correctly written to Cosmos
* Test coverage above threshold
