### PR TITLE
Only render PendingTransferOrder when expanded

### DIFF
--- a/user-interface/src/data-verification/TransferOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/TransferOrderAccordion.test.tsx
@@ -126,6 +126,7 @@ describe('TransferOrderAccordion', () => {
     expect(heading?.textContent).toContain(formatDate(order.orderDate));
 
     const content = findAccordionContent(order.id, false);
+    if (heading) fireEvent.click(heading);
 
     expect(content?.textContent).toContain(order.docketEntries[0]?.summaryText);
     expect(content?.textContent).toContain(order.docketEntries[0]?.fullText);

--- a/user-interface/src/data-verification/TransferOrderAccordion.tsx
+++ b/user-interface/src/data-verification/TransferOrderAccordion.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Accordion } from '@/lib/components/uswds/Accordion';
 import { OfficeDetails } from '@common/cams/courts';
 import { TransferOrder } from '@common/cams/orders';
@@ -27,6 +27,7 @@ export interface TransferOrderAccordionProps {
 
 export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
   const { order, hidden, statusType, orderType, officesList, expandedId, onExpand } = props;
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   const pendingTransferOrderRef = useRef<PendingTransferOrderImperative>(null);
 
@@ -34,12 +35,17 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
     pendingTransferOrderRef?.current?.cancel();
   }
 
+  function handleOnExpand(expandedId: string) {
+    if (onExpand) onExpand(expandedId);
+    setExpanded(true);
+  }
+
   return (
     <Accordion
       key={order.id}
       id={`order-list-${order.id}`}
       expandedId={expandedId}
-      onExpand={onExpand}
+      onExpand={handleOnExpand}
       onCollapse={onCollapse}
       hidden={hidden}
     >
@@ -75,21 +81,26 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
         </div>
       </section>
       <section className="accordion-content" data-testid={`accordion-content-${order.id}`}>
-        {order.status === 'pending' && (
-          <PendingTransferOrder
-            order={order}
-            onOrderUpdate={props.onOrderUpdate}
-            officesList={officesList}
-            ref={pendingTransferOrderRef}
-          />
-        )}
-        {order.status === 'approved' && (
-          <ApprovedTransferOrder order={order} onOrderUpdate={props.onOrderUpdate} />
-        )}
-        {order.status === 'rejected' && (
-          <RejectedTransferOrder order={order} onOrderUpdate={props.onOrderUpdate} />
+        {expanded && (
+          <>
+            {order.status === 'pending' && (
+              <PendingTransferOrder
+                order={order}
+                onOrderUpdate={props.onOrderUpdate}
+                officesList={officesList}
+                ref={pendingTransferOrderRef}
+              />
+            )}
+            {order.status === 'approved' && (
+              <ApprovedTransferOrder order={order} onOrderUpdate={props.onOrderUpdate} />
+            )}
+            {order.status === 'rejected' && (
+              <RejectedTransferOrder order={order} onOrderUpdate={props.onOrderUpdate} />
+            )}
+          </>
         )}
       </section>
+      )
     </Accordion>
   );
 }


### PR DESCRIPTION
# Purpose

We were immediately calling the orders-suggestions endpoint for many orders (40+) immediately upon page load. This seems to have caused an issue with the SQL Server instance in staging.

# Major Changes

Do not render the PendingTransferOrder component until the accordion is expanded.

# Testing/Validation

- [ ] automated tests updated and pass
- [ ] manually confirmed that requests are not made until accordion is expanded

# Notes

Future work could be to gather the necessary information and hydrate in Cosmos so that we can get it faster or to implement cacheing or something.
