### PR TITLE
CAMS-418 Fixed misnamed SQL parameter for office lookup

### DIFF
--- a/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
@@ -65,7 +65,7 @@ export default class OfficesDxtrGateway implements OfficesGatewayInterface {
     }
 
     input.push({
-      name: 'courtId',
+      name: 'groupDesignator',
       type: mssql.VarChar,
       value: groupDesignator,
     });


### PR DESCRIPTION
# Purpose

Fix the office lookup by group designator.

# Major Changes

* Renamed the SQL parameter to match the placeholder in the SQL statement.

# Testing/Validation

Manual integration test with Okta revealed the bug and showed it is now fixed.
