### PR TITLE
CAMS-349: check uncheck all

### DIFF
--- a/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MockData } from '@common/cams/test-utilities/mock-data';
 import CaseDetailAssociatedCases from './CaseDetailAssociatedCases';
 import { ConsolidationFrom, ConsolidationTo, EventCaseReference } from '@common/cams/events';
@@ -77,7 +77,7 @@ describe('associated cases tests', () => {
     const sortedMock = sortMock(mock);
 
     let header3, header4;
-    await vi.waitFor(() => {
+    await waitFor(() => {
       header3 = document.querySelector('.associated-cases h3');
       header4 = document.querySelector('.associated-cases h4');
     });

--- a/user-interface/src/data-verification/CaseTable.tsx
+++ b/user-interface/src/data-verification/CaseTable.tsx
@@ -4,7 +4,7 @@ import { CaseSummary } from '@common/cams/cases';
 import { SyntheticEvent, forwardRef, useImperativeHandle, useState } from 'react';
 
 export type CaseTableImperative = {
-  clearSelection: () => void;
+  clearAllCheckboxes: () => void;
 };
 
 interface CaseTableProps {
@@ -26,12 +26,12 @@ function _CaseTable(props: CaseTableProps, CaseTableRef: React.Ref<CaseTableImpe
     if (onSelect) onSelect(bCase);
   }
 
-  function clearSelection() {
+  function clearAllCheckboxes() {
     setSelectedIdx(null);
   }
 
   useImperativeHandle(CaseTableRef, () => ({
-    clearSelection,
+    clearAllCheckboxes,
   }));
 
   return (

--- a/user-interface/src/data-verification/ConsolidationCasesTable.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.test.tsx
@@ -1,0 +1,105 @@
+import { BrowserRouter } from 'react-router-dom';
+import {
+  ConsolidationCaseTable,
+  ConsolidationCaseTableProps,
+  OrderTableImperative,
+} from './ConsolidationCasesTable';
+import { render } from '@testing-library/react';
+import { MockData } from '@common/cams/test-utilities/mock-data';
+import React from 'react';
+
+describe('test ConsolidationCasesTable component', () => {
+  function renderWithProps(
+    props?: Partial<ConsolidationCaseTableProps>,
+    tableRef?: React.Ref<OrderTableImperative>,
+  ) {
+    const defaultProps: ConsolidationCaseTableProps = {
+      id: 'test-consolidation-cases-table',
+      cases: props?.cases ?? [],
+      onSelect: props?.onSelect ?? vi.fn(),
+      isAssignmentLoaded: props?.isAssignmentLoaded ?? true,
+      displayDocket: props?.displayDocket ?? false,
+    };
+
+    const renderProps = { ...defaultProps, ...props };
+    render(
+      <BrowserRouter>
+        <ConsolidationCaseTable {...renderProps} ref={tableRef} />
+      </BrowserRouter>,
+    );
+  }
+
+  test('should select all checkboxes when ref.selectAll() is called and clear them when ref.clearSelection() is called', async () => {
+    const tableRef = React.createRef<OrderTableImperative>();
+    let checkboxes: NodeListOf<HTMLInputElement>;
+    let checkbox: HTMLInputElement;
+
+    const props = {
+      cases: MockData.buildArray(() => MockData.getConsolidatedOrderCase(), 5),
+    };
+
+    renderWithProps(props, tableRef);
+
+    checkboxes = document.querySelectorAll(`.consolidation-cases-table input`);
+
+    expect(checkboxes).not.toBeUndefined();
+
+    if (checkboxes) {
+      for (checkbox of checkboxes) {
+        expect(checkbox.checked).toBeFalsy();
+      }
+    }
+
+    const selectedItems = tableRef.current?.selectAll();
+
+    expect(selectedItems).toEqual(props.cases);
+
+    await vi.waitFor(() => {
+      checkboxes = document.querySelectorAll(`.consolidation-cases-table input`);
+      for (checkbox of checkboxes) {
+        expect((checkbox as HTMLInputElement).checked).toBeTruthy();
+      }
+    });
+
+    tableRef.current?.clearSelection();
+
+    await vi.waitFor(() => {
+      checkboxes = document.querySelectorAll(`.consolidation-cases-table input`);
+      for (checkbox of checkboxes) {
+        expect((checkbox as HTMLInputElement).checked).toBeFalsy();
+      }
+    });
+  });
+
+  test('should have text (unassigned) when no assignments are passed in', async () => {
+    const props = {
+      cases: [
+        MockData.getConsolidatedOrderCase({
+          override: {
+            attorneyAssignments: [],
+          },
+        }),
+      ],
+    };
+
+    renderWithProps(props);
+
+    expect(document.body).toHaveTextContent('(unassigned)');
+  });
+
+  test('should have text "no docket entries" when no docket entries are passed in', async () => {
+    const props = {
+      cases: [
+        MockData.getConsolidatedOrderCase({
+          override: {
+            docketEntries: undefined,
+          },
+        }),
+      ],
+    };
+
+    renderWithProps(props);
+
+    expect(document.body).toHaveTextContent('No docket entries');
+  });
+});

--- a/user-interface/src/data-verification/ConsolidationCasesTable.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.test.tsx
@@ -29,7 +29,7 @@ describe('test ConsolidationCasesTable component', () => {
     );
   }
 
-  test('should select all checkboxes when ref.selectAll() is called and clear them when ref.clearSelection() is called', async () => {
+  test('should select all checkboxes when ref.selectAllCheckboxes() is called and clear them when ref.clearAllCheckboxes() is called', async () => {
     const tableRef = React.createRef<OrderTableImperative>();
     let checkboxes: NodeListOf<HTMLInputElement>;
     let checkbox: HTMLInputElement;
@@ -50,7 +50,7 @@ describe('test ConsolidationCasesTable component', () => {
       }
     }
 
-    const selectedItems = tableRef.current?.selectAll();
+    const selectedItems = tableRef.current?.selectAllCheckboxes();
 
     expect(selectedItems).toEqual(props.cases);
 
@@ -61,7 +61,7 @@ describe('test ConsolidationCasesTable component', () => {
       }
     });
 
-    tableRef.current?.clearSelection();
+    tableRef.current?.clearAllCheckboxes();
 
     await vi.waitFor(() => {
       checkboxes = document.querySelectorAll(`.consolidation-cases-table input`);

--- a/user-interface/src/data-verification/ConsolidationCasesTable.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.test.tsx
@@ -4,7 +4,7 @@ import {
   ConsolidationCaseTableProps,
   OrderTableImperative,
 } from './ConsolidationCasesTable';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { MockData } from '@common/cams/test-utilities/mock-data';
 import React from 'react';
 
@@ -54,7 +54,7 @@ describe('test ConsolidationCasesTable component', () => {
 
     expect(selectedItems).toEqual(props.cases);
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       checkboxes = document.querySelectorAll(`.consolidation-cases-table input`);
       for (checkbox of checkboxes) {
         expect((checkbox as HTMLInputElement).checked).toBeTruthy();
@@ -63,7 +63,7 @@ describe('test ConsolidationCasesTable component', () => {
 
     tableRef.current?.clearAllCheckboxes();
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       checkboxes = document.querySelectorAll(`.consolidation-cases-table input`);
       for (checkbox of checkboxes) {
         expect((checkbox as HTMLInputElement).checked).toBeFalsy();

--- a/user-interface/src/data-verification/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.tsx
@@ -7,8 +7,8 @@ import { formatDate } from '@/lib/utils/datetime';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 
 export type OrderTableImperative = {
-  clearSelection: () => void;
-  selectAll: () => ConsolidationOrderCase[];
+  clearAllCheckboxes: () => void;
+  selectAllCheckboxes: () => ConsolidationOrderCase[];
 };
 
 export interface ConsolidationCaseTableProps {
@@ -39,11 +39,11 @@ function _ConsolidationCaseTable(
     if (onSelect) onSelect(_case);
   }
 
-  function clearSelection() {
+  function clearAllCheckboxes() {
     setIncluded([]);
   }
 
-  function selectAll() {
+  function selectAllCheckboxes() {
     const newIdList = [];
     const newCaseList = [];
     let bCase = 0;
@@ -60,8 +60,8 @@ function _ConsolidationCaseTable(
   }
 
   useImperativeHandle(OrderTableRef, () => ({
-    clearSelection,
-    selectAll,
+    clearAllCheckboxes,
+    selectAllCheckboxes,
   }));
 
   return (

--- a/user-interface/src/data-verification/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.tsx
@@ -8,6 +8,7 @@ import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 
 export type OrderTableImperative = {
   clearSelection: () => void;
+  selectAll: () => ConsolidationOrderCase[];
 };
 
 interface ConsolidationCaseTableProps {
@@ -42,8 +43,25 @@ function _ConsolidationCaseTable(
     setIncluded([]);
   }
 
+  function selectAll() {
+    const newIdList = [];
+    const newCaseList = [];
+    let bCase = 0;
+    const checkboxes = document.querySelectorAll(`#${id}.consolidation-cases-table input`);
+    if (checkboxes) {
+      for (const checkBox of checkboxes) {
+        bCase = parseInt((checkBox as HTMLInputElement).value);
+        newIdList.push(bCase);
+        newCaseList.push(cases[bCase]);
+      }
+    }
+    setIncluded(newIdList);
+    return newCaseList;
+  }
+
   useImperativeHandle(OrderTableRef, () => ({
     clearSelection,
+    selectAll,
   }));
 
   return (

--- a/user-interface/src/data-verification/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.tsx
@@ -11,7 +11,7 @@ export type OrderTableImperative = {
   selectAll: () => ConsolidationOrderCase[];
 };
 
-interface ConsolidationCaseTableProps {
+export interface ConsolidationCaseTableProps {
   id: string;
   cases: Array<ConsolidationOrderCase>;
   onSelect?: (bCase: ConsolidationOrderCase) => void;

--- a/user-interface/src/data-verification/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.tsx
@@ -92,7 +92,7 @@ function _ConsolidationCaseTable(
                 {onSelect && (
                   <td scope="row">
                     <Checkbox
-                      id={`${id}-case-selection-${idx}`}
+                      id={`case-selection-${id}-${idx}`}
                       onChange={handleCaseSelection}
                       name="case-selection"
                       value={idx}

--- a/user-interface/src/data-verification/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.tsx
@@ -5,6 +5,7 @@ import { SyntheticEvent, forwardRef, useImperativeHandle, useState, ReactNode } 
 import { Link } from 'react-router-dom';
 import { formatDate } from '@/lib/utils/datetime';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
+import Checkbox from '@/lib/components/uswds/Checkbox';
 
 export type OrderTableImperative = {
   clearAllCheckboxes: () => void;
@@ -88,15 +89,14 @@ function _ConsolidationCaseTable(
               <tr key={`${key}-case-info`} data-testid={`${key}-case-info`} className="case-info">
                 {onSelect && (
                   <td scope="row">
-                    <input
-                      type="checkbox"
+                    <Checkbox
+                      id={`${id}-case-selection-${idx}`}
                       onChange={handleCaseSelection}
-                      value={idx}
                       name="case-selection"
-                      data-testid={`${id}-checkbox-${idx}`}
-                      checked={included.includes(idx)}
+                      value={idx}
                       title={`select ${bCase.caseTitle}`}
-                    ></input>
+                      checked={included.includes(idx)}
+                    ></Checkbox>
                   </td>
                 )}
                 <td scope="row">

--- a/user-interface/src/data-verification/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/ConsolidationCasesTable.tsx
@@ -48,7 +48,9 @@ function _ConsolidationCaseTable(
     const newIdList = [];
     const newCaseList = [];
     let bCase = 0;
-    const checkboxes = document.querySelectorAll(`#${id}.consolidation-cases-table input`);
+    const checkboxes = document.querySelectorAll(
+      `#consolidation-cases-${id}.consolidation-cases-table input`,
+    );
     if (checkboxes) {
       for (const checkBox of checkboxes) {
         bCase = parseInt((checkBox as HTMLInputElement).value);
@@ -68,7 +70,7 @@ function _ConsolidationCaseTable(
   return (
     <table
       className="usa-table usa-table--borderless consolidation-cases-table"
-      id={id}
+      id={`consolidation-cases-${id}`}
       data-testid={id}
     >
       <thead>

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
@@ -60,6 +60,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
+
   function renderWithProps(props?: Partial<ConsolidationOrderAccordionProps>) {
     const defaultProps: ConsolidationOrderAccordionProps = {
       order,

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
@@ -140,7 +140,9 @@ describe('ConsolidationOrderAccordion tests', () => {
 
   test('should correctly enable/disable buttons', async () => {
     renderWithProps();
-    const checkbox = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
+    const checkbox: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
 
     const includeAllButton = document.querySelector(`#${order.id}-checkbox-toggle-button`);
 
@@ -191,7 +193,9 @@ describe('ConsolidationOrderAccordion tests', () => {
       `#accordion-approve-button-${order.id}`,
     ) as HTMLButtonElement;
     expect(approveButton).not.toBeEnabled();
-    const checkbox = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
+    const checkbox: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(approveButton).toBeEnabled();
@@ -214,7 +218,9 @@ describe('ConsolidationOrderAccordion tests', () => {
       `#accordion-reject-button-${order.id}`,
     ) as HTMLButtonElement;
     expect(rejectButton).not.toBeEnabled();
-    const checkbox = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
+    const checkbox: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(rejectButton).toBeEnabled();
@@ -250,7 +256,9 @@ describe('ConsolidationOrderAccordion tests', () => {
       `#accordion-reject-button-${order.id}`,
     ) as HTMLButtonElement;
     expect(rejectButton).not.toBeEnabled();
-    const checkbox = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
+    const checkbox: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(rejectButton).toBeEnabled();
@@ -300,7 +308,9 @@ describe('ConsolidationOrderAccordion tests', () => {
       `#accordion-reject-button-${order.id}`,
     ) as HTMLButtonElement;
     expect(rejectButton).not.toBeEnabled();
-    const checkbox = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
+    const checkbox: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(rejectButton).toBeEnabled();
@@ -360,7 +370,9 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
     expect(approveButton).not.toBeEnabled();
-    const checkbox = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
+    const checkbox: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(approveButton).toBeEnabled();
@@ -432,7 +444,9 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
     expect(approveButton).not.toBeEnabled();
-    const checkbox = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
+    const checkbox: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(approveButton).toBeEnabled();
@@ -491,8 +505,12 @@ describe('ConsolidationOrderAccordion tests', () => {
     const cancelButton = document.querySelector(`#accordion-cancel-button-${order.id}`);
     expect(approveButton).not.toBeEnabled();
 
-    const checkbox1: HTMLInputElement = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
-    const checkbox2: HTMLInputElement = screen.getByTestId(`${order.id}-case-list-checkbox-1`);
+    const checkbox1: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
+    const checkbox2: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-1`,
+    );
 
     fireEvent.click(checkbox1);
     fireEvent.click(checkbox2);
@@ -519,8 +537,12 @@ describe('ConsolidationOrderAccordion tests', () => {
     const collapseButton = screen.getByTestId(`accordion-button-order-list-${order.id}`);
     expect(approveButton).not.toBeEnabled();
 
-    let checkbox1: HTMLInputElement = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
-    let checkbox2: HTMLInputElement = screen.getByTestId(`${order.id}-case-list-checkbox-1`);
+    let checkbox1: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-0`,
+    );
+    let checkbox2: HTMLInputElement = screen.getByTestId(
+      `checkbox-${order.id}-case-list-case-selection-1`,
+    );
 
     fireEvent.click(checkbox1);
     fireEvent.click(checkbox2);
@@ -534,8 +556,8 @@ describe('ConsolidationOrderAccordion tests', () => {
     fireEvent.click(collapseButton as HTMLButtonElement); // collapse accordian
 
     fireEvent.click(collapseButton as HTMLButtonElement);
-    checkbox1 = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
-    checkbox2 = screen.getByTestId(`${order.id}-case-list-checkbox-1`);
+    checkbox1 = screen.getByTestId(`checkbox-${order.id}-case-list-case-selection-0`);
+    checkbox2 = screen.getByTestId(`checkbox-${order.id}-case-list-case-selection-1`);
 
     await waitFor(() => {
       expect(checkbox1.checked).toBeFalsy();

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
@@ -142,12 +142,16 @@ describe('ConsolidationOrderAccordion tests', () => {
     renderWithProps();
     const checkbox = screen.getByTestId(`${order.id}-case-list-checkbox-0`);
 
+    const includeAllButton = document.querySelector(`#${order.id}-checkbox-toggle-button`);
+
     const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
     expect(approveButton).not.toBeEnabled();
+
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(approveButton).toBeEnabled();
     });
+
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(approveButton).not.toBeEnabled();
@@ -159,9 +163,25 @@ describe('ConsolidationOrderAccordion tests', () => {
     await waitFor(() => {
       expect(rejectButton).toBeEnabled();
     });
+
     fireEvent.click(checkbox);
     await waitFor(() => {
       expect(rejectButton).not.toBeEnabled();
+    });
+
+    fireEvent.click(includeAllButton!);
+    await waitFor(() => {
+      expect(approveButton).toBeEnabled();
+    });
+
+    fireEvent.click(includeAllButton!);
+    await waitFor(() => {
+      expect(approveButton).not.toBeEnabled();
+    });
+
+    fireEvent.click(checkbox);
+    await waitFor(() => {
+      expect(approveButton).toBeEnabled();
     });
   });
 
@@ -521,6 +541,48 @@ describe('ConsolidationOrderAccordion tests', () => {
       expect(checkbox1.checked).toBeFalsy();
       expect(checkbox2.checked).toBeFalsy();
       expect(approveButton).not.toBeEnabled();
+    });
+  });
+
+  test('should select all checkboxes and enable approve button when Include All button is clicked', async () => {
+    renderWithProps();
+
+    const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
+    expect(approveButton).not.toBeEnabled();
+    const includeAllButton = document.querySelector(`#${order.id}-checkbox-toggle-button`);
+
+    const checkboxList: NodeListOf<HTMLInputElement> = document.querySelectorAll(
+      'table input[type="checkbox"]',
+    );
+
+    fireEvent.click(includeAllButton!);
+
+    await waitFor(() => {
+      for (const checkbox of checkboxList) {
+        expect(checkbox.checked).toBeTruthy();
+      }
+      expect(approveButton).toBeEnabled();
+    });
+
+    fireEvent.click(checkboxList[0]);
+    await waitFor(() => {
+      expect(checkboxList[0].checked).toBeFalsy();
+    });
+
+    fireEvent.click(includeAllButton!);
+    await waitFor(() => {
+      for (const checkbox of checkboxList) {
+        expect(checkbox.checked).toBeTruthy();
+      }
+      expect(approveButton).toBeEnabled();
+    });
+
+    fireEvent.click(includeAllButton!);
+    await waitFor(() => {
+      for (const checkbox of checkboxList) {
+        expect(checkbox.checked).toBeFalsy();
+      }
+      expect(approveButton).toBeDisabled();
     });
   });
 });

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
@@ -141,10 +141,10 @@ describe('ConsolidationOrderAccordion tests', () => {
   test('should correctly enable/disable buttons', async () => {
     renderWithProps();
     const checkbox: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
 
-    const includeAllButton = document.querySelector(`#${order.id}-checkbox-toggle-button`);
+    const includeAllButton = document.querySelector(`#checkbox-toggle-button-${order.id}`);
 
     const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
     expect(approveButton).not.toBeEnabled();
@@ -194,7 +194,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     ) as HTMLButtonElement;
     expect(approveButton).not.toBeEnabled();
     const checkbox: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
     fireEvent.click(checkbox);
     await waitFor(() => {
@@ -219,7 +219,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     ) as HTMLButtonElement;
     expect(rejectButton).not.toBeEnabled();
     const checkbox: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
     fireEvent.click(checkbox);
     await waitFor(() => {
@@ -257,7 +257,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     ) as HTMLButtonElement;
     expect(rejectButton).not.toBeEnabled();
     const checkbox: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
     fireEvent.click(checkbox);
     await waitFor(() => {
@@ -309,7 +309,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     ) as HTMLButtonElement;
     expect(rejectButton).not.toBeEnabled();
     const checkbox: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
     fireEvent.click(checkbox);
     await waitFor(() => {
@@ -371,7 +371,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
     expect(approveButton).not.toBeEnabled();
     const checkbox: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
     fireEvent.click(checkbox);
     await waitFor(() => {
@@ -445,7 +445,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
     expect(approveButton).not.toBeEnabled();
     const checkbox: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
     fireEvent.click(checkbox);
     await waitFor(() => {
@@ -506,10 +506,10 @@ describe('ConsolidationOrderAccordion tests', () => {
     expect(approveButton).not.toBeEnabled();
 
     const checkbox1: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
     const checkbox2: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-1`,
+      `checkbox-case-selection-${order.id}-case-list-1`,
     );
 
     fireEvent.click(checkbox1);
@@ -538,10 +538,10 @@ describe('ConsolidationOrderAccordion tests', () => {
     expect(approveButton).not.toBeEnabled();
 
     let checkbox1: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-0`,
+      `checkbox-case-selection-${order.id}-case-list-0`,
     );
     let checkbox2: HTMLInputElement = screen.getByTestId(
-      `checkbox-${order.id}-case-list-case-selection-1`,
+      `checkbox-case-selection-${order.id}-case-list-1`,
     );
 
     fireEvent.click(checkbox1);
@@ -556,8 +556,8 @@ describe('ConsolidationOrderAccordion tests', () => {
     fireEvent.click(collapseButton as HTMLButtonElement); // collapse accordian
 
     fireEvent.click(collapseButton as HTMLButtonElement);
-    checkbox1 = screen.getByTestId(`checkbox-${order.id}-case-list-case-selection-0`);
-    checkbox2 = screen.getByTestId(`checkbox-${order.id}-case-list-case-selection-1`);
+    checkbox1 = screen.getByTestId(`checkbox-case-selection-${order.id}-case-list-0`);
+    checkbox2 = screen.getByTestId(`checkbox-case-selection-${order.id}-case-list-1`);
 
     await waitFor(() => {
       expect(checkbox1.checked).toBeFalsy();
@@ -571,7 +571,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
     expect(approveButton).not.toBeEnabled();
-    const includeAllButton = document.querySelector(`#${order.id}-checkbox-toggle-button`);
+    const includeAllButton = document.querySelector(`#checkbox-toggle-button-${order.id}`);
 
     const checkboxList: NodeListOf<HTMLInputElement> = document.querySelectorAll(
       'table input[type="checkbox"]',

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -80,9 +80,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     if (caseList) {
       setSelectedCases(caseList);
       setCheckboxGroupState(CheckBoxState.CHECKED);
-    } else {
-      setSelectedCases([]);
-      setCheckboxGroupState(CheckBoxState.UNCHECKED);
     }
   }
 

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -279,7 +279,11 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
               <div className="grid-col-10">
                 <div>
                   <h3>Cases</h3>
-                  <Button uswdsStyle={UswdsButtonStyle.Outline} onClick={toggleAllCheckBoxes}>
+                  <Button
+                    id={`${order.id}-checkbox-toggle-button`}
+                    uswdsStyle={UswdsButtonStyle.Outline}
+                    onClick={toggleAllCheckBoxes}
+                  >
                     {checkboxGroupState === CheckBoxState.CHECKED && <>Exclude All</>}
                     {checkboxGroupState !== CheckBoxState.CHECKED && <>Include All</>}
                   </Button>

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -24,7 +24,7 @@ import { CaseNumber } from '@/lib/components/CaseNumber';
 import './ConsolidationOrderAccordion.scss';
 import { useApi } from '@/lib/hooks/UseApi';
 import { CaseAssignmentResponseData } from '@/lib/type-declarations/chapter-15';
-import { CheckBoxState } from '@/lib/components/uswds/Checkbox';
+import { CheckboxState } from '@/lib/components/uswds/Checkbox';
 
 export interface ConsolidationOrderAccordionProps {
   order: ConsolidationOrder;
@@ -48,8 +48,8 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
 
   const [order, setOrder] = useState<ConsolidationOrder>(props.order);
   const [selectedCases, setSelectedCases] = useState<Array<ConsolidationOrderCase>>([]);
-  const [checkboxGroupState, setCheckboxGroupState] = useState<CheckBoxState>(
-    CheckBoxState.UNCHECKED,
+  const [checkboxGroupState, setCheckboxGroupState] = useState<CheckboxState>(
+    CheckboxState.UNCHECKED,
   );
   const [isAssignmentLoaded, setIsAssignmentLoaded] = useState<boolean>(false);
   const [filteredOfficesList] = useState<OfficeDetails[] | null>(
@@ -70,27 +70,27 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     }
     setSelectedCases(tempSelectedCases);
     const total = tempSelectedCases.length;
-    if (total === 0) setCheckboxGroupState(CheckBoxState.UNCHECKED);
-    else if (total < order.childCases.length) setCheckboxGroupState(CheckBoxState.INDETERMINATE);
-    else if (total === order.childCases.length) setCheckboxGroupState(CheckBoxState.CHECKED);
+    if (total === 0) setCheckboxGroupState(CheckboxState.UNCHECKED);
+    else if (total < order.childCases.length) setCheckboxGroupState(CheckboxState.INDETERMINATE);
+    else if (total === order.childCases.length) setCheckboxGroupState(CheckboxState.CHECKED);
   }
 
   function selectAllCheckboxes() {
     const caseList = caseTable.current?.selectAllCheckboxes();
     if (caseList) {
       setSelectedCases(caseList);
-      setCheckboxGroupState(CheckBoxState.CHECKED);
+      setCheckboxGroupState(CheckboxState.CHECKED);
     }
   }
 
   function clearAllCheckboxes() {
     setSelectedCases([]);
     caseTable.current?.clearAllCheckboxes();
-    setCheckboxGroupState(CheckBoxState.UNCHECKED);
+    setCheckboxGroupState(CheckboxState.UNCHECKED);
   }
 
   function toggleAllCheckBoxes() {
-    if (checkboxGroupState === CheckBoxState.CHECKED) {
+    if (checkboxGroupState === CheckboxState.CHECKED) {
       clearAllCheckboxes();
     } else {
       selectAllCheckboxes();
@@ -277,12 +277,12 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
                 <div>
                   <h3>Cases</h3>
                   <Button
-                    id={`${order.id}-checkbox-toggle-button`}
+                    id={`checkbox-toggle-button-${order.id}`}
                     uswdsStyle={UswdsButtonStyle.Outline}
                     onClick={toggleAllCheckBoxes}
                   >
-                    {checkboxGroupState === CheckBoxState.CHECKED && <>Exclude All</>}
-                    {checkboxGroupState !== CheckBoxState.CHECKED && <>Include All</>}
+                    {checkboxGroupState === CheckboxState.CHECKED && <>Exclude All</>}
+                    {checkboxGroupState !== CheckboxState.CHECKED && <>Include All</>}
                   </Button>
                 </div>
                 <ConsolidationCaseTable

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -58,13 +58,10 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
   const api = useApi();
 
   function handleIncludeCase(bCase: ConsolidationOrderCase) {
-    console.log(`Adding ${bCase.caseId} to selectedCases`, selectedCases.length);
     if (selectedCases.includes(bCase)) {
       setSelectedCases(selectedCases.filter((aCase) => bCase !== aCase));
     } else {
-      console.log('selectedCases was empty');
       setSelectedCases([...selectedCases, bCase]);
-      console.log(selectedCases);
     }
   }
 

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -1,9 +1,9 @@
 import { Accordion } from '@/lib/components/uswds/Accordion';
 import { formatDate } from '@/lib/utils/datetime';
 import { AlertDetails } from '@/data-verification/DataVerificationScreen';
-import { CaseTable, CaseTableImperative } from './CaseTable';
+import { CaseTable } from './CaseTable';
 import { useEffect, useRef, useState } from 'react';
-import { ConsolidationCaseTable } from './ConsolidationCasesTable';
+import { ConsolidationCaseTable, OrderTableImperative } from './ConsolidationCasesTable';
 import './TransferOrderAccordion.scss';
 import {
   ConsolidationOrder,
@@ -43,7 +43,7 @@ export interface ConsolidationOrderAccordionProps {
 
 export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionProps) {
   const { hidden, statusType, orderType, officesList, expandedId } = props;
-  const caseTable = useRef<CaseTableImperative>(null);
+  const caseTable = useRef<OrderTableImperative>(null);
 
   const [order, setOrder] = useState<ConsolidationOrder>(props.order);
   const [selectedCases, setSelectedCases] = useState<Array<ConsolidationOrderCase>>([]);
@@ -58,10 +58,27 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
   const api = useApi();
 
   function handleIncludeCase(bCase: ConsolidationOrderCase) {
+    console.log(`Adding ${bCase.caseId} to selectedCases`, selectedCases.length);
     if (selectedCases.includes(bCase)) {
       setSelectedCases(selectedCases.filter((aCase) => bCase !== aCase));
     } else {
+      console.log('selectedCases was empty');
       setSelectedCases([...selectedCases, bCase]);
+      console.log(selectedCases);
+    }
+  }
+
+  function toggleAllCheckBoxes() {
+    if (selectedCases.length > 0) {
+      setSelectedCases([]);
+      caseTable.current?.clearSelection();
+    } else {
+      const caseList = caseTable.current?.selectAll();
+      if (caseList) {
+        setSelectedCases(caseList);
+      } else {
+        setSelectedCases([]);
+      }
     }
   }
 
@@ -242,6 +259,12 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
             <div className="grid-row grid-gap-lg">
               <div className="grid-col-1"></div>
               <div className="grid-col-10">
+                <div>
+                  <h3>Cases</h3>
+                  <Button uswdsStyle={UswdsButtonStyle.Outline} onClick={toggleAllCheckBoxes}>
+                    Include/Exclude All
+                  </Button>
+                </div>
                 <ConsolidationCaseTable
                   id={`${order.id}-case-list`}
                   data-testid={`${order.id}-case-list`}

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -71,7 +71,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     setSelectedCases(tempSelectedCases);
     const total = tempSelectedCases.length;
     if (total === 0) setCheckboxGroupState(CheckBoxState.UNCHECKED);
-    else if (total < order.childCases.length) setCheckboxGroupState(CheckBoxState.INTERMEDIATE);
+    else if (total < order.childCases.length) setCheckboxGroupState(CheckBoxState.INDETERMINATE);
     else if (total === order.childCases.length) setCheckboxGroupState(CheckBoxState.CHECKED);
   }
 

--- a/user-interface/src/data-verification/TransferOrderAccordion.tsx
+++ b/user-interface/src/data-verification/TransferOrderAccordion.tsx
@@ -251,7 +251,7 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
     setOrderTransfer(getOrderTransferFromOrder(order));
     setNewCaseSummary(null);
     setValidationState(ValidationStates.notValidated);
-    if (suggestedCasesRef.current) suggestedCasesRef.current.clearSelection();
+    if (suggestedCasesRef.current) suggestedCasesRef.current.clearAllCheckboxes();
     setLoadingCaseSummary(false);
     approveButtonRef.current?.disableButton(true);
   }

--- a/user-interface/src/lib/components/uswds/Checkbox.test.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import Checkbox, { CheckboxProps, CheckboxRef, CheckboxState } from './Checkbox';
@@ -61,12 +61,12 @@ describe('Test Checkbox component', async () => {
     const checkbox = document.querySelector('input[type="checkbox"]');
     expect(checkbox).not.toBeChecked();
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       cbRef.current?.setChecked(true);
     });
     expect(checkbox).toBeChecked();
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       cbRef.current?.setChecked(false);
     });
     expect(checkbox).not.toBeChecked();
@@ -80,19 +80,19 @@ describe('Test Checkbox component', async () => {
     expect(checkbox).not.toBeChecked();
     expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       cbRef.current?.setChecked(CheckboxState.CHECKED);
     });
     expect(checkbox).toBeChecked();
     expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       cbRef.current?.setChecked(CheckboxState.UNCHECKED);
     });
     expect(checkbox).not.toBeChecked();
     expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       cbRef.current?.setChecked(CheckboxState.INDETERMINATE);
     });
     expect(checkbox).not.toBeChecked();

--- a/user-interface/src/lib/components/uswds/Checkbox.test.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import Checkbox, { CheckboxProps, CheckboxRef } from './Checkbox';
+import Checkbox, { CheckboxProps, CheckboxRef, CheckBoxState } from './Checkbox';
 
 describe('Test Checkbox component', async () => {
   function renderWithProps(props?: Partial<CheckboxProps>, ref?: React.Ref<CheckboxRef>) {
@@ -70,5 +70,32 @@ describe('Test Checkbox component', async () => {
       cbRef.current?.setChecked(false);
     });
     expect(checkbox).not.toBeChecked();
+  });
+
+  test('Should check box when calling ref.setChecked(CheckBoxState.CHECKED), uncheck when calling ref.setChecked(CheckBoxState.UNCHECKED), and set to intermediate state when calling ref.setChecked(CheckBoxState.INTERMEDIATE)', async () => {
+    const cbRef = React.createRef<CheckboxRef>();
+    renderWithProps({}, cbRef);
+
+    const checkbox = document.querySelector('input[type="checkbox"]');
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).not.toHaveAttribute('data-intermediate', 'true');
+
+    await vi.waitFor(() => {
+      cbRef.current?.setChecked(CheckBoxState.CHECKED);
+    });
+    expect(checkbox).toBeChecked();
+    expect(checkbox).not.toHaveAttribute('data-intermediate', 'true');
+
+    await vi.waitFor(() => {
+      cbRef.current?.setChecked(CheckBoxState.UNCHECKED);
+    });
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).not.toHaveAttribute('data-intermediate', 'true');
+
+    await vi.waitFor(() => {
+      cbRef.current?.setChecked(CheckBoxState.INTERMEDIATE);
+    });
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).toHaveAttribute('data-intermediate', 'true');
   });
 });

--- a/user-interface/src/lib/components/uswds/Checkbox.test.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.test.tsx
@@ -72,30 +72,30 @@ describe('Test Checkbox component', async () => {
     expect(checkbox).not.toBeChecked();
   });
 
-  test('Should check box when calling ref.setChecked(CheckBoxState.CHECKED), uncheck when calling ref.setChecked(CheckBoxState.UNCHECKED), and set to intermediate state when calling ref.setChecked(CheckBoxState.INTERMEDIATE)', async () => {
+  test('Should check box when calling ref.setChecked(CheckBoxState.CHECKED), uncheck when calling ref.setChecked(CheckBoxState.UNCHECKED), and set to indeterminate state when calling ref.setChecked(CheckBoxState.INDETERMINATE)', async () => {
     const cbRef = React.createRef<CheckboxRef>();
     renderWithProps({}, cbRef);
 
     const checkbox = document.querySelector('input[type="checkbox"]');
     expect(checkbox).not.toBeChecked();
-    expect(checkbox).not.toHaveAttribute('data-intermediate', 'true');
+    expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
     await vi.waitFor(() => {
       cbRef.current?.setChecked(CheckBoxState.CHECKED);
     });
     expect(checkbox).toBeChecked();
-    expect(checkbox).not.toHaveAttribute('data-intermediate', 'true');
+    expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
     await vi.waitFor(() => {
       cbRef.current?.setChecked(CheckBoxState.UNCHECKED);
     });
     expect(checkbox).not.toBeChecked();
-    expect(checkbox).not.toHaveAttribute('data-intermediate', 'true');
+    expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
     await vi.waitFor(() => {
-      cbRef.current?.setChecked(CheckBoxState.INTERMEDIATE);
+      cbRef.current?.setChecked(CheckBoxState.INDETERMINATE);
     });
     expect(checkbox).not.toBeChecked();
-    expect(checkbox).toHaveAttribute('data-intermediate', 'true');
+    expect(checkbox).toHaveAttribute('data-indeterminate', 'true');
   });
 });

--- a/user-interface/src/lib/components/uswds/Checkbox.test.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import Checkbox, { CheckboxProps, CheckboxRef, CheckBoxState } from './Checkbox';
+import Checkbox, { CheckboxProps, CheckboxRef, CheckboxState } from './Checkbox';
 
 describe('Test Checkbox component', async () => {
   function renderWithProps(props?: Partial<CheckboxProps>, ref?: React.Ref<CheckboxRef>) {
@@ -72,7 +72,7 @@ describe('Test Checkbox component', async () => {
     expect(checkbox).not.toBeChecked();
   });
 
-  test('Should check box when calling ref.setChecked(CheckBoxState.CHECKED), uncheck when calling ref.setChecked(CheckBoxState.UNCHECKED), and set to indeterminate state when calling ref.setChecked(CheckBoxState.INDETERMINATE)', async () => {
+  test('Should check box when calling ref.setChecked(CheckboxState.CHECKED), uncheck when calling ref.setChecked(CheckboxState.UNCHECKED), and set to indeterminate state when calling ref.setChecked(CheckboxState.INDETERMINATE)', async () => {
     const cbRef = React.createRef<CheckboxRef>();
     renderWithProps({}, cbRef);
 
@@ -81,19 +81,19 @@ describe('Test Checkbox component', async () => {
     expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
     await vi.waitFor(() => {
-      cbRef.current?.setChecked(CheckBoxState.CHECKED);
+      cbRef.current?.setChecked(CheckboxState.CHECKED);
     });
     expect(checkbox).toBeChecked();
     expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
     await vi.waitFor(() => {
-      cbRef.current?.setChecked(CheckBoxState.UNCHECKED);
+      cbRef.current?.setChecked(CheckboxState.UNCHECKED);
     });
     expect(checkbox).not.toBeChecked();
     expect(checkbox).not.toHaveAttribute('data-indeterminate', 'true');
 
     await vi.waitFor(() => {
-      cbRef.current?.setChecked(CheckBoxState.INDETERMINATE);
+      cbRef.current?.setChecked(CheckboxState.INDETERMINATE);
     });
     expect(checkbox).not.toBeChecked();
     expect(checkbox).toHaveAttribute('data-indeterminate', 'true');

--- a/user-interface/src/lib/components/uswds/Checkbox.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.tsx
@@ -1,5 +1,11 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 
+export enum CheckBoxState {
+  UNCHECKED = -1,
+  INTERMEDIATE = 0,
+  CHECKED = 1,
+}
+
 export interface CheckboxProps {
   id: string;
   label?: string;

--- a/user-interface/src/lib/components/uswds/Checkbox.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 
-export enum CheckBoxState {
+export enum CheckboxState {
   UNCHECKED = -1,
   INDETERMINATE = 0,
   CHECKED = 1,
@@ -19,7 +19,7 @@ export interface CheckboxProps {
 }
 
 export interface CheckboxRef {
-  setChecked: (value: boolean | CheckBoxState) => void;
+  setChecked: (value: boolean | CheckboxState) => void;
   getLabel: () => string;
 }
 
@@ -50,16 +50,16 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
     return props.label ?? '';
   }
 
-  function setChecked(value: boolean | CheckBoxState) {
+  function setChecked(value: boolean | CheckboxState) {
     let indeterminate = false;
     if (value === true || value === false) {
       setIsChecked(value);
     } else {
-      if (value === CheckBoxState.CHECKED) {
+      if (value === CheckboxState.CHECKED) {
         setIsChecked(true);
-      } else if (value === CheckBoxState.UNCHECKED) {
+      } else if (value === CheckboxState.UNCHECKED) {
         setIsChecked(false);
-      } else if (value === CheckBoxState.INDETERMINATE) {
+      } else if (value === CheckboxState.INDETERMINATE) {
         setIsChecked(false);
         indeterminate = true;
       }

--- a/user-interface/src/lib/components/uswds/Checkbox.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.tsx
@@ -25,7 +25,7 @@ export interface CheckboxRef {
 
 const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) => {
   const [isChecked, setIsChecked] = useState(props.checked);
-  const [intermediateState, setIntermediateState] = useState<boolean>(false);
+  const [indeterminateState, setIndeterminateState] = useState<boolean>(false);
 
   let classes = 'usa-checkbox ';
 
@@ -64,7 +64,7 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
         indeterminate = true;
       }
     }
-    setIntermediateState(indeterminate);
+    setIndeterminateState(indeterminate);
   }
 
   useEffect(() => {
@@ -93,7 +93,7 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
         checked={isChecked}
         onChange={checkHandler}
         onFocus={focusHandler}
-        data-indeterminate={intermediateState}
+        data-indeterminate={indeterminateState || null}
         name={props.name}
         title={props.title}
       />

--- a/user-interface/src/lib/components/uswds/Checkbox.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.tsx
@@ -24,7 +24,7 @@ export interface CheckboxRef {
 }
 
 const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) => {
-  const [isChecked, setIsChecked] = useState(props.checked);
+  const [isChecked, setIsChecked] = useState<boolean>(props.checked ?? false);
   const [indeterminateState, setIndeterminateState] = useState<boolean>(false);
 
   let classes = 'usa-checkbox ';
@@ -69,7 +69,7 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
 
   useEffect(() => {
     // initializing isChecked above as a default doesn't work for some reason.
-    setIsChecked(props.checked);
+    setIsChecked(props.checked ?? false);
   }, [props.checked]);
 
   useImperativeHandle(

--- a/user-interface/src/lib/components/uswds/Checkbox.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 
 export enum CheckBoxState {
   UNCHECKED = -1,
-  INTERMEDIATE = 0,
+  INDETERMINATE = 0,
   CHECKED = 1,
 }
 
@@ -12,7 +12,7 @@ export interface CheckboxProps {
   name?: string;
   value: string | number;
   title?: string;
-  checked: boolean;
+  checked?: boolean;
   onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
   className?: string;
@@ -51,7 +51,7 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
   }
 
   function setChecked(value: boolean | CheckBoxState) {
-    let intermediate = false;
+    let indeterminate = false;
     if (value === true || value === false) {
       setIsChecked(value);
     } else {
@@ -59,12 +59,12 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
         setIsChecked(true);
       } else if (value === CheckBoxState.UNCHECKED) {
         setIsChecked(false);
-      } else if (value === CheckBoxState.INTERMEDIATE) {
+      } else if (value === CheckBoxState.INDETERMINATE) {
         setIsChecked(false);
-        intermediate = true;
+        indeterminate = true;
       }
     }
-    setIntermediateState(intermediate);
+    setIntermediateState(indeterminate);
   }
 
   useEffect(() => {
@@ -93,7 +93,7 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
         checked={isChecked}
         onChange={checkHandler}
         onFocus={focusHandler}
-        data-intermediate={intermediateState}
+        data-indeterminate={intermediateState}
         name={props.name}
         title={props.title}
       />

--- a/user-interface/src/lib/components/uswds/Checkbox.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.tsx
@@ -9,7 +9,9 @@ export enum CheckBoxState {
 export interface CheckboxProps {
   id: string;
   label?: string;
-  value: string;
+  name?: string;
+  value: string | number;
+  title?: string;
   checked: boolean;
   onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
@@ -17,12 +19,14 @@ export interface CheckboxProps {
 }
 
 export interface CheckboxRef {
-  setChecked: (value: boolean) => void;
+  setChecked: (value: boolean | CheckBoxState) => void;
   getLabel: () => string;
 }
 
 const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) => {
   const [isChecked, setIsChecked] = useState(props.checked);
+  const [intermediateState, setIntermediateState] = useState<boolean>(false);
+
   let classes = 'usa-checkbox ';
 
   if (props.className) {
@@ -46,13 +50,26 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
     return props.label ?? '';
   }
 
-  function setChecked(value: boolean) {
-    setIsChecked(value);
+  function setChecked(value: boolean | CheckBoxState) {
+    let intermediate = false;
+    if (value === true || value === false) {
+      setIsChecked(value);
+    } else {
+      if (value === CheckBoxState.CHECKED) {
+        setIsChecked(true);
+      } else if (value === CheckBoxState.UNCHECKED) {
+        setIsChecked(false);
+      } else if (value === CheckBoxState.INTERMEDIATE) {
+        setIsChecked(false);
+        intermediate = true;
+      }
+    }
+    setIntermediateState(intermediate);
   }
 
   useEffect(() => {
     // initializing isChecked above as a default doesn't work for some reason.
-    if (props.checked) setIsChecked(true);
+    setIsChecked(props.checked);
   }, [props.checked]);
 
   useImperativeHandle(
@@ -76,12 +93,13 @@ const CheckboxComponent = (props: CheckboxProps, ref: React.Ref<CheckboxRef>) =>
         checked={isChecked}
         onChange={checkHandler}
         onFocus={focusHandler}
+        data-intermediate={intermediateState}
+        name={props.name}
+        title={props.title}
       />
-      {props.label && (
-        <label className="usa-checkbox__label" htmlFor={props.id} data-testid={labelTestId}>
-          {props.label}
-        </label>
-      )}
+      <label className="usa-checkbox__label" htmlFor={props.id} data-testid={labelTestId}>
+        {props.label}
+      </label>
     </div>
   );
 };


### PR DESCRIPTION
# Purpose

Provide toggle button to check and uncheck all checkboxes in the consolidations table

# Major Changes

- Added a button that selects or deselects all checkboxes.
- The button label changes depending on whether all checkboxes are checked or (some or all) checkboxes are unchecked.
- Updated Checkbox component to add indeterminate state.
- Changed all inputs of type "checkbox" to actual USWDS Checkbox components in the consolidations table.

# Testing/Validation

Testing added or modified to bring coverage above 90%.

