### PR TITLE
CAMS-301 Add docket table to rejected consolidation accordion

### DIFF
--- a/user-interface/src/data-verification/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.tsx
@@ -13,7 +13,7 @@ export type OrderTableImperative = {
 interface ConsolidationCaseTableProps {
   id: string;
   cases: Array<ConsolidationOrderCase>;
-  onSelect: (bCase: ConsolidationOrderCase) => void;
+  onSelect?: (bCase: ConsolidationOrderCase) => void;
   isAssignmentLoaded: boolean;
   displayDocket?: boolean;
 }
@@ -35,7 +35,7 @@ function _ConsolidationCaseTable(
       setIncluded([...included, idx]);
     }
     const _case = cases[idx];
-    onSelect(_case);
+    if (onSelect) onSelect(_case);
   }
 
   function clearSelection() {
@@ -54,7 +54,7 @@ function _ConsolidationCaseTable(
     >
       <thead>
         <tr>
-          <th scope="col">Include</th>
+          {onSelect && <th scope="col">Include</th>}
           <th scope="col">Case Number (Division)</th>
           <th scope="col">Debtor</th>
           <th scope="col">Chapter</th>
@@ -68,17 +68,19 @@ function _ConsolidationCaseTable(
             const key = `${id}-row-${idx}`;
             accumulator.push(
               <tr key={`${key}-case-info`} data-testid={`${key}-case-info`} className="case-info">
-                <td scope="row">
-                  <input
-                    type="checkbox"
-                    onChange={handleCaseSelection}
-                    value={idx}
-                    name="case-selection"
-                    data-testid={`${id}-checkbox-${idx}`}
-                    checked={included.includes(idx)}
-                    title={`select ${bCase.caseTitle}`}
-                  ></input>
-                </td>
+                {onSelect && (
+                  <td scope="row">
+                    <input
+                      type="checkbox"
+                      onChange={handleCaseSelection}
+                      value={idx}
+                      name="case-selection"
+                      data-testid={`${id}-checkbox-${idx}`}
+                      checked={included.includes(idx)}
+                      title={`select ${bCase.caseTitle}`}
+                    ></input>
+                  </td>
+                )}
                 <td scope="row">
                   <CaseNumber caseId={bCase.caseId} /> ({bCase.courtDivisionName})
                 </td>
@@ -117,7 +119,7 @@ function _ConsolidationCaseTable(
                 data-testid={`${key}-docket-entry`}
                 className="docket-entry"
               >
-                <td></td>
+                {onSelect && <td></td>}
                 <td colSpan={5} className="measure-6">
                   {!bCase.docketEntries && <>No docket entries</>}
                   {bCase.docketEntries &&

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
@@ -131,7 +131,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     }
 
     order.childCases.forEach((bCase, idx) => {
-      const tableRow = screen.queryByTestId(`order-${order.id}-child-cases-row-${idx}`);
+      const tableRow = screen.queryByTestId(`${order.id}-case-list-row-${idx}-case-info`);
       expect(tableRow).toBeInTheDocument();
       expect(tableRow?.textContent).toContain(bCase.caseTitle);
     });

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -367,16 +367,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
               </div>
               <div className="grid-col-1"></div>
             </div>
-            {/* <div className="grid-row grid-gap-lg">
-              <div className="grid-col-1"></div>
-              <div className="grid-col-10">
-                <CaseTable
-                  id={`order-${order.id}-child-cases`}
-                  cases={order.childCases}
-                ></CaseTable>
-              </div>
-              <div className="grid-col-1"></div>
-            </div> */}
           </section>
         )}
       </>

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -358,13 +358,25 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
             <div className="grid-row grid-gap-lg">
               <div className="grid-col-1"></div>
               <div className="grid-col-10">
+                <ConsolidationCaseTable
+                  id={`${order.id}-case-list`}
+                  data-testid={`${order.id}-case-list`}
+                  cases={order.childCases}
+                  isAssignmentLoaded={isAssignmentLoaded}
+                ></ConsolidationCaseTable>
+              </div>
+              <div className="grid-col-1"></div>
+            </div>
+            {/* <div className="grid-row grid-gap-lg">
+              <div className="grid-col-1"></div>
+              <div className="grid-col-10">
                 <CaseTable
                   id={`order-${order.id}-child-cases`}
                   cases={order.childCases}
                 ></CaseTable>
               </div>
               <div className="grid-col-1"></div>
-            </div>
+            </div> */}
           </section>
         )}
       </>


### PR DESCRIPTION
# Purpose

Add docket entries to rejected consolidation accordion content.

# Major Changes

Added table from pending content to the rejected content. Dynamically removed the checkboxes used by the pending screen.

# Testing/Validation

Manually tested and reviewed.
