### PR TITLE
Add script to check for outdated packages

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -40,3 +40,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./ops/scripts/utility/check-outdated.sh -c
+
+      - name: Audit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./ops/scripts/utility/audit.sh -c

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -35,3 +35,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr create --title "Update NPM packages" --body-file .github/PULL_REQUEST_TEMPLATE/dependencies.md
+
+      - name: Check Outdated
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./ops/scripts/utility/check-outdated.sh -c

--- a/ops/scripts/utility/audit-comment.md
+++ b/ops/scripts/utility/audit-comment.md
@@ -1,0 +1,1 @@
+# Audit Results

--- a/ops/scripts/utility/check-outdated.sh
+++ b/ops/scripts/utility/check-outdated.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# A utility script useful for checking for outdated packages
+
+# Usage
+#   From the root directory, run the following command:
+#     ./ops/scripts/utility/check-outdated.sh [-c|h]
+
+############################################################
+# Help                                                     #
+############################################################
+Help()
+{
+   # Display Help
+   echo "This script runs 'npm outdated' for all Node projects in the repository and"
+   echo "creates a comment on an open PR."
+   echo
+   echo "Syntax: ./ops/scripts/utility/check-outdated.sh [-c|h]"
+   echo "options:"
+   echo "c     Run this script from a CI/CD workflow. Incompatible with other options."
+   echo "h     Print this Help and exit."
+   echo
+}
+
+############################################################
+############################################################
+# Main program                                             #
+############################################################
+############################################################
+while getopts ":ch" option; do
+  case $option in
+    c) # CI/CD
+      CICD=true
+      ;;
+    h) # display help
+      Help
+      exit;;
+    \?) # Invalid option
+      echo "Run with the '-h' option to see valid usage."
+      exit 1
+      ;;
+  esac
+done
+
+
+if [[ -n "${CICD}" ]]; then
+  BRANCH_NAME="dependency-updates-auto"
+else
+  BRANCH_NAME="dependency-updates"
+fi
+
+
+# Temporary file for storing outputs
+TEMP_FILE=$(mktemp)
+
+# Ensure cleanup of the temp file on exit
+trap 'rm -f "$TEMP_FILE"' EXIT
+
+cat ./ops/scripts/utility/outdated-comment.md >> "$TEMP_FILE"
+
+PROJECTS=("backend/functions" "common" "dev-tools" "test/e2e" "user-interface")
+for dir in "${PROJECTS[@]}"; do
+  pushd "${dir}" || exit
+  npm ci
+  npm outdated | sed -e '1d' \
+                      -e 's/  */ | /g' \
+                      -e 's/^/| /' \
+                      -e 's/ $/ |/' >> "$TEMP_FILE"
+  popd || exit
+done
+
+gh pr comment "${BRANCH_NAME}" --body-file "$TEMP_FILE"
+
+exit 0

--- a/ops/scripts/utility/no-outdated-comment.md
+++ b/ops/scripts/utility/no-outdated-comment.md
@@ -1,0 +1,3 @@
+# Outdated Packages
+
+No packages were outdated across all NPM projects.

--- a/ops/scripts/utility/outdated-comment.md
+++ b/ops/scripts/utility/outdated-comment.md
@@ -1,0 +1,4 @@
+# Outdated Packages
+
+| Package | Current | Wanted | Latest | Location | Depended by |
+| -- | -- | -- | -- | -- | -- |


### PR DESCRIPTION
# Problem

Node packages need to be kept up to date.

# Major Changes

- Add running of a script to the workflow that will get a list of outdated packages and add a PR comment to automatically inform us of what packages have major updates available.
- Add running of a script that runs `npm audit` against all NPM projects and leaves a comment on the PR with the results.

# Testing/Validation

- Ran the workflow https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/9007894138
  - Triggered the creation of #703 and created the comment https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/pull/703#issuecomment-2101346767
