### PR TITLE
Extract sast upload scan to standalone workflow

### DIFF
--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -73,23 +73,3 @@ jobs:
         run: |
           az storage blob upload --account-name ${{ secrets.AZ_STOR_VERACODE_NAME }} --account-key ${{ secrets.AZ_STOR_VERACODE_KEY }} -f results.json -c results -n results-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.ref_name }}.json
           az storage blob upload --account-name ${{ secrets.AZ_STOR_VERACODE_NAME }} --account-key ${{ secrets.AZ_STOR_VERACODE_KEY }} -f filtered_results.json -c results -n filtered_results-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.ref_name }}.json
-
-  sast-scan-and-upload:
-    name: SAST Scan Uploaded
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Package source code for scan
-        run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*" -i "./common/*"
-
-      - name: Veracode Upload And Scan
-        uses: veracode/veracode-uploadandscan-action@0.2.7
-        with:
-          appname: "CAMS"
-          createprofile: false
-          filepath: "cams.zip"
-          vid: "${{ secrets.VERACODE_API_ID }}"
-          vkey: "${{ secrets.VERACODE_API_KEY }}"
-          criticality: "Medium"

--- a/.github/workflows/veracode-sast-upload.yml
+++ b/.github/workflows/veracode-sast-upload.yml
@@ -1,0 +1,29 @@
+name: Veracode Static Analysis Scan
+
+concurrency: ${{ github.ref }}-${{ github.workflow }}
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  sast-upload-and-scan:
+    name: SAST Upload and Scan
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Package source code for scan
+        run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*" -i "./common/*"
+
+      - name: Veracode Upload And Scan
+        uses: veracode/veracode-uploadandscan-action@0.2.7
+        with:
+          appname: "CAMS"
+          createprofile: false
+          filepath: "cams.zip"
+          vid: "${{ secrets.VERACODE_API_ID }}"
+          vkey: "${{ secrets.VERACODE_API_KEY }}"
+          criticality: "Medium"


### PR DESCRIPTION
# Purpose

The upload and scan job occasionally breaks builds on main because only one such scan may be in progress at a time. We need to not run on every merge to main.

# Major Changes

- Adds a new scheduled workflow (Mondays at 6 a.m. UTC) with the option to trigger manually.
- Removes the upload and scan from the continuous deployment workflow.

# Testing/Validation

Workflow dispatch triggers cannot be run until after merge to main, so validation will be performed after the merge.