### PR TITLE
Update to the latest upload-artifact action

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -97,7 +97,7 @@ jobs:
           OKTA_USER_NAME=${{secrets.OKTA_USER_NAME}} OKTA_PASSWORD=${{secrets.OKTA_PASSWORD}} TARGET_HOST=https://${{ inputs.webappName }}.azurewebsites${{ vars.AZ_HOSTNAME_SUFFIX }} CAMS_LOGIN_PROVIDER=${{ vars.CAMS_LOGIN_PROVIDER }} npx playwright test --reporter=list,html
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/sub-build.yml
+++ b/.github/workflows/sub-build.yml
@@ -75,7 +75,7 @@ jobs:
           mv ./build/${{ inputs.webappName }}.zip ./artifacts/
 
       - name: Upload Frontend Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: ${{ inputs.webappName }}-build
           path: user-interface/artifacts/
@@ -104,7 +104,7 @@ jobs:
         run: OUT=${{ inputs.apiName }} npm run pack
 
       - name: Upload Node Azure Functions Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: ${{ inputs.apiName }}-build
           path: backend/functions/${{ inputs.apiName }}.zip


### PR DESCRIPTION
# Purpose

Downloading the build artifact uploaded by the newest version of the `actions/upload-artifact` Action failed.

# Major Changes

Update the `actions/download-artifact` Action version to the latest.

# Testing/Validation

[Run the full deployment](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/10704818750).
