### PR TITLE
Fix jsdocs

### DIFF
--- a/backend/functions/orders-manual-sync/orders-manual-sync.function.ts
+++ b/backend/functions/orders-manual-sync/orders-manual-sync.function.ts
@@ -18,10 +18,10 @@ const MODULE_NAME = 'ORDERS-MANUAL-SYNC-FUNCTION';
  * specific AO_TX.TX_ID to start the sync from or omit it from the request body to use the last runtime state
  * stored in CosmosDB.
  *
- * curl -v -d '{"txIdOverride": '0'}' -H "Content-Type: application/json" http://localhost:7071/api/orders-sync
+ * curl -v -d '{"txIdOverride": "0"}' -H "Content-Type: application/json" http://localhost:7071/api/orders-sync
  *
- * @param invocationContext
- * @param request
+ * @param {HttpRequest} request
+ * @param {InvocationContext} invocationContext
  */
 export default async function handler(
   request: HttpRequest,

--- a/common/src/cams/auditable.ts
+++ b/common/src/cams/auditable.ts
@@ -9,11 +9,14 @@ export type Auditable = {
 export const SYSTEM_USER_REFERENCE: CamsUserReference = { id: 'SYSTEM', name: 'SYSTEM' };
 
 /**
- * Decorates the record with the Auditable properties. Any necessary overriding of the properties must be completed
- * after or in lieu of calling this function.
- * @param record T extends Auditable required The record to be decorated.
- * @param camsUser CamsUserReference optional The user to be assigned to `updatedBy`. Defaults to the system user, so
- * this parameter MUST be provided for user-initiated actions.
+ * Decorates and returns the record with the Auditable properties. Any necessary overriding of the properties must be
+ * completed after or in lieu of calling this function.
+ *
+ * @template {T extends Auditable}
+ * @param {T extends Auditable} record The record to be decorated.
+ * @param {CamsUserReference} [camsUser=SYSTEM_USER_REFERENCE] The user to be assigned to `updatedBy`. Defaults to the
+ * system user, so this parameter MUST be provided for user-initiated actions.
+ * @returns {T}
  */
 export function createAuditRecord<T extends Auditable>(
   record: Omit<T, 'updatedOn' | 'updatedBy'>,

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -201,11 +201,12 @@ function getCaseDetail(
 }
 
 /**
- * @param data T required There is no simple way to determine what type T is and generate
+ * @param {T} data There is no simple way to determine what type T is and generate
  *  random data accordingly, so it is required to provide it. We could modify to behave like
  *  buildArray does and accept a function from here as well, but it should verify the type
  *  is correct if we do that.
- * @param self String optional The URI for the resource being mocked
+ * @param {String} [self='some-url'] The URI for the resource being mocked
+ * @returns {ResponseBody<T>}
  */
 function getNonPaginatedResponseBody<T>(data: T, self: string = 'some-url'): ResponseBody<T> {
   return {
@@ -217,11 +218,11 @@ function getNonPaginatedResponseBody<T>(data: T, self: string = 'some-url'): Res
 }
 
 /**
- * @param data T required There is no simple way to determine what type T is and generate
+ * @param {T} data There is no simple way to determine what type T is and generate
  *  random data accordingly, so it is required to provide it. We could modify to behave like
- *  buildArray does and accept a function from here as well, but it should verify the type
+ *  `buildArray` does and accept a function from here as well, but it should verify the type
  *  is correct if we do that.
- * @param options Options<WithPagination> optional Provide an object like the following:
+ * @param {Options<Pagination>} [options={ override: {} }] Provide an object like the following:
  *  {
  *    entityType?: 'company' | 'person',
  *    override?: {
@@ -232,7 +233,8 @@ function getNonPaginatedResponseBody<T>(data: T, self: string = 'some-url'): Res
  *      currentPage?: number
  *    }
  *  }
- * @param self String optional The URI for the resource being mocked
+ * @param {String} [self='some-url'] The URI for the resource being mocked
+ * @returns {ResponseBody<T>}
  */
 function getPaginatedResponseBody<T>(
   data: T,

--- a/common/src/cams/test-utilities/offices.mock.ts
+++ b/common/src/cams/test-utilities/offices.mock.ts
@@ -1,7 +1,7 @@
 import { OfficeDetails } from '../courts';
 
 /***************************************************************************\
- * !! The Following Offices are aligend with legitimate court divisions
+ * !! The Following Offices are aligned with legitimate court divisions
  *    as found in the adapters/gateways/dxtr/dxtr.constants.ts file.
  *    Because many of our tests will take an office at random out of
  *    this list, and then do a lookup in dxtr.constants.ts ( which is

--- a/dev-tools/test-data/utility.ts
+++ b/dev-tools/test-data/utility.ts
@@ -1,9 +1,9 @@
 import { ColumnNames, TableRecordHelper } from './types';
 
 /**
- * Quick and dirty assert function.
- * @param condition results of some evaluation
- * @param message a message to use in a thrown Error
+ * Throws a new error with the provided message if condition evaluates to false.
+ * @param {boolean} condition results of some evaluation
+ * @param {string} [message='Assertion failed.'] a message to use in a thrown Error
  */
 export function assert(condition: boolean, message: string = 'Assertion failed.') {
   if (!condition) {

--- a/user-interface/src/lib/models/api.ts
+++ b/user-interface/src/lib/models/api.ts
@@ -57,9 +57,10 @@ export default class Api {
    * This function makes assumptions about the responses to POST requests that do not handle
    * all possibilities according to the HTTP specifications.
    *
-   * @param path string The path after '/api'.
-   * @param body object The payload for the request.
-   * @param options ObjectKeyVal Query params in the form of key/value pairs.
+   * @param {string} path The path after '/api'.
+   * @param {object} body The payload for the request.
+   * @param {ObjectKeyVal} [options] Query params in the form of key/value pairs.
+   * @returns {Promise<ResponseBody | void>}
    */
   public static async post(
     path: string,
@@ -114,9 +115,10 @@ export default class Api {
    * This function makes assumptions about the responses to PATCH requests that do not handle
    * all possibilities according to the HTTP specifications.
    *
-   * @param path string The path after '/api'.
-   * @param body object The payload for the request.
-   * @param options ObjectKeyVal Query params in the form of key/value pairs.
+   * @param {string} path The path after '/api'.
+   * @param {object} body The payload for the request.
+   * @param {ObjectKeyVal} [options] Query params in the form of key/value pairs.
+   * @returns {Promise<ResponseBody | void>}
    */
   public static async patch(
     path: string,

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -122,9 +122,9 @@ export function useGenericApi(): GenericApiClient {
       const body = await api.get(uriOrPathSubstring, options);
       return body as ResponseBody<T>;
     },
-    async patch<T extends object = object>(
+    async patch<T extends object = object, U extends object = object>(
       path: string,
-      body: object,
+      body: U,
       options?: ObjectKeyVal,
     ): Promise<ResponseBody<T> | void> {
       const { uriOrPathSubstring, queryParams } = justThePath(path);
@@ -135,9 +135,9 @@ export function useGenericApi(): GenericApiClient {
       }
       return responseBody as ResponseBody<T>;
     },
-    async post<T extends object = object>(
+    async post<T extends object = object, U extends object = object>(
       path: string,
-      body: object,
+      body: U,
       options?: ObjectKeyVal,
     ): Promise<ResponseBody<T> | void> {
       const { uriOrPathSubstring, queryParams } = justThePath(path);

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -40,31 +40,27 @@ interface GenericApiClient {
    * This function makes assumptions about the responses to PATCH requests that do not handle
    * all possibilities according to the HTTP specifications.
    *
-   * @param path string The path after '/api'.
-   * @param body object The payload for the request.
-   * @param options ObjectKeyVal Query params in the form of key/value pairs.
+   * @template {object} T
+   * @param {string} path The path after '/api'.
+   * @param {T} body The payload for the request.
+   * @param {ObjectKeyVal} [options] Query params in the form of key/value pairs.
+   * @returns {Promise<ResponseBody | void>}
    */
-  patch<T = object>(
-    path: string,
-    body: object,
-    options?: ObjectKeyVal,
-  ): Promise<ResponseBody<T> | void>;
+  patch<T = object>(path: string, body: T, options?: ObjectKeyVal): Promise<ResponseBody<T> | void>;
 
   /**
    * ONLY USE WITH OUR OWN API!!!!
    * This function makes assumptions about the responses to POST requests that do not handle
    * all possibilities according to the HTTP specifications.
    *
-   * @param path string The path after '/api'.
-   * @param body object The payload for the request.
-   * @param options ObjectKeyVal Query params in the form of key/value pairs.
+   * @template {object} T
+   * @param {string} path The path after '/api'.
+   * @param {T} body The payload for the request.
+   * @param {ObjectKeyVal} [options] Query params in the form of key/value pairs.
+   * @returns {Promise<ResponseBody | void>}
    */
-  post<T = object>(
-    path: string,
-    body: object,
-    options?: ObjectKeyVal,
-  ): Promise<ResponseBody<T> | void>;
-  put<T = object>(path: string, body: object, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
+  post<T = object>(path: string, body: T, options?: ObjectKeyVal): Promise<ResponseBody<T> | void>;
+  put<T = object>(path: string, body: T, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
 }
 
 export function extractPathFromUri(uriOrPath: string, api: ApiClient) {

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -40,27 +40,41 @@ interface GenericApiClient {
    * This function makes assumptions about the responses to PATCH requests that do not handle
    * all possibilities according to the HTTP specifications.
    *
-   * @template {object} T
+   * @template {T extends object = object} T
+   * @template {U extends object = object} U
    * @param {string} path The path after '/api'.
-   * @param {T} body The payload for the request.
+   * @param {U} body The payload for the request.
    * @param {ObjectKeyVal} [options] Query params in the form of key/value pairs.
    * @returns {Promise<ResponseBody | void>}
    */
-  patch<T = object>(path: string, body: T, options?: ObjectKeyVal): Promise<ResponseBody<T> | void>;
+  patch<T extends object = object, U extends object = object>(
+    path: string,
+    body: U,
+    options?: ObjectKeyVal,
+  ): Promise<ResponseBody<T> | void>;
 
   /**
    * ONLY USE WITH OUR OWN API!!!!
    * This function makes assumptions about the responses to POST requests that do not handle
    * all possibilities according to the HTTP specifications.
    *
-   * @template {object} T
+   * @template {T extends object = object} T
+   * @template {U extends object = object} U
    * @param {string} path The path after '/api'.
-   * @param {T} body The payload for the request.
+   * @param {U} body The payload for the request.
    * @param {ObjectKeyVal} [options] Query params in the form of key/value pairs.
    * @returns {Promise<ResponseBody | void>}
    */
-  post<T = object>(path: string, body: T, options?: ObjectKeyVal): Promise<ResponseBody<T> | void>;
-  put<T = object>(path: string, body: T, options?: ObjectKeyVal): Promise<ResponseBody<T>>;
+  post<T extends object = object, U extends object = object>(
+    path: string,
+    body: U,
+    options?: ObjectKeyVal,
+  ): Promise<ResponseBody<T> | void>;
+  put<T extends object = object, U extends object = object>(
+    path: string,
+    body: U,
+    options?: ObjectKeyVal,
+  ): Promise<ResponseBody<T>>;
 }
 
 export function extractPathFromUri(uriOrPath: string, api: ApiClient) {
@@ -108,7 +122,7 @@ export function useGenericApi(): GenericApiClient {
       const body = await api.get(uriOrPathSubstring, options);
       return body as ResponseBody<T>;
     },
-    async patch<T = object>(
+    async patch<T extends object = object>(
       path: string,
       body: object,
       options?: ObjectKeyVal,
@@ -121,7 +135,7 @@ export function useGenericApi(): GenericApiClient {
       }
       return responseBody as ResponseBody<T>;
     },
-    async post<T = object>(
+    async post<T extends object = object>(
       path: string,
       body: object,
       options?: ObjectKeyVal,
@@ -134,9 +148,9 @@ export function useGenericApi(): GenericApiClient {
       }
       return responseBody as ResponseBody<T>;
     },
-    async put<T = object>(
+    async put<T extends object = object, U extends object = object>(
       path: string,
-      body: object,
+      body: U,
       options?: ObjectKeyVal,
     ): Promise<ResponseBody<T>> {
       const { uriOrPathSubstring, queryParams } = justThePath(path);
@@ -198,19 +212,25 @@ async function getOrderSuggestions(caseId: string) {
 }
 
 async function patchTransferOrder(data: FlexibleTransferOrderAction) {
-  await api().patch<TransferOrder>(`/orders/${data.id}`, data);
+  await api().patch<TransferOrder, FlexibleTransferOrderAction>(`/orders/${data.id}`, data);
 }
 
 async function putConsolidationOrderApproval(data: ConsolidationOrderActionApproval) {
-  return api().put<ConsolidationOrder[]>('/consolidations/approve', data);
+  return api().put<ConsolidationOrder[], ConsolidationOrderActionApproval>(
+    '/consolidations/approve',
+    data,
+  );
 }
 
 async function putConsolidationOrderRejection(data: ConsolidationOrderActionRejection) {
-  return api().put<ConsolidationOrder[]>('/consolidations/reject', data);
+  return api().put<ConsolidationOrder[], ConsolidationOrderActionRejection>(
+    '/consolidations/reject',
+    data,
+  );
 }
 
 async function searchCases(predicate: CasesSearchPredicate) {
-  return api().post<CaseBasics[]>('/cases', predicate);
+  return api().post<CaseBasics[], CasesSearchPredicate>('/cases', predicate);
 }
 
 async function postStaffAssignments(action: StaffAssignmentAction): Promise<void> {


### PR DESCRIPTION
# Purpose

When we have JSDocs, it is most helpful if they properly follow the syntax.

# Major Changes

- Move types to their proper place in `@param` tags.
- Add `@return` tags where needed.
- Add `@template` tags where generics are used.
- Add stronger typing to `api2.ts` interface and functions as the JSDoc actually caused build failures without these changes.

# Testing/Validation

Ran build successfully.