### PR TITLE
CAMS-282 updated uriPath functions to properly handle query params

### DIFF
--- a/user-interface/src/lib/models/api2.test.ts
+++ b/user-interface/src/lib/models/api2.test.ts
@@ -57,11 +57,11 @@ describe('extractPathFromUri', () => {
     const api = addAuthHeaderToApi();
     api.host = `https://some-domain.gov`;
     const expectedPath = '/this/is/a/path';
-    const uri = `${api.host}${expectedPath}?these=are;the=params`;
+    const uri = `${api.host}${expectedPath}?these=are&the=params`;
 
-    const actualPath = extractPathFromUri(uri, api);
+    const { uriOrPathSubstring } = extractPathFromUri(uri, api);
 
-    expect(actualPath).toEqual(expectedPath);
+    expect(uriOrPathSubstring).toEqual(expectedPath);
   });
 
   test('should return path when given only a path', () => {
@@ -69,9 +69,9 @@ describe('extractPathFromUri', () => {
     api.host = '';
     const expectedPath = '/this/is/a/path';
 
-    const actualPath = extractPathFromUri(expectedPath, api);
+    const { uriOrPathSubstring } = extractPathFromUri(expectedPath, api);
 
-    expect(actualPath).toEqual(expectedPath);
+    expect(uriOrPathSubstring).toEqual(expectedPath);
   });
 });
 


### PR DESCRIPTION
Jira ticket: CAMS-282

# Problem

Application was not handling query params from the uri properly. This was causing issues becausse we use query params in our E2E tests to hit the staging slots

# Solution

- updated uriPath functions and api function to properly handle query params

# Testing/Validation

- ran locally and verified
- deployed environment and ran E2E tests
