### PR TITLE
Cams 282 restrict data verification fritz

### DIFF
--- a/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/case.assignment.cosmosdb.repository.test.ts
@@ -32,7 +32,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: clairHuxtable,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
     const testCaseAttorneyAssignment2: CaseAssignment = {
       documentType: 'ASSIGNMENT',
@@ -41,7 +42,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: perryMason,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     const assignmentId1 = await repository.createAssignment(testCaseAttorneyAssignment1);
@@ -75,7 +77,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: clairHuxtable,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     const actualIdResponse = await repository.createAssignment(testCaseAttorneyAssignment);
@@ -98,7 +101,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: clairHuxtable,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     await repository.createAssignment(existingCaseAttorneyAssignment);
@@ -110,7 +114,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: benMatlock,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     await expect(repository.updateAssignment(testCaseAttorneyAssignment)).rejects.toThrow(
@@ -128,7 +133,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: clairHuxtable,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
     const testCaseAttorneyAssignment2: CaseAssignment = {
       documentType: 'ASSIGNMENT',
@@ -137,7 +143,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: perryMason,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     const assignmentId1 = await repository.createAssignment(testCaseAttorneyAssignment1);
@@ -176,7 +183,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: benMatlock,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     await expect(repository.createAssignment(testCaseAttorneyAssignment)).rejects.toThrow(
@@ -222,7 +230,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: perryMason,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
     const testCaseAttorneyAssignment2: CaseAssignment = {
       documentType: 'ASSIGNMENT',
@@ -231,7 +240,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: benMatlock,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     const caseIdTwo = randomUUID();
@@ -242,7 +252,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: clairHuxtable,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
     const testCaseAttorneyAssignment4: CaseAssignment = {
       documentType: 'ASSIGNMENT',
@@ -251,7 +262,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: perryMason,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     const caseIdThree = randomUUID();
@@ -262,7 +274,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: clairHuxtable,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
     const testCaseAttorneyAssignment6: CaseAssignment = {
       documentType: 'ASSIGNMENT',
@@ -271,7 +284,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: benMatlock,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     await repository.createAssignment(testCaseAttorneyAssignment1);
@@ -362,7 +376,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: clairHuxtable,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     await expect(repository.createAssignment(existingCaseAttorneyAssignment)).rejects.toThrow(
@@ -379,7 +394,8 @@ describe('Test case assignment cosmosdb repository tests', () => {
       name: benMatlock,
       role: CamsRole.TrialAttorney,
       assignedOn: currentDate,
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: currentDate,
+      updatedBy: MockData.getCamsUserReference(),
     };
 
     await expect(repository.updateAssignment(testCaseAttorneyAssignment)).rejects.toThrow(

--- a/backend/functions/lib/adapters/gateways/cases.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/cases.cosmosdb.repository.test.ts
@@ -12,6 +12,7 @@ import {
 import { AggregateAuthenticationError } from '@azure/identity';
 import { CaseAssignmentHistory } from '../../../../../common/src/cams/history';
 import { MockData } from '../../../../../common/src/cams/test-utilities/mock-data';
+import { SYSTEM_USER_REFERENCE } from '../../../../../common/src/cams/auditable';
 
 describe('Runtime State Repo', () => {
   const caseId1 = '111-11-11111';
@@ -122,7 +123,8 @@ describe('Test case history cosmosdb repository tests', () => {
     const testCaseAssignmentHistory: CaseAssignmentHistory = {
       caseId,
       documentType: 'AUDIT_ASSIGNMENT',
-      occurredAtTimestamp: new Date().toISOString(),
+      updatedOn: new Date().toISOString(),
+      updatedBy: SYSTEM_USER_REFERENCE,
       before: [],
       after: [],
     };
@@ -137,7 +139,8 @@ describe('Test case history cosmosdb repository tests', () => {
     const testCaseAssignmentHistory: CaseAssignmentHistory = {
       caseId,
       documentType: 'AUDIT_ASSIGNMENT',
-      occurredAtTimestamp: new Date().toISOString(),
+      updatedBy: SYSTEM_USER_REFERENCE,
+      updatedOn: new Date().toISOString(),
       before: [],
       after: [],
     };

--- a/backend/functions/lib/adapters/gateways/cases.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/cases.cosmosdb.repository.ts
@@ -13,6 +13,7 @@ import { isPreExistingDocumentError } from './cosmos/cosmos.helper';
 import { CasesRepository } from '../../use-cases/gateways.types';
 import { UnknownError } from '../../common-errors/unknown-error';
 import { CaseHistory } from '../../../../../common/src/cams/history';
+import { getCamsUserReference } from '../../../../../common/src/cams/session';
 
 const MODULE_NAME: string = 'COSMOS_DB_REPOSITORY_CASES';
 
@@ -112,6 +113,9 @@ export class CasesCosmosDbRepository implements CasesRepository {
     try {
       if (!history.occurredAtTimestamp) {
         history.occurredAtTimestamp = new Date().toISOString();
+      }
+      if (!history.changedBy) {
+        history.changedBy = getCamsUserReference(context.session.user);
       }
       const { resource } = await this.cosmosDbClient
         .database(this.cosmosConfig.databaseName)

--- a/backend/functions/lib/adapters/gateways/cases.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/cases.cosmosdb.repository.ts
@@ -13,7 +13,6 @@ import { isPreExistingDocumentError } from './cosmos/cosmos.helper';
 import { CasesRepository } from '../../use-cases/gateways.types';
 import { UnknownError } from '../../common-errors/unknown-error';
 import { CaseHistory } from '../../../../../common/src/cams/history';
-import { getCamsUserReference } from '../../../../../common/src/cams/session';
 
 const MODULE_NAME: string = 'COSMOS_DB_REPOSITORY_CASES';
 
@@ -111,12 +110,6 @@ export class CasesCosmosDbRepository implements CasesRepository {
 
   async createCaseHistory(context: ApplicationContext, history: CaseHistory): Promise<string> {
     try {
-      if (!history.occurredAtTimestamp) {
-        history.occurredAtTimestamp = new Date().toISOString();
-      }
-      if (!history.changedBy) {
-        history.changedBy = getCamsUserReference(context.session.user);
-      }
       const { resource } = await this.cosmosDbClient
         .database(this.cosmosConfig.databaseName)
         .container(this.containerName)

--- a/backend/functions/lib/cosmos-humble-objects/fake.assignments.cosmos-client-humble.ts
+++ b/backend/functions/lib/cosmos-humble-objects/fake.assignments.cosmos-client-humble.ts
@@ -46,7 +46,8 @@ export default class FakeAssignmentsCosmosClientHumble {
                   name: 'Test Attorney',
                   role: 'TrialAttorney',
                   assignedOn: '2024-03-05',
-                  changedBy: MockData.getCamsUserReference(),
+                  updatedOn: '2024-03-05',
+                  updatedBy: MockData.getCamsUserReference(),
                 };
               }
               assignment.id = `assignment-id-${Math.round(Math.random() * 1000)}`;

--- a/backend/functions/lib/testing/local-data/local-cases-repository.ts
+++ b/backend/functions/lib/testing/local-data/local-cases-repository.ts
@@ -10,6 +10,7 @@ import {
 import { CaseHistory } from '../../../../../common/src/cams/history';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { CasesRepository } from '../../use-cases/gateways.types';
+import { getCamsUserReference } from '../../../../../common/src/cams/session';
 
 export class LocalCasesRepository implements CasesRepository {
   caseHistoryContainer: CaseHistory[] = [];
@@ -69,7 +70,13 @@ export class LocalCasesRepository implements CasesRepository {
     throw new Error('Not implemented.');
   }
 
-  async createCaseHistory(_context: ApplicationContext, history: CaseHistory) {
+  async createCaseHistory(context: ApplicationContext, history: CaseHistory) {
+    if (!history.occurredAtTimestamp) {
+      history.occurredAtTimestamp = new Date().toISOString();
+    }
+    if (!history.changedBy) {
+      history.changedBy = getCamsUserReference(context.session.user);
+    }
     this.caseHistoryContainer.push(history);
   }
 }

--- a/backend/functions/lib/testing/local-data/local-cases-repository.ts
+++ b/backend/functions/lib/testing/local-data/local-cases-repository.ts
@@ -10,7 +10,6 @@ import {
 import { CaseHistory } from '../../../../../common/src/cams/history';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { CasesRepository } from '../../use-cases/gateways.types';
-import { getCamsUserReference } from '../../../../../common/src/cams/session';
 
 export class LocalCasesRepository implements CasesRepository {
   caseHistoryContainer: CaseHistory[] = [];
@@ -71,12 +70,6 @@ export class LocalCasesRepository implements CasesRepository {
   }
 
   async createCaseHistory(context: ApplicationContext, history: CaseHistory) {
-    if (!history.occurredAtTimestamp) {
-      history.occurredAtTimestamp = new Date().toISOString();
-    }
-    if (!history.changedBy) {
-      history.changedBy = getCamsUserReference(context.session.user);
-    }
     this.caseHistoryContainer.push(history);
   }
 }

--- a/backend/functions/lib/testing/mock-data/case-history.mock.ts
+++ b/backend/functions/lib/testing/mock-data/case-history.mock.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_USER_REFERENCE } from '../../../../../common/src/cams/auditable';
 import { CaseAssignmentHistory } from '../../../../../common/src/cams/history';
 import MockData from '../../../../../common/src/cams/test-utilities/mock-data';
 
@@ -6,7 +7,8 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
     id: 'da2ba8c0-b38b-4b4b-a4d7-986e0fdb671a',
     caseId: '081-22-84687',
     documentType: 'AUDIT_ASSIGNMENT',
-    occurredAtTimestamp: '2023-12-14T21:39:18.909Z',
+    updatedOn: '2023-12-14T21:39:18.909Z',
+    updatedBy: SYSTEM_USER_REFERENCE,
     before: [],
     after: [
       {
@@ -17,7 +19,8 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         name: 'Susan Arbeit',
         role: 'TrialAttorney',
         assignedOn: '2023-12-14T21:39:18.909Z',
-        changedBy: MockData.getCamsUserReference(),
+        updatedOn: '2023-12-14T21:39:18.909Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
       {
         id: 'de6f4277-b7a8-4d90-bdb7-59a52d14d895',
@@ -27,7 +30,8 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         name: 'Mark Bruh',
         role: 'TrialAttorney',
         assignedOn: '2023-12-14T21:39:18.909Z',
-        changedBy: MockData.getCamsUserReference(),
+        updatedOn: '2023-12-14T21:39:18.909Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
       {
         id: 'a2cb1c7c-2c1f-412d-bd0a-c1b412769de1',
@@ -37,7 +41,8 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         name: 'Shara Cornell',
         role: 'TrialAttorney',
         assignedOn: '2023-12-14T21:39:18.909Z',
-        changedBy: MockData.getCamsUserReference(),
+        updatedOn: '2023-12-14T21:39:18.909Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
     ],
   },
@@ -45,7 +50,8 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
     id: '72515281-2ac9-49f6-b40c-affcc12ec059',
     caseId: '081-22-84687',
     documentType: 'AUDIT_ASSIGNMENT',
-    occurredAtTimestamp: '2023-12-14T21:39:26.755Z',
+    updatedOn: '2023-12-14T21:39:18.909Z',
+    updatedBy: SYSTEM_USER_REFERENCE,
     before: [
       {
         id: '2265215f-88e8-4cc7-a2d1-2d5ebaaabe73',
@@ -55,7 +61,8 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         name: 'Susan Arbeit',
         role: 'TrialAttorney',
         assignedOn: '2023-12-14T21:39:18.909Z',
-        changedBy: MockData.getCamsUserReference(),
+        updatedOn: '2023-12-14T21:39:18.909Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
       {
         id: 'de6f4277-b7a8-4d90-bdb7-59a52d14d895',
@@ -65,7 +72,8 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         name: 'Mark Bruh',
         role: 'TrialAttorney',
         assignedOn: '2023-12-14T21:39:18.909Z',
-        changedBy: MockData.getCamsUserReference(),
+        updatedOn: '2023-12-14T21:39:18.909Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
       {
         id: 'a2cb1c7c-2c1f-412d-bd0a-c1b412769de1',
@@ -75,7 +83,8 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         name: 'Shara Cornell',
         role: 'TrialAttorney',
         assignedOn: '2023-12-14T21:39:18.909Z',
-        changedBy: MockData.getCamsUserReference(),
+        updatedOn: '2023-12-14T21:39:18.909Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
     ],
     after: [
@@ -85,9 +94,10 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         userId: 'userId-Shara Cornell',
         name: 'Shara Cornell',
         role: 'TrialAttorney',
-        assignedOn: '2023-12-14T21:39:18.909Z',
         id: 'a2cb1c7c-2c1f-412d-bd0a-c1b412769de1',
-        changedBy: MockData.getCamsUserReference(),
+        assignedOn: '2023-12-14T21:39:18.909Z',
+        updatedOn: '2023-12-14T21:39:18.909Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
       {
         documentType: 'ASSIGNMENT',
@@ -95,9 +105,10 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         userId: 'userId-Brian S Masumoto',
         name: 'Brian S Masumoto',
         role: 'TrialAttorney',
-        assignedOn: '2023-12-14T21:39:26.755Z',
         id: '8d101caa-e3c8-4927-8cf4-3a57a481bf9c',
-        changedBy: MockData.getCamsUserReference(),
+        assignedOn: '2023-12-14T21:39:26.755Z',
+        updatedOn: '2023-12-14T21:39:26.755Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
       {
         documentType: 'ASSIGNMENT',
@@ -105,9 +116,10 @@ export const CASE_HISTORY: CaseAssignmentHistory[] = [
         userId: 'userId-Daniel Rudewicz',
         name: 'Daniel Rudewicz',
         role: 'TrialAttorney',
-        assignedOn: '2023-12-14T21:39:26.755Z',
         id: '7a6e1dba-4a27-4c59-85bb-919a6746a676',
-        changedBy: MockData.getCamsUserReference(),
+        assignedOn: '2023-12-14T21:39:26.755Z',
+        updatedOn: '2023-12-14T21:39:26.755Z',
+        updatedBy: MockData.getCamsUserReference(),
       },
     ],
   },

--- a/backend/functions/lib/use-cases/case-assignment.ts
+++ b/backend/functions/lib/use-cases/case-assignment.ts
@@ -118,7 +118,6 @@ export class CaseAssignmentUseCase {
       occurredAtTimestamp: currentDate,
       before: existingAssignmentRecords,
       after: newAssignmentRecords,
-      changedBy: getCamsUserReference(context.session!.user),
     };
     await this.casesRepository.createCaseHistory(context, history);
 

--- a/backend/functions/lib/use-cases/case-management.test.ts
+++ b/backend/functions/lib/use-cases/case-management.test.ts
@@ -25,7 +25,8 @@ const assignments: CaseAssignment[] = [
     name: attorneyJaneSmith.name,
     role: CamsRole.TrialAttorney,
     assignedOn: currentDate,
-    changedBy: MockData.getCamsUserReference(),
+    updatedOn: currentDate,
+    updatedBy: MockData.getCamsUserReference(),
   },
   {
     documentType: 'ASSIGNMENT',
@@ -35,7 +36,8 @@ const assignments: CaseAssignment[] = [
     name: attorneyJoeNobel.name,
     role: CamsRole.TrialAttorney,
     assignedOn: currentDate,
-    changedBy: MockData.getCamsUserReference(),
+    updatedOn: currentDate,
+    updatedBy: MockData.getCamsUserReference(),
   },
 ];
 

--- a/backend/functions/lib/use-cases/orders/orders-consolidation-approval.test.ts
+++ b/backend/functions/lib/use-cases/orders/orders-consolidation-approval.test.ts
@@ -24,6 +24,7 @@ import { CaseHistory, ConsolidationOrderSummary } from '../../../../../common/sr
 import { CaseAssignmentUseCase } from '../case-assignment';
 import { CamsRole } from '../../../../../common/src/cams/roles';
 import { MANHATTAN } from '../../../../../common/src/cams/test-utilities/offices.mock';
+import { SYSTEM_USER_REFERENCE } from '../../../../../common/src/cams/auditable';
 
 describe('Orders use case', () => {
   let mockContext;
@@ -136,7 +137,8 @@ describe('Orders use case', () => {
       caseId: pendingConsolidation.childCases[0].caseId,
       before: null,
       after: before,
-      occurredAtTimestamp: '2024-01-01T12:00:00.000Z',
+      updatedOn: '2024-01-01T12:00:00.000Z',
+      updatedBy: SYSTEM_USER_REFERENCE,
     };
 
     const mockGetHistory = jest
@@ -246,7 +248,8 @@ describe('Orders use case', () => {
       caseId: originalConsolidation.childCases[0].caseId,
       before: null,
       after: before,
-      occurredAtTimestamp: '2024-01-01T12:00:00.000Z',
+      updatedOn: '2024-01-01T12:00:00.000Z',
+      updatedBy: SYSTEM_USER_REFERENCE,
     };
     const mockGetHistory = jest
       .spyOn(CasesCosmosDbRepository.prototype, 'getCaseHistory')

--- a/backend/functions/lib/use-cases/orders/orders.test.ts
+++ b/backend/functions/lib/use-cases/orders/orders.test.ts
@@ -380,7 +380,8 @@ describe('Orders use case', () => {
       caseId: pendingConsolidation.childCases[0].caseId,
       before: null,
       after: before,
-      occurredAtTimestamp: '2024-01-01T12:00:00.000Z',
+      updatedOn: '2024-01-01T12:00:00.000Z',
+      updatedBy: authorizedUser,
     };
     const mockGetHistory = jest
       .spyOn(CasesCosmosDbRepository.prototype, 'getCaseHistory')
@@ -568,7 +569,7 @@ describe('Orders use case', () => {
     await useCase.approveConsolidation(mockContext, approval);
     expect(mockCreateCaseHistory).toHaveBeenCalledWith(
       mockContext,
-      expect.objectContaining({ changedBy: getCamsUserReference(authorizedUser) }),
+      expect.objectContaining({ updatedBy: getCamsUserReference(authorizedUser) }),
     );
   });
 
@@ -595,7 +596,7 @@ describe('Orders use case', () => {
     await useCase.rejectConsolidation(mockContext, rejection);
     expect(mockCreateCaseHistory).toHaveBeenCalledWith(
       mockContext,
-      expect.objectContaining({ changedBy: getCamsUserReference(authorizedUser) }),
+      expect.objectContaining({ updatedBy: getCamsUserReference(authorizedUser) }),
     );
   });
 });

--- a/backend/functions/lib/use-cases/orders/orders.ts
+++ b/backend/functions/lib/use-cases/orders/orders.ts
@@ -137,8 +137,6 @@ export class OrdersUseCase {
         documentType: 'AUDIT_TRANSFER',
         before: initialOrder as TransferOrder,
         after: order,
-        occurredAtTimestamp: new Date().toISOString(),
-        changedBy: getCamsUserReference(context.session.user),
       };
       await this.casesRepo.createCaseHistory(context, caseHistory);
     }
@@ -203,7 +201,10 @@ export class OrdersUseCase {
           documentType: 'AUDIT_TRANSFER',
           before: null,
           after: order,
-          occurredAtTimestamp: new Date().toISOString(),
+          changedBy: {
+            id: '',
+            name: '',
+          },
         };
         await this.casesRepo.createCaseHistory(context, caseHistory);
       }
@@ -227,7 +228,6 @@ export class OrdersUseCase {
         documentType: 'AUDIT_CONSOLIDATION',
         before: null,
         after: history,
-        occurredAtTimestamp: new Date().toISOString(),
       };
       await this.casesRepo.createCaseHistory(context, caseHistory);
     }

--- a/common/src/cams/assignments.ts
+++ b/common/src/cams/assignments.ts
@@ -1,7 +1,8 @@
 import { CamsUserReference } from './users';
 import { CamsRole } from './roles';
+import { Auditable } from './auditable';
 
-export type CaseAssignment = {
+export type CaseAssignment = Auditable & {
   id?: string;
   documentType: 'ASSIGNMENT';
   caseId: string;
@@ -10,7 +11,6 @@ export type CaseAssignment = {
   role: string;
   assignedOn: string;
   unassignedOn?: string;
-  changedBy: CamsUserReference;
 };
 
 export type StaffAssignmentAction = {

--- a/common/src/cams/auditable.ts
+++ b/common/src/cams/auditable.ts
@@ -1,0 +1,21 @@
+import { getCamsUserReference } from './session';
+import { CamsUserReference } from './users';
+
+export type Auditable = {
+  updatedOn: string;
+  updatedBy: CamsUserReference;
+};
+
+export const SYSTEM_USER_REFERENCE: CamsUserReference = { id: 'SYSTEM', name: 'SYSTEM' };
+
+export function createAuditRecord<
+  T extends Auditable,
+  U extends CamsUserReference = CamsUserReference,
+>(record: Omit<T, 'updatedOn' | 'updatedBy'>, user?: U, override?: Partial<Auditable>): T {
+  return {
+    updatedOn: new Date().toISOString(),
+    updatedBy: user ? getCamsUserReference(user) : SYSTEM_USER_REFERENCE,
+    ...record,
+    ...override,
+  } as T;
+}

--- a/common/src/cams/history.ts
+++ b/common/src/cams/history.ts
@@ -23,7 +23,7 @@ export function isConsolidationHistory(history: unknown): history is Consolidati
 type AbstractCaseHistory<B, A> = {
   id?: string;
   caseId: string;
-  occurredAtTimestamp: string;
+  occurredAtTimestamp?: string;
   before: B;
   after: A;
   changedBy?: CamsUserReference;

--- a/common/src/cams/history.ts
+++ b/common/src/cams/history.ts
@@ -1,7 +1,7 @@
 import { CaseAssignment } from './assignments';
+import { Auditable } from './auditable';
 import { CaseSummary } from './cases';
 import { OrderStatus, TransferOrder } from './orders';
-import { CamsUserReference } from './users';
 
 export interface ConsolidationOrderSummary {
   status: OrderStatus;
@@ -20,13 +20,11 @@ export function isConsolidationHistory(history: unknown): history is Consolidati
 }
 
 // TODO: Consider a way to make the occurredAtTimestamp optional when creating a record, otherwise it is required.
-type AbstractCaseHistory<B, A> = {
+type AbstractCaseHistory<B, A> = Auditable & {
   id?: string;
   caseId: string;
-  occurredAtTimestamp?: string;
   before: B;
   after: A;
-  changedBy?: CamsUserReference;
 };
 
 export type CaseAssignmentHistory = AbstractCaseHistory<CaseAssignment[], CaseAssignment[]> & {

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -410,6 +410,7 @@ function getDebtorAttorney(override: Partial<DebtorAttorney> = {}): DebtorAttorn
 
 function getAttorneyAssignment(override: Partial<CaseAssignment> = {}): CaseAssignment {
   const firstDate = someDateAfterThisDate(`2023-01-01`, 28);
+  const secondDate = someDateAfterThisDate(firstDate, 28);
   return {
     id: randomId(),
     documentType: 'ASSIGNMENT',
@@ -418,8 +419,9 @@ function getAttorneyAssignment(override: Partial<CaseAssignment> = {}): CaseAssi
     name: faker.person.fullName(),
     role: 'TrialAttorney',
     assignedOn: firstDate,
-    unassignedOn: someDateAfterThisDate(firstDate, 28),
-    changedBy: getCamsUserReference(),
+    unassignedOn: secondDate,
+    updatedOn: secondDate,
+    updatedBy: getCamsUserReference(),
     ...override,
   };
 }

--- a/user-interface/src/case-detail/panels/CaseDetailAuditHistory.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailAuditHistory.test.tsx
@@ -5,6 +5,7 @@ import { CaseHistory } from '@common/cams/history';
 import { ConsolidationOrder } from '@common/cams/orders';
 import MockData from '@common/cams/test-utilities/mock-data';
 import Api2 from '@/lib/models/api2';
+import { SYSTEM_USER_REFERENCE } from '@common/cams/auditable';
 
 describe('audit history tests', () => {
   const caseId = '000-11-22222';
@@ -28,7 +29,8 @@ describe('audit history tests', () => {
       name: 'Alfred',
       role: 'TrialAttorney',
       assignedOn: '2023-12-25T00:00:00.000Z',
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: '2023-12-25T00:00:00.000Z',
+      updatedBy: MockData.getCamsUserReference(),
     },
     {
       caseId,
@@ -37,7 +39,8 @@ describe('audit history tests', () => {
       name: 'Bradford',
       role: 'TrialAttorney',
       assignedOn: '2023-12-25T00:00:00.000Z',
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: '2023-12-25T00:00:00.000Z',
+      updatedBy: MockData.getCamsUserReference(),
     },
   ];
   const assignmentAfter: CaseAssignment[] = [
@@ -48,7 +51,8 @@ describe('audit history tests', () => {
       name: 'Charles',
       role: 'TrialAttorney',
       assignedOn: '2023-12-25T00:00:00.000Z',
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: '2023-12-25T00:00:00.000Z',
+      updatedBy: MockData.getCamsUserReference(),
     },
     {
       caseId,
@@ -57,7 +61,8 @@ describe('audit history tests', () => {
       name: 'Daniel',
       role: 'TrialAttorney',
       assignedOn: '2023-12-25T00:00:00.000Z',
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: '2023-12-25T00:00:00.000Z',
+      updatedBy: MockData.getCamsUserReference(),
     },
     {
       caseId,
@@ -66,7 +71,8 @@ describe('audit history tests', () => {
       name: 'Edward',
       role: 'TrialAttorney',
       assignedOn: '2023-12-25T00:00:00.000Z',
-      changedBy: MockData.getCamsUserReference(),
+      updatedOn: '2023-12-25T00:00:00.000Z',
+      updatedBy: MockData.getCamsUserReference(),
     },
   ];
   const caseHistory: CaseHistory[] = [
@@ -74,37 +80,37 @@ describe('audit history tests', () => {
       id: '1234567890',
       documentType: 'AUDIT_ASSIGNMENT',
       caseId,
-      occurredAtTimestamp: '2023-12-25T00:00:00.000Z',
+      updatedOn: '2023-12-25T00:00:00.000Z',
       before: assignmentBefore,
       after: assignmentAfter,
-      changedBy: MockData.getCamsUserReference(),
+      updatedBy: MockData.getCamsUserReference(),
     },
     {
       id: '1234567890',
       documentType: 'AUDIT_TRANSFER',
       caseId,
-      occurredAtTimestamp: '2023-12-25T00:00:00.000Z',
+      updatedOn: '2023-12-25T00:00:00.000Z',
       before: pendingTransferOrder,
       after: approvedTransferOrder,
-      changedBy: MockData.getCamsUserReference(),
+      updatedBy: MockData.getCamsUserReference(),
     },
     {
       id: '1234567890',
       documentType: 'AUDIT_CONSOLIDATION',
       caseId,
-      occurredAtTimestamp: '2023-12-25T00:00:00.000Z',
+      updatedOn: '2023-12-25T00:00:00.000Z',
       before: null,
       after: pendingConsolidationOrder,
-      changedBy: MockData.getCamsUserReference(),
+      updatedBy: MockData.getCamsUserReference(),
     },
     {
       id: '1234567890',
       documentType: 'AUDIT_CONSOLIDATION',
       caseId,
-      occurredAtTimestamp: '2023-12-25T00:00:00.000Z',
+      updatedOn: '2023-12-25T00:00:00.000Z',
       before: pendingConsolidationOrder,
       after: rejectedConsolidationOrder,
-      changedBy: MockData.getCamsUserReference(),
+      updatedBy: MockData.getCamsUserReference(),
     },
   ];
 
@@ -157,9 +163,9 @@ describe('audit history tests', () => {
     expect(dateElement).toBeInTheDocument();
     expect(dateElement).toHaveTextContent('12/25/2023');
 
-    const changedByElement = screen.queryByTestId('changed-by-0');
-    expect(changedByElement).toBeInTheDocument();
-    expect(changedByElement).toHaveTextContent(caseHistory[0].changedBy!.name);
+    const updatedByElement = screen.queryByTestId('changed-by-0');
+    expect(updatedByElement).toBeInTheDocument();
+    expect(updatedByElement).toHaveTextContent(caseHistory[0].updatedBy!.name);
   });
 
   test('should display (none) when no assignments exist.', async () => {
@@ -168,7 +174,8 @@ describe('audit history tests', () => {
         id: '',
         documentType: 'AUDIT_ASSIGNMENT',
         caseId,
-        occurredAtTimestamp: '',
+        updatedOn: '',
+        updatedBy: SYSTEM_USER_REFERENCE,
         before: [],
         after: [],
       },
@@ -196,7 +203,8 @@ describe('audit history tests', () => {
         id: '',
         documentType: 'AUDIT_TRANSFER',
         caseId,
-        occurredAtTimestamp: '2024-01-31T12:00:00Z',
+        updatedOn: '2024-01-31T12:00:00Z',
+        updatedBy: SYSTEM_USER_REFERENCE,
         before: pendingTransferOrder,
         after: approvedTransferOrder,
       },
@@ -204,7 +212,8 @@ describe('audit history tests', () => {
         id: '',
         documentType: 'AUDIT_TRANSFER',
         caseId,
-        occurredAtTimestamp: '2024-01-29T12:00:00Z',
+        updatedOn: '2024-01-29T12:00:00Z',
+        updatedBy: SYSTEM_USER_REFERENCE,
         before: null,
         after: pendingTransferOrder,
       },

--- a/user-interface/src/case-detail/panels/CaseDetailAuditHistory.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailAuditHistory.tsx
@@ -58,10 +58,10 @@ export default function CaseDetailAuditHistory(props: CaseDetailAuditHistoryProp
             .join(', ')}
         </td>
         <td data-testid={`changed-by-${idx}`}>
-          {history.changedBy && <>{history.changedBy.name}</>}
+          {history.updatedBy && <>{history.updatedBy.name}</>}
         </td>
         <td data-testid={`change-date-${idx}`}>
-          <span className="text-no-wrap">{formatDate(history.occurredAtTimestamp)}</span>
+          <span className="text-no-wrap">{formatDate(history.updatedOn)}</span>
         </td>
       </tr>
     );
@@ -82,10 +82,10 @@ export default function CaseDetailAuditHistory(props: CaseDetailAuditHistoryProp
           {history.after && orderStatusType.get(history.after.status)}
         </td>
         <td data-testid={`changed-by-${idx}`}>
-          {history.changedBy && <>{history.changedBy.name}</>}
+          {history.updatedBy && <>{history.updatedBy.name}</>}
         </td>
         <td data-testid={`change-date-${idx}`}>
-          <span className="text-no-wrap">{formatDate(history.occurredAtTimestamp)}</span>
+          <span className="text-no-wrap">{formatDate(history.updatedOn)}</span>
         </td>
       </tr>
     );


### PR DESCRIPTION

# Purpose

Add common logging of `changedOn` and `changedBy` properties to audit records.
