### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+LICENSE.md @US-Trustee-Program/ustp-team


### PR DESCRIPTION
# Purpose

We need a way for specific files to require PR approval from a different set of people.

# Major Changes

Adds a CODEOWNERS file which specifies the `@US-Trustee-Program/ustp-team` team as owners of the `LICENSE.md` file. This should let us test the branch policy after merge and is a reasonable setting anyway.