### PR TITLE
added try catch for mock-oath2 function with more meaningful error

### DIFF
--- a/backend/functions/lib/testing/mock-gateways/mock-oauth2-gateway.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock-oauth2-gateway.ts
@@ -18,7 +18,7 @@ const key = 'mock-secret'; //pragma: allowlist secret
 
 export async function mockAuthentication(context: ApplicationContext): Promise<string> {
   if (context.config.authConfig.provider !== 'mock') {
-    throw new ForbiddenError(MODULE_NAME);
+    throw new ForbiddenError(MODULE_NAME, { message: 'Not in mock mode...' });
   }
   const requestedSubject = context.req.body as Pick<MockUser, 'sub'>;
   const validMockRole = mockUsers.find((role) => role.sub === requestedSubject.sub);

--- a/backend/functions/oauth2/mock-oauth2.function.ts
+++ b/backend/functions/oauth2/mock-oauth2.function.ts
@@ -1,5 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from '@azure/functions';
-import { httpSuccess } from '../lib/adapters/utils/http-response';
+import { httpError, httpSuccess } from '../lib/adapters/utils/http-response';
 import ContextCreator from '../lib/adapters/utils/application-context-creator';
 import { mockAuthentication } from '../lib/testing/mock-gateways/mock-oauth2-gateway';
 
@@ -11,8 +11,13 @@ const httpTrigger: AzureFunction = async function (
     functionContext,
     request,
   );
-  const token = await mockAuthentication(applicationContext);
-  functionContext.res = httpSuccess({ token });
+  try {
+    const token = await mockAuthentication(applicationContext);
+    functionContext.res = httpSuccess({ token });
+  } catch (camsError) {
+    applicationContext.logger.camsError(camsError);
+    functionContext.res = httpError(camsError);
+  }
 };
 
 export default httpTrigger;


### PR DESCRIPTION


# Problem

Provide a catch for misconfigured mock auth provider and meaningful error thrown when not in mock mode. 

# Solution

try catch in mock-oauth function, override in forbidden message

# Testing/Validation
N/A
