### PR TITLE
CAMS-283 update cosmos with office staff sync state

### DIFF
--- a/backend/functions/lib/adapters/gateways/runtime-state.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/runtime-state.cosmosdb.repository.ts
@@ -60,8 +60,7 @@ export class RuntimeStateCosmosDbRepository implements RuntimeStateRepository {
       await this.cosmosDbClient
         .database(this.cosmosConfig.databaseName)
         .container(this.containerName)
-        .item(syncState.id, syncState.documentType)
-        .replace(syncState);
+        .items.upsert(syncState, { partitionKey: syncState.documentType });
     } catch (e) {
       context.logger.error(MODULE_NAME, `${e.status} : ${e.name} : ${e.message}`);
       if (e instanceof AggregateAuthenticationError) {

--- a/backend/functions/lib/use-cases/gateways.types.ts
+++ b/backend/functions/lib/use-cases/gateways.types.ts
@@ -14,7 +14,8 @@ import {
 import { CaseAssignmentHistory, CaseHistory } from '../../../../common/src/cams/history';
 import { CaseDocket } from '../../../../common/src/cams/cases';
 import { OrdersSearchPredicate } from '../../../../common/src/api/search';
-import { AttorneyUser, CamsUserReference } from '../../../../common/src/cams/users';
+import { AttorneyUser, CamsUserGroup, CamsUserReference } from '../../../../common/src/cams/users';
+import { UstpOfficeDetails } from '../../../../common/src/cams/courts';
 
 export interface RepositoryResource {
   id?: string;
@@ -91,7 +92,7 @@ export interface OfficesRepository {
 }
 
 // TODO: Move these models to a top level models file?
-export type RuntimeStateDocumentType = 'ORDERS_SYNC_STATE';
+export type RuntimeStateDocumentType = 'ORDERS_SYNC_STATE' | 'OFFICE_STAFF_SYNC_STATE';
 
 export type RuntimeState = {
   id?: string;
@@ -101,6 +102,13 @@ export type RuntimeState = {
 export type OrderSyncState = RuntimeState & {
   documentType: 'ORDERS_SYNC_STATE';
   txId: string;
+};
+
+export type OfficeStaffSyncState = RuntimeState & {
+  documentType: 'OFFICE_STAFF_SYNC_STATE';
+  userGroups: CamsUserGroup[];
+  users: CamsUserReference[];
+  officesWithUsers: UstpOfficeDetails[];
 };
 
 export interface RuntimeStateRepository {

--- a/backend/functions/lib/use-cases/offices/offices.ts
+++ b/backend/functions/lib/use-cases/offices/offices.ts
@@ -6,8 +6,10 @@ import {
   getUserGroupGateway,
   getOfficesRepository,
   getStorageGateway,
+  getRuntimeStateRepository,
 } from '../../factory';
 import { AttorneyUser } from '../../../../../common/src/cams/users';
+import { OfficeStaffSyncState } from '../gateways.types';
 
 export class OfficesUseCase {
   public async getOffices(context: ApplicationContext): Promise<OfficeDetails[]> {
@@ -75,11 +77,18 @@ export class OfficesUseCase {
       officesWithUsers.push(office);
     }
 
-    // TODO: What to do with users with roles WITHOUT offices?
-    return {
+    const result: OfficeStaffSyncState = {
+      documentType: 'OFFICE_STAFF_SYNC_STATE',
       userGroups,
       users: [...userMap.values()],
       officesWithUsers,
     };
+
+    const runtimeStateRepo = getRuntimeStateRepository(context);
+
+    await runtimeStateRepo.updateState<OfficeStaffSyncState>(context, result);
+
+    // TODO: What to do with users with roles WITHOUT offices?
+    return result;
   }
 }

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -347,6 +347,10 @@ var applicationSettings = concat(
       name: 'FEATURE_FLAG_SDK_KEY'
       value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=FEATURE-FLAG-SDK-KEY)'
     }
+    {
+      name: 'CAMS_USER_GROUP_GATEWAY_CONFIG'
+      value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=CAMS-USER-GROUP-GATEWAY-CONFIG)'
+    }
   ],
   createApplicationInsights
     ? [{ name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsights.outputs.connectionString }]


### PR DESCRIPTION
# Purpose

update cosmos with office staff sync state

# Major Changes

- use upsert within runtime state repo
- add OFFICE_STAFF_SYNC_STATE document type
- update backend env vars with new conf

# Testing/Validation

- ran locally
- deployed ENV

# Notes

We have updated the staging and prod environment with the new keyvault secret references
