### PR TITLE
CAMS-370: Add EA team and general code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,7 @@
+* @US-Trustee-Program/ustp-team @US-Trustee-Program/flexion
+
 LICENSE.md @US-Trustee-Program/ustp-team
+
+*.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline @US-Trustee-Program/enterprise-architecture

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 * @US-Trustee-Program/ustp-team @US-Trustee-Program/flexion
 
+CODEOWNERS @US-Trustee-Program/ustp-team
 LICENSE.md @US-Trustee-Program/ustp-team
 
 *.bicep @US-Trustee-Program/enterprise-architecture


### PR DESCRIPTION
# Purpose

We want the EA team to be required approvers for files affecting deployment in USTP environments.

# Major Changes

- Add EA as code owners for all `.bicep` files, and the directories where we store scripts and other files relating to deployment that affect USTP environments.
