### PR TITLE
CAMS-283 - Add MockOfficesRepository

### DIFF
--- a/backend/functions/lib/factory.ts
+++ b/backend/functions/lib/factory.ts
@@ -42,6 +42,7 @@ import { MockOfficesGateway } from './testing/mock-gateways/mock.offices.gateway
 import { OfficesCosmosDbRepository } from './adapters/gateways/offices.cosmosdb.repository';
 import OktaUserGroupGateway from './adapters/gateways/okta/okta-user-group-gateway';
 import { UserSessionUseCase } from './use-cases/user-session/user-session';
+import { MockOfficesRepository } from './testing/mock-gateways/mock-offices.repository';
 
 export const getAttorneyGateway = (): AttorneyGatewayInterface => {
   return MockAttorneysGateway;
@@ -117,6 +118,9 @@ export const getOfficesGateway = (
 };
 
 export const getOfficesRepository = (applicationContext: ApplicationContext): OfficesRepository => {
+  if (applicationContext.config.authConfig.provider === 'mock') {
+    return new MockOfficesRepository();
+  }
   return new OfficesCosmosDbRepository(applicationContext);
 };
 

--- a/backend/functions/lib/testing/mock-gateways/mock-offices.repository.test.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock-offices.repository.test.ts
@@ -1,0 +1,19 @@
+import { createMockApplicationContext } from '../testing-utilities';
+import { MockOfficesRepository } from './mock-offices.repository';
+
+describe('MockOfficesRepository', () => {
+  test('should return expected attorney lists by office code', async () => {
+    const context = await createMockApplicationContext();
+    const repo = new MockOfficesRepository();
+
+    const nyAttys = await repo.getOfficeAttorneys(context, 'USTP_CAMS_Region_2_Office_Manhattan');
+    expect(nyAttys.map((atty) => atty.name)).toEqual([
+      'Jessica Pearson',
+      'Jack McCoy',
+      "Martha's Son",
+    ]);
+
+    const buAttys = await repo.getOfficeAttorneys(context, 'USTP_CAMS_Region_2_Office_Buffalo');
+    expect(buAttys.map((atty) => atty.name)).toEqual([]);
+  });
+});

--- a/backend/functions/lib/testing/mock-gateways/mock-offices.repository.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock-offices.repository.ts
@@ -4,7 +4,6 @@ import { AttorneyUser, CamsUserReference } from '../../../../../common/src/cams/
 import { ApplicationContext } from '../../adapters/types/basic';
 import { getStorageGateway } from '../../factory';
 import { OfficesRepository } from '../../use-cases/gateways.types';
-import { createMockApplicationContext } from '../testing-utilities';
 
 export class MockOfficesRepository implements OfficesRepository {
   async getOfficeAttorneys(
@@ -36,18 +35,3 @@ export class MockOfficesRepository implements OfficesRepository {
     throw new Error('Method not implemented.');
   }
 }
-
-// Test
-createMockApplicationContext().then((context) => {
-  const repo = new MockOfficesRepository();
-  const printAttorneys = (attorneys: AttorneyUser[]) =>
-    console.log(
-      JSON.stringify(
-        attorneys.map((a) => a.name),
-        null,
-        2,
-      ),
-    );
-  repo.getOfficeAttorneys(context, 'USTP_CAMS_Region_2_Office_Manhattan').then(printAttorneys);
-  repo.getOfficeAttorneys(context, 'USTP_CAMS_Region_2_Office_Buffalo').then(printAttorneys);
-});

--- a/backend/functions/lib/testing/mock-gateways/mock-offices.repository.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock-offices.repository.ts
@@ -1,0 +1,53 @@
+import { CamsRole } from '../../../../../common/src/cams/roles';
+import MockUsers from '../../../../../common/src/cams/test-utilities/mock-user';
+import { AttorneyUser, CamsUserReference } from '../../../../../common/src/cams/users';
+import { ApplicationContext } from '../../adapters/types/basic';
+import { getStorageGateway } from '../../factory';
+import { OfficesRepository } from '../../use-cases/gateways.types';
+import { createMockApplicationContext } from '../testing-utilities';
+
+export class MockOfficesRepository implements OfficesRepository {
+  async getOfficeAttorneys(
+    context: ApplicationContext,
+    officeCode: string,
+  ): Promise<AttorneyUser[]> {
+    // TODO: Remap the office code to use the user.offices when user.offices is changed to use UstpOfficeDetail.
+    const storageGateway = getStorageGateway(context);
+    const ustpOffices = storageGateway.getUstpOffices();
+    if (!ustpOffices.has(officeCode)) {
+      return Promise.resolve([]);
+    }
+    const ustpOffice = ustpOffices.get(officeCode);
+    const users: AttorneyUser[] = MockUsers.filter(
+      (mockUser) =>
+        mockUser.user.roles.includes(CamsRole.TrialAttorney) &&
+        !!mockUser.user.offices.find(
+          (office) => !!ustpOffice.groups.find((o) => o.groupDesignator === office.groupDesignator),
+        ),
+    ).map<AttorneyUser>((mockUser) => mockUser.user);
+    return Promise.resolve(users);
+  }
+
+  putOfficeStaff(
+    _context: ApplicationContext,
+    _officeCode: string,
+    _user: CamsUserReference,
+  ): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+// Test
+createMockApplicationContext().then((context) => {
+  const repo = new MockOfficesRepository();
+  const printAttorneys = (attorneys: AttorneyUser[]) =>
+    console.log(
+      JSON.stringify(
+        attorneys.map((a) => a.name),
+        null,
+        2,
+      ),
+    );
+  repo.getOfficeAttorneys(context, 'USTP_CAMS_Region_2_Office_Manhattan').then(printAttorneys);
+  repo.getOfficeAttorneys(context, 'USTP_CAMS_Region_2_Office_Buffalo').then(printAttorneys);
+});

--- a/backend/functions/lib/use-cases/offices/offices.test.ts
+++ b/backend/functions/lib/use-cases/offices/offices.test.ts
@@ -2,7 +2,7 @@ import { OfficesUseCase } from './offices';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { OFFICES } from '../../../../../common/src/cams/test-utilities/offices.mock';
-import { OfficesCosmosDbRepository } from '../../adapters/gateways/offices.cosmosdb.repository';
+import * as factory from '../../factory';
 
 describe('offices use case tests', () => {
   let applicationContext: ApplicationContext;
@@ -21,9 +21,13 @@ describe('offices use case tests', () => {
 
   test('should return attorneys', async () => {
     const useCase = new OfficesUseCase();
-    const repoSpy = jest
-      .spyOn(OfficesCosmosDbRepository.prototype, 'getOfficeAttorneys')
-      .mockResolvedValue([]);
+    const repoSpy = jest.fn().mockResolvedValue([]);
+    jest.spyOn(factory, 'getOfficesRepository').mockImplementation(() => {
+      return {
+        putOfficeStaff: jest.fn(),
+        getOfficeAttorneys: repoSpy,
+      };
+    });
 
     const officeCode = 'new-york';
     const officeAttorneys = await useCase.getOfficeAttorneys(applicationContext, officeCode);


### PR DESCRIPTION
# Purpose

Support getting office attorneys when in mock user auth mode.

# Major Changes

* Added MockOfficesRepository

# Testing/Validation

Tested that the mock repo returned Manhattan attorneys from the mock users file.
