### PR TITLE
CAMS-282 Fixed logic error when loading orders without session

### DIFF
--- a/backend/functions/lib/use-cases/case-assignment.ts
+++ b/backend/functions/lib/use-cases/case-assignment.ts
@@ -79,7 +79,7 @@ export class CaseAssignmentUseCase {
           role: CamsRole[role],
           assignedOn: currentDate,
         },
-        context.session.user,
+        context.session,
         { updatedOn: currentDate },
       );
       listOfAssignments.push(assignment);
@@ -122,7 +122,7 @@ export class CaseAssignmentUseCase {
         before: existingAssignmentRecords,
         after: newAssignmentRecords,
       },
-      context.session.user,
+      context.session,
       { updatedOn: currentDate },
     );
     await this.casesRepository.createCaseHistory(context, history);

--- a/common/src/cams/auditable.ts
+++ b/common/src/cams/auditable.ts
@@ -1,4 +1,4 @@
-import { getCamsUserReference } from './session';
+import { CamsSession, getCamsUserReference } from './session';
 import { CamsUserReference } from './users';
 
 export type Auditable = {
@@ -8,13 +8,14 @@ export type Auditable = {
 
 export const SYSTEM_USER_REFERENCE: CamsUserReference = { id: 'SYSTEM', name: 'SYSTEM' };
 
-export function createAuditRecord<
-  T extends Auditable,
-  U extends CamsUserReference = CamsUserReference,
->(record: Omit<T, 'updatedOn' | 'updatedBy'>, user?: U, override?: Partial<Auditable>): T {
+export function createAuditRecord<T extends Auditable>(
+  record: Omit<T, 'updatedOn' | 'updatedBy'>,
+  session?: CamsSession,
+  override?: Partial<Auditable>,
+): T {
   return {
     updatedOn: new Date().toISOString(),
-    updatedBy: user ? getCamsUserReference(user) : SYSTEM_USER_REFERENCE,
+    updatedBy: session ? getCamsUserReference(session.user) : SYSTEM_USER_REFERENCE,
     ...record,
     ...override,
   } as T;


### PR DESCRIPTION
# Purpose

Orders sync fails when there is no session from a timer function

# Major Changes

Corrected logic in audit record creation when a session/user does not exist.

# Testing/Validation

Tests are working
