### PR TITLE
Fix broken update workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 10 * * 3'
       # Every Wednesday morning at 5 ET
+  workflow_dispatch:
 
 jobs:
   update-all:
@@ -14,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Update
-        run: ./ops/scripts/utility/update-dependencies.sh
+        run: ./ops/scripts/utility/update-dependencies.sh -c
 
       - name: Create PR
         env:

--- a/ops/scripts/utility/update-dependencies.sh
+++ b/ops/scripts/utility/update-dependencies.sh
@@ -49,11 +49,11 @@ while getopts ":chru" option; do
   esac
 done
 
-BRANCH_NAME="dependency-updates-test"
+BRANCH_NAME="dependency-updates"
 
 if [[ -n "${CICD}" ]]; then
   BRANCH_NAME="dependency-updates-auto"
-  git checkout -b "${BRANCH_NAME}"
+  git switch -c "${BRANCH_NAME}"
 else
   CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
   if [[ -n $(git status -s) ]]; then
@@ -61,10 +61,10 @@ else
     git stash
   fi
   if [[ -z "${UPDATE}" ]]; then
-    git checkout main
+    git switch main
     git pull --rebase
     git branch -D "${BRANCH_NAME}"
-    git checkout -b "${BRANCH_NAME}"
+    git switch -c "${BRANCH_NAME}"
   else
     git checkout "${BRANCH_NAME}"
     git pull --rebase
@@ -91,7 +91,7 @@ if [[ -c "${CICD}" ]]; then
 fi
 
 if [[ -z "${REMAIN}" ]]; then
-  git checkout "$CURRENT_BRANCH"
+  git switch "$CURRENT_BRANCH"
   if [[ -n "${STASHED_CHANGE}" ]]; then
     git stash pop
   fi


### PR DESCRIPTION
# Problem

Node packages need to be kept up to date.

# Major Changes

- Add `-c` flag to the usage of the script to indicate it is a CI/CD run
- Add a manual trigger of the workflow

# Minor Changes

- Fix branch name
- Replace usages of `git checkout` with `git switch`

# Testing/Validation

Manual testing already performed of the script, but will need to test the workflow once it is merged to main.
