### PR TITLE
CAMS-283 - Add TTL to OfficeStaff documents

### DIFF
--- a/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.test.ts
@@ -1,11 +1,10 @@
 import { MockHumbleQuery } from '../../testing/mock.cosmos-client-humble';
-import { OfficesCosmosDbRepository } from './offices.cosmosdb.repository';
+import { OfficesCosmosDbRepository, OfficeStaff } from './offices.cosmosdb.repository';
 import { ApplicationContext } from '../types/basic';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import MockData from '../../../../../common/src/cams/test-utilities/mock-data';
 import { CosmosDbRepository } from './cosmos/cosmos.repository';
 import { CamsRole } from '../../../../../common/src/cams/roles';
-import { OfficeStaff } from '../../../../../common/src/cams/staff';
 import { SYSTEM_USER_REFERENCE } from '../../../../../common/src/cams/auditable';
 import { getCamsUserReference } from '../../../../../common/src/cams/session';
 
@@ -35,6 +34,7 @@ describe('offices cosmosDB repository tests', () => {
         ...user,
         updatedOn: '2024-10-01T00:00:00.000Z',
         updatedBy: SYSTEM_USER_REFERENCE,
+        ttl: 100,
       };
     });
     jest.spyOn(MockHumbleQuery.prototype, 'fetchAll').mockResolvedValue({ resources: staffDocs });

--- a/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
@@ -3,13 +3,19 @@ import { ApplicationContext } from '../types/basic';
 import { AttorneyUser, CamsUserReference } from '../../../../../common/src/cams/users';
 import { CosmosDbRepository } from './cosmos/cosmos.repository';
 import { UstpOfficeDetails } from '../../../../../common/src/cams/courts';
-import { OfficeStaff } from '../../../../../common/src/cams/staff';
 import { CamsRole } from '../../../../../common/src/cams/roles';
-import { createAuditRecord } from '../../../../../common/src/cams/auditable';
+import { Auditable, createAuditRecord } from '../../../../../common/src/cams/auditable';
 import { getCamsUserReference } from '../../../../../common/src/cams/session';
 
 const MODULE_NAME: string = 'COSMOS_DB_REPOSITORY_OFFICES';
 const CONTAINER_NAME: string = 'offices';
+
+export type OfficeStaff = CamsUserReference &
+  Auditable & {
+    documentType: 'OFFICE_STAFF';
+    officeCode: string;
+    ttl: number;
+  };
 
 export class OfficesCosmosDbRepository implements OfficesRepository {
   private officeStaffRepo: CosmosDbRepository<OfficeStaff>;
@@ -32,11 +38,13 @@ export class OfficesCosmosDbRepository implements OfficesRepository {
     officeCode: string,
     user: CamsUserReference,
   ): Promise<void> {
+    const ttl = 4500; // 75 minutes
     const staff = createAuditRecord<OfficeStaff>({
       id: user.id,
       documentType: 'OFFICE_STAFF',
       officeCode,
       ...user,
+      ttl,
     });
     await this.officeStaffRepo.upsert(context, officeCode, staff);
   }

--- a/common/src/cams/staff.ts
+++ b/common/src/cams/staff.ts
@@ -1,8 +1,0 @@
-import { Auditable } from './auditable';
-import { CamsUserReference } from './users';
-
-export type OfficeStaff = CamsUserReference &
-  Auditable & {
-    documentType: 'OFFICE_STAFF';
-    officeCode: string;
-  };


### PR DESCRIPTION
# Purpose

Add TTL to office staff records

# Major Changes

* Moved OfficeStaff document type to the backend from common
* Added ttl property to the OfficeStaff type.
* Added 75 minute TTL to all OfficeStaff documents written to Cosmos.

# Testing/Validation

Tests pass

