### PR TITLE
Configure git so the commit will work

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          token: ${{ github.token }}
 
       - name: Import GPG
         id: import-gpg

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -15,7 +15,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PAT }}
+          username: ${{ secrets.BOT_GIT_USERNAME }}
 
       - name: Import GPG
         id: import-gpg
@@ -29,15 +30,12 @@ jobs:
 
       - name: Update
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
-        run: |
-          ./ops/scripts/utility/update-dependencies.sh -c
-          git config --list
-          git push -u origin HEAD
+        run: ./ops/scripts/utility/update-dependencies.sh -c
 
       - name: Create PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
         run: gh pr create --title "Update NPM packages" --body-file .github/PULL_REQUEST_TEMPLATE/dependencies.md

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -27,6 +27,12 @@ jobs:
           git_user_signingkey: true
 
       - name: Update
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
         run: ./ops/scripts/utility/update-dependencies.sh -c
 
       - name: Create PR

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
           token: ${{ secrets.BOT_PAT }}
-          username: ${{ secrets.BOT_GIT_USERNAME }}
 
       - name: Import GPG
         id: import-gpg

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          token: ${{ github.token }}
+          token: ${{ secrets.BOT_PAT }}
 
       - name: Import GPG
         id: import-gpg
@@ -29,7 +29,7 @@ jobs:
 
       - name: Update
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
           GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
@@ -38,9 +38,5 @@ jobs:
 
       - name: Create PR
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
-          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
         run: gh pr create --title "Update NPM packages" --body-file .github/PULL_REQUEST_TEMPLATE/dependencies.md

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           ./ops/scripts/utility/update-dependencies.sh -c
           git config --list
-          git push -u origin dependency-updates-auto
+          git push -u origin HEAD
 
       - name: Create PR
         env:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -12,7 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Import GPG
+        uses: crazy-max/ghaction-import-gpg@v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BOT_PASSPHRASE }}
+          git_committer_name: ${{ secrets.BOT_USER_NAME }}
+          git_committer_email: ${{ secrets.BOT_EMAIL_ADDRESS }}
+          git_commit_gpgsign: true
+          git_user_signingkey: true
 
       - name: Update
         run: ./ops/scripts/utility/update-dependencies.sh -c

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -17,6 +17,7 @@ jobs:
           persist-credentials: false
 
       - name: Import GPG
+        id: import-gpg
         uses: crazy-max/ghaction-import-gpg@v6.1.0
         with:
           gpg_private_key: ${{ secrets.BOT_PRIVATE_KEY }}
@@ -31,6 +32,8 @@ jobs:
       - name: Create PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GIT_AUTHOR_NAME: ${{ secrets.BOT_USER_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.BOT_EMAIL_ADDRESS }}
+          GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
         run: gh pr create --title "Update NPM packages" --body-file .github/PULL_REQUEST_TEMPLATE/dependencies.md

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -32,7 +32,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
-        run: ./ops/scripts/utility/update-dependencies.sh -c
+        run: |
+          ./ops/scripts/utility/update-dependencies.sh -c
+          git push -u origin dependency-updates
 
       - name: Create PR
         env:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.BOT_PAT }}
 
       - name: Import GPG
         id: import-gpg
@@ -28,12 +26,12 @@ jobs:
 
       - name: Update
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
         run: ./ops/scripts/utility/update-dependencies.sh -c
 
       - name: Create PR
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr create --title "Update NPM packages" --body-file .github/PULL_REQUEST_TEMPLATE/dependencies.md

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -34,6 +34,7 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
         run: |
           ./ops/scripts/utility/update-dependencies.sh -c
+          git config --list
           git push -u origin dependency-updates-auto
 
       - name: Create PR

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -34,7 +34,7 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
         run: |
           ./ops/scripts/utility/update-dependencies.sh -c
-          git push -u origin dependency-updates
+          git push -u origin dependency-updates-auto
 
       - name: Create PR
         env:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          token: ${{ secrets.BOT_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import GPG
         id: import-gpg
@@ -29,14 +29,12 @@ jobs:
 
       - name: Update
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
-          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
         run: ./ops/scripts/utility/update-dependencies.sh -c
 
       - name: Create PR
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr create --title "Update NPM packages" --body-file .github/PULL_REQUEST_TEMPLATE/dependencies.md

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.BOT_PRIVATE_KEY }}
           passphrase: ${{ secrets.BOT_PASSPHRASE }}
-          git_committer_name: ${{ secrets.BOT_USER_NAME }}
-          git_committer_email: ${{ secrets.BOT_EMAIL_ADDRESS }}
+          git_config_global: true
           git_commit_gpgsign: true
           git_user_signingkey: true
 
@@ -32,4 +31,6 @@ jobs:
       - name: Create PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GIT_AUTHOR_NAME: ${{ secrets.BOT_USER_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.BOT_EMAIL_ADDRESS }}
         run: gh pr create --title "Update NPM packages" --body-file .github/PULL_REQUEST_TEMPLATE/dependencies.md

--- a/ops/scripts/utility/update-dependencies.sh
+++ b/ops/scripts/utility/update-dependencies.sh
@@ -87,9 +87,7 @@ git add .
 git commit -m "Update all npm projects"
 echo $?
 echo "Commit complete?"
-if [[ -z "${CICD}" ]]; then
-  git push -u origin "${BRANCH_NAME}"
-fi
+git push -u origin "${BRANCH_NAME}"
 
 if [[ -c "${CICD}" ]]; then
   exit 0

--- a/ops/scripts/utility/update-dependencies.sh
+++ b/ops/scripts/utility/update-dependencies.sh
@@ -48,7 +48,7 @@ while getopts ":chru" option; do
       ;;
   esac
 done
-git config --list
+
 BRANCH_NAME="dependency-updates"
 
 if [[ -n "${CICD}" ]]; then
@@ -72,8 +72,7 @@ else
 fi
 
 
-#PROJECTS=("backend/functions" "common" "dev-tools" "test/e2e" "user-interface")
-PROJECTS=("common")
+PROJECTS=("backend/functions" "common" "dev-tools" "test/e2e" "user-interface")
 
 for str in "${PROJECTS[@]}"; do
   pushd "${str}" || exit
@@ -85,8 +84,6 @@ done
 
 git add .
 git commit -m "Update all npm projects"
-echo $?
-echo "Commit complete?"
 git push -u origin "${BRANCH_NAME}"
 
 if [[ -c "${CICD}" ]]; then

--- a/ops/scripts/utility/update-dependencies.sh
+++ b/ops/scripts/utility/update-dependencies.sh
@@ -48,7 +48,7 @@ while getopts ":chru" option; do
       ;;
   esac
 done
-
+git config --list
 BRANCH_NAME="dependency-updates"
 
 if [[ -n "${CICD}" ]]; then

--- a/ops/scripts/utility/update-dependencies.sh
+++ b/ops/scripts/utility/update-dependencies.sh
@@ -85,6 +85,8 @@ done
 
 git add .
 git commit -m "Update all npm projects"
+echo $?
+echo "Commit complete?"
 git push -u origin "${BRANCH_NAME}"
 
 if [[ -c "${CICD}" ]]; then

--- a/ops/scripts/utility/update-dependencies.sh
+++ b/ops/scripts/utility/update-dependencies.sh
@@ -72,7 +72,8 @@ else
 fi
 
 
-PROJECTS=("backend/functions" "common" "dev-tools" "test/e2e" "user-interface")
+#PROJECTS=("backend/functions" "common" "dev-tools" "test/e2e" "user-interface")
+PROJECTS=("common")
 
 for str in "${PROJECTS[@]}"; do
   pushd "${str}" || exit

--- a/ops/scripts/utility/update-dependencies.sh
+++ b/ops/scripts/utility/update-dependencies.sh
@@ -87,7 +87,9 @@ git add .
 git commit -m "Update all npm projects"
 echo $?
 echo "Commit complete?"
-git push -u origin "${BRANCH_NAME}"
+if [[ -z "${CICD}" ]]; then
+  git push -u origin "${BRANCH_NAME}"
+fi
 
 if [[ -c "${CICD}" ]]; then
   exit 0


### PR DESCRIPTION
# Problem

Node packages need to be kept up to date.

# Major Changes

Add use of a GitHub Action that handles git config including signing the commit.

# Testing/Validation

- [x] #691 was created by [this run of the workflow](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/8915839747)

# Notes

Hashicorp used to have a fork of the action used here which they have archived and recommended using the base repo. This is a fairly widely used action.
