### PR TITLE
Document usage of the architecture diagram script

### DIFF
--- a/architecture/export-architecture-diagrams.sh
+++ b/architecture/export-architecture-diagrams.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# This script is used to generate architecture diagrams from the dsl.
+# It relies on the Structurizr CLI being installed locally in a particular way.
+# https://docs.structurizr.com/cli/installation#local-installation
+# Following the instructions at the above link, ensuring that the $PATH variable
+# is updated will enable this script to execute properly.
+
+# Usage
+#   From the root directory, run the following command:
+#     sh ./architecture/export-architecture-diagrams.sh
+
 # Export the diagrams from our model
 structurizr.sh export -workspace architecture/cams.dsl -format mermaid
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -109,3 +109,7 @@ az cloud set --name AzureUSGovernment
 ```
 
 After that is complete, running `az login` will open a browser tab to log you in to your Azure account.
+
+## Architecture Diagrams
+
+We use the Structurizr domain-specific-language (DSL) to describe non-sensitive portions of our system architecture. When the architecture changes, the `/architecture/cams.dsl` file must be updated to reflect that change, and the `/architecture/export-architecture-diagrams.sh` script must be run. The script contains information about proper usage.


### PR DESCRIPTION
# Purpose

We need to document how to keep the architecture diagrams up-to-date.

# Major Changes

Add documentation about how to use the script that updates the architecture diagrams.