### PR TITLE
CAMS-349 Fixed issues in E2E tests caused by the use of USWDS Checkbox

### DIFF
--- a/test/e2e/playwright/consolidation-orders.spec.ts
+++ b/test/e2e/playwright/consolidation-orders.spec.ts
@@ -42,8 +42,17 @@ test.describe('Consolidation Orders', () => {
     }
 
     for (let i = 0; i < childCaseCount; ++i) {
-      const checkbox = page.getByTestId(`${pendingConsolidationOrder.id}-case-list-checkbox-${i}`);
-      await checkbox.check();
+      // The following is neccessary because the USWDS checkbox input is rendered hidden off-screen.
+      // Therefore playwright can't check the box if it can't see it using the normal page.getByTestId.
+      // So using this method, you can locate the checkbox and fire a click event.
+      // I tried getting the label by test id, but it can't click on the label because the checkbox
+      // image is rendered in a css pseudo class, and javascript can not access the pseudo class.
+      // Clicking the label did not seem to fire the click event on the checkbox input.
+      await page
+        .locator(
+          `input[data-testid="checkbox-case-selection-${pendingConsolidationOrder.id}-case-list-${i}"]`,
+        )
+        .dispatchEvent('click');
     }
 
     const approveButton = page.getByTestId(
@@ -80,7 +89,11 @@ test.describe('Consolidation Orders', () => {
     // Action open accordian
     await page.getByTestId(`accordion-button-order-list-${pendingConsolidationOrder.id}`).click();
 
-    await page.getByTestId(`${pendingConsolidationOrder.id}-case-list-checkbox-0`).check();
+    await page
+      .locator(
+        `input[data-testid="checkbox-case-selection-${pendingConsolidationOrder.id}-case-list-0"]`,
+      )
+      .dispatchEvent('click');
 
     await page
       .getByTestId(`button-accordion-approve-button-${pendingConsolidationOrder.id}`)


### PR DESCRIPTION
# Purpose

New USWDS Checkbox component cause some issues with E2E testing.

The following is neccessary because the USWDS checkbox input is rendered hidden off-screen.

Therefore playwright can't check the box if it can't see it using the normal page.getByTestId.

So using this method, you can locate the checkbox and fire a click event.

I tried getting the label by test id, but it can't click on the label because the checkbox image is rendered in a css pseudo class, and javascript can not access the pseudo class.

Clicking the label did not seem to fire the click event on the checkbox input.

# Major Changes

Instead of the usual `const checkbox = page.getByTestId()` and `checkbox.check()` we need to use the following:

```
await page
        .locator(
          `input[data-testid="checkbox-case-selection-${pendingConsolidationOrder.id}-case-list-${i}"]`,
        )
        .dispatchEvent('click');
```

# Testing/Validation

E2E tests now pass without issue.


