### PR TITLE
CAMS-283 corrected app setting name for OKTA_API_KEY

### DIFF
--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -352,7 +352,7 @@ var applicationSettings = concat(
       value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=CAMS-USER-GROUP-GATEWAY-CONFIG)'
     }
     {
-      name: 'OKTA-API-KEY'
+      name: 'OKTA_API_KEY'
       value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=OKTA-API-KEY)'
     }
   ],


### PR DESCRIPTION
Jira ticket: CAMS-283

# Problem

hyphens not allowed in Azure app config settings, replaced with underscores

# Solution

hyphens not allowed in Azure app config settings, replaced with underscores within OKTA_API_KEY

# Testing/Validation

N/A

# Other Changes

N/A
