### PR TITLE
CAMS-446 - Refactor logic to get any case variation of ad_groups

### DIFF
--- a/backend/functions/lib/adapters/gateways/okta/okta-gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/okta/okta-gateway.test.ts
@@ -64,6 +64,7 @@ describe('Okta gateway tests', () => {
       aud: 'api://default',
       iat: 0,
       exp: Math.floor(Date.now() / 1000) + 600,
+      AD_Groups: ['groupD'],
       ad_groups: ['groupA', 'groupB'],
       groups: ['groupB', 'groupC'],
     };
@@ -91,7 +92,10 @@ describe('Okta gateway tests', () => {
       user: { id: undefined, name: userInfo.name },
       jwt: {
         ...jwt,
-        claims: { ...jwt.claims, groups: expect.arrayContaining(['groupA', 'groupB', 'groupC']) },
+        claims: {
+          ...jwt.claims,
+          groups: expect.arrayContaining(['groupA', 'groupB', 'groupC', 'groupD']),
+        },
       },
     });
   });

--- a/backend/functions/lib/adapters/gateways/okta/okta-gateway.ts
+++ b/backend/functions/lib/adapters/gateways/okta/okta-gateway.ts
@@ -70,14 +70,16 @@ async function getUser(accessToken: string): Promise<{ user: CamsUser; jwt: Cams
       // DOJ Login Okta instances return a custom `AD_Groups` attribute on claims that does not
       // appear on standard Okta claims. This line checks to see if it exists and if not
       // appends an empty array for groups that will carry no permissions for the user.
+
+      const adGroups = Object.keys(jwt.claims).reduce((acc, key) => {
+        if (key.toLowerCase() === 'ad_groups') {
+          acc.push(jwt.claims[key]);
+        }
+        return acc;
+      }, []);
+
       jwt.claims.groups = Array.from(
-        new Set<string>(
-          [].concat(
-            jwt.claims.groups ?? [],
-            jwt.claims.AD_Groups ?? [],
-            jwt.claims.ad_groups ?? [],
-          ),
-        ),
+        new Set<string>([].concat(jwt.claims.groups ?? [], ...adGroups)),
       );
 
       return { user, jwt };


### PR DESCRIPTION
# Purpose

Catch all variations on the case of the ad_groups property.

# Testing/Validation

Tested more than one case variation of ad_groups property in unit test.

