### PR TITLE
CAMS-396 reject without type or lead and also without validation

### DIFF
--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
@@ -19,7 +19,7 @@ import { SimpleResponseData } from '@/lib/type-declarations/api';
 import { CaseAssignment } from '@common/cams/assignments';
 import { Consolidation, ConsolidationFrom, ConsolidationTo } from '@common/cams/events';
 import { CaseSummary } from '@common/cams/cases';
-import { selectItemInMockSelect } from '../lib/components/CamsSelect.mock';
+import { selectItemInMockSelect } from '@/lib/components/CamsSelect.mock';
 
 vi.mock('../lib/components/CamsSelect', () => import('../lib/components/CamsSelect.mock'));
 
@@ -87,7 +87,9 @@ function setupApiGetMock(options: { bCase?: CaseSummary; associations?: Consolid
 }
 
 describe('ConsolidationOrderAccordion tests', () => {
-  const order: ConsolidationOrder = MockData.getConsolidationOrder();
+  const order: ConsolidationOrder = MockData.getConsolidationOrder({
+    override: { courtDivisionCode: '081' },
+  });
   const offices: OfficeDetails[] = MockData.getOffices();
   const regionMap = new Map();
 
@@ -364,7 +366,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       expect(markAsLeadButton).toHaveClass('usa-button--outline');
     });
 
-    selectItemInMockSelect(`lead-case-court`, 1);
+    selectItemInMockSelect(`lead-case-court`, 0);
 
     const caseNumberInput = findCaseNumberInput(order.id!);
 
@@ -416,7 +418,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await toggleEnableCaseListForm(order.id!);
 
-    selectItemInMockSelect(`lead-case-court`, 1);
+    selectItemInMockSelect(`lead-case-court`, 0);
     const caseNumberInput = findCaseNumberInput(order.id!);
 
     enterCaseNumber(caseNumberInput, '11111111');
@@ -457,7 +459,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await toggleEnableCaseListForm(order.id!);
 
-    selectItemInMockSelect(`lead-case-court`, 1);
+    selectItemInMockSelect(`lead-case-court`, 0);
     const caseNumberInput = findCaseNumberInput(order.id!);
 
     enterCaseNumber(caseNumberInput, '00000000');
@@ -479,7 +481,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await toggleEnableCaseListForm(order.id!);
 
-    selectItemInMockSelect(`lead-case-court`, 1);
+    selectItemInMockSelect(`lead-case-court`, 0);
     const caseNumberInput = findCaseNumberInput(order.id!);
 
     enterCaseNumber(caseNumberInput, '9999999');
@@ -949,7 +951,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     fireEvent.click(leadCaseFormCheckbox);
     expect(leadCaseFormCheckbox).toBeChecked();
     // Select lead case court.
-    selectItemInMockSelect(`lead-case-court`, 1);
+    selectItemInMockSelect(`lead-case-court`, 0);
 
     // Enter case number.
     const leadCaseNumber = getCaseNumber(leadCase.caseId);
@@ -960,8 +962,6 @@ describe('ConsolidationOrderAccordion tests', () => {
     });
 
     await waitFor(async () => {
-      const form = document.querySelector('.lead-case-form-container');
-      if (form) screen.debug(form);
       const alertElement = await screen.findByTestId(
         `alert-message-lead-case-number-alert-${order.id}`,
       );
@@ -996,7 +996,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     fireEvent.click(leadCaseFormCheckbox);
     expect(leadCaseFormCheckbox).toBeChecked();
     // Select lead case court.
-    selectItemInMockSelect(`lead-case-court`, 1);
+    selectItemInMockSelect(`lead-case-court`, 0);
 
     // Enter case number.
     const leadCaseNumber = getCaseNumber(leadCase.caseId);
@@ -1008,9 +1008,6 @@ describe('ConsolidationOrderAccordion tests', () => {
     await waitFor(() => {
       expect(caseNumberInput).toHaveValue(leadCaseNumber);
     });
-
-    const docDebug = document.querySelector(`.lead-case-form-container-${order.id}`);
-    screen.debug(docDebug!);
 
     await waitFor(async () => {
       const alertElement = await screen.findByTestId(

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.test.tsx
@@ -280,10 +280,9 @@ describe('ConsolidationOrderAccordion tests', () => {
     expect(approveButton).not.toBeEnabled();
     expect(rejectButton).not.toBeEnabled();
 
-    // at least 2 cases must be checked before verify button is enabled.
     const firstCheckbox = clickCaseCheckbox(order.id!, 0);
     await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
+      expect(approveButton).toBeEnabled();
       expect(rejectButton).toBeEnabled();
     });
 
@@ -296,7 +295,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     clickMarkLeadButton(0);
     await waitFor(() => {
       expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).not.toBeEnabled();
+      expect(rejectButton).toBeEnabled();
     });
 
     clickMarkLeadButton(0);
@@ -307,7 +306,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     fireEvent.click(firstCheckbox);
     await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
+      expect(approveButton).toBeEnabled();
       expect(rejectButton).toBeEnabled();
     });
 
@@ -361,7 +360,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await waitFor(() => {
       expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).not.toBeEnabled();
+      expect(rejectButton).toBeEnabled();
       expect(markAsLeadButton).toHaveClass('usa-button--outline');
     });
 
@@ -381,14 +380,14 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await waitFor(() => {
       expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).not.toBeEnabled();
+      expect(rejectButton).toBeEnabled();
     });
 
     enterCaseNumber(caseNumberInput, '111111');
 
     await waitFor(() => {
       expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).not.toBeEnabled();
+      expect(rejectButton).toBeEnabled();
     });
 
     enterCaseNumber(caseNumberInput, validCaseNumber);
@@ -405,7 +404,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await waitFor(() => {
       expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).not.toBeEnabled();
+      expect(rejectButton).toBeEnabled();
       expect(leadCaseForm).not.toBeInTheDocument();
     });
   });

--- a/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/ConsolidationOrderAccordion.tsx
@@ -131,16 +131,20 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     leadCaseNumberRef.current?.disable(disabled);
   }
 
-  function disableSubmitButtons() {
-    rejectButtonRef.current?.disableButton(true);
-    approveButtonRef.current?.disableButton(true);
-  }
+  function updateSubmitButtonsState() {
+    if (selectedCases.length) {
+      rejectButtonRef.current?.disableButton(false);
 
-  function enableSubmitButtons() {
-    rejectButtonRef.current?.disableButton(false);
-    approveButtonRef.current?.disableButton(
-      !isDataEnhanced || selectedCasesAreConsolidationCases() || selectedCases.length < 2,
-    );
+      approveButtonRef.current?.disableButton(
+        !isDataEnhanced ||
+          leadCaseId === '' ||
+          consolidationType === null ||
+          selectedCasesAreConsolidationCases(),
+      );
+    } else {
+      rejectButtonRef.current?.disableButton(true);
+      approveButtonRef.current?.disableButton(true);
+    }
   }
 
   function getCurrentLeadCaseId(leadCaseNumber: string) {
@@ -180,7 +184,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
   }
 
   function handleClearInputs(): void {
-    disableSubmitButtons();
     clearLeadCase();
     clearSelectedCases();
     setLeadCaseNumber('');
@@ -190,6 +193,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     jointAdministrationRef.current?.check(false);
     substantiveRef.current?.check(false);
     toggleLeadCaseFormRef.current?.setChecked(false);
+    updateSubmitButtonsState();
   }
 
   function handleConfirmAction(action: ConfirmActionResults): void {
@@ -211,6 +215,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
       tempSelectedCases = [...selectedCases, bCase];
     }
     setSelectedCases(tempSelectedCases);
+    updateSubmitButtonsState();
   }
 
   async function handleLeadCaseInputChange(caseNumber?: string) {
@@ -221,7 +226,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
       setFoundValidCaseNumber(false);
       setLeadCase(null);
       setLeadCaseNumberError('');
-      disableSubmitButtons();
+      approveButtonRef.current?.disableButton(true);
     }
   }
 
@@ -279,21 +284,16 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
   //========== USE EFFECTS ==========
 
   useEffect(() => {
+    updateSubmitButtonsState();
     if (isConsolidationProcessing) {
-      disableSubmitButtons();
       clearButtonRef.current?.disableButton(true);
     } else {
-      enableSubmitButtons();
       clearButtonRef.current?.disableButton(false);
     }
   }, [isConsolidationProcessing]);
 
   useEffect(() => {
-    if (selectedCases.length && leadCaseId !== '' && consolidationType !== null) {
-      enableSubmitButtons();
-    } else {
-      disableSubmitButtons();
-    }
+    updateSubmitButtonsState();
   }, [selectedCases, leadCaseId, isDataEnhanced, consolidationType]);
 
   useEffect(() => {


### PR DESCRIPTION
# Purpose

User must be able to reject a consolidation without entering a lead case or a consolidation type.

# Major Changes

Removed requirement for lead case and consolidation type to be selected in order to reject a consolidation.

Also removed the need to have at least 2 cases selected to approve a rejection.

# Testing/Validation

Test coverage is over 90%

# Notes

This work does NOT include the validation component nor the logic to ensure that the user can not mark the case as the lead case when there is only 1 case on the order.  We will need to address this since, it is only a valid consolidation if there are at least 2 cases involved.  1 must be a lead case, and a different case must be a child.  