### PR TITLE
added enable access post-swap

### DIFF
--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -197,3 +197,28 @@ jobs:
       azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
       slotName: "self"
     secrets: inherit # pragma: allowlist secret
+
+  enable-access:
+    runs-on: ubuntu-latest
+    needs: [endpoint-test-application-post-swap]
+    environment: ${{ inputs.ghaEnvironment }}
+    env:
+      webappName: ${{ inputs.webappName }}
+      apiName: ${{ inputs.apiName }}
+    steps:
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          environment: ${{ vars.AZURE_ENVIRONMENT }}
+
+      - uses: cloudposse/github-action-secret-outputs@main
+        id: rgApp
+        with:
+          secret: ${{ secrets.PGP_SIGNING_PASSPHRASE }}
+          op: decode
+          in: ${{ inputs.azResourceGrpAppEncrypted }}
+
+      - name: Enable production slot access
+        run: |
+          az webapp config access-restriction add --resource-group ${{ steps.rgApp.outputs.out }} --name ${{ env.webappName }} --rule-name AllowAll --action Allow --ip-address 0.0.0.0/0 --priority 100 1>/dev/null || true
+          az functionapp config access-restriction add --resource-group ${{ steps.rgApp.outputs.out }} --name ${{ env.apiName }} --rule-name AllowAll --action Allow --ip-address 0.0.0.0/0 --priority 100 1>/dev/null || true


### PR DESCRIPTION
# Problem

workflow did not enable access after slot swap, it worked previously because we retained the access policies that have been unchanged for some time

# Solution

- added enable access step to the end of deployment

# Testing/Validation

- ran workflow deployment
