### PR TITLE
CAMS-356: testing wrap up

### DIFF
--- a/backend/functions/case-assignments/case.assignment.function.test.ts
+++ b/backend/functions/case-assignments/case.assignment.function.test.ts
@@ -3,8 +3,6 @@ import { CaseAssignmentController } from '../lib/controllers/case-assignment/cas
 import ContextCreator from '../azure/application-context-creator';
 import { CaseAssignment } from '../../../common/src/cams/assignments';
 import { MockData } from '../../../common/src/cams/test-utilities/mock-data';
-import { CamsRole } from '../../../common/src/cams/roles';
-import { MANHATTAN } from '../../../common/src/cams/test-utilities/offices.mock';
 import { CamsHttpRequest } from '../lib/adapters/types/http';
 import { InvocationContext } from '@azure/functions';
 import { createMockApplicationContext } from '../lib/testing/testing-utilities';
@@ -30,16 +28,9 @@ describe('Case Assignment Function Tests', () => {
   let context;
 
   beforeEach(() => {
-    jest.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
-      MockData.getCamsSession({
-        user: {
-          id: 'userId-Bob Jones',
-          name: 'Bob Jones',
-          offices: [MANHATTAN],
-          roles: [CamsRole.CaseAssignmentManager],
-        },
-      }),
-    );
+    jest
+      .spyOn(ContextCreator, 'getApplicationContextSession')
+      .mockResolvedValue(MockData.getManhattanAssignmentManagerSession());
     context = new InvocationContext({
       logHandler: () => {},
       invocationId: 'id',

--- a/backend/functions/case-associated/case-associated.function.test.ts
+++ b/backend/functions/case-associated/case-associated.function.test.ts
@@ -3,8 +3,6 @@ import { CaseAssociatedController } from '../lib/controllers/case-associated/cas
 import handler from './case-associated.function';
 import ContextCreator from '../azure/application-context-creator';
 import MockData from '../../../common/src/cams/test-utilities/mock-data';
-import { MANHATTAN } from '../../../common/src/cams/test-utilities/offices.mock';
-import { CamsRole } from '../../../common/src/cams/roles';
 import { InvocationContext } from '@azure/functions';
 import {
   buildTestResponseError,
@@ -14,16 +12,9 @@ import {
 import { EventCaseReference } from '../../../common/src/cams/events';
 
 describe('Case summary function', () => {
-  jest.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
-    MockData.getCamsSession({
-      user: {
-        id: 'userId-Bob Jones',
-        name: 'Bob Jones',
-        offices: [MANHATTAN],
-        roles: [CamsRole.TrialAttorney],
-      },
-    }),
-  );
+  jest
+    .spyOn(ContextCreator, 'getApplicationContextSession')
+    .mockResolvedValue(MockData.getManhattanTrialAttorneySession());
 
   const request = createMockAzureFunctionRequest({
     params: {

--- a/backend/functions/case-history/case-history.function.test.ts
+++ b/backend/functions/case-history/case-history.function.test.ts
@@ -6,8 +6,6 @@ import { InvocationContext } from '@azure/functions';
 import handler from './case-history.function';
 import ContextCreator from '../azure/application-context-creator';
 import MockData from '../../../common/src/cams/test-utilities/mock-data';
-import { MANHATTAN } from '../../../common/src/cams/test-utilities/offices.mock';
-import { CamsRole } from '../../../common/src/cams/roles';
 import { CaseHistoryController } from '../lib/controllers/case-history/case-history.controller';
 import {
   buildTestResponseError,
@@ -27,16 +25,9 @@ describe('Case History Function Tests', () => {
 
   beforeEach(() => {
     context = new InvocationContext();
-    jest.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
-      MockData.getCamsSession({
-        user: {
-          id: 'userId-Bob Jones',
-          name: 'Bob Jones',
-          offices: [MANHATTAN],
-          roles: [CamsRole.CaseAssignmentManager],
-        },
-      }),
-    );
+    jest
+      .spyOn(ContextCreator, 'getApplicationContextSession')
+      .mockResolvedValue(MockData.getManhattanAssignmentManagerSession());
   });
 
   test('Should return case history for an existing case ID', async () => {

--- a/backend/functions/case-summary/case-summary.function.test.ts
+++ b/backend/functions/case-summary/case-summary.function.test.ts
@@ -4,8 +4,6 @@ import { MockData } from '../../../common/src/cams/test-utilities/mock-data';
 import { NotFoundError } from '../lib/common-errors/not-found-error';
 import handler from './case-summary.function';
 import ContextCreator from '../azure/application-context-creator';
-import { MANHATTAN } from '../../../common/src/cams/test-utilities/offices.mock';
-import { CamsRole } from '../../../common/src/cams/roles';
 import {
   buildTestResponseError,
   buildTestResponseSuccess,
@@ -15,16 +13,9 @@ import { CamsHttpRequest } from '../lib/adapters/types/http';
 import { CaseSummaryController } from '../lib/controllers/case-summary/case-summary.controller';
 
 describe('Case summary function', () => {
-  jest.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
-    MockData.getCamsSession({
-      user: {
-        id: 'userId-Bob Jones',
-        name: 'Bob Jones',
-        offices: [MANHATTAN],
-        roles: [CamsRole.TrialAttorney],
-      },
-    }),
-  );
+  jest
+    .spyOn(ContextCreator, 'getApplicationContextSession')
+    .mockResolvedValue(MockData.getManhattanTrialAttorneySession());
 
   const baseRequest: Partial<CamsHttpRequest> = {
     method: 'GET',

--- a/backend/functions/cases/cases.function.test.ts
+++ b/backend/functions/cases/cases.function.test.ts
@@ -9,23 +9,14 @@ import { CasesController } from '../lib/controllers/cases/cases.controller';
 import { NotFoundError } from '../lib/common-errors/not-found-error';
 import ContextCreator from '../azure/application-context-creator';
 import MockData from '../../../common/src/cams/test-utilities/mock-data';
-import { MANHATTAN } from '../../../common/src/cams/test-utilities/offices.mock';
-import { CamsRole } from '../../../common/src/cams/roles';
 import { InvocationContext } from '@azure/functions';
 import { ResourceActions } from '../../../common/src/cams/actions';
 import { CaseBasics, CaseDetail } from '../../../common/src/cams/cases';
 
 describe('Cases function', () => {
-  jest.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
-    MockData.getCamsSession({
-      user: {
-        id: 'userId-Bob Jones',
-        name: 'Bob Jones',
-        offices: [MANHATTAN],
-        roles: [CamsRole.TrialAttorney],
-      },
-    }),
-  );
+  jest
+    .spyOn(ContextCreator, 'getApplicationContextSession')
+    .mockResolvedValue(MockData.getManhattanTrialAttorneySession());
 
   const originalEnv = process.env;
 

--- a/backend/functions/consolidations/consolidations.function.test.ts
+++ b/backend/functions/consolidations/consolidations.function.test.ts
@@ -2,8 +2,6 @@ import { MockData } from '../../../common/src/cams/test-utilities/mock-data';
 import handler from './consolidations.function';
 import { CamsHttpRequest } from '../lib/adapters/types/http';
 import ContextCreator from '../azure/application-context-creator';
-import { MANHATTAN } from '../../../common/src/cams/test-utilities/offices.mock';
-import { CamsRole } from '../../../common/src/cams/roles';
 import {
   buildTestResponseError,
   buildTestResponseSuccess,
@@ -25,16 +23,9 @@ describe('Consolidations Function tests', () => {
 
   const context = createMockAzureFunctionContext();
 
-  jest.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
-    MockData.getCamsSession({
-      user: {
-        id: 'userId-Bob Jones',
-        name: 'Bob Jones',
-        offices: [MANHATTAN],
-        roles: [CamsRole.CaseAssignmentManager],
-      },
-    }),
-  );
+  jest
+    .spyOn(ContextCreator, 'getApplicationContextSession')
+    .mockResolvedValue(MockData.getManhattanAssignmentManagerSession());
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/backend/functions/lib/controllers/attorneys/attorneys.controller.test.ts
+++ b/backend/functions/lib/controllers/attorneys/attorneys.controller.test.ts
@@ -1,3 +1,30 @@
+import MockData from '../../../../../common/src/cams/test-utilities/mock-data';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import AttorneysController from './attorneys.controller';
+import { commonHeaders } from '../../adapters/utils/http-response';
+import AttorneysList from '../../use-cases/attorneys';
+
 describe('Attorneys Controller Tests', () => {
-  test('', () => {});
+  let applicationContext;
+
+  beforeEach(async () => {
+    applicationContext = await createMockApplicationContext();
+  });
+
+  test('should get list of attorneys', async () => {
+    const attorneysList = MockData.buildArray(MockData.getAttorneyUser, 5);
+    jest.spyOn(AttorneysList.prototype, 'getAttorneyList').mockResolvedValue(attorneysList);
+    const response = await AttorneysController.getAttorneyList(applicationContext);
+    expect(response).toEqual({
+      body: { data: attorneysList },
+      statusCode: 200,
+      headers: commonHeaders,
+    });
+  });
+
+  test('should throw error', async () => {
+    const error = new Error();
+    jest.spyOn(AttorneysList.prototype, 'getAttorneyList').mockRejectedValue(error);
+    await expect(AttorneysController.getAttorneyList(applicationContext)).rejects.toThrow(error);
+  });
 });

--- a/backend/functions/offices/offices.function.test.ts
+++ b/backend/functions/offices/offices.function.test.ts
@@ -2,7 +2,6 @@ import { CamsError } from '../lib/common-errors/cams-error';
 import ContextCreator from '../azure/application-context-creator';
 import MockData from '../../../common/src/cams/test-utilities/mock-data';
 import { BUFFALO, DELAWARE, MANHATTAN } from '../../../common/src/cams/test-utilities/offices.mock';
-import { CamsRole } from '../../../common/src/cams/roles';
 import handler from './offices.function';
 import {
   buildTestResponseError,
@@ -27,16 +26,9 @@ describe('offices Function tests', () => {
     jest.clearAllMocks();
   });
 
-  jest.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
-    MockData.getCamsSession({
-      user: {
-        id: 'userId-Bob Jones',
-        name: 'Bob Jones',
-        offices: [MANHATTAN],
-        roles: [CamsRole.CaseAssignmentManager],
-      },
-    }),
-  );
+  jest
+    .spyOn(ContextCreator, 'getApplicationContextSession')
+    .mockResolvedValue(MockData.getManhattanAssignmentManagerSession());
 
   test('should set successful response', async () => {
     const bodySuccess: OfficeDetails[] = testOffices;

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -33,6 +33,7 @@ import { CamsSession } from '../session';
 import { CamsJwtClaims } from '../jwt';
 import { Pagination } from '../../api/pagination';
 import { sortDates } from '../../date-helper';
+import { CamsRole } from '../roles';
 
 type EntityType = 'company' | 'person';
 type BankruptcyChapters = '9' | '11' | '12' | '15';
@@ -480,6 +481,28 @@ function getCamsSession(override: Partial<CamsSession> = {}): CamsSession {
   };
 }
 
+function getManhattanAssignmentManagerSession(): CamsSession {
+  return getCamsSession({
+    user: {
+      id: 'userId-Bob Jones',
+      name: 'Bob Jones',
+      offices: [MANHATTAN],
+      roles: [CamsRole.CaseAssignmentManager],
+    },
+  });
+}
+
+function getManhattanTrialAttorneySession(): CamsSession {
+  return getCamsSession({
+    user: {
+      id: 'userId-Bob Jones',
+      name: 'Bob Jones',
+      offices: [MANHATTAN],
+      roles: [CamsRole.TrialAttorney],
+    },
+  });
+}
+
 function getJwt(claims: Partial<CamsJwtClaims> = {}): string {
   const SECONDS_SINCE_EPOCH = Math.floor(Date.now() / 1000);
   const ONE_HOUR = 3600;
@@ -533,6 +556,8 @@ export const MockData = {
   getCamsUser,
   getAttorneyUser,
   getCamsSession,
+  getManhattanAssignmentManagerSession,
+  getManhattanTrialAttorneySession,
   getJwt,
 };
 

--- a/user-interface/src/data-verification/DataVerificationScreen.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.test.tsx
@@ -219,7 +219,7 @@ describe('Review Orders screen', () => {
     const mockFeatureFlags = {
       'consolidations-enabled': false,
     };
-    vitest.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
     render(
       <BrowserRouter>
         <DataVerificationScreen />
@@ -279,7 +279,7 @@ describe('Review Orders screen', () => {
     const mockFeatureFlags = {
       'consolidations-enabled': true,
     };
-    vitest.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
     const ordersResponse = {
       data: MockData.getSortedOrders(15),
     };

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
@@ -48,8 +48,8 @@ describe('ConsolidationOrderAccordion tests', () => {
   const offices: OfficeDetails[] = MockData.getOffices();
   const regionMap = new Map();
 
-  const onOrderUpdateMockFunc = vitest.fn();
-  const onExpandMockFunc = vitest.fn();
+  const onOrderUpdateMockFunc = vi.fn();
+  const onExpandMockFunc = vi.fn();
   let mockFeatureFlags: FeatureFlagSet;
 
   beforeEach(async () => {
@@ -57,14 +57,14 @@ describe('ConsolidationOrderAccordion tests', () => {
     mockFeatureFlags = {
       'consolidations-enabled': true,
     };
-    vitest.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
-    vitest
-      .spyOn(Api2, 'getCaseAssignments')
-      .mockResolvedValue({ data: MockData.buildArray(MockData.getAttorneyAssignment, 2) });
-    vitest
-      .spyOn(Api2, 'getCaseAssociations')
-      .mockRejectedValue('404 Case associations not found for the case ID.');
-    vitest.spyOn(Api2, 'getCaseSummary').mockResolvedValue({ data: MockData.getCaseSummary() });
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+    vi.spyOn(Api2, 'getCaseAssignments').mockResolvedValue({
+      data: MockData.buildArray(MockData.getAttorneyAssignment, 2),
+    });
+    vi.spyOn(Api2, 'getCaseAssociations').mockRejectedValue(
+      '404 Case associations not found for the case ID.',
+    );
+    vi.spyOn(Api2, 'getCaseSummary').mockResolvedValue({ data: MockData.getCaseSummary() });
   });
 
   afterEach(() => {
@@ -234,7 +234,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     renderWithProps();
     openAccordion(order.id!);
     // setupApiGetMock({ bCase: order.childCases[0] });
-    // vitest.spyOn(Api2, 'getCaseSummary').mockResolvedValue({ data: order.childCases[0] });
+    // vi.spyOn(Api2, 'getCaseSummary').mockResolvedValue({ data: order.childCases[0] });
 
     const includeAllCheckbox = document.querySelector(`.checkbox-toggle label`);
     const approveButton = findApproveButton(order.id!);

--- a/user-interface/src/data-verification/consolidation/consolidationOrderAccordionUtils.test.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationOrderAccordionUtils.test.ts
@@ -17,7 +17,7 @@ describe('consolidationOrderAccordion presenter tests', () => {
     mockFeatureFlags = {
       'consolidations-enabled': true,
     };
-    vitest.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
   });
 
   test('should get lead case id', () => {


### PR DESCRIPTION
# Purpose

We want our tests to provide good coverage while also reducing pain in writing them.

# Major Changes

- Add tests for attorneys controller.
- Add and make use of mock data functions.
- Replace usage of `vitest.spyOn` with `vi.spyOn`.

# Testing/Validation

Tests all pass and coverage increased.