### PR TITLE
CAMS-397 E2E standalone test manual workflow and workflow testing resource updates

### DIFF
--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -2,12 +2,12 @@ name: Clean up Flexion Azure Resources
 
 on:
   pull_request:
-    types: [ closed ]
+    types: [closed]
   workflow_dispatch:
     inputs:
       hashId:
         description: "Hash id of target branch deployemnt"
-        default: ''
+        default: ""
         type: string
 
 jobs:
@@ -63,10 +63,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check]
     if: needs.check.outputs.executeCleanup == 'true'
+    env:
+      environment: ${{ endsWith(github.ref,'refs/heads/main') && 'Main-Gov' || 'Develop' }}
+
     steps:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
       - uses: actions/checkout@v3
+      - name: Clean up e2e test database
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        run: |
+          e2eDatabaseName="${{ secrets.AZ_COSMOS_DATABASE_NAME }}-e2e"
+          if [[ ${{ env.environment }} != "Main-Gov" ]]; then
+            echo "Adding suffix to database name"
+            e2eDatabaseName="${e2eDatabaseName}-${{ inputs.hashId }}"
+          fi
+          az cosmosdb sql database delete \
+          --account-name ${{ secrets.AZ_COSMOS_ACCOUNT_NAME }} \
+          --name "${e2eDatabaseName}" \
+          --resource-group  ${{ secrets.AZURE_RG }} \
+          --yes
       - run: ./ops/scripts/utility/az-delete-branch-resources.sh ${{ needs.check.outputs.targetBranchHashId }} false

--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -73,7 +73,6 @@ jobs:
           environment: ${{ vars.AZURE_ENVIRONMENT }}
       - uses: actions/checkout@v3
       - name: Clean up e2e test database
-        if: ${{ always() && github.ref == 'refs/heads/main' }}
         run: |
           e2eDatabaseName="${{ secrets.AZ_COSMOS_DATABASE_NAME }}-e2e"
           if [[ ${{ env.environment }} != "Main-Gov" ]]; then

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -176,6 +176,22 @@ jobs:
       cosmosDbPrincipalId: ${{ needs.deploy.outputs.cosmosDbPrincipalId }}
     secrets: inherit # pragma: allowlist secret
 
+  initial-slot-resource-deployment: ##setup slot resources on initial deployment
+    name: Initial Deployment of Slot Resources
+    uses: ./.github/workflows/sub-deploy-slot-resources.yml
+    needs: [setup, deploy-code]
+    if: ${{ needs.setup.outputs.slotDeploymentEnabled == 'false' && github.ref != 'refs/heads/main' }}
+    with:
+      webAppName: ${{ needs.setup.outputs.webappName }}
+      apiName: ${{ needs.setup.outputs.apiName }}
+      ghaEnvironment: ${{ needs.setup.outputs.ghaEnvironment }}
+      azResourceGrpAppEncrypted: ${{ needs.setup.outputs.azResourceGrpAppEncrypted }}
+      azResourceGrpNetworkEncrypted: ${{ needs.setup.outputs.azResourceGrpNetworkEncrypted }}
+      slotName: ${{ needs.setup.outputs.slotName }}
+      slotDeploymentEnabled: true
+      environmentHash: ${{ needs.setup.outputs.environmentHash }}
+    secrets: inherit # pragma: allowlist secret
+
   deploy-code-slot:
     name: Slot Code Deployment
     uses: ./.github/workflows/sub-deploy-code-slot.yml

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -188,7 +188,7 @@ jobs:
       azResourceGrpAppEncrypted: ${{ needs.setup.outputs.azResourceGrpAppEncrypted }}
       azResourceGrpNetworkEncrypted: ${{ needs.setup.outputs.azResourceGrpNetworkEncrypted }}
       slotName: ${{ needs.setup.outputs.slotName }}
-      slotDeploymentEnabled: true
+      slotDeploymentEnabled: "true"
       environmentHash: ${{ needs.setup.outputs.environmentHash }}
     secrets: inherit # pragma: allowlist secret
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,6 +15,20 @@ jobs:
       enableSlotDeployment: true
       enableBicepDeployment: true
       deployVnet: false
+  set-cosmos-db:
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set CosmosDB Name for Node API
+        run: |
+          databaseName="$databaseName-e2e"
+          if [[ ${branch_hash_id} != 'DOES_NOT_EXIST' ]]; then
+              databaseName="$databaseName-${{ needs.setup.outputs.environmentHash }}"
+          fi
+
+          echo "Database Name :${databaseName}"ß
+
+          az functionapp config appsettings set -g "$app_rg" -n "$api_name" --slot "$slot_name" --slot-settings COSMOS_DATABASE_NAME="$databaseName"
 
   execute-e2e-test-pre-swap:
     needs: [setup]

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,30 @@
+name: Stand Alone E2E Test Runs
+
+concurrency: ${{ github.ref }}-${{ github.workflow }}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  setup:
+    name: Setup
+    uses: ./.github/workflows/reusable-build-info.yml
+    secrets: inherit # pragma: allowlist secret
+    with:
+      environment: ${{ endsWith(github.ref,'refs/heads/main') && 'Main-Gov' || 'Develop' }}
+      enableSlotDeployment: true
+      enableBicepDeployment: true
+      deployVnet: false
+
+  execute-e2e-test-pre-swap:
+    needs: [setup]
+    uses: ./.github/workflows/reusable-e2e.yml
+    with:
+      apiName: ${{ needs.setup.outputs.apiName }}
+      slotName: ${{ needs.setup.outputs.slotName }}
+      webappName: ${{ needs.setup.outputs.webappName }}
+      stackName: ${{ needs.setup.outputs.stackName }}
+      azResourceGrpAppEncrypted: ${{ needs.setup.outputs.azResourceGrpAppEncrypted }}
+      ghaEnvironment: ${{ needs.setup.outputs.ghaEnvironment }}
+      branchHashId: ${{ needs.setup.outputs.environmentHash }}
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -2,8 +2,7 @@ name: Stand Alone E2E Test Runs
 
 concurrency: ${{ github.ref }}-${{ github.workflow }}
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   setup:
@@ -12,9 +11,9 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     with:
       environment: ${{ endsWith(github.ref,'refs/heads/main') && 'Main-Gov' || 'Develop' }}
-      enableSlotDeployment: true
-      enableBicepDeployment: true
-      deployVnet: false
+      enableSlotDeployment: "true"
+      enableBicepDeployment: "true"
+      deployVnet: "false"
   set-cosmos-db:
     needs: [setup]
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-database-deploy.yml
+++ b/.github/workflows/reusable-database-deploy.yml
@@ -15,9 +15,6 @@ on:
       environmentHash:
         required: true
         type: string
-      slotDeploymentEnabled:
-        required: true
-        type: string
     outputs:
       cosmosDbClientId:
         description: "CosmosDB Client ID"
@@ -61,7 +58,6 @@ jobs:
             --actionGroupResourceGroup ${{ secrets.AZ_ANALYTICS_RG }} \
             --actionGroupName ${{ secrets.AZ_ACTION_GROUP_NAME }} \
             --branchHashId ${{ inputs.environmentHash || 'DOES_NOT_EXIST' }} \
-            --slotDeploymentEnabled ${{ inputs.slotDeploymentEnabled }}
 
       - name: Check deployment and set params
         id: set-deploy-params

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -24,9 +24,6 @@ on:
       branchHashId:
         required: true
         type: string
-      environmentHash:
-        required: true
-        type: string
 
 jobs:
   smoke-test-application-slot:
@@ -36,7 +33,7 @@ jobs:
       stackName: ${{ inputs.stackName }}
       webappName: ${{ inputs.webappName }}
       apiName: ${{ inputs.apiName }}
-      branchHashId: ${{ inputs.environmentHash }}
+      branchHashId: ${{ inputs.branchHashId }}
       priority: 200
     steps:
       - uses: actions/checkout@v3
@@ -144,7 +141,7 @@ jobs:
           -r ${name:0:32} \
           --slot-name ${{ inputs.slotName }}
       - name: Clean up e2e test database
-        if: always()
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
         run: |
           e2eDatabaseName="${{ secrets.AZ_COSMOS_DATABASE_NAME }}-e2e"
           if [[ ${{ inputs.ghaEnvironment }} != "Main-Gov" ]]; then

--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -131,7 +131,6 @@ jobs:
       azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
       ghaEnvironment: ${{ inputs.ghaEnvironment }}
       branchHashId: ${{ inputs.environmentHash }}
-      environmentHash: ${{ inputs.environmentHash }}
     secrets: inherit # pragma: allowlist secret
 
   swap-webapp-deployment-slot:

--- a/.github/workflows/sub-deploy.yml
+++ b/.github/workflows/sub-deploy.yml
@@ -74,7 +74,6 @@ jobs:
       azResourceGrpNetworkEncrypted: ${{ inputs.azResourceGrpNetworkEncrypted }}
       environmentHash: ${{ inputs.environmentHash }}
       apiName: ${{ inputs.apiName }}
-      slotDeploymentEnabled: ${{ inputs.slotDeploymentEnabled }}
     secrets: inherit # pragma: allowlist secret
 
   deploy-slot-resources:

--- a/ops/scripts/pipeline/az-cosmos-deploy.sh
+++ b/ops/scripts/pipeline/az-cosmos-deploy.sh
@@ -17,7 +17,6 @@ analyticsWorkspaceId=
 actionGroupResourceGroup=
 actionGroupName=
 branchHashId=
-slotDeploymentEnabled='false'
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -66,10 +65,6 @@ while [[ $# -gt 0 ]]; do
         shift 2
         ;;
 
-    --slotDeploymentEnabled)
-        slotDeploymentEnabled="${2}"
-        shift 2
-        ;;
 
     *)
         echo "$1"
@@ -97,16 +92,14 @@ az deployment group create -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-
 
 # Provision and configure e2e CosmosDB databases and containers only if slot deployments occur. Otherwise we do not need an e2e database.
 
-if [[ ${slotDeploymentEnabled} == 'true' ]]; then
-    echo "Deploying Cosmos Database for E2E testing"
-    e2eDatabaseName="${database}-e2e"
-    if [[ ${environment} != 'Main-Gov' ]]; then
-        e2eDatabaseName="${e2eDatabaseName}-${branchHashId}"
-    fi
-    az deployment group create -w -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos-e2e.bicep \
-        -p ./ops/cloud-deployment/params/ustp-cams-cosmos-containers.parameters.json \
-        -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${e2eDatabaseName}"
-    az deployment group create -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos-e2e.bicep \
-        -p ./ops/cloud-deployment/params/ustp-cams-cosmos-containers.parameters.json \
-        -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${e2eDatabaseName}"
+echo "Deploying Cosmos Database for E2E testing"
+e2eDatabaseName="${database}-e2e"
+if [[ ${environment} != 'Main-Gov' ]]; then
+    e2eDatabaseName="${e2eDatabaseName}-${branchHashId}"
 fi
+az deployment group create -w -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos-e2e.bicep \
+    -p ./ops/cloud-deployment/params/ustp-cams-cosmos-containers.parameters.json \
+    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${e2eDatabaseName}"
+az deployment group create -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos-e2e.bicep \
+    -p ./ops/cloud-deployment/params/ustp-cams-cosmos-containers.parameters.json \
+    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${e2eDatabaseName}"


### PR DESCRIPTION

# Purpose

Create Standalone E2e tests and properly handle E2E database and slot resource creation during deployment

# Major Changes

- Addition of standalone e2e tests
- removal of automatic e2e database deletion for branches
- creation of slot resources on initial branch deployment

# Testing/Validation

- deployed environment and ran tests through to verify tests run properly

# Notes

Will need to merge this to main so I can make additional changes to the E2E standalone tests. Manual dispatch workflows are not able to be created outside the main branch
