### PR TITLE
CAMS-283: Retrieve attorneys by office

### DIFF
--- a/backend/functions/lib/adapters/gateways/cases.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/cases.cosmosdb.repository.ts
@@ -158,7 +158,7 @@ export class CasesCosmosDbRepository implements CasesRepository {
     }
   }
 
-  private async queryData<T>(context: ApplicationContext, querySpec: object): Promise<Array<T>> {
+  private async queryData<T>(context: ApplicationContext, querySpec: object): Promise<T[]> {
     try {
       const { resources: results } = await this.cosmosDbClient
         .database(this.cosmosConfig.databaseName)

--- a/backend/functions/lib/adapters/gateways/consolidations.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/consolidations.cosmosdb.repository.test.ts
@@ -1,0 +1,65 @@
+import { ApplicationContext } from '../types/basic';
+import ConsolidationOrdersCosmosDbRepository from './consolidations.cosmosdb.repository';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { OrdersSearchPredicate } from '../../../../../common/src/api/search';
+import { MockHumbleQuery } from '../../testing/mock.cosmos-client-humble';
+import MockData from '../../../../../common/src/cams/test-utilities/mock-data';
+import { CosmosDbRepository } from './cosmos/cosmos.repository';
+
+describe('Consolidations Repository tests', () => {
+  let context: ApplicationContext;
+  let repo: ConsolidationOrdersCosmosDbRepository;
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    repo = new ConsolidationOrdersCosmosDbRepository(context);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should find all', async () => {
+    const consolidationOrders = MockData.buildArray(MockData.getConsolidationOrder, 5);
+    const fetchAllSpy = jest
+      .spyOn(MockHumbleQuery.prototype, 'fetchAll')
+      .mockResolvedValue({ resources: consolidationOrders });
+    const querySpy = jest.spyOn(CosmosDbRepository.prototype, 'query');
+
+    const actual = await repo.search(context);
+
+    expect(actual).toEqual(consolidationOrders);
+    expect(fetchAllSpy).toHaveBeenCalled();
+    expect(querySpy).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({ query: expect.any(String), parameters: [] }),
+    );
+    expect(querySpy.mock.calls[0][1]['query']).not.toContain('WHERE');
+    expect(querySpy.mock.calls[0][1]['query']).toContain('ORDER BY');
+  });
+
+  test('should query by predicate', async () => {
+    const consolidationOrders = MockData.buildArray(MockData.getConsolidationOrder, 5);
+    jest
+      .spyOn(MockHumbleQuery.prototype, 'fetchAll')
+      .mockResolvedValue({ resources: consolidationOrders });
+    const querySpy = jest.spyOn(CosmosDbRepository.prototype, 'query');
+
+    const predicate: OrdersSearchPredicate = {
+      divisionCodes: ['one', 'two'],
+    };
+
+    const actual = await repo.search(context, predicate);
+
+    expect(actual).toEqual(consolidationOrders);
+    expect(querySpy).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({ query: expect.any(String), parameters: [] }),
+    );
+    expect(querySpy.mock.calls[0][1]['query']).toContain('WHERE');
+    expect(querySpy.mock.calls[0][1]['query']).toContain('one');
+    expect(querySpy.mock.calls[0][1]['query']).toContain('OR');
+    expect(querySpy.mock.calls[0][1]['query']).toContain('two');
+    expect(querySpy.mock.calls[0][1]['query']).toContain('ORDER BY');
+  });
+});

--- a/backend/functions/lib/adapters/gateways/consolidations.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/consolidations.cosmosdb.repository.ts
@@ -8,12 +8,40 @@ const MODULE_NAME: string = 'COSMOS_DB_REPOSITORY_CONSOLIDATION_ORDERS';
 const CONTAINER_NAME: string = 'consolidations';
 
 export default class ConsolidationOrdersCosmosDbRepository
-  extends CosmosDbRepository<ConsolidationOrder>
   implements ConsolidationOrdersRepository
 {
+  private repo: CosmosDbRepository<ConsolidationOrder>;
+
   constructor(context: ApplicationContext) {
-    super(context, CONTAINER_NAME, MODULE_NAME);
+    this.repo = new CosmosDbRepository<ConsolidationOrder>(context, CONTAINER_NAME, MODULE_NAME);
   }
+
+  get(context: ApplicationContext, id: string, partitionKey: string): Promise<ConsolidationOrder> {
+    return this.repo.get(context, id, partitionKey);
+  }
+
+  update(
+    _context: ApplicationContext,
+    _id: string,
+    _partitionKey: string,
+    _data: ConsolidationOrder,
+  ) {
+    throw new Error('Method not implemented.');
+  }
+
+  put(context: ApplicationContext, data: ConsolidationOrder): Promise<ConsolidationOrder> {
+    return this.repo.put(context, data);
+    throw new Error('Method not implemented.');
+  }
+
+  putAll(context: ApplicationContext, list: ConsolidationOrder[]): Promise<ConsolidationOrder[]> {
+    return this.repo.putAll(context, list);
+  }
+
+  delete(context: ApplicationContext, id: string, partitionKey: string) {
+    return this.repo.delete(context, id, partitionKey);
+  }
+
   public async search(
     context: ApplicationContext,
     predicate?: OrdersSearchPredicate,
@@ -38,6 +66,6 @@ export default class ConsolidationOrdersCosmosDbRepository
         parameters: [],
       };
     }
-    return await this.query(context, querySpec);
+    return await this.repo.query(context, querySpec);
   }
 }

--- a/backend/functions/lib/adapters/gateways/cosmos/cosmos.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/cosmos/cosmos.repository.test.ts
@@ -1,12 +1,12 @@
 import { createMockApplicationContext } from '../../../testing/testing-utilities';
 import { MockHumbleItem, MockHumbleItems } from '../../../testing/mock.cosmos-client-humble';
 import { ApplicationContext } from '../../types/basic';
-import { getCosmosDbCrudRepository } from '../../../factory';
 import { AggregateAuthenticationError } from '@azure/identity';
 import { ServerConfigError } from '../../../common-errors/server-config-error';
 import { ErrorResponse } from '@azure/cosmos';
 import { ID_ALREADY_EXISTS } from './cosmos.helper';
 import { DocumentRepository } from '../../../use-cases/gateways.types';
+import { CosmosDbRepository } from './cosmos.repository';
 
 interface TestType {
   id?: string;
@@ -20,7 +20,7 @@ describe('Test generic cosmosdb repository', () => {
 
   beforeEach(async () => {
     mockDbContext = await createMockApplicationContext();
-    cosmosCrudRepo = getCosmosDbCrudRepository(mockDbContext, 'cases', moduleName);
+    cosmosCrudRepo = new CosmosDbRepository<TestType>(mockDbContext, 'cases', moduleName);
   });
 
   test('should get ServerConfigError', async () => {

--- a/backend/functions/lib/adapters/gateways/cosmos/cosmos.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/cosmos/cosmos.repository.test.ts
@@ -7,6 +7,7 @@ import { ErrorResponse } from '@azure/cosmos';
 import { ID_ALREADY_EXISTS } from './cosmos.helper';
 import { DocumentRepository } from '../../../use-cases/gateways.types';
 import { CosmosDbRepository } from './cosmos.repository';
+import { UnknownError } from '../../../common-errors/unknown-error';
 
 interface TestType {
   id?: string;
@@ -30,13 +31,6 @@ describe('Test generic cosmosdb repository', () => {
     });
     jest.spyOn(MockHumbleItem.prototype, 'read').mockRejectedValue(error);
     await expect(cosmosCrudRepo.get(mockDbContext, '', '')).rejects.toThrow(expectedError);
-  });
-
-  test('should get error', async () => {
-    const errorMessage = 'something bad happened';
-    const error = new Error(errorMessage);
-    jest.spyOn(MockHumbleItem.prototype, 'read').mockRejectedValue(error);
-    await expect(cosmosCrudRepo.get(mockDbContext, '', '')).rejects.toThrow(errorMessage);
   });
 
   test('should get mocked item', async () => {
@@ -154,12 +148,13 @@ describe('Test generic cosmosdb repository', () => {
     ];
 
     const otherError = new Error('mock error');
+    const camsError = new UnknownError(moduleName, { originalError: otherError });
 
     const mockCreate = jest
       .spyOn(MockHumbleItems.prototype, 'create')
       .mockRejectedValueOnce(otherError);
 
-    await expect(cosmosCrudRepo.putAll(mockDbContext, items)).rejects.toThrow(otherError);
+    await expect(cosmosCrudRepo.putAll(mockDbContext, items)).rejects.toThrow(camsError);
     expect(mockCreate).toHaveBeenCalled();
   });
 });

--- a/backend/functions/lib/adapters/gateways/cosmos/cosmos.repository.ts
+++ b/backend/functions/lib/adapters/gateways/cosmos/cosmos.repository.ts
@@ -5,6 +5,7 @@ import { CosmosConfig } from '../../types/database';
 import { ServerConfigError } from '../../../common-errors/server-config-error';
 import { isPreExistingDocumentError } from './cosmos.helper';
 import { DocumentRepository } from '../../../use-cases/gateways.types';
+import { UnknownError } from '../../../common-errors/unknown-error';
 
 export class CosmosDbRepository<T> implements DocumentRepository<T> {
   protected cosmosDbClient;
@@ -35,7 +36,7 @@ export class CosmosDbRepository<T> implements DocumentRepository<T> {
           originalError,
         });
       } else {
-        throw originalError;
+        throw new UnknownError(this.moduleName, { originalError });
       }
     }
   }

--- a/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.test.ts
@@ -35,6 +35,8 @@ describe('offices cosmosDB repository tests', () => {
       }),
     );
     expect(querySpy.mock.calls[0][1]['query']).toContain('OFFICE_STAFF');
-    expect(querySpy.mock.calls[0][1]['query']).toContain(CamsRole.TrialAttorney);
+    expect(querySpy.mock.calls[0][1]['parameters']).toEqual(
+      expect.arrayContaining([expect.objectContaining({ value: CamsRole.TrialAttorney })]),
+    );
   });
 });

--- a/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.test.ts
@@ -1,0 +1,40 @@
+import { MockHumbleQuery } from '../../testing/mock.cosmos-client-humble';
+import { OfficesCosmosDbRepository } from './offices.cosmosdb.repository';
+import { ApplicationContext } from '../types/basic';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import MockData from '../../../../../common/src/cams/test-utilities/mock-data';
+import { CosmosDbRepository } from './cosmos/cosmos.repository';
+import { CamsRole } from '../../../../../common/src/cams/roles';
+
+describe('offices cosmosDB repository tests', () => {
+  let context: ApplicationContext;
+  let repo: OfficesCosmosDbRepository;
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    repo = new OfficesCosmosDbRepository(context);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should query data with office code, staff doc type, and trial attorney role', async () => {
+    const officeCode = 'test-office';
+    const attorneys = MockData.buildArray(MockData.getAttorneyUser, 5);
+    jest.spyOn(MockHumbleQuery.prototype, 'fetchAll').mockResolvedValue({ resources: attorneys });
+    const querySpy = jest.spyOn(CosmosDbRepository.prototype, 'query');
+
+    const actual = await repo.getOfficeAttorneys(context, officeCode);
+    expect(actual).toEqual(attorneys);
+    expect(querySpy).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({
+        query: expect.any(String),
+        parameters: expect.arrayContaining([expect.objectContaining({ value: officeCode })]),
+      }),
+    );
+    expect(querySpy.mock.calls[0][1]['query']).toContain('OFFICE_STAFF');
+    expect(querySpy.mock.calls[0][1]['query']).toContain(CamsRole.TrialAttorney);
+  });
+});

--- a/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
@@ -3,6 +3,7 @@ import { ApplicationContext } from '../types/basic';
 import { AttorneyUser, CamsUserReference } from '../../../../../common/src/cams/users';
 import { CosmosDbRepository } from './cosmos/cosmos.repository';
 import { UstpOfficeDetails } from '../../../../../common/src/cams/courts';
+import { CamsRole } from '../../../../../common/src/cams/roles';
 
 const MODULE_NAME: string = 'COSMOS_DB_REPOSITORY_OFFICES';
 const CONTAINER_NAME: string = 'offices';
@@ -28,8 +29,7 @@ export class OfficesCosmosDbRepository implements OfficesRepository {
     context: ApplicationContext,
     officeCode: string,
   ): Promise<AttorneyUser[]> {
-    const query =
-      "SELECT * FROM c WHERE c.officeCode = @officeCode and c.documentType = 'OFFICE_STAFF' and CamsRole.TRIAL_ATTORNEY IN c.roles";
+    const query = `SELECT * FROM c WHERE c.officeCode = @officeCode and c.documentType = 'OFFICE_STAFF' and ${CamsRole.TrialAttorney} IN c.roles`;
     const querySpec = {
       query,
       parameters: [
@@ -39,10 +39,6 @@ export class OfficesCosmosDbRepository implements OfficesRepository {
         },
       ],
     };
-    try {
-      return await this.officeStaffRepo.query(context, querySpec);
-    } catch (error) {
-      // do stuff
-    }
+    return await this.officeStaffRepo.query(context, querySpec);
   }
 }

--- a/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
@@ -29,13 +29,17 @@ export class OfficesCosmosDbRepository implements OfficesRepository {
     context: ApplicationContext,
     officeCode: string,
   ): Promise<AttorneyUser[]> {
-    const query = `SELECT * FROM c WHERE c.officeCode = @officeCode and c.documentType = 'OFFICE_STAFF' and ${CamsRole.TrialAttorney} IN c.roles`;
+    const query = `SELECT * FROM c WHERE c.officeCode = @officeCode and c.documentType = 'OFFICE_STAFF' and ARRAY_CONTAINS(c.roles, @role)`;
     const querySpec = {
       query,
       parameters: [
         {
           name: '@officeCode',
           value: officeCode,
+        },
+        {
+          name: '@role',
+          value: CamsRole.TrialAttorney,
         },
       ],
     };

--- a/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
@@ -1,0 +1,48 @@
+import { OfficesRepository } from '../../use-cases/gateways.types';
+import { ApplicationContext } from '../types/basic';
+import { AttorneyUser, CamsUserReference } from '../../../../../common/src/cams/users';
+import { CosmosDbRepository } from './cosmos/cosmos.repository';
+import { UstpOfficeDetails } from '../../../../../common/src/cams/courts';
+
+const MODULE_NAME: string = 'COSMOS_DB_REPOSITORY_OFFICES';
+const CONTAINER_NAME: string = 'offices';
+
+export class OfficesCosmosDbRepository implements OfficesRepository {
+  private officeStaffRepo: CosmosDbRepository<CamsUserReference>;
+  private officesRepo: CosmosDbRepository<UstpOfficeDetails>;
+
+  constructor(context: ApplicationContext) {
+    this.officeStaffRepo = new CosmosDbRepository<CamsUserReference>(
+      context,
+      CONTAINER_NAME,
+      MODULE_NAME,
+    );
+    this.officesRepo = new CosmosDbRepository<UstpOfficeDetails>(
+      context,
+      CONTAINER_NAME,
+      MODULE_NAME,
+    );
+  }
+
+  async getOfficeAttorneys(
+    context: ApplicationContext,
+    officeCode: string,
+  ): Promise<AttorneyUser[]> {
+    const query =
+      "SELECT * FROM c WHERE c.officeCode = @officeCode and c.documentType = 'OFFICE_STAFF' and CamsRole.TRIAL_ATTORNEY IN c.roles";
+    const querySpec = {
+      query,
+      parameters: [
+        {
+          name: '@officeCode',
+          value: officeCode,
+        },
+      ],
+    };
+    try {
+      return await this.officeStaffRepo.query(context, querySpec);
+    } catch (error) {
+      // do stuff
+    }
+  }
+}

--- a/backend/functions/lib/controllers/offices/offices.controller.test.ts
+++ b/backend/functions/lib/controllers/offices/offices.controller.test.ts
@@ -5,13 +5,15 @@ import { OFFICES } from '../../../../../common/src/cams/test-utilities/offices.m
 import { CamsError } from '../../common-errors/cams-error';
 import { mockCamsHttpRequest } from '../../testing/mock-data/cams-http-request-helper';
 
-let getOffices;
+let getOffices = jest.fn();
+let getOfficeAttorneys = jest.fn();
 
 jest.mock('../../use-cases/offices/offices', () => {
   return {
     OfficesUseCase: jest.fn().mockImplementation(() => {
       return {
         getOffices,
+        getOfficeAttorneys,
       };
     }),
   };
@@ -24,13 +26,15 @@ describe('offices controller tests', () => {
     applicationContext = await createMockApplicationContext();
   });
 
-  test('should return successful response', async () => {
-    getOffices = jest.fn().mockImplementation(() => {
-      return Promise.resolve(OFFICES);
-    });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-    const controller = new OfficesController(applicationContext);
-    const camsHttpRequest = mockCamsHttpRequest({ query: { caseNumber: '00-00000' } });
+  test('should return successful response', async () => {
+    getOffices = jest.fn().mockResolvedValue(OFFICES);
+
+    const controller = new OfficesController();
+    const camsHttpRequest = mockCamsHttpRequest();
     applicationContext.request = camsHttpRequest;
     const offices = await controller.handleRequest(applicationContext);
     expect(offices).toEqual(
@@ -38,31 +42,77 @@ describe('offices controller tests', () => {
         body: { meta: expect.objectContaining({ self: expect.any(String) }), data: OFFICES },
       }),
     );
+    expect(getOfficeAttorneys).not.toHaveBeenCalled();
   });
 
   test('should throw CamsError when one is caught', async () => {
-    getOffices = jest.fn().mockImplementation(() => {
-      throw new CamsError('MOCK_OFFICES_CONTROLLER', { message: 'Some expected CAMS error.' });
-    });
+    getOffices = jest
+      .fn()
+      .mockRejectedValue(
+        new CamsError('MOCK_OFFICES_CONTROLLER', { message: 'Some expected CAMS error.' }),
+      );
 
-    const controller = new OfficesController(applicationContext);
+    const controller = new OfficesController();
+    const camsHttpRequest = mockCamsHttpRequest();
+    applicationContext.request = camsHttpRequest;
     await expect(async () => {
-      const camsHttpRequest = mockCamsHttpRequest({ query: { caseNumber: '00-00000' } });
-      applicationContext.request = camsHttpRequest;
       await controller.handleRequest(applicationContext);
     }).rejects.toThrow('Some expected CAMS error.');
+    expect(getOfficeAttorneys).not.toHaveBeenCalled();
   });
 
   test('should wrap unexpected error in UnknownError', async () => {
-    getOffices = jest.fn().mockImplementation(() => {
-      throw new Error('Some unknown error.');
-    });
+    getOffices = jest.fn().mockRejectedValue(new Error('Some unknown error.'));
 
-    const controller = new OfficesController(applicationContext);
+    const controller = new OfficesController();
     await expect(async () => {
-      const camsHttpRequest = mockCamsHttpRequest({ query: { caseNumber: '00-00000' } });
+      const camsHttpRequest = mockCamsHttpRequest();
       applicationContext.request = camsHttpRequest;
       await controller.handleRequest(applicationContext);
     }).rejects.toThrow('Unknown error');
+    expect(getOfficeAttorneys).not.toHaveBeenCalled();
+  });
+
+  test('should call getOfficeAttorneys', async () => {
+    getOffices = jest
+      .fn()
+      .mockRejectedValue(new CamsError('TEST', { message: 'some known error' }));
+    getOfficeAttorneys = jest.fn().mockResolvedValue([]);
+
+    const officeCode = 'new-york';
+    const subResource = 'attorneys';
+    const camsHttpRequest = mockCamsHttpRequest({ params: { officeCode, subResource } });
+    applicationContext.request = camsHttpRequest;
+
+    const controller = new OfficesController();
+    const attorneys = await controller.handleRequest(applicationContext);
+    expect(attorneys).toEqual(
+      expect.objectContaining({
+        body: { meta: expect.objectContaining({ self: expect.any(String) }), data: [] },
+      }),
+    );
+    expect(getOffices).not.toHaveBeenCalled();
+    expect(getOfficeAttorneys).toHaveBeenCalledWith(applicationContext, officeCode);
+  });
+
+  test('should throw error for unsupported subResource', async () => {
+    getOffices = jest
+      .fn()
+      .mockRejectedValue(new CamsError('TEST', { message: 'some known error' }));
+    getOfficeAttorneys = jest
+      .fn()
+      .mockRejectedValue(new CamsError('TEST', { message: 'some known error' }));
+
+    const officeCode = 'new-york';
+    const subResource = 'auditors';
+    const camsHttpRequest = mockCamsHttpRequest({ params: { officeCode, subResource } });
+    applicationContext.request = camsHttpRequest;
+
+    const controller = new OfficesController();
+    await expect(async () => {
+      await controller.handleRequest(applicationContext);
+    }).rejects.toThrow(`Sub resource ${subResource} is not supported.`);
+    expect(getOffices).not.toHaveBeenCalled();
+    expect(getOfficeAttorneys).not.toHaveBeenCalled();
   });
 });

--- a/backend/functions/lib/controllers/offices/offices.controller.ts
+++ b/backend/functions/lib/controllers/offices/offices.controller.ts
@@ -4,28 +4,39 @@ import { OfficeDetails } from '../../../../../common/src/cams/courts';
 import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
 import { getCamsError } from '../../common-errors/error-utilities';
 import { CamsController } from '../controller';
+import { CamsUserReference } from '../../../../../common/src/cams/users';
+import { BadRequestError } from '../../common-errors/bad-request';
 
 const MODULE_NAME = 'OFFICES-CONTROLLER';
 
 export class OfficesController implements CamsController {
   private readonly useCase: OfficesUseCase;
-  private readonly applicationContext: ApplicationContext;
 
-  constructor(applicationContext: ApplicationContext) {
-    this.applicationContext = applicationContext;
+  constructor() {
     this.useCase = new OfficesUseCase();
   }
+
   public async handleRequest(
     context: ApplicationContext,
-  ): Promise<CamsHttpResponseInit<OfficeDetails[]>> {
+  ): Promise<CamsHttpResponseInit<OfficeDetails[] | CamsUserReference[]>> {
     try {
-      const offices = await this.useCase.getOffices(context);
+      const params = context.request.params;
+      let data;
+      if (params?.officeCode && params?.subResource === 'attorneys') {
+        data = await this.useCase.getOfficeAttorneys(context, params.officeCode);
+      } else if (params?.officeCode && params?.subResource) {
+        throw new BadRequestError(MODULE_NAME, {
+          message: `Sub resource ${params?.subResource} is not supported.`,
+        });
+      } else {
+        data = await this.useCase.getOffices(context);
+      }
       return httpSuccess({
         body: {
           meta: {
             self: context.request.url,
           },
-          data: offices,
+          data,
         },
       });
     } catch (originalError) {

--- a/backend/functions/lib/factory.ts
+++ b/backend/functions/lib/factory.ts
@@ -16,7 +16,6 @@ import { ConnectionPool, config } from 'mssql';
 import {
   CasesRepository,
   ConsolidationOrdersRepository,
-  DocumentRepository,
   OfficesRepository,
   OrdersGateway,
   OrdersRepository,
@@ -30,7 +29,6 @@ import { RuntimeStateCosmosDbRepository } from './adapters/gateways/runtime-stat
 import { CasesCosmosDbRepository } from './adapters/gateways/cases.cosmosdb.repository';
 import ConsolidationOrdersCosmosDbRepository from './adapters/gateways/consolidations.cosmosdb.repository';
 import { MockHumbleClient } from './testing/mock.cosmos-client-humble';
-import { CosmosDbRepository } from './adapters/gateways/cosmos/cosmos.repository';
 import { OpenIdConnectGateway, UserGroupGateway } from './adapters/types/authorization';
 import OktaGateway from './adapters/gateways/okta/okta-gateway';
 import { UserSessionCacheRepository } from './adapters/gateways/user-session-cache.repository';
@@ -144,13 +142,13 @@ export const getRuntimeStateRepository = (
   return new RuntimeStateCosmosDbRepository(applicationContext);
 };
 
-export const getCosmosDbCrudRepository = <T>(
-  context: ApplicationContext,
-  containerName: string,
-  moduleName: string,
-): DocumentRepository<T> => {
-  return new CosmosDbRepository<T>(context, containerName, moduleName);
-};
+// export const getCosmosDbCrudRepository = <T>(
+//   context: ApplicationContext,
+//   containerName: string,
+//   moduleName: string,
+// ): DocumentRepository<T> => {
+//   return new CosmosDbRepository<T>(context, containerName, moduleName);
+// };
 
 export const getAuthorizationGateway = (context: ApplicationContext): OpenIdConnectGateway => {
   if (context.config.authConfig.provider === 'okta') return OktaGateway;

--- a/backend/functions/lib/factory.ts
+++ b/backend/functions/lib/factory.ts
@@ -17,6 +17,7 @@ import {
   CasesRepository,
   ConsolidationOrdersRepository,
   DocumentRepository,
+  OfficesRepository,
   OrdersGateway,
   OrdersRepository,
   RuntimeStateRepository,
@@ -43,6 +44,7 @@ import LocalStorageGateway from './adapters/gateways/storage/local-storage-gatew
 import MockAttorneysGateway from './testing/mock-gateways/mock-attorneys.gateway';
 import { MockOrdersGateway } from './testing/mock-gateways/mock.orders.gateway';
 import { MockOfficesGateway } from './testing/mock-gateways/mock.offices.gateway';
+import { OfficesCosmosDbRepository } from './adapters/gateways/offices.cosmosdb.repository';
 import OktaUserGroupGateway from './adapters/gateways/okta/okta-user-group-gateway';
 
 export const getAttorneyGateway = (): AttorneyGatewayInterface => {
@@ -116,6 +118,10 @@ export const getOfficesGateway = (
   } else {
     return new OfficesDxtrGateway();
   }
+};
+
+export const getOfficesRepository = (applicationContext: ApplicationContext): OfficesRepository => {
+  return new OfficesCosmosDbRepository(applicationContext);
 };
 
 export const getOrdersRepository = (applicationContext: ApplicationContext): OrdersRepository => {

--- a/backend/functions/lib/factory.ts
+++ b/backend/functions/lib/factory.ts
@@ -9,7 +9,6 @@ import { CaseAssignmentCosmosDbRepository } from './adapters/gateways/case.assig
 import CosmosClientHumble from './cosmos-humble-objects/cosmos-client-humble';
 import FakeAssignmentsCosmosClientHumble from './cosmos-humble-objects/fake.assignments.cosmos-client-humble';
 import { CaseDocketUseCase } from './use-cases/case-docket/case-docket';
-
 import { DxtrCaseDocketGateway } from './adapters/gateways/dxtr/case-docket.dxtr.gateway';
 import { MockCaseDocketGateway } from './adapters/gateways/dxtr/case-docket.mock.gateway';
 import { ConnectionPool, config } from 'mssql';
@@ -141,14 +140,6 @@ export const getRuntimeStateRepository = (
 ): RuntimeStateRepository => {
   return new RuntimeStateCosmosDbRepository(applicationContext);
 };
-
-// export const getCosmosDbCrudRepository = <T>(
-//   context: ApplicationContext,
-//   containerName: string,
-//   moduleName: string,
-// ): DocumentRepository<T> => {
-//   return new CosmosDbRepository<T>(context, containerName, moduleName);
-// };
 
 export const getAuthorizationGateway = (context: ApplicationContext): OpenIdConnectGateway => {
   if (context.config.authConfig.provider === 'okta') return OktaGateway;

--- a/backend/functions/lib/testing/mock-gateways/mock-attorneys.gateway.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock-attorneys.gateway.ts
@@ -10,9 +10,11 @@ async function getAttorneysByUstpOffice(
   const attorneys = TRIAL_ATTORNEYS.filter((att) => att.offices['officeCode'].includes(officeCode));
   return attorneys;
 }
+
 async function getAttorneys(_applicationContext: ApplicationContext): Promise<Array<AttorneyUser>> {
   return TRIAL_ATTORNEYS;
 }
+
 const MockAttorneysGateway: AttorneyGatewayInterface = {
   getAttorneys,
   getAttorneysByUstpOffice,

--- a/backend/functions/lib/testing/mock-gateways/mock-attorneys.gateway.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock-attorneys.gateway.ts
@@ -3,12 +3,19 @@ import { AttorneyUser } from '../../../../../common/src/cams/users';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { AttorneyGatewayInterface } from '../../use-cases/attorney.gateway.interface';
 
+async function getAttorneysByUstpOffice(
+  applicationContext: ApplicationContext,
+): Promise<Array<AttorneyUser>> {
+  const officeCode = applicationContext.request.params['officeCode'];
+  const attorneys = TRIAL_ATTORNEYS.filter((att) => att.offices['officeCode'].includes(officeCode));
+  return attorneys;
+}
 async function getAttorneys(_applicationContext: ApplicationContext): Promise<Array<AttorneyUser>> {
   return TRIAL_ATTORNEYS;
 }
-
 const MockAttorneysGateway: AttorneyGatewayInterface = {
   getAttorneys,
+  getAttorneysByUstpOffice,
 };
 
 export default MockAttorneysGateway;

--- a/backend/functions/lib/use-cases/attorney.gateway.interface.d.ts
+++ b/backend/functions/lib/use-cases/attorney.gateway.interface.d.ts
@@ -3,4 +3,5 @@ import { AttorneyUser } from '../../../../common/src/cams/users';
 
 export interface AttorneyGatewayInterface {
   getAttorneys(applicationContext: ApplicationContext): Promise<Array<AttorneyUser>>;
+  getAttorneysByUstpOffice(applicationContext: ApplicationContext): Promise<Array<AttorneyUser>>;
 }

--- a/backend/functions/lib/use-cases/attorneys.test.ts
+++ b/backend/functions/lib/use-cases/attorneys.test.ts
@@ -1,19 +1,22 @@
-import { ApplicationContext } from '../adapters/types/basic';
 import { TRIAL_ATTORNEYS } from '../../../../common/src/cams/test-utilities/attorneys.mock';
 import { createMockApplicationContext } from '../testing/testing-utilities';
 import AttorneysList from './attorneys';
 import { CaseAssignmentUseCase } from './case-assignment';
+import * as factory from '../factory';
 
 describe('Test attorneys use-case', () => {
+  const gateway = {
+    getAttorneys: jest.fn(),
+    getAttorneysByUstpOffice: jest.fn(),
+  };
+
   test('Should use gateway passed to it in constructor', async () => {
     const attorneyUsers = TRIAL_ATTORNEYS;
-
-    const gateway = {
-      getAttorneys: async (_applicationContext: ApplicationContext) => attorneyUsers,
-    };
+    jest.spyOn(factory, 'getAttorneyGateway').mockReturnValue(gateway);
+    jest.spyOn(gateway, 'getAttorneys').mockResolvedValue(attorneyUsers);
 
     const mockContext = await createMockApplicationContext();
-    const caseList = new AttorneysList(gateway);
+    const caseList = new AttorneysList();
     const results = await caseList.getAttorneyList(mockContext);
 
     expect(results).toEqual(attorneyUsers);
@@ -21,9 +24,8 @@ describe('Test attorneys use-case', () => {
 
   test('should log errors when looking up attorney assignments', async () => {
     const attorneyUsers = TRIAL_ATTORNEYS;
-    const gateway = {
-      getAttorneys: async (_applicationContext: ApplicationContext) => attorneyUsers,
-    };
+    jest.spyOn(factory, 'getAttorneyGateway').mockReturnValue(gateway);
+    jest.spyOn(gateway, 'getAttorneys').mockResolvedValue(attorneyUsers);
 
     const mockContext = await createMockApplicationContext();
     const loggerSpy = jest.spyOn(mockContext.logger, 'error');
@@ -32,7 +34,7 @@ describe('Test attorneys use-case', () => {
       .spyOn(CaseAssignmentUseCase.prototype, 'getCaseLoad')
       .mockRejectedValue(new Error('TEST'));
 
-    const caseList = new AttorneysList(gateway);
+    const caseList = new AttorneysList();
     await caseList.getAttorneyList(mockContext);
 
     expect(assignmentUseCaseSpy).toHaveBeenCalled();

--- a/backend/functions/lib/use-cases/attorneys.ts
+++ b/backend/functions/lib/use-cases/attorneys.ts
@@ -19,7 +19,7 @@ export default class AttorneysList {
 
   async getAttorneyList(applicationContext: ApplicationContext): Promise<Array<AttorneyUser>> {
     const assignmentsUseCase = new CaseAssignmentUseCase(applicationContext);
-    const attorneys = await this.gateway.getAttorneys(applicationContext);
+    const attorneys = await this.gateway.getAttorneysByUstpOffice(applicationContext);
 
     for (const atty of attorneys) {
       try {

--- a/backend/functions/lib/use-cases/attorneys.ts
+++ b/backend/functions/lib/use-cases/attorneys.ts
@@ -9,17 +9,13 @@ const MODULE_NAME = 'ATTORNEYS-USE-CASE';
 export default class AttorneysList {
   gateway: AttorneyGatewayInterface;
 
-  constructor(gateway?: AttorneyGatewayInterface) {
-    if (!gateway) {
-      this.gateway = getAttorneyGateway();
-    } else {
-      this.gateway = gateway;
-    }
+  constructor() {
+    this.gateway = getAttorneyGateway();
   }
 
   async getAttorneyList(applicationContext: ApplicationContext): Promise<Array<AttorneyUser>> {
     const assignmentsUseCase = new CaseAssignmentUseCase(applicationContext);
-    const attorneys = await this.gateway.getAttorneysByUstpOffice(applicationContext);
+    const attorneys = await this.gateway.getAttorneys(applicationContext);
 
     for (const atty of attorneys) {
       try {

--- a/backend/functions/lib/use-cases/gateways.types.ts
+++ b/backend/functions/lib/use-cases/gateways.types.ts
@@ -14,6 +14,7 @@ import {
 import { CaseAssignmentHistory, CaseHistory } from '../../../../common/src/cams/history';
 import { CaseDocket } from '../../../../common/src/cams/cases';
 import { OrdersSearchPredicate } from '../../../../common/src/api/search';
+import { AttorneyUser } from '../../../../common/src/cams/users';
 
 export interface RepositoryResource {
   id?: string;
@@ -77,6 +78,10 @@ export interface CasesRepository {
   ): Promise<Array<ConsolidationTo | ConsolidationFrom>>;
   getCaseHistory(context: ApplicationContext, caseId: string): Promise<CaseHistory[]>;
   createCaseHistory(context: ApplicationContext, history: CaseHistory);
+}
+
+export interface OfficesRepository {
+  getOfficeAttorneys(context: ApplicationContext, officeCode: string): Promise<AttorneyUser[]>;
 }
 
 // TODO: Move these models to a top level models file?

--- a/backend/functions/lib/use-cases/offices/offices.test.ts
+++ b/backend/functions/lib/use-cases/offices/offices.test.ts
@@ -2,6 +2,7 @@ import { OfficesUseCase } from './offices';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { OFFICES } from '../../../../../common/src/cams/test-utilities/offices.mock';
+import { OfficesCosmosDbRepository } from '../../adapters/gateways/offices.cosmosdb.repository';
 
 describe('offices use case tests', () => {
   let applicationContext: ApplicationContext;
@@ -16,5 +17,17 @@ describe('offices use case tests', () => {
     const offices = await useCase.getOffices(applicationContext);
 
     expect(offices).toEqual(OFFICES);
+  });
+
+  test('should return attorneys', async () => {
+    const useCase = new OfficesUseCase();
+    const repoSpy = jest
+      .spyOn(OfficesCosmosDbRepository.prototype, 'getOfficeAttorneys')
+      .mockResolvedValue([]);
+
+    const officeCode = 'new-york';
+    const officeAttorneys = await useCase.getOfficeAttorneys(applicationContext, officeCode);
+    expect(officeAttorneys).toEqual([]);
+    expect(repoSpy).toHaveBeenCalledWith(applicationContext, officeCode);
   });
 });

--- a/backend/functions/lib/use-cases/offices/offices.ts
+++ b/backend/functions/lib/use-cases/offices/offices.ts
@@ -1,10 +1,19 @@
 import { OfficeDetails } from '../../../../../common/src/cams/courts';
 import { ApplicationContext } from '../../adapters/types/basic';
-import { getOfficesGateway } from '../../factory';
+import { getOfficesGateway, getOfficesRepository } from '../../factory';
+import { AttorneyUser } from '../../../../../common/src/cams/users';
 
 export class OfficesUseCase {
-  public async getOffices(applicationContext: ApplicationContext): Promise<Array<OfficeDetails>> {
-    const gateway = getOfficesGateway(applicationContext);
-    return gateway.getOffices(applicationContext);
+  public async getOffices(context: ApplicationContext): Promise<OfficeDetails[]> {
+    const gateway = getOfficesGateway(context);
+    return gateway.getOffices(context);
+  }
+
+  public async getOfficeAttorneys(
+    context: ApplicationContext,
+    officeCode: string,
+  ): Promise<AttorneyUser[]> {
+    const repository = getOfficesRepository(context);
+    return repository.getOfficeAttorneys(context, officeCode);
   }
 }

--- a/backend/functions/offices/offices.function.ts
+++ b/backend/functions/offices/offices.function.ts
@@ -16,7 +16,6 @@ export default async function handler(
       logger,
       request,
     );
-    console.log(applicationContext.request.params);
     const officesController = new OfficesController();
     applicationContext.session =
       await ContextCreator.getApplicationContextSession(applicationContext);

--- a/backend/functions/offices/offices.function.ts
+++ b/backend/functions/offices/offices.function.ts
@@ -16,7 +16,8 @@ export default async function handler(
       logger,
       request,
     );
-    const officesController = new OfficesController(applicationContext);
+    console.log(applicationContext.request.params);
+    const officesController = new OfficesController();
     applicationContext.session =
       await ContextCreator.getApplicationContextSession(applicationContext);
 
@@ -31,5 +32,5 @@ app.http('offices', {
   methods: ['GET'],
   authLevel: 'anonymous',
   handler,
-  route: 'offices',
+  route: 'offices/{officeCode?}/{subResource?}',
 });

--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -39,7 +39,7 @@
     "@azure/identity": "$@azure/identity"
   },
   "scripts": {
-    "clean": "rm -rf ./dist & rm -rf ./node_modules & rm -rf ./coverage",
+    "clean": "rm -rf ./dist && rm -rf ./node_modules && rm -rf ./coverage",
     "build": "tsc --build tsconfig.build.json",
     "build-common": "pushd ../../common && npm ci && npm run build && popd",
     "watch": "tsc --project tsconfig.build.json -w",

--- a/common/package.json
+++ b/common/package.json
@@ -4,7 +4,7 @@
   "description": "CAMS common package",
   "main": "index.js",
   "scripts": {
-    "clean": "rm -rf ./dist & rm -rf ./node_modules & rm tsconfig.tsbuildinfo",
+    "clean": "rm -rf ./dist && rm -rf ./node_modules && rm -rf ./coverage & rm tsconfig.tsbuildinfo",
     "build": "npx tsc",
     "test": "jest",
     "coverage": "jest --coverage",

--- a/common/src/api/search.ts
+++ b/common/src/api/search.ts
@@ -24,6 +24,6 @@ export type CasesSearchPredicate = SearchPredicate & {
   caseIds?: string[];
 };
 
-export type OrdersSearchPredicate = SearchPredicate & {
-  divisionCodes?: string[];
+export type OrdersSearchPredicate = {
+  divisionCodes: string[];
 };

--- a/common/src/cams/test-utilities/attorneys.mock.ts
+++ b/common/src/cams/test-utilities/attorneys.mock.ts
@@ -18,6 +18,7 @@ const manhattanAttorneys = MockUsers.filter(
   (user) => user.user.offices[0] === MANHATTAN && user.user.roles[0] === CamsRole.TrialAttorney,
 ).map((user) => user.user);
 
+export const USTP_OFFICE_TRIAL_ATTORNEYS: AttorneyUser[] = [];
 export const TRIAL_ATTORNEYS: AttorneyUser[] = [
   ...manhattanAttorneys,
   {

--- a/user-interface/package.json
+++ b/user-interface/package.json
@@ -73,7 +73,7 @@
     "semver": "^7.5.4"
   },
   "scripts": {
-    "clean": "rm -rf build & rm -rf node_modules & rm -rf ./coverage",
+    "clean": "rm -rf build && rm -rf node_modules && rm -rf ./coverage",
     "start": "vite",
     "start:pa11y": "export CAMS_PA11Y=true && export CAMS_LOGIN_PROVIDER=none && tsc -b && vite build && vite preview --port 3000",
     "build": "tsc -b && vite build",

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -185,6 +185,10 @@ async function getMe() {
   return api().get<CamsSession>(`/me`);
 }
 
+async function getOfficeAttorneys(officeCode: string) {
+  return api().get<AttorneyUser[]>(`/offices/${officeCode}/attorneys`);
+}
+
 async function getOffices() {
   return api().get<OfficeDetails[]>(`/offices`);
 }
@@ -226,6 +230,7 @@ export const _Api2 = {
   getCaseAssociations,
   getCaseHistory,
   getMe,
+  getOfficeAttorneys,
   getOffices,
   getOrders,
   getOrderSuggestions,


### PR DESCRIPTION
# Purpose

We need to be able to get the list of attorneys who work in an office.

# Major Changes

We extend the offices endpoint to retrieve staff from a new CosmosDB container.

# Testing/Validation

Deployed the branch and verified that the api does return data from the container.