### PR TITLE
CAMS-386: Added bicep files related to networking and permission to EA Ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,4 +16,4 @@ ops/scripts/pipeline/slots/az-slot-web-resource-deploy.sh @US-Trustee-Program/en
 ops/scripts/pipeline/az-add-allowed-ip.sh @US-Trustee-Program/enterprise-architecture
 ops/scripts/pipeline/az-rm-allowed-ip.sh @US-Trustee-Program/enterprise-architecture
 ops/scripts/pipeline/azure-deploy.sh @US-Trustee-Program/enterprise-architecture
-ops/scripts/pipeline/az=cosmos-deploy.sh @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline/az-cosmos-deploy.sh @US-Trustee-Program/enterprise-architecture

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@ CODEOWNERS @US-Trustee-Program/ustp-team
 LICENSE.md @US-Trustee-Program/ustp-team
 
 ops/cloud-deployment/lib/network @US-Trustee-Program/enterprise-architecture
-ops/cloud-deployment/lib/sql @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/sql/sql-vnet-rule.bicep @US-Trustee-Program/enterprise-architecture
 ops/cloud-deployment/lib/keyvault @US-Trustee-Program/enterprise-architecture
 ops/cloud-deployment/lib/cosmos/cosmos-account.bicep @US-Trustee-Program/enterprise-architecture
 ops/cloud-deployment/lib/cosmos/cosmos-role-assignment.bicep @US-Trustee-Program/enterprise-architecture

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,4 +10,10 @@ ops/cloud-deployment/lib/cosmos/cosmos-account.bicep @US-Trustee-Program/enterpr
 ops/cloud-deployment/lib/cosmos/cosmos-role-assignment.bicep @US-Trustee-Program/enterprise-architecture
 ops/cloud-deployment/lib/cosmos/cosmos-custom-role.bicep @US-Trustee-Program/enterprise-architecture
 ops/cloud-deployment/lib/identity @US-Trustee-Program/enterprise-architecture
-ops/scripts/pipeline @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline/slots/az-config-pep.sh @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline/slots/az-slot-api-resource-deploy.sh @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline/slots/az-slot-web-resource-deploy.sh @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline/az-add-allowed-ip.sh @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline/az-rm-allowed-ip.sh @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline/azure-deploy.sh @US-Trustee-Program/enterprise-architecture
+ops/scripts/pipeline/az=cosmos-deploy.sh @US-Trustee-Program/enterprise-architecture

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,13 @@
-- @US-Trustee-Program/ustp-team @US-Trustee-Program/flexion
+* @US-Trustee-Program/ustp-team @US-Trustee-Program/flexion
 
 CODEOWNERS @US-Trustee-Program/ustp-team
 LICENSE.md @US-Trustee-Program/ustp-team
 
-ops/cloud-deployment/lib/network/*.bicep @US-Trustee-Program/enterprise-architecture
-ops/cloud-deployment/lib/sql/*.bicep @US-Trustee-Program/enterprise-architecture
-ops/cloud-deployment/lib/keyvault/*.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/network @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/sql @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/keyvault @US-Trustee-Program/enterprise-architecture
 ops/cloud-deployment/lib/cosmos/cosmos-account.bicep @US-Trustee-Program/enterprise-architecture
 ops/cloud-deployment/lib/cosmos/cosmos-role-assignment.bicep @US-Trustee-Program/enterprise-architecture
 ops/cloud-deployment/lib/cosmos/cosmos-custom-role.bicep @US-Trustee-Program/enterprise-architecture
-ops/cloud-deployment/lib/identity/*.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/identity @US-Trustee-Program/enterprise-architecture
 ops/scripts/pipeline @US-Trustee-Program/enterprise-architecture

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,13 @@
-* @US-Trustee-Program/ustp-team @US-Trustee-Program/flexion
+- @US-Trustee-Program/ustp-team @US-Trustee-Program/flexion
 
 CODEOWNERS @US-Trustee-Program/ustp-team
 LICENSE.md @US-Trustee-Program/ustp-team
 
-*.bicep @US-Trustee-Program/enterprise-architecture
-ops/cloud-deployment @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/network/*.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/sql/*.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/keyvault/*.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/cosmos/cosmos-account.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/cosmos/cosmos-role-assignment.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/cosmos/cosmos-custom-role.bicep @US-Trustee-Program/enterprise-architecture
+ops/cloud-deployment/lib/identity/*.bicep @US-Trustee-Program/enterprise-architecture
 ops/scripts/pipeline @US-Trustee-Program/enterprise-architecture


### PR DESCRIPTION
Jira ticket: CAMS-386

# Purpose

Update EA Ownership of files with only bicep that makes changes to permissions and/or networking

# Major Changes

Added bicep files that manipulate permissions or networking to EA ownership for PR review

# Testing/Validation

N/A

# Notes

Do we want to include parent templates that call child templates? e.g. ustp-cams-cosmos.bicep >> cosmos-account.bicep. do we want to add ustp-cams-cosmos.bicep as well?
