### PR TITLE
CAMS-418 - Return a list of offices for a group designator

### DIFF
--- a/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.test.ts
@@ -102,14 +102,14 @@ describe('offices gateway tests', () => {
 
       const gateway = new OfficesDxtrGateway();
 
-      const offices = await gateway.getOfficeByGroupDesignator(applicationContext, 'NY');
-      expect(offices).toEqual(MANHATTAN);
+      const offices = await gateway.getOfficesByGroupDesignator(applicationContext, 'NY');
+      expect(offices).toEqual([MANHATTAN]);
     });
 
     test('should throw invalid parameter exception with invalid parameters', async () => {
       const gateway = new OfficesDxtrGateway();
       await expect(async () => {
-        await gateway.getOfficeByGroupDesignator(applicationContext, '');
+        await gateway.getOfficesByGroupDesignator(applicationContext, '');
       }).rejects.toThrow('Invalid group designator supplied');
     });
 
@@ -127,7 +127,7 @@ describe('offices gateway tests', () => {
 
       const gateway = new OfficesDxtrGateway();
       await expect(async () => {
-        await gateway.getOfficeByGroupDesignator(applicationContext, 'ZZ');
+        await gateway.getOfficesByGroupDesignator(applicationContext, 'ZZ');
       }).rejects.toThrow('Office not found by query designator.');
     });
 
@@ -144,7 +144,7 @@ describe('offices gateway tests', () => {
       const gateway = new OfficesDxtrGateway();
 
       await expect(async () => {
-        await gateway.getOfficeByGroupDesignator(applicationContext, 'NY');
+        await gateway.getOfficesByGroupDesignator(applicationContext, 'NY');
       }).rejects.toThrow('Some expected SQL error.');
     });
   });

--- a/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
@@ -52,10 +52,10 @@ export default class OfficesDxtrGateway implements OfficesGatewayInterface {
     }
   }
 
-  async getOfficeByGroupDesignator(
+  async getOfficesByGroupDesignator(
     context: ApplicationContext,
     groupDesignator: string,
-  ): Promise<OfficeDetails> {
+  ): Promise<OfficeDetails[]> {
     const input: DbTableFieldSpec[] = [];
 
     if (groupDesignator.length !== 2) {
@@ -103,7 +103,7 @@ export default class OfficesDxtrGateway implements OfficesGatewayInterface {
           message: 'Office not found by query designator.',
         });
       }
-      return results.recordset[0];
+      return results.recordset;
     } else {
       throw new CamsError(MODULE_NAME, { message: queryResult.message });
     }

--- a/backend/functions/lib/adapters/gateways/user-session-gateway.ts
+++ b/backend/functions/lib/adapters/gateways/user-session-gateway.ts
@@ -61,8 +61,11 @@ async function getOffices(
   const offices: OfficeDetails[] = [];
   for (const designator of dxtrGroupDesignators) {
     try {
-      const office = await officesGateway.getOfficeByGroupDesignator(context, designator);
-      offices.push(office);
+      const officesPerDesignator = await officesGateway.getOfficesByGroupDesignator(
+        context,
+        designator,
+      );
+      officesPerDesignator.forEach((office) => offices.push(office));
     } catch (error) {
       context.logger.warn(MODULE_NAME, error.message, { designator });
     }

--- a/backend/functions/lib/testing/mock-gateways/mock.offices.gateway.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock.offices.gateway.ts
@@ -20,13 +20,13 @@ export class MockOfficesGateway implements OfficesGatewayInterface {
     return Promise.resolve(MockData.getOffices());
   }
 
-  async getOfficeByGroupDesignator(
+  async getOfficesByGroupDesignator(
     _applicationContext: ApplicationContext,
     groupDesignator: string,
-  ): Promise<OfficeDetails> {
-    const office = MockData.getOfficeByGroupDesignator(groupDesignator);
-    if (!office)
+  ): Promise<OfficeDetails[]> {
+    const offices = MockData.getOfficesByGroupDesignator(groupDesignator);
+    if (offices.length === 0)
       throw new CamsError(MODULE_NAME, { message: 'Office not found by group designator.' });
-    return office;
+    return offices;
   }
 }

--- a/backend/functions/lib/use-cases/offices/offices.gateway.interface.ts
+++ b/backend/functions/lib/use-cases/offices/offices.gateway.interface.ts
@@ -4,10 +4,10 @@ import { ApplicationContext } from '../../adapters/types/basic';
 export interface OfficesGatewayInterface {
   getOfficeName(id: string): string;
 
-  getOfficeByGroupDesignator(
+  getOfficesByGroupDesignator(
     applicationContext: ApplicationContext,
     groupDesignator: string,
-  ): Promise<OfficeDetails>;
+  ): Promise<OfficeDetails[]>;
 
   getOffices(applicationContext: ApplicationContext): Promise<OfficeDetails[]>;
 }

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -77,8 +77,8 @@ function getOffices() {
   return OFFICES;
 }
 
-function getOfficeByGroupDesignator(groupDesignator: string) {
-  return OFFICES.find((office) => office.groupDesignator === groupDesignator);
+function getOfficesByGroupDesignator(groupDesignator: string) {
+  return OFFICES.filter((office) => office.groupDesignator === groupDesignator);
 }
 
 function randomOffice() {
@@ -498,7 +498,7 @@ export const MockData = {
   getCaseSummary,
   getCaseDetail,
   getOffices,
-  getOfficeByGroupDesignator,
+  getOfficesByGroupDesignator,
   getParty,
   getDocketEntry,
   getNonPaginatedResponseBodySuccess,


### PR DESCRIPTION
# Purpose

Return a list of offices per a given group designator

# Major Changes

Changed the function that used to return a single office to return a list of offices.

# Testing/Validation

Testing passes

