### PR TITLE
CAMS-380: Add clean:all script to the top level package.json

### DIFF
--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -66,7 +66,7 @@ jobs:
           -bf results-latest.json \
           -jf results.json \
           -fjf filtered_results.json \
-          -pf Veracode_Medium_+_SCA_+_OWASP.json \
+          -pf ${{ secrets.VERACODE_SAST_POLICY }} \
           --file cams.zip
 
       - name: Upload to storage account

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -66,7 +66,7 @@ jobs:
           -bf results-latest.json \
           -jf results.json \
           -fjf filtered_results.json \
-          -pf ${{ secrets.VERACODE_SAST_POLICY }} \
+          -pf ${{ secrets.VERACODE_SAST_POLICY }}.json \
           --file cams.zip
 
       - name: Upload to storage account

--- a/ops/scripts/utility/clean-all-projects.sh
+++ b/ops/scripts/utility/clean-all-projects.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# A utility script useful for cleaning all project directories
+
+# Usage
+#   From the root directory, run the following command:
+#     ./ops/scripts/utility/clean-all-projects.sh
+
+PROJECTS=("backend/functions" "common" "dev-tools" "test/e2e" "user-interface")
+
+for str in "${PROJECTS[@]}"; do
+  pushd "${str}" || exit
+  echo "Cleaning ${str}."
+  npm run clean
+  popd || exit
+done
+
+exit 0

--- a/ops/scripts/utility/clean-install-all-projects.sh
+++ b/ops/scripts/utility/clean-install-all-projects.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# A utility script useful for cleaning all project directories
+
+# Usage
+#   From the root directory, run the following command:
+#     ./ops/scripts/utility/clean-all-projects.sh
+
+PROJECTS=("backend/functions" "common" "dev-tools" "test/e2e" "user-interface")
+
+for str in "${PROJECTS[@]}"; do
+  pushd "${str}" || exit
+  echo "Cleaning ${str}."
+  npm ci
+  popd || exit
+done
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Bankruptcy Oversight Support System - Parent Project",
   "scripts": {
     "clean:all": "./ops/scripts/utility/clean-all-projects.sh",
+    "ci:all": "./ops/scripts/utility/clean-install-all-projects.sh",
     "start:backend": "cd backend/functions && npm run start",
     "start:frontend": "cd user-interface && npm run start",
     "build": "npm run build:common && npm run build:backend && npm run build:frontend",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "CC0 v1.0",
   "description": "Bankruptcy Oversight Support System - Parent Project",
   "scripts": {
+    "clean:all": "./ops/scripts/utility/clean-all-projects.sh",
     "start:backend": "cd backend/functions && npm run start",
     "start:frontend": "cd user-interface && npm run start",
     "build": "npm run build:common && npm run build:backend && npm run build:frontend",


### PR DESCRIPTION
# Purpose

It would be nice to have a single command available to clean all projects for things like creating a zip file for VeraCode.

# Major Changes

- Add a shell script to loop through all npm projects and run their clean script
- Add a shell script to loop through all npm projects and run `npm ci`
- Add top-level npm scripts to call the new shell scripts

# Testing/Validation

Ran the npm script locally.

# Additional Opportunities

We could add other similar scripts such as:

- `install:all`

We could also update `build` to utilize a shell script.
