### PR TITLE
CAMS-356: Fix frontend handling of 201 and bad parameter

### DIFF
--- a/backend/functions/case-associated/case-associated.function.ts
+++ b/backend/functions/case-associated/case-associated.function.ts
@@ -36,5 +36,5 @@ app.http('case-associated', {
   methods: ['GET'],
   authLevel: 'anonymous',
   handler,
-  route: 'cases/{id?}/associated',
+  route: 'cases/{caseId?}/associated',
 });

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -243,6 +243,7 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
       .then((response) => {
         if (response) {
           setAssociatedCases(response.data);
+          // If an empty array comes back, we break
           setIsAssociatedCasesLoading(false);
         }
       })
@@ -392,8 +393,8 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
                   caseId={caseId}
                   initiallySelectedNavLink={navState}
                   showAssociatedCasesList={
-                    caseBasicInfo.consolidation != undefined &&
-                    caseBasicInfo.consolidation?.length > 0
+                    caseBasicInfo.consolidation !== undefined &&
+                    caseBasicInfo.consolidation.length > 0
                   }
                 />
                 {hasDocketEntries && navState === NavState.COURT_DOCKET && (

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -243,7 +243,6 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
       .then((response) => {
         if (response) {
           setAssociatedCases(response.data);
-          // If an empty array comes back, we break
           setIsAssociatedCasesLoading(false);
         }
       })

--- a/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.test.tsx
@@ -70,6 +70,13 @@ describe('associated cases tests', () => {
     expect(loadingIndicator).toBeInTheDocument();
   });
 
+  test('should display alert if no associated cases are available', async () => {
+    renderComponent([], false);
+
+    const alert = screen.queryByTestId('alert-container-no-cases');
+    expect(alert).toBeInTheDocument();
+  });
+
   test('should display associated case table when data exists', async () => {
     const mock: EventCaseReference[] = getAssociatedCasesMock('081-34-34811', 'substantive');
     renderComponent(mock, false);

--- a/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.tsx
@@ -5,6 +5,7 @@ import { formatDate } from '@/lib/utils/datetime';
 import { consolidationTypeMap } from '@/lib/utils/labels';
 import './CaseDetailAssociatedCases.scss';
 import { getCaseNumber } from '@/lib/utils/formatCaseNumber';
+import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 
 export interface CaseDetailAssociatedCasesProps {
   associatedCases: EventCaseReference[];
@@ -20,7 +21,15 @@ export default function CaseDetailAssociatedCases(props: CaseDetailAssociatedCas
   return (
     <div className="associated-cases">
       {isAssociatedCasesLoading && <LoadingIndicator />}
-      {!isAssociatedCasesLoading && (
+      {!isAssociatedCasesLoading && consolidation.length === 0 && (
+        <Alert
+          id="no-cases"
+          type={UswdsAlertStyle.Error}
+          title="Associated Cases Not Available"
+          message="We are unable to retrieve associated cases at this time. Please try again later. If the problem persists, please submit a feedback request describing the issue."
+        ></Alert>
+      )}
+      {!isAssociatedCasesLoading && consolidation.length > 0 && (
         <>
           <h3>Consolidated cases ({consolidation.length})</h3>
           <h4>{consolidationTypeMap.get(consolidation[0].consolidationType)}</h4>

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
@@ -442,7 +442,6 @@ describe('ConsolidationOrderAccordion tests', () => {
     openAccordion(order.id!);
     const testCase = { ...order.childCases[0] };
     testCase.caseId = '999-99-99999';
-    // setupApiGetMock({ bCase: testCase });
 
     await toggleEnableCaseListForm(order.id!);
 

--- a/user-interface/src/lib/models/api.test.ts
+++ b/user-interface/src/lib/models/api.test.ts
@@ -92,15 +92,26 @@ describe('Specific tests for the API model', () => {
     expect(Api.get('/some/path', {})).resolves.toEqual(payload);
   });
 
-  test('should return data when response is Ok', () => {
+  test('should return data when response is Ok with a payload', () => {
     const payload = { foo: 'mock post' };
     const mockHttpPost = vi.fn().mockResolvedValue({
       json: () => Promise.resolve(payload),
+      text: () => Promise.resolve(JSON.stringify(payload)),
       ok: true,
     });
     vi.spyOn(httpAdapter, 'httpPost').mockImplementation(mockHttpPost);
 
     expect(Api.post('/some/path', {})).resolves.toEqual(payload);
+  });
+
+  test('should return data when response is Ok without a payload', () => {
+    const mockHttpPost = vi.fn().mockResolvedValue({
+      json: () => JSON.parse(''),
+      text: () => Promise.resolve('{'),
+      ok: true,
+    });
+    vi.spyOn(httpAdapter, 'httpPost').mockImplementation(mockHttpPost);
+    expect(Api.post('/some/path', {})).resolves.toBeUndefined();
   });
 
   test('should throw error when "patch" response is not ok', () => {

--- a/user-interface/src/lib/models/api.test.ts
+++ b/user-interface/src/lib/models/api.test.ts
@@ -150,7 +150,7 @@ describe('Specific tests for the API model', () => {
     const key = 'x-ms-routing-name';
     const value = 'theValue';
     const search = `${key}=${value}`;
-    const options = Api.getQueryStringsToPassthrough(search, {});
+    const options = Api.getQueryStringsToPassThrough(search, {});
     expect(options[key]).toEqual(value);
   });
 
@@ -166,7 +166,7 @@ describe('Specific tests for the API model', () => {
       ...passedOptions,
       [key]: value,
     };
-    const options = Api.getQueryStringsToPassthrough(search, passedOptions);
+    const options = Api.getQueryStringsToPassThrough(search, passedOptions);
     expect(options).toEqual(expectedOptions);
   });
 });

--- a/user-interface/src/lib/models/api.ts
+++ b/user-interface/src/lib/models/api.ts
@@ -24,9 +24,6 @@ export function addApiAfterHook(hook: (response: Response) => Promise<void>) {
   }
 }
 
-/**
- * ONLY USE WITH OUR OWN API!!!!
- */
 export default class Api {
   public static headers: Record<string, string> = {};
 
@@ -55,6 +52,15 @@ export default class Api {
     }
   }
 
+  /**
+   * ONLY USE WITH OUR OWN API!!!!
+   * This function makes assumptions about the responses to POST requests that do not handle
+   * all possibilities according to the HTTP specifications.
+   *
+   * @param path string The path after '/api'.
+   * @param body object The payload for the request.
+   * @param options ObjectKeyVal Query params in the form of key/value pairs.
+   */
   public static async post(
     path: string,
     body: object,
@@ -62,7 +68,7 @@ export default class Api {
   ): Promise<ResponseBody | void> {
     try {
       await this.executeBeforeHooks();
-      const apiOptions = this.getQueryStringsToPassthrough(window.location.search, options);
+      const apiOptions = this.getQueryStringsToPassThrough(window.location.search, options);
       const pathStr = Api.createPath(path, apiOptions);
 
       const response = await httpPost({ url: Api.host + pathStr, body, headers: this.headers });
@@ -83,7 +89,7 @@ export default class Api {
   public static async get(path: string, options?: ObjectKeyVal): Promise<ResponseBody> {
     try {
       await this.executeBeforeHooks();
-      const apiOptions = this.getQueryStringsToPassthrough(window.location.search, options);
+      const apiOptions = this.getQueryStringsToPassThrough(window.location.search, options);
       const pathStr = Api.createPath(path, apiOptions);
       const response = await httpGet({ url: Api.host + pathStr, headers: this.headers });
       await this.executeAfterHooks(response);
@@ -110,7 +116,7 @@ export default class Api {
   ): Promise<ResponseBody> {
     try {
       await this.executeBeforeHooks();
-      const apiOptions = this.getQueryStringsToPassthrough(window.location.search, options);
+      const apiOptions = this.getQueryStringsToPassThrough(window.location.search, options);
       const pathStr = Api.createPath(path, apiOptions);
       const response = await httpPatch({ url: Api.host + pathStr, body, headers: this.headers });
       await this.executeAfterHooks(response);
@@ -134,7 +140,7 @@ export default class Api {
   ): Promise<ResponseBody> {
     try {
       await this.executeBeforeHooks();
-      const apiOptions = this.getQueryStringsToPassthrough(window.location.search, options);
+      const apiOptions = this.getQueryStringsToPassThrough(window.location.search, options);
       const pathStr = Api.createPath(path, apiOptions);
       const response = await httpPut({ url: Api.host + pathStr, body, headers: this.headers });
       await this.executeAfterHooks(response);
@@ -151,7 +157,7 @@ export default class Api {
     }
   }
 
-  public static getQueryStringsToPassthrough(
+  public static getQueryStringsToPassThrough(
     search: string,
     options: ObjectKeyVal = {},
   ): ObjectKeyVal {

--- a/user-interface/src/lib/models/api2.test.ts
+++ b/user-interface/src/lib/models/api2.test.ts
@@ -1,8 +1,10 @@
 import { describe } from 'vitest';
 import MockApi2 from '@/lib/testing/mock-api2';
-import Api2, { extractPathFromUri, addAuthHeaderToApi, useGenericApi, _Api2 } from './api2';
-import Api, { addApiBeforeHook, addApiAfterHook } from '@/lib/models/api';
+import Api2, { _Api2, addAuthHeaderToApi, extractPathFromUri, useGenericApi } from './api2';
+import Api, { addApiAfterHook, addApiBeforeHook } from '@/lib/models/api';
 import MockData from '@common/cams/test-utilities/mock-data';
+import { StaffAssignmentAction } from '@common/cams/assignments';
+import { CamsRole } from '@common/cams/roles';
 
 type ApiType = {
   addApiBeforeHook: typeof addApiBeforeHook;
@@ -98,7 +100,19 @@ describe('_Api2 functions', async () => {
     await callApiFunction(api2.Api2.putConsolidationOrderApproval, 'some-id', api);
     await callApiFunction(api2.Api2.putConsolidationOrderRejection, 'some-id', api);
     await callApiFunction(api2.Api2.searchCases, 'some-id', api);
-    await callApiFunction(api2.Api2.postStaffAssignments, 'some-id', api);
+  });
+
+  test('should handle no body properly', async () => {
+    const postSpy = vi.spyOn(api.default, 'post').mockImplementation(() => {
+      return Promise.resolve();
+    });
+    const assignmentAction: StaffAssignmentAction = {
+      caseId: '000-00-00000',
+      attorneyList: MockData.buildArray(MockData.getAttorneyUser, 2),
+      role: CamsRole.TrialAttorney,
+    };
+    await api2.Api2.postStaffAssignments(assignmentAction);
+    expect(postSpy).toHaveBeenCalled();
   });
 
   test('should handle error properly', async () => {

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -24,7 +24,7 @@ interface ApiClient {
   headers: Record<string, string>;
   host: string;
   createPath(path: string, params: ObjectKeyVal): string;
-  post(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody>;
+  post(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody | void>;
   get(path: string, options?: ObjectKeyVal): Promise<ResponseBody>;
   patch(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody>;
   put(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody>;
@@ -34,7 +34,11 @@ interface ApiClient {
 interface GenericApiClient {
   get<T = object>(path: string, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
   patch<T = object>(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
-  post<T = object>(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
+  post<T = object>(
+    path: string,
+    body: object,
+    options?: ObjectKeyVal,
+  ): Promise<ResponseBody<T> | void>;
   put<T = object>(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
 }
 
@@ -83,8 +87,11 @@ export function useGenericApi(): GenericApiClient {
       path: string,
       body: object,
       options?: ObjectKeyVal,
-    ): Promise<ResponseBody<T>> {
+    ): Promise<ResponseBody<T> | void> {
       const responseBody = await api.post(justThePath(path), body, options);
+      if (!responseBody) {
+        return;
+      }
       return responseBody as ResponseBody<T>;
     },
     async put<T = object>(
@@ -159,8 +166,8 @@ async function searchCases(predicate: CasesSearchPredicate) {
   return api().post<CaseBasics[]>('/cases', predicate);
 }
 
-async function postStaffAssignments(action: StaffAssignmentAction): Promise<ResponseBody> {
-  return api().post('/case-assignments', action);
+async function postStaffAssignments(action: StaffAssignmentAction): Promise<void> {
+  await api().post('/case-assignments', action);
 }
 
 export const _Api2 = {

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -24,16 +24,27 @@ interface ApiClient {
   headers: Record<string, string>;
   host: string;
   createPath(path: string, params: ObjectKeyVal): string;
+
   post(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody | void>;
   get(path: string, options?: ObjectKeyVal): Promise<ResponseBody>;
   patch(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody>;
   put(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody>;
-  getQueryStringsToPassthrough(search: string, options: ObjectKeyVal): ObjectKeyVal;
+  getQueryStringsToPassThrough(search: string, options: ObjectKeyVal): ObjectKeyVal;
 }
 
 interface GenericApiClient {
   get<T = object>(path: string, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
   patch<T = object>(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
+
+  /**
+   * ONLY USE WITH OUR OWN API!!!!
+   * This function makes assumptions about the responses to POST requests that do not handle
+   * all possibilities according to the HTTP specifications.
+   *
+   * @param path string The path after '/api'.
+   * @param body object The payload for the request.
+   * @param options ObjectKeyVal Query params in the form of key/value pairs.
+   */
   post<T = object>(
     path: string,
     body: object,

--- a/user-interface/src/search-results/SearchResults.tsx
+++ b/user-interface/src/search-results/SearchResults.tsx
@@ -60,9 +60,14 @@ export function SearchResults(props: SearchResultsProps) {
 
   const api = useApi2();
 
-  function handleSearchResults(response: ResponseBody<CaseBasics[]>) {
-    setSearchResults(response);
-    setEmptyResponse(response.data.length === 0);
+  function handleSearchResults(response: ResponseBody<CaseBasics[]> | void) {
+    if (response) {
+      setSearchResults(response);
+      setEmptyResponse(response.data.length === 0);
+    } else {
+      setSearchResults(null);
+      setEmptyResponse(true);
+    }
   }
 
   function handleSearchError() {

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModal.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModal.tsx
@@ -178,24 +178,22 @@ function _AssignAttorneyModal(
     setIsUpdatingAssignment(true);
 
     try {
-      const result = await api.postStaffAssignments({
+      await api.postStaffAssignments({
         caseId: bCase?.caseId,
         attorneyList: finalAttorneyList,
         role: CamsRole.TrialAttorney,
       });
-      if (result) {
-        if (submitCallbackRef.current) {
-          submitCallbackRef.current({
-            bCase,
-            selectedAttorneyList: finalAttorneyList,
-            previouslySelectedList,
-            status: 'success',
-            apiResult: result,
-          });
-        }
-        setCheckListValues([]);
-        setIsUpdatingAssignment(false);
+      if (submitCallbackRef.current) {
+        submitCallbackRef.current({
+          bCase,
+          selectedAttorneyList: finalAttorneyList,
+          previouslySelectedList,
+          status: 'success',
+          apiResult: {},
+        });
       }
+      setCheckListValues([]);
+      setIsUpdatingAssignment(false);
     } catch (e) {
       if (submitCallbackRef.current) {
         submitCallbackRef.current({


### PR DESCRIPTION
# Purpose

We discovered some errors with the deployed application.

# Major Changes

- associated cases function now correctly takes the `caseId` path param
- the frontend api can now handle 2xx responses with no payload

# Testing/Validation

Automated tests were added/updated.