### PR TITLE
CAMS-380: remove continue on fail condition

### DIFF
--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -24,7 +24,6 @@ jobs:
   sast-pipeline-scan:
     name: SAST Pipeline Scan
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
# Purpose

We want the deployment to the Flexion environment to fail if any of the security steps fails.

# Major Changes

Removed continue on failure condition.

# Testing/Validation



# Notes


