### PR TITLE
CAMS-387: setup clearly visibile environment when not in production

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -129,6 +129,7 @@ jobs:
       camsBasePath: ${{ vars.CAMS_BASE_PATH }}
       webappName: ${{ needs.setup.outputs.webappName }}
       environment: ${{ needs.setup.outputs.ghaEnvironment }}
+      launchDarklyEnvironment: ${{ vars.CAMS_LAUNCH_DARKLY_ENV }}
 
   deploy:
     name: Cloud Resource Deployment

--- a/.github/workflows/sub-build.yml
+++ b/.github/workflows/sub-build.yml
@@ -27,6 +27,9 @@ on:
       environment:
         required: true
         type: string
+      launchDarklyEnvironment:
+        required: true
+        type: string
 
 jobs:
   frontend:
@@ -57,7 +60,7 @@ jobs:
           export CAMS_BASE_PATH=${{ inputs.camsBasePath }}
           export CAMS_APPLICATIONINSIGHTS_CONNECTION_STRING="${{ secrets.AZ_APPINSIGHTS_WEBAPP_CONNECTION_STRING }}"
           export CAMS_FEATURE_FLAG_CLIENT_ID="${{ secrets.LD_DEVELOPMENT_CLIENT_ID }}"
-          export CAMS_LAUNCH_DARKLY_ENV="${{ secrets.LD_DEVELOPMENT_CLIENT_ID }}"
+          export CAMS_LAUNCH_DARKLY_ENV="${{ inputs.launchDarklyEnvironment }}"
           export CAMS_INFO_SHA=${{ github.sha }}
           npm run build --if-present
       - name: Package

--- a/.github/workflows/sub-build.yml
+++ b/.github/workflows/sub-build.yml
@@ -57,6 +57,7 @@ jobs:
           export CAMS_BASE_PATH=${{ inputs.camsBasePath }}
           export CAMS_APPLICATIONINSIGHTS_CONNECTION_STRING="${{ secrets.AZ_APPINSIGHTS_WEBAPP_CONNECTION_STRING }}"
           export CAMS_FEATURE_FLAG_CLIENT_ID="${{ secrets.LD_DEVELOPMENT_CLIENT_ID }}"
+          export CAMS_LAUNCH_DARKLY_ENV="${{ secrets.LD_DEVELOPMENT_CLIENT_ID }}"
           export CAMS_INFO_SHA=${{ github.sha }}
           npm run build --if-present
       - name: Package

--- a/user-interface/src/lib/components/Header.scss
+++ b/user-interface/src/lib/components/Header.scss
@@ -74,14 +74,6 @@
     .sub-title {
       display: block;
       font-size: 1.5rem;
-
-      .app-name {
-        display: inline-block;
-      }
-      .app-environment {
-        text-transform: uppercase;
-        margin-left: 1rem;
-      }
     }
   }
 }

--- a/user-interface/src/lib/components/Header.scss
+++ b/user-interface/src/lib/components/Header.scss
@@ -74,8 +74,14 @@
     .sub-title {
       display: block;
       font-size: 1.5rem;
+
+      .app-name {
+        display: inline-block;
+      }
+      .app-environment {
+        text-transform: uppercase;
+        margin-left: 1rem;
+      }
     }
   }
-
-
 }

--- a/user-interface/src/lib/components/Header.tsx
+++ b/user-interface/src/lib/components/Header.tsx
@@ -41,9 +41,8 @@ export const Header = () => {
   const flags = useFeatureFlags();
   const transferOrdersFlag = flags[TRANSFER_ORDERS_ENABLED];
   const caseSearchFlag = flags[CASE_SEARCH_ENABLED];
-
+  const launchDarklyEnvironment = import.meta.env['CAMS_LAUNCH_DARKLY_ENV'];
   const [activeNav, setActiveNav] = useState<NavState>(mapNavState(location.pathname));
-
   useEffect(() => {
     setActiveNav(mapNavState(location.pathname));
   }, [location]);
@@ -68,7 +67,12 @@ export const Header = () => {
           </div>
           <div className="site-title">
             <span className="text-no-wrap">U.S. Trustee Program</span>
-            <span className="sub-title text-no-wrap">CAse Management System (CAMS)</span>
+            <span className="sub-title text-no-wrap">
+              <p className="app-name">CAse Management System (CAMS)</p>
+              {launchDarklyEnvironment != 'production' && (
+                <p className="app-name app-environment">: {launchDarklyEnvironment} environment</p>
+              )}
+            </span>
           </div>
           <nav aria-label="Primary navigation" className="usa-nav cams-nav-bar" role="navigation">
             <button type="button" className="usa-nav__close">

--- a/user-interface/src/lib/components/Header.tsx
+++ b/user-interface/src/lib/components/Header.tsx
@@ -41,7 +41,6 @@ export const Header = () => {
   const flags = useFeatureFlags();
   const transferOrdersFlag = flags[TRANSFER_ORDERS_ENABLED];
   const caseSearchFlag = flags[CASE_SEARCH_ENABLED];
-  const launchDarklyEnvironment = import.meta.env['CAMS_LAUNCH_DARKLY_ENV'];
   const [activeNav, setActiveNav] = useState<NavState>(mapNavState(location.pathname));
   useEffect(() => {
     setActiveNav(mapNavState(location.pathname));
@@ -67,12 +66,7 @@ export const Header = () => {
           </div>
           <div className="site-title">
             <span className="text-no-wrap">U.S. Trustee Program</span>
-            <span className="sub-title text-no-wrap">
-              <p className="app-name">CAse Management System (CAMS)</p>
-              {launchDarklyEnvironment != 'production' && (
-                <p className="app-name app-environment">: {launchDarklyEnvironment} environment</p>
-              )}
-            </span>
+            <span className="sub-title text-no-wrap">CAse Management System (CAMS)</span>
           </div>
           <nav aria-label="Primary navigation" className="usa-nav cams-nav-bar" role="navigation">
             <button type="button" className="usa-nav__close">

--- a/user-interface/src/lib/components/Header.tsx
+++ b/user-interface/src/lib/components/Header.tsx
@@ -41,7 +41,9 @@ export const Header = () => {
   const flags = useFeatureFlags();
   const transferOrdersFlag = flags[TRANSFER_ORDERS_ENABLED];
   const caseSearchFlag = flags[CASE_SEARCH_ENABLED];
+
   const [activeNav, setActiveNav] = useState<NavState>(mapNavState(location.pathname));
+
   useEffect(() => {
     setActiveNav(mapNavState(location.pathname));
   }, [location]);

--- a/user-interface/src/lib/components/uswds/Banner.scss
+++ b/user-interface/src/lib/components/uswds/Banner.scss
@@ -11,4 +11,13 @@
     background-color: #ffd700;
     color: black;
   }
+  .environment-text {
+    font-weight: bold;
+    text-transform: uppercase;
+    float: inline-end;
+  }
+  .header-flag-container {
+    width: fit-content;
+    display: inline-block;
+  }
 }

--- a/user-interface/src/lib/components/uswds/Banner.scss
+++ b/user-interface/src/lib/components/uswds/Banner.scss
@@ -3,17 +3,12 @@
     max-width: none;
   }
   .development {
-    background-color: #4169e1;
+    background-color: #419ce1;
     color: white;
   }
 
   .staging {
     background-color: #ffd700;
     color: black;
-  }
-
-  .production {
-    background-color: #008000;
-    color: white;
   }
 }

--- a/user-interface/src/lib/components/uswds/Banner.scss
+++ b/user-interface/src/lib/components/uswds/Banner.scss
@@ -2,20 +2,23 @@
   .usa-banner__inner {
     max-width: none;
   }
+
   .development {
     background-color: #419ce1;
     color: white;
   }
 
-  .staging {
+  .test {
     background-color: #ffd700;
     color: black;
   }
+
   .environment-text {
     font-weight: bold;
     text-transform: uppercase;
     float: inline-end;
   }
+
   .header-flag-container {
     width: fit-content;
     display: inline-block;

--- a/user-interface/src/lib/components/uswds/Banner.scss
+++ b/user-interface/src/lib/components/uswds/Banner.scss
@@ -2,4 +2,18 @@
   .usa-banner__inner {
     max-width: none;
   }
+  .development {
+    background-color: #4169e1;
+    color: white;
+  }
+
+  .staging {
+    background-color: #ffd700;
+    color: black;
+  }
+
+  .production {
+    background-color: #008000;
+    color: white;
+  }
 }

--- a/user-interface/src/lib/components/uswds/Banner.test.tsx
+++ b/user-interface/src/lib/components/uswds/Banner.test.tsx
@@ -1,21 +1,32 @@
 import { render, screen } from '@testing-library/react';
 import { Banner } from './Banner';
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 
 describe('Test Banner Environment', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-  test('Should have proper class based on launchDarklyEnvironment', () => {
-    //const expectedEnv = 'staging';
+  test('Should not have a css class based on launchDarklyEnvironment env var', () => {
+    const expectedEnv = 'production';
     vi.stubEnv('CAMS_LAUNCH_DARKLY_ENV', 'production');
     render(
-      <React.StrictMode>
-        <Banner></Banner>
-      </React.StrictMode>,
+      <BrowserRouter>
+        <Banner />
+      </BrowserRouter>,
     );
+    const header = screen.getByTestId('banner-header');
+    expect(header).not.toHaveClass(expectedEnv);
   });
-  const header = document.querySelector('.usa-banner__header');
-  screen.debug;
-  expect(header).toHaveClass('staging');
+  test('Should have a css class based on launchDarklyEnvironment env var', () => {
+    const expectedEnv = 'staging';
+    vi.stubEnv('CAMS_LAUNCH_DARKLY_ENV', 'staging');
+    render(
+      <BrowserRouter>
+        <Banner />
+      </BrowserRouter>,
+    );
+    const header = screen.getByTestId('banner-header');
+    expect(header).toHaveClass(expectedEnv);
+  });
 });

--- a/user-interface/src/lib/components/uswds/Banner.test.tsx
+++ b/user-interface/src/lib/components/uswds/Banner.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { Banner } from './Banner';
+import React from 'react';
+
+describe('Test Banner Environment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  test('Should have proper class based on launchDarklyEnvironment', () => {
+    //const expectedEnv = 'staging';
+    vi.stubEnv('CAMS_LAUNCH_DARKLY_ENV', 'production');
+    render(
+      <React.StrictMode>
+        <Banner></Banner>
+      </React.StrictMode>,
+    );
+  });
+  const header = document.querySelector('.usa-banner__header');
+  screen.debug;
+  expect(header).toHaveClass('staging');
+});

--- a/user-interface/src/lib/components/uswds/Banner.tsx
+++ b/user-interface/src/lib/components/uswds/Banner.tsx
@@ -12,7 +12,7 @@ export const Banner = () => {
       aria-label="Official website of the United States government"
     >
       <div className="usa-accordion">
-        <header className={envHeaderClassName}>
+        <header className={envHeaderClassName} data-testid="banner-header">
           <div className="usa-banner__inner">
             <div className="grid-col-auto">
               <img

--- a/user-interface/src/lib/components/uswds/Banner.tsx
+++ b/user-interface/src/lib/components/uswds/Banner.tsx
@@ -1,13 +1,19 @@
 import './Banner.scss';
 
 export const Banner = () => {
+  const launchDarklyEnvironment = import.meta.env['CAMS_LAUNCH_DARKLY_ENV'];
+  const envHeaderClassName =
+    'usa-banner__header ' +
+    (launchDarklyEnvironment === 'production' ? '' : `${launchDarklyEnvironment}`);
+  console.log(envHeaderClassName);
+
   return (
     <section
       className="usa-banner cams-banner"
       aria-label="Official website of the United States government"
     >
       <div className="usa-accordion">
-        <header className="usa-banner__header">
+        <header className={envHeaderClassName}>
           <div className="usa-banner__inner">
             <div className="grid-col-auto">
               <img

--- a/user-interface/src/lib/components/uswds/Banner.tsx
+++ b/user-interface/src/lib/components/uswds/Banner.tsx
@@ -5,7 +5,6 @@ export const Banner = () => {
   const envHeaderClassName =
     'usa-banner__header ' +
     (launchDarklyEnvironment === 'production' ? '' : `${launchDarklyEnvironment}`);
-  console.log(envHeaderClassName);
 
   return (
     <section

--- a/user-interface/src/lib/components/uswds/Banner.tsx
+++ b/user-interface/src/lib/components/uswds/Banner.tsx
@@ -13,8 +13,8 @@ export const Banner = () => {
     >
       <div className="usa-accordion">
         <header className={envHeaderClassName} data-testid="banner-header">
-          <div className="usa-banner__inner">
-            <div className="grid-col-auto">
+          <div className="usa-banner__inner grid-row grid-gap-sm">
+            <div className="grid-col-1 header-flag-container">
               <img
                 aria-hidden="true"
                 className="usa-banner__header-flag"
@@ -22,11 +22,16 @@ export const Banner = () => {
                 alt=""
               />
             </div>
-            <div className="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
-              <p className="usa-banner__header-text">
+            <div className="grid-col-auto tablet:grid-col-auto" aria-hidden="true">
+              <span className="usa-banner__header-text">
                 An official website of the United States government
-              </p>
+              </span>
             </div>
+            {launchDarklyEnvironment != 'production' && (
+              <div className="grid-col-5 usa-banner__header-text">
+                <span className="environment-text">{launchDarklyEnvironment} ENVIRONMENT</span>
+              </div>
+            )}
           </div>
         </header>
       </div>


### PR DESCRIPTION
Jira ticket: CAMS-387

# Purpose

Clearly state environment when the user is not within the production application

# Major Changes

- Change color of banner dependent on environment
- Display environment centered within banner for development and staging
- Edited workflow to include CAMS_LAINCH_DARKLY_ENV as an env var

# Testing/Validation

- ran build locally with all 3 LaunchDarkly environments as env var CAMS_LAUNCH_DARKLY_ENV= (development, staging, production) and verified the app functioned as expected

# Notes

We can modify this however we want. these were just my initial thoughts

We will also need to add the var for CAMS_LAUNCH_DARKLY_ENV to the USTP STG and PRD AzDO variable libraries
- 'staging' within CAMS_STG

