### PR TITLE
CAMS-283: Get Court Division Details

### DIFF
--- a/backend/functions/courts/courts.function.test.ts
+++ b/backend/functions/courts/courts.function.test.ts
@@ -1,6 +1,4 @@
 import { CamsError } from '../lib/common-errors/cams-error';
-import ContextCreator from '../azure/application-context-creator';
-import MockData from '../../../common/src/cams/test-utilities/mock-data';
 import handler from './courts.function';
 import {
   buildTestResponseError,
@@ -22,12 +20,8 @@ describe('Courts Function tests', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
-
-  jest
-    .spyOn(ContextCreator, 'getApplicationContextSession')
-    .mockResolvedValue(MockData.getManhattanAssignmentManagerSession());
 
   test('should set successful response', async () => {
     const bodySuccess: CourtDivisionDetails[] = COURT_DIVISIONS;

--- a/backend/functions/courts/courts.function.test.ts
+++ b/backend/functions/courts/courts.function.test.ts
@@ -1,17 +1,18 @@
 import { CamsError } from '../lib/common-errors/cams-error';
 import ContextCreator from '../azure/application-context-creator';
 import MockData from '../../../common/src/cams/test-utilities/mock-data';
-import handler from './offices.function';
+import handler from './courts.function';
 import {
   buildTestResponseError,
   buildTestResponseSuccess,
   createMockAzureFunctionContext,
   createMockAzureFunctionRequest,
 } from '../azure/testing-helpers';
-import { OfficesController } from '../lib/controllers/offices/offices.controller';
-import { USTP_OFFICES_ARRAY, UstpOfficeDetails } from '../../../common/src/cams/offices';
+import { CourtsController } from '../lib/controllers/courts/courts.controller';
+import { CourtDivisionDetails } from '../../../common/src/cams/courts';
+import { COURT_DIVISIONS } from '../../../common/src/cams/test-utilities/courts.mock';
 
-describe('offices Function tests', () => {
+describe('Courts Function tests', () => {
   let request;
   let context;
 
@@ -29,13 +30,15 @@ describe('offices Function tests', () => {
     .mockResolvedValue(MockData.getManhattanAssignmentManagerSession());
 
   test('should set successful response', async () => {
-    const bodySuccess: UstpOfficeDetails[] = USTP_OFFICES_ARRAY;
+    const bodySuccess: CourtDivisionDetails[] = COURT_DIVISIONS;
 
-    const { camsHttpResponse, azureHttpResponse } = buildTestResponseSuccess<UstpOfficeDetails[]>({
+    const { camsHttpResponse, azureHttpResponse } = buildTestResponseSuccess<
+      CourtDivisionDetails[]
+    >({
       data: bodySuccess,
     });
 
-    jest.spyOn(OfficesController.prototype, 'handleRequest').mockResolvedValue(camsHttpResponse);
+    jest.spyOn(CourtsController.prototype, 'handleRequest').mockResolvedValue(camsHttpResponse);
 
     const response = await handler(request, context);
 
@@ -48,7 +51,7 @@ describe('offices Function tests', () => {
     });
 
     const { azureHttpResponse, loggerCamsErrorSpy } = buildTestResponseError(error);
-    jest.spyOn(OfficesController.prototype, 'handleRequest').mockRejectedValue(error);
+    jest.spyOn(CourtsController.prototype, 'handleRequest').mockRejectedValue(error);
 
     const response = await handler(request, context);
 

--- a/backend/functions/courts/courts.function.test.ts
+++ b/backend/functions/courts/courts.function.test.ts
@@ -40,7 +40,7 @@ describe('Courts Function tests', () => {
   });
 
   test('should set error response', async () => {
-    const error = new CamsError('MOCK_OFFICES_CONTROLLER', {
+    const error = new CamsError('MOCK_COURTS_CONTROLLER', {
       message: 'Some expected CAMS error.',
     });
 

--- a/backend/functions/courts/courts.function.ts
+++ b/backend/functions/courts/courts.function.ts
@@ -1,0 +1,35 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import ContextCreator from '../azure/application-context-creator';
+import { toAzureError, toAzureSuccess } from '../azure/functions';
+import { CourtsController } from '../lib/controllers/courts/courts.controller';
+
+const MODULE_NAME = 'COURTS_FUNCTION';
+
+export default async function handler(
+  request: HttpRequest,
+  invocationContext: InvocationContext,
+): Promise<HttpResponseInit> {
+  const logger = ContextCreator.getLogger(invocationContext);
+  try {
+    const applicationContext = await ContextCreator.applicationContextCreator(
+      invocationContext,
+      logger,
+      request,
+    );
+    const controller = new CourtsController();
+    applicationContext.session =
+      await ContextCreator.getApplicationContextSession(applicationContext);
+
+    const responseBody = await controller.handleRequest(applicationContext);
+    return toAzureSuccess(responseBody);
+  } catch (error) {
+    return toAzureError(logger, MODULE_NAME, error);
+  }
+}
+
+app.http('courts', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  handler,
+  route: 'courts',
+});

--- a/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.test.ts
@@ -4,8 +4,8 @@ import { ApplicationContext } from '../../types/basic';
 import { createMockApplicationContext } from '../../../testing/testing-utilities';
 import * as database from '../../utils/database';
 import { QueryResults } from '../../types/database';
-import { OFFICES } from '../../../../../../common/src/cams/test-utilities/offices.mock';
-import { USTP_OFFICES_ARRAY, UstpOfficeDetails } from '../../../../../../common/src/cams/courts';
+import { COURT_DIVISIONS } from '../../../../../../common/src/cams/test-utilities/courts.mock';
+import { USTP_OFFICES_ARRAY, UstpOfficeDetails } from '../../../../../../common/src/cams/offices';
 
 describe('offices gateway tests', () => {
   describe('getOffice tests', () => {
@@ -44,7 +44,7 @@ describe('offices gateway tests', () => {
       const mockResults: QueryResults = {
         success: true,
         results: {
-          recordset: OFFICES,
+          recordset: COURT_DIVISIONS,
         },
         message: '',
       };

--- a/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
+++ b/backend/functions/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
@@ -10,7 +10,7 @@ import {
   UstpDivision,
   UstpGroup,
   UstpOfficeDetails,
-} from '../../../../../../common/src/cams/courts';
+} from '../../../../../../common/src/cams/offices';
 
 const MODULE_NAME = 'OFFICES-GATEWAY';
 

--- a/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
+++ b/backend/functions/lib/adapters/gateways/offices.cosmosdb.repository.ts
@@ -2,7 +2,7 @@ import { OfficesRepository } from '../../use-cases/gateways.types';
 import { ApplicationContext } from '../types/basic';
 import { AttorneyUser, CamsUserReference } from '../../../../../common/src/cams/users';
 import { CosmosDbRepository } from './cosmos/cosmos.repository';
-import { UstpOfficeDetails } from '../../../../../common/src/cams/courts';
+import { UstpOfficeDetails } from '../../../../../common/src/cams/offices';
 import { CamsRole } from '../../../../../common/src/cams/roles';
 import { Auditable, createAuditRecord } from '../../../../../common/src/cams/auditable';
 import { getCamsUserReference } from '../../../../../common/src/cams/session';

--- a/backend/functions/lib/adapters/gateways/okta/okta-user-group-gateway.test.ts
+++ b/backend/functions/lib/adapters/gateways/okta/okta-user-group-gateway.test.ts
@@ -154,11 +154,11 @@ describe('OktaGroupGateway', () => {
 
       const expected: CamsUserReference[] = [
         {
-          id: user1.profile.login,
+          id: user1.id,
           name: user1.profile.displayName,
         },
         {
-          id: user2.profile.login,
+          id: user2.id,
           name: user2.profile.lastName + ', ' + user2.profile.firstName,
         },
       ];

--- a/backend/functions/lib/adapters/gateways/okta/okta-user-group-gateway.ts
+++ b/backend/functions/lib/adapters/gateways/okta/okta-user-group-gateway.ts
@@ -152,7 +152,7 @@ async function getUserGroupUsers(
 
     for await (const oktaUser of oktaUsers) {
       camsUserReferences.push({
-        id: oktaUser.profile.login,
+        id: oktaUser.id,
         name:
           oktaUser.profile.displayName ??
           oktaUser.profile.lastName + ', ' + oktaUser.profile.firstName,

--- a/backend/functions/lib/adapters/gateways/storage/local-storage-gateway.ts
+++ b/backend/functions/lib/adapters/gateways/storage/local-storage-gateway.ts
@@ -1,6 +1,6 @@
 import { CamsRole } from '../../../../../../common/src/cams/roles';
 import { StorageGateway } from '../../types/storage';
-import { USTP_OFFICES_ARRAY, UstpOfficeDetails } from '../../../../../../common/src/cams/courts';
+import { USTP_OFFICES_ARRAY, UstpOfficeDetails } from '../../../../../../common/src/cams/offices';
 
 let roleMapping;
 

--- a/backend/functions/lib/adapters/types/storage.ts
+++ b/backend/functions/lib/adapters/types/storage.ts
@@ -1,5 +1,5 @@
 import { CamsRole } from '../../../../../common/src/cams/roles';
-import { UstpOfficeDetails } from '../../../../../common/src/cams/courts';
+import { UstpOfficeDetails } from '../../../../../common/src/cams/offices';
 
 export type StorageGateway = {
   get(key: string): string | null;

--- a/backend/functions/lib/controllers/case-assignment/case.assignment.controller.test.ts
+++ b/backend/functions/lib/controllers/case-assignment/case.assignment.controller.test.ts
@@ -100,6 +100,96 @@ describe('Case Assignment Creation Tests', () => {
     expect(assignmentResponse.body).toBeUndefined();
   });
 
+  test('should identify a singular missing parameter', async () => {
+    const listOfAttorneys: CamsUserReference[] = [Jane, Tom, Jane, Adrian, Tom];
+    const testCaseAssignment = {
+      caseId: undefined,
+      listOfAttorneyNames: listOfAttorneys,
+      role: CamsRole.TrialAttorney,
+    };
+    applicationContext.request = mockCamsHttpRequest({
+      method: 'POST',
+      params: undefined,
+      body: testCaseAssignment,
+    });
+    const assignmentController = new CaseAssignmentController(applicationContext);
+    await expect(assignmentController.handleRequest(applicationContext)).rejects.toThrow(
+      'Required parameter caseId is absent.',
+    );
+  });
+
+  test('should identify plural missing parameters', async () => {
+    const listOfAttorneys: CamsUserReference[] = [Jane, Tom, Jane, Adrian, Tom];
+    const testCaseAssignment = {
+      caseId: undefined,
+      listOfAttorneyNames: listOfAttorneys,
+      role: undefined,
+    };
+    applicationContext.request = mockCamsHttpRequest({
+      method: 'POST',
+      params: undefined,
+      body: testCaseAssignment,
+    });
+    const assignmentController = new CaseAssignmentController(applicationContext);
+    await expect(assignmentController.handleRequest(applicationContext)).rejects.toThrow(
+      'Required parameters caseId, role are absent.',
+    );
+  });
+
+  test('should identify invalid case id', async () => {
+    const listOfAttorneys: CamsUserReference[] = [Jane, Tom, Jane, Adrian, Tom];
+    const testCaseAssignment = {
+      caseId: 'hello',
+      listOfAttorneyNames: listOfAttorneys,
+      role: CamsRole.TrialAttorney,
+    };
+    applicationContext.request = mockCamsHttpRequest({
+      method: 'POST',
+      params: { id: 'bogus-id' },
+      body: testCaseAssignment,
+    });
+    const assignmentController = new CaseAssignmentController(applicationContext);
+    await expect(assignmentController.handleRequest(applicationContext)).rejects.toThrow(
+      'caseId must be formatted like 01-12345.',
+    );
+  });
+
+  test('should identify a bad role assignment', async () => {
+    const listOfAttorneys: CamsUserReference[] = [Jane, Tom, Jane, Adrian, Tom];
+    const testCaseAssignment = {
+      caseId: '081-18-12345',
+      listOfAttorneyNames: listOfAttorneys,
+      role: 'bad-role',
+    };
+    applicationContext.request = mockCamsHttpRequest({
+      method: 'POST',
+      params: { id: '081-18-12345' },
+      body: testCaseAssignment,
+    });
+    const assignmentController = new CaseAssignmentController(applicationContext);
+    await expect(assignmentController.handleRequest(applicationContext)).rejects.toThrow(
+      'Invalid role for the attorney. Requires role to be a TrialAttorney for case assignment.',
+    );
+  });
+
+  test('should identify a bad role assignment', async () => {
+    const listOfAttorneys: CamsUserReference[] = [Jane, Tom, Jane, Adrian, Tom];
+    const testCaseAssignment = {
+      caseId: '081-18-12345',
+      listOfAttorneyNames: listOfAttorneys,
+      role: 'bad-role',
+    };
+    applicationContext.request = mockCamsHttpRequest({
+      method: 'POST',
+      params: { id: '081-18-12345' },
+      body: testCaseAssignment,
+    });
+    const assignmentController = new CaseAssignmentController(applicationContext);
+    await expect(assignmentController.handleRequest(applicationContext)).rejects.toThrow(
+      'Invalid role for the attorney. Requires role to be a TrialAttorney for case assignment.',
+    );
+  });
+
   test('should fetch a list of assignments when a GET request is called', async () => {
     const assignments = MockData.buildArray(MockData.getAttorneyAssignment, 3);
     const camsHttpResponse = httpSuccess({ body: { data: assignments } });

--- a/backend/functions/lib/controllers/courts/courts.controller.test.ts
+++ b/backend/functions/lib/controllers/courts/courts.controller.test.ts
@@ -1,10 +1,10 @@
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { ApplicationContext } from '../../adapters/types/basic';
-import { OfficesController } from './offices.controller';
 import { COURT_DIVISIONS } from '../../../../../common/src/cams/test-utilities/courts.mock';
 import { CamsError } from '../../common-errors/cams-error';
 import { mockCamsHttpRequest } from '../../testing/mock-data/cams-http-request-helper';
 import { UnknownError } from '../../common-errors/unknown-error';
+import { OfficesController } from '../offices/offices.controller';
 
 let getOffices = jest.fn();
 let getOfficeAttorneys = jest.fn();

--- a/backend/functions/lib/controllers/courts/courts.controller.test.ts
+++ b/backend/functions/lib/controllers/courts/courts.controller.test.ts
@@ -3,26 +3,21 @@ import { ApplicationContext } from '../../adapters/types/basic';
 import { COURT_DIVISIONS } from '../../../../../common/src/cams/test-utilities/courts.mock';
 import { CamsError } from '../../common-errors/cams-error';
 import { mockCamsHttpRequest } from '../../testing/mock-data/cams-http-request-helper';
-import { UnknownError } from '../../common-errors/unknown-error';
-import { OfficesController } from '../offices/offices.controller';
+import { CourtsController } from './courts.controller';
 
-let getOffices = jest.fn();
-let getOfficeAttorneys = jest.fn();
-const syncOfficeStaff = jest.fn();
+let getCourts = jest.fn();
 
-jest.mock('../../use-cases/offices/offices', () => {
+jest.mock('../../use-cases/courts/courts', () => {
   return {
-    OfficesUseCase: jest.fn().mockImplementation(() => {
+    CourtsUseCase: jest.fn().mockImplementation(() => {
       return {
-        getOffices,
-        getOfficeAttorneys,
-        syncOfficeStaff,
+        getCourts,
       };
     }),
   };
 });
 
-describe('offices controller tests', () => {
+describe('courts controller tests', () => {
   let applicationContext: ApplicationContext;
 
   beforeEach(async () => {
@@ -33,24 +28,10 @@ describe('offices controller tests', () => {
     jest.restoreAllMocks();
   });
 
-  test('should return successful when handleTimer is called', async () => {
-    const controller = new OfficesController();
-    await expect(controller.handleTimer(applicationContext)).resolves.toBeFalsy();
-    expect(syncOfficeStaff).toHaveBeenCalled();
-  });
-
-  test('should throw error when handleTimer throws', async () => {
-    const error = new UnknownError('TEST_MODULE');
-    syncOfficeStaff.mockRejectedValue(error);
-    const controller = new OfficesController();
-    await expect(controller.handleTimer(applicationContext)).rejects.toThrow(error);
-    expect(syncOfficeStaff).toHaveBeenCalled();
-  });
-
   test('should return successful response', async () => {
-    getOffices = jest.fn().mockResolvedValue(COURT_DIVISIONS);
+    getCourts = jest.fn().mockResolvedValue(COURT_DIVISIONS);
 
-    const controller = new OfficesController();
+    const controller = new CourtsController();
     const camsHttpRequest = mockCamsHttpRequest();
     applicationContext.request = camsHttpRequest;
     const offices = await controller.handleRequest(applicationContext);
@@ -62,77 +43,31 @@ describe('offices controller tests', () => {
         },
       }),
     );
-    expect(getOfficeAttorneys).not.toHaveBeenCalled();
   });
 
   test('should throw CamsError when one is caught', async () => {
-    getOffices = jest
+    getCourts = jest
       .fn()
       .mockRejectedValue(
         new CamsError('MOCK_OFFICES_CONTROLLER', { message: 'Some expected CAMS error.' }),
       );
 
-    const controller = new OfficesController();
+    const controller = new CourtsController();
     const camsHttpRequest = mockCamsHttpRequest();
     applicationContext.request = camsHttpRequest;
     await expect(async () => {
       await controller.handleRequest(applicationContext);
     }).rejects.toThrow('Some expected CAMS error.');
-    expect(getOfficeAttorneys).not.toHaveBeenCalled();
   });
 
   test('should wrap unexpected error in UnknownError', async () => {
-    getOffices = jest.fn().mockRejectedValue(new Error('Some unknown error.'));
+    getCourts = jest.fn().mockRejectedValue(new Error('Some unknown error.'));
 
-    const controller = new OfficesController();
+    const controller = new CourtsController();
     await expect(async () => {
       const camsHttpRequest = mockCamsHttpRequest();
       applicationContext.request = camsHttpRequest;
       await controller.handleRequest(applicationContext);
     }).rejects.toThrow('Unknown error');
-    expect(getOfficeAttorneys).not.toHaveBeenCalled();
-  });
-
-  test('should call getOfficeAttorneys', async () => {
-    getOffices = jest
-      .fn()
-      .mockRejectedValue(new CamsError('TEST', { message: 'some known error' }));
-    getOfficeAttorneys = jest.fn().mockResolvedValue([]);
-
-    const officeCode = 'new-york';
-    const subResource = 'attorneys';
-    const camsHttpRequest = mockCamsHttpRequest({ params: { officeCode, subResource } });
-    applicationContext.request = camsHttpRequest;
-
-    const controller = new OfficesController();
-    const attorneys = await controller.handleRequest(applicationContext);
-    expect(attorneys).toEqual(
-      expect.objectContaining({
-        body: { meta: expect.objectContaining({ self: expect.any(String) }), data: [] },
-      }),
-    );
-    expect(getOffices).not.toHaveBeenCalled();
-    expect(getOfficeAttorneys).toHaveBeenCalledWith(applicationContext, officeCode);
-  });
-
-  test('should throw error for unsupported subResource', async () => {
-    getOffices = jest
-      .fn()
-      .mockRejectedValue(new CamsError('TEST', { message: 'some known error' }));
-    getOfficeAttorneys = jest
-      .fn()
-      .mockRejectedValue(new CamsError('TEST', { message: 'some known error' }));
-
-    const officeCode = 'new-york';
-    const subResource = 'auditors';
-    const camsHttpRequest = mockCamsHttpRequest({ params: { officeCode, subResource } });
-    applicationContext.request = camsHttpRequest;
-
-    const controller = new OfficesController();
-    await expect(async () => {
-      await controller.handleRequest(applicationContext);
-    }).rejects.toThrow(`Sub resource ${subResource} is not supported.`);
-    expect(getOffices).not.toHaveBeenCalled();
-    expect(getOfficeAttorneys).not.toHaveBeenCalled();
   });
 });

--- a/backend/functions/lib/controllers/courts/courts.controller.ts
+++ b/backend/functions/lib/controllers/courts/courts.controller.ts
@@ -1,0 +1,34 @@
+import { ApplicationContext } from '../../adapters/types/basic';
+import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
+import { getCamsError } from '../../common-errors/error-utilities';
+import { CamsController } from '../controller';
+import { CourtsUseCase } from '../../use-cases/courts/courts';
+import { CourtDivisionDetails } from '../../../../../common/src/cams/courts';
+
+const MODULE_NAME = 'COURTS-CONTROLLER';
+
+export class CourtsController implements CamsController {
+  private readonly useCase: CourtsUseCase;
+
+  constructor() {
+    this.useCase = new CourtsUseCase();
+  }
+
+  public async handleRequest(
+    context: ApplicationContext,
+  ): Promise<CamsHttpResponseInit<CourtDivisionDetails[]>> {
+    try {
+      const data = await this.useCase.getCourts(context);
+      return httpSuccess({
+        body: {
+          meta: {
+            self: context.request.url,
+          },
+          data,
+        },
+      });
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME);
+    }
+  }
+}

--- a/backend/functions/lib/controllers/offices/offices.controller.ts
+++ b/backend/functions/lib/controllers/offices/offices.controller.ts
@@ -1,6 +1,6 @@
 import { OfficesUseCase } from '../../use-cases/offices/offices';
 import { ApplicationContext } from '../../adapters/types/basic';
-import { UstpOfficeDetails } from '../../../../../common/src/cams/courts';
+import { UstpOfficeDetails } from '../../../../../common/src/cams/offices';
 import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
 import { getCamsError } from '../../common-errors/error-utilities';
 import { CamsController, CamsTimerController } from '../controller';

--- a/backend/functions/lib/testing/isolated-integration/test-okta-group-api.ts
+++ b/backend/functions/lib/testing/isolated-integration/test-okta-group-api.ts
@@ -13,18 +13,19 @@ async function testOktaGroupApi() {
   console.log(config, '\n');
 
   try {
-    const groups = await OktaUserGroupGateway.getUserGroups(config);
-    console.log('groups', groups, '\n');
-
-    for (const group of groups) {
-      const users = await OktaUserGroupGateway.getUserGroupUsers(config, group);
-      console.log(`${group.name} users`, users, '\n');
-    }
-
     const context = await applicationContextCreator.getApplicationContext({
       invocationContext: new InvocationContext(),
       logger: new LoggerImpl('test-invocation'),
     });
+
+    const groups = await OktaUserGroupGateway.getUserGroups(context, config);
+    console.log('groups', groups, '\n');
+
+    for (const group of groups) {
+      const users = await OktaUserGroupGateway.getUserGroupUsers(context, config, group);
+      console.log(`${group.name} users`, users, '\n');
+    }
+
     const useCase = new OfficesUseCase();
     const results = await useCase.syncOfficeStaff(context);
 

--- a/backend/functions/lib/testing/mock-gateways/mock-oauth2-gateway.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock-oauth2-gateway.ts
@@ -6,7 +6,7 @@ import { CamsUser } from '../../../../../common/src/cams/users';
 import { CamsRole } from '../../../../../common/src/cams/roles';
 import { CamsJwt, CamsJwtClaims, CamsJwtHeader } from '../../../../../common/src/cams/jwt';
 import { OpenIdConnectGateway } from '../../adapters/types/authorization';
-import { USTP_OFFICES_ARRAY } from '../../../../../common/src/cams/courts';
+import { USTP_OFFICES_ARRAY } from '../../../../../common/src/cams/offices';
 
 const MODULE_NAME = 'MOCK_OAUTH2_GATEWAY';
 const mockUsers: MockUser[] = MockUsers;

--- a/backend/functions/lib/testing/mock-gateways/mock.offices.gateway.ts
+++ b/backend/functions/lib/testing/mock-gateways/mock.offices.gateway.ts
@@ -1,4 +1,4 @@
-import { USTP_OFFICES_ARRAY, UstpOfficeDetails } from '../../../../../common/src/cams/courts';
+import { USTP_OFFICES_ARRAY, UstpOfficeDetails } from '../../../../../common/src/cams/offices';
 import { USTP_OFFICE_NAME_MAP } from '../../adapters/gateways/dxtr/dxtr.constants';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { CamsError } from '../../common-errors/cams-error';

--- a/backend/functions/lib/use-cases/case-management.test.ts
+++ b/backend/functions/lib/use-cases/case-management.test.ts
@@ -15,7 +15,7 @@ import {
   REGION_02_GROUP_BU,
   REGION_02_GROUP_NY,
 } from '../../../../common/src/cams/test-utilities/mock-user';
-import { ustpOfficeToCourtOffice } from '../../../../common/src/cams/courts';
+import { ustpOfficeToCourtDivision } from '../../../../common/src/cams/courts';
 
 const attorneyJaneSmith = { id: '001', name: 'Jane Smith' };
 const attorneyJoeNobel = { id: '002', name: 'Joe Nobel' };
@@ -106,7 +106,7 @@ describe('Case management tests', () => {
 
   describe('getAction tests', () => {
     test('should return post action if user has office with correct division code and Case Assignment Manager role', async () => {
-      const courtOffices = ustpOfficeToCourtOffice(applicationContext.session.user.offices[0]);
+      const courtOffices = ustpOfficeToCourtDivision(applicationContext.session.user.offices[0]);
       const officeDetail = courtOffices[0];
       const caseNumber = '00-00000';
       const bCase = MockData.getCaseDetail({
@@ -211,7 +211,7 @@ describe('Case management tests', () => {
 
     test('should include case assignment action if the user has case assignment role', async () => {
       const officeName = 'Test Office';
-      const courtOffices = ustpOfficeToCourtOffice(applicationContext.session.user.offices[0]);
+      const courtOffices = ustpOfficeToCourtDivision(applicationContext.session.user.offices[0]);
       const officeDetail = courtOffices[0];
       const caseNumber = '00-00000';
       const bCase = MockData.getCaseDetail({

--- a/backend/functions/lib/use-cases/courts/courts.test.ts
+++ b/backend/functions/lib/use-cases/courts/courts.test.ts
@@ -1,0 +1,34 @@
+import { CourtsUseCase } from './courts';
+import { ApplicationContext } from '../../adapters/types/basic';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { OfficesUseCase } from '../offices/offices';
+import { USTP_OFFICES_ARRAY } from '../../../../../common/src/cams/offices';
+import { ustpOfficeToCourtDivision } from '../../../../../common/src/cams/courts';
+
+describe('Courts use case tests', () => {
+  let useCase: CourtsUseCase;
+  let context: ApplicationContext;
+
+  beforeEach(async () => {
+    useCase = new CourtsUseCase();
+    context = await createMockApplicationContext();
+  });
+
+  test('should get courts', async () => {
+    jest.spyOn(OfficesUseCase.prototype, 'getOffices').mockResolvedValue(USTP_OFFICES_ARRAY);
+    const expected = USTP_OFFICES_ARRAY.reduce((acc, office) => {
+      acc.push(...ustpOfficeToCourtDivision(office));
+      return acc;
+    }, []);
+
+    const courts = await useCase.getCourts(context);
+    expect(courts).toEqual(expected);
+  });
+
+  test('should throw errors when errors are encountered', async () => {
+    const errorMessage = 'TestError';
+    jest.spyOn(OfficesUseCase.prototype, 'getOffices').mockRejectedValue(new Error(errorMessage));
+
+    await expect(useCase.getCourts(context)).rejects.toThrow(errorMessage);
+  });
+});

--- a/backend/functions/lib/use-cases/courts/courts.ts
+++ b/backend/functions/lib/use-cases/courts/courts.ts
@@ -1,0 +1,18 @@
+import { ApplicationContext } from '../../adapters/types/basic';
+import {
+  CourtDivisionDetails,
+  ustpOfficeToCourtDivision,
+} from '../../../../../common/src/cams/courts';
+import { OfficesUseCase } from '../offices/offices';
+
+export class CourtsUseCase {
+  public async getCourts(context: ApplicationContext): Promise<CourtDivisionDetails[]> {
+    const officesUseCase = new OfficesUseCase();
+    const offices = await officesUseCase.getOffices(context);
+    const courts = [];
+    offices.forEach((office) => {
+      courts.push(...ustpOfficeToCourtDivision(office));
+    });
+    return courts;
+  }
+}

--- a/backend/functions/lib/use-cases/gateways.types.ts
+++ b/backend/functions/lib/use-cases/gateways.types.ts
@@ -15,7 +15,7 @@ import { CaseAssignmentHistory, CaseHistory } from '../../../../common/src/cams/
 import { CaseDocket } from '../../../../common/src/cams/cases';
 import { OrdersSearchPredicate } from '../../../../common/src/api/search';
 import { AttorneyUser, CamsUserGroup, CamsUserReference } from '../../../../common/src/cams/users';
-import { UstpOfficeDetails } from '../../../../common/src/cams/courts';
+import { UstpOfficeDetails } from '../../../../common/src/cams/offices';
 
 export interface RepositoryResource {
   id?: string;

--- a/backend/functions/lib/use-cases/offices/offices.test.ts
+++ b/backend/functions/lib/use-cases/offices/offices.test.ts
@@ -8,7 +8,7 @@ import { CamsUserGroup, CamsUserReference } from '../../../../../common/src/cams
 import MockData from '../../../../../common/src/cams/test-utilities/mock-data';
 import { RuntimeStateCosmosDbRepository } from '../../adapters/gateways/runtime-state.cosmosdb.repository';
 import { MockOfficesRepository } from '../../testing/mock-gateways/mock-offices.repository';
-import { USTP_OFFICES_ARRAY } from '../../../../../common/src/cams/courts';
+import { USTP_OFFICES_ARRAY } from '../../../../../common/src/cams/offices';
 
 describe('offices use case tests', () => {
   let applicationContext: ApplicationContext;

--- a/backend/functions/lib/use-cases/offices/offices.types.ts
+++ b/backend/functions/lib/use-cases/offices/offices.types.ts
@@ -1,4 +1,4 @@
-import { UstpOfficeDetails } from '../../../../../common/src/cams/courts';
+import { UstpOfficeDetails } from '../../../../../common/src/cams/offices';
 import { ApplicationContext } from '../../adapters/types/basic';
 
 export interface OfficesGateway {

--- a/backend/functions/lib/use-cases/user-session/user-session.ts
+++ b/backend/functions/lib/use-cases/user-session/user-session.ts
@@ -3,7 +3,7 @@ import { ApplicationContext } from '../../adapters/types/basic';
 import { UnauthorizedError } from '../../common-errors/unauthorized-error';
 import { isCamsError } from '../../common-errors/cams-error';
 import { ServerConfigError } from '../../common-errors/server-config-error';
-import { UstpOfficeDetails } from '../../../../../common/src/cams/courts';
+import { UstpOfficeDetails } from '../../../../../common/src/cams/offices';
 import LocalStorageGateway from '../../adapters/gateways/storage/local-storage-gateway';
 import { CamsRole } from '../../../../../common/src/cams/roles';
 import { CamsSession } from '../../../../../common/src/cams/session';

--- a/common/src/cams/courts.test.ts
+++ b/common/src/cams/courts.test.ts
@@ -1,10 +1,6 @@
-import {
-  CourtOfficeDetails,
-  filterCourtByDivision,
-  UstpOfficeDetails,
-  ustpOfficeToCourtOffice,
-} from './courts';
-import { OFFICES } from './test-utilities/offices.mock';
+import { CourtDivisionDetails, filterCourtByDivision, ustpOfficeToCourtDivision } from './courts';
+import { COURT_DIVISIONS } from './test-utilities/courts.mock';
+import { UstpOfficeDetails } from './offices';
 
 describe('common court library tests', () => {
   test('should filter court offices list by court division', async () => {
@@ -34,20 +30,20 @@ describe('common court library tests', () => {
         regionName: 'NEW ORLEANS',
       },
     ];
-    const newOfficeList = filterCourtByDivision('3N3', OFFICES);
+    const newOfficeList = filterCourtByDivision('3N3', COURT_DIVISIONS);
 
     expect(newOfficeList.length).toEqual(2);
     expect(newOfficeList).toEqual(expect.arrayContaining([...expectedOffices]));
   });
 
   test('should filter court offices list by court division', async () => {
-    const newOfficeList = filterCourtByDivision('555', OFFICES);
+    const newOfficeList = filterCourtByDivision('555', COURT_DIVISIONS);
     expect(newOfficeList).toBeNull();
   });
 
   test('should map a ustp office to a court office', () => {
     const ustpOffice: UstpOfficeDetails = seattleOffice;
-    const expectedCourtOffices: CourtOfficeDetails[] = [
+    const expectedCourtOffices: CourtDivisionDetails[] = [
       {
         courtDivisionCode: '812',
         courtDivisionName: 'Seattle',
@@ -126,7 +122,7 @@ describe('common court library tests', () => {
         regionName: 'Seattle',
       },
     ];
-    const courtOffices = ustpOfficeToCourtOffice(ustpOffice);
+    const courtOffices = ustpOfficeToCourtDivision(ustpOffice);
     expect(courtOffices).toEqual(expectedCourtOffices);
   });
 });

--- a/common/src/cams/courts.ts
+++ b/common/src/cams/courts.ts
@@ -1,7 +1,17 @@
+import { UstpOfficeDetails } from './offices';
 import { CamsUserReference } from './users';
 
-export function ustpOfficeToCourtOffice(ustp: UstpOfficeDetails): CourtOfficeDetails[] {
-  const courtOffices: CourtOfficeDetails[] = [];
+export function filterCourtByDivision(divisionCode: string, officeList: CourtDivisionDetails[]) {
+  const divisionOffice = officeList.find((office) => office.courtDivisionCode === divisionCode);
+  if (divisionOffice) {
+    return officeList.filter((office) => office.courtId === divisionOffice.courtId);
+  } else {
+    return null;
+  }
+}
+
+export function ustpOfficeToCourtDivision(ustp: UstpOfficeDetails): CourtDivisionDetails[] {
+  const courtOffices: CourtDivisionDetails[] = [];
   ustp.groups.reduce((acc, group) => {
     group.divisions.forEach((division) => {
       acc.push({
@@ -21,7 +31,7 @@ export function ustpOfficeToCourtOffice(ustp: UstpOfficeDetails): CourtOfficeDet
   return courtOffices;
 }
 
-export type CourtOfficeDetails = {
+export type CourtDivisionDetails = {
   officeName: string;
   officeCode: string;
   courtId: string;
@@ -34,217 +44,3 @@ export type CourtOfficeDetails = {
   state?: string;
   staff?: CamsUserReference[];
 };
-
-// THIS IS THE LEGACY MODEL.
-// TODO: Delete this and see what breaks! :)
-export interface OfficeDetails {
-  officeName: string;
-  officeCode: string;
-  courtId: string;
-  courtName: string;
-  courtDivisionCode: string;
-  courtDivisionName: string;
-  groupDesignator: string;
-  regionId: string;
-  regionName: string;
-  state?: string;
-  staff?: CamsUserReference[];
-}
-
-//TODO: Some of these probably do not belong here
-export type UstpOfficeDetails = {
-  officeCode: string; // Active Directory Group name (for now)
-  officeName: string; // https://www.justice.gov/ust/us-trustee-regions-and-offices and dxtr.constants.ts
-  groups: UstpGroup[];
-  idpGroupId: string; // Okta
-  regionId: string; // DXTR AO_REGION
-  regionName: string; // DXTR AO_REGION
-  state?: string; // https://www.justice.gov/ust/us-trustee-regions-and-offices
-  staff?: CamsUserReference[];
-};
-
-export type UstpGroup = {
-  groupDesignator: string; // ACMS Group Office_Regions_and_Divisions.pdf
-  divisions: UstpDivision[];
-};
-
-export type UstpDivision = {
-  divisionCode: string; // ACMS Div Code Office_Regions_and_Divisions.pdf
-  court: Court;
-  courtOffice: CourtOffice;
-};
-
-export type Court = {
-  courtId: string; // DXTR AO_CS_DIV.COURT_ID
-  courtName?: string; // DXTR AO_COURT.COURT_NAME
-};
-
-export type CourtOffice = {
-  courtOfficeCode: string; // DXTR AO_OFFICE.OFFICE_CODE
-  courtOfficeName: string; // DXTR AO_OFFICE.OFFICE_DISPLAY_NAME
-};
-
-export function filterCourtByDivision(divisionCode: string, officeList: OfficeDetails[]) {
-  const divisionOffice = officeList.find((office) => office.courtDivisionCode === divisionCode);
-  if (divisionOffice) {
-    return officeList.filter((office) => office.courtId === divisionOffice.courtId);
-  } else {
-    return null;
-  }
-}
-
-export const USTP_OFFICES_ARRAY: UstpOfficeDetails[] = [
-  {
-    officeCode: 'USTP_CAMS_Region_18_Office_Seattle',
-    idpGroupId: 'USTP CAMS Region 18 Office Seattle',
-    officeName: 'Seattle',
-    groups: [
-      {
-        groupDesignator: 'SE',
-        divisions: [
-          {
-            divisionCode: '812',
-            court: { courtId: '0981', courtName: 'Western District of Washington' },
-            courtOffice: {
-              courtOfficeCode: '2',
-              courtOfficeName: 'Seattle',
-            },
-          },
-          {
-            divisionCode: '813',
-            court: { courtId: '0981', courtName: 'Western District of Washington' },
-            courtOffice: {
-              courtOfficeCode: '3',
-              courtOfficeName: 'Tacoma',
-            },
-          },
-        ],
-      },
-      {
-        groupDesignator: 'AK',
-        divisions: [
-          {
-            divisionCode: '710',
-            court: { courtId: '097-', courtName: 'District of Alaska' },
-            courtOffice: {
-              courtOfficeCode: '1',
-              courtOfficeName: 'Juneau',
-            },
-          },
-          {
-            divisionCode: '720',
-            court: { courtId: '097-', courtName: 'District of Alaska' },
-            courtOffice: {
-              courtOfficeCode: '2',
-              courtOfficeName: 'Nome',
-            },
-          },
-          {
-            divisionCode: '730',
-            court: { courtId: '097-', courtName: 'District of Alaska' },
-            courtOffice: {
-              courtOfficeCode: '3',
-              courtOfficeName: 'Anchorage',
-            },
-          },
-          {
-            divisionCode: '740',
-            court: { courtId: '097-', courtName: 'District of Alaska' },
-            courtOffice: {
-              courtOfficeCode: '4',
-              courtOfficeName: 'Fairbanks',
-            },
-          },
-          {
-            divisionCode: '750',
-            court: { courtId: '097-', courtName: 'District of Alaska' },
-            courtOffice: {
-              courtOfficeCode: '5',
-              courtOfficeName: 'Ketchikan',
-            },
-          },
-        ],
-      },
-    ],
-    regionId: '18',
-    regionName: 'SEATTLE',
-  },
-  {
-    officeCode: 'USTP_CAMS_Region_3_Office_Wilmington',
-    idpGroupId: 'USTP CAMS Region 3 Office Wilmington',
-    officeName: 'Wilmington',
-    groups: [
-      {
-        groupDesignator: 'WL',
-        divisions: [
-          {
-            divisionCode: '111',
-            court: { courtId: '0311', courtName: 'District of Delaware' },
-            courtOffice: {
-              courtOfficeCode: '1',
-              courtOfficeName: 'Delaware',
-            },
-          },
-        ],
-      },
-    ],
-    regionId: '3',
-    regionName: 'PHILADELPHIA',
-  },
-  {
-    officeCode: 'USTP_CAMS_Region_2_Office_Manhattan',
-    idpGroupId: 'USTP CAMS Region 2 Office Manhattan',
-    officeName: 'Manhattan',
-    groups: [
-      {
-        groupDesignator: 'NY',
-        divisions: [
-          {
-            divisionCode: '081',
-            court: { courtId: '0208', courtName: 'Southern District of New York' },
-            courtOffice: {
-              courtOfficeCode: '1',
-              courtOfficeName: 'Manhattan',
-            },
-          },
-          {
-            divisionCode: '087',
-            court: { courtId: '0208', courtName: 'Southern District of New York' },
-            courtOffice: {
-              courtOfficeCode: '7',
-              courtOfficeName: 'White Plains',
-            },
-          },
-        ],
-      },
-    ],
-    regionId: '2',
-    regionName: 'NEW YORK',
-  },
-  {
-    officeCode: 'USTP_CAMS_Region_2_Office_Buffalo',
-    idpGroupId: 'USTP CAMS Region 2 Office Buffalo',
-    officeName: 'Buffalo',
-    groups: [
-      {
-        groupDesignator: 'BU',
-        divisions: [
-          {
-            divisionCode: '091',
-            court: { courtId: '0209', courtName: 'Western District of New York' },
-            courtOffice: {
-              courtOfficeCode: '1',
-              courtOfficeName: 'Buffalo',
-            },
-          },
-        ],
-      },
-    ],
-    regionId: '2',
-    regionName: 'NEW YORK',
-  },
-];
-
-export const USTP_OFFICE_DATA_MAP = new Map<string, UstpOfficeDetails>(
-  USTP_OFFICES_ARRAY.map((office) => [office.officeCode, office]),
-);

--- a/common/src/cams/offices.ts
+++ b/common/src/cams/offices.ts
@@ -1,0 +1,190 @@
+import { CamsUserReference } from './users';
+
+//TODO: Some of these probably do not belong here
+export type UstpOfficeDetails = {
+  officeCode: string; // Active Directory Group name (for now)
+  officeName: string; // https://www.justice.gov/ust/us-trustee-regions-and-offices and dxtr.constants.ts
+  groups: UstpGroup[];
+  idpGroupId: string; // Okta
+  regionId: string; // DXTR AO_REGION
+  regionName: string; // DXTR AO_REGION
+  state?: string; // https://www.justice.gov/ust/us-trustee-regions-and-offices
+  staff?: CamsUserReference[];
+};
+
+export type UstpGroup = {
+  groupDesignator: string; // ACMS Group Office_Regions_and_Divisions.pdf
+  divisions: UstpDivision[];
+};
+
+export type UstpDivision = {
+  divisionCode: string; // ACMS Div Code Office_Regions_and_Divisions.pdf
+  court: Court;
+  courtOffice: CourtOffice;
+};
+
+export type Court = {
+  courtId: string; // DXTR AO_CS_DIV.COURT_ID
+  courtName?: string; // DXTR AO_COURT.COURT_NAME
+};
+
+export type CourtOffice = {
+  courtOfficeCode: string; // DXTR AO_OFFICE.OFFICE_CODE
+  courtOfficeName: string; // DXTR AO_OFFICE.OFFICE_DISPLAY_NAME
+};
+
+export const USTP_OFFICES_ARRAY: UstpOfficeDetails[] = [
+  {
+    officeCode: 'USTP_CAMS_Region_18_Office_Seattle',
+    idpGroupId: 'USTP CAMS Region 18 Office Seattle',
+    officeName: 'Seattle',
+    groups: [
+      {
+        groupDesignator: 'SE',
+        divisions: [
+          {
+            divisionCode: '812',
+            court: { courtId: '0981', courtName: 'Western District of Washington' },
+            courtOffice: {
+              courtOfficeCode: '2',
+              courtOfficeName: 'Seattle',
+            },
+          },
+          {
+            divisionCode: '813',
+            court: { courtId: '0981', courtName: 'Western District of Washington' },
+            courtOffice: {
+              courtOfficeCode: '3',
+              courtOfficeName: 'Tacoma',
+            },
+          },
+        ],
+      },
+      {
+        groupDesignator: 'AK',
+        divisions: [
+          {
+            divisionCode: '710',
+            court: { courtId: '097-', courtName: 'District of Alaska' },
+            courtOffice: {
+              courtOfficeCode: '1',
+              courtOfficeName: 'Juneau',
+            },
+          },
+          {
+            divisionCode: '720',
+            court: { courtId: '097-', courtName: 'District of Alaska' },
+            courtOffice: {
+              courtOfficeCode: '2',
+              courtOfficeName: 'Nome',
+            },
+          },
+          {
+            divisionCode: '730',
+            court: { courtId: '097-', courtName: 'District of Alaska' },
+            courtOffice: {
+              courtOfficeCode: '3',
+              courtOfficeName: 'Anchorage',
+            },
+          },
+          {
+            divisionCode: '740',
+            court: { courtId: '097-', courtName: 'District of Alaska' },
+            courtOffice: {
+              courtOfficeCode: '4',
+              courtOfficeName: 'Fairbanks',
+            },
+          },
+          {
+            divisionCode: '750',
+            court: { courtId: '097-', courtName: 'District of Alaska' },
+            courtOffice: {
+              courtOfficeCode: '5',
+              courtOfficeName: 'Ketchikan',
+            },
+          },
+        ],
+      },
+    ],
+    regionId: '18',
+    regionName: 'SEATTLE',
+  },
+  {
+    officeCode: 'USTP_CAMS_Region_3_Office_Wilmington',
+    idpGroupId: 'USTP CAMS Region 3 Office Wilmington',
+    officeName: 'Wilmington',
+    groups: [
+      {
+        groupDesignator: 'WL',
+        divisions: [
+          {
+            divisionCode: '111',
+            court: { courtId: '0311', courtName: 'District of Delaware' },
+            courtOffice: {
+              courtOfficeCode: '1',
+              courtOfficeName: 'Delaware',
+            },
+          },
+        ],
+      },
+    ],
+    regionId: '3',
+    regionName: 'PHILADELPHIA',
+  },
+  {
+    officeCode: 'USTP_CAMS_Region_2_Office_Manhattan',
+    idpGroupId: 'USTP CAMS Region 2 Office Manhattan',
+    officeName: 'Manhattan',
+    groups: [
+      {
+        groupDesignator: 'NY',
+        divisions: [
+          {
+            divisionCode: '081',
+            court: { courtId: '0208', courtName: 'Southern District of New York' },
+            courtOffice: {
+              courtOfficeCode: '1',
+              courtOfficeName: 'Manhattan',
+            },
+          },
+          {
+            divisionCode: '087',
+            court: { courtId: '0208', courtName: 'Southern District of New York' },
+            courtOffice: {
+              courtOfficeCode: '7',
+              courtOfficeName: 'White Plains',
+            },
+          },
+        ],
+      },
+    ],
+    regionId: '2',
+    regionName: 'NEW YORK',
+  },
+  {
+    officeCode: 'USTP_CAMS_Region_2_Office_Buffalo',
+    idpGroupId: 'USTP CAMS Region 2 Office Buffalo',
+    officeName: 'Buffalo',
+    groups: [
+      {
+        groupDesignator: 'BU',
+        divisions: [
+          {
+            divisionCode: '091',
+            court: { courtId: '0209', courtName: 'Western District of New York' },
+            courtOffice: {
+              courtOfficeCode: '1',
+              courtOfficeName: 'Buffalo',
+            },
+          },
+        ],
+      },
+    ],
+    regionId: '2',
+    regionName: 'NEW YORK',
+  },
+];
+
+export const USTP_OFFICE_DATA_MAP = new Map<string, UstpOfficeDetails>(
+  USTP_OFFICES_ARRAY.map((office) => [office.officeCode, office]),
+);

--- a/common/src/cams/test-utilities/courts.mock.ts
+++ b/common/src/cams/test-utilities/courts.mock.ts
@@ -1,4 +1,4 @@
-import { OfficeDetails } from '../courts';
+import { CourtDivisionDetails } from '../courts';
 
 /***************************************************************************\
  * !! The Following Offices are aligned with legitimate court divisions
@@ -7,7 +7,7 @@ import { OfficeDetails } from '../courts';
  *    this list, and then do a lookup in dxtr.constants.ts ( which is
  *    used in our live system ), DO NOT ADD mock offices to this file.
  \***************************************************************************/
-export const OFFICES: OfficeDetails[] = [
+export const COURT_DIVISIONS: CourtDivisionDetails[] = [
   {
     courtDivisionCode: '710',
     groupDesignator: 'AK',
@@ -3502,7 +3502,7 @@ export const OFFICES: OfficeDetails[] = [
   },
 ];
 
-export const MANHATTAN = OFFICES.find((office) => office.courtDivisionCode === '081');
-export const WHITE_PLAINS = OFFICES.find((office) => office.courtDivisionCode === '087');
-export const BUFFALO = OFFICES.find((office) => office.courtDivisionCode === '091');
-export const DELAWARE = OFFICES.find((office) => office.courtDivisionCode === '111');
+export const MANHATTAN = COURT_DIVISIONS.find((office) => office.courtDivisionCode === '081');
+export const WHITE_PLAINS = COURT_DIVISIONS.find((office) => office.courtDivisionCode === '087');
+export const BUFFALO = COURT_DIVISIONS.find((office) => office.courtDivisionCode === '091');
+export const DELAWARE = COURT_DIVISIONS.find((office) => office.courtDivisionCode === '111');

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -16,7 +16,7 @@ import {
   TransferOrder,
 } from '../orders';
 import { DebtorAttorney, Party } from '../parties';
-import { OFFICES } from './offices.mock';
+import { COURT_DIVISIONS } from './courts.mock';
 import { TRIAL_ATTORNEYS } from './attorneys.mock';
 import { ConsolidationOrderSummary } from '../history';
 import {
@@ -34,7 +34,7 @@ import { CamsJwtClaims } from '../jwt';
 import { Pagination } from '../../api/pagination';
 import { sortDates } from '../../date-helper';
 import { CamsRole } from '../roles';
-import { USTP_OFFICES_ARRAY } from '../courts';
+import { USTP_OFFICES_ARRAY } from '../offices';
 import { REGION_02_GROUP_NY } from './mock-user';
 
 type EntityType = 'company' | 'person';
@@ -78,12 +78,16 @@ function randomEin() {
   return '99-' + ('0000000' + randomInt(9999999)).slice(-7);
 }
 
+function getCourts() {
+  return COURT_DIVISIONS;
+}
+
 function getOffices() {
-  return OFFICES;
+  return USTP_OFFICES_ARRAY;
 }
 
 function randomOffice() {
-  return OFFICES[randomInt(OFFICES.length - 1)];
+  return COURT_DIVISIONS[randomInt(COURT_DIVISIONS.length - 1)];
 }
 
 function randomUstpOffice() {
@@ -557,6 +561,7 @@ export const MockData = {
   getCaseBasics,
   getCaseSummary,
   getCaseDetail,
+  getCourts,
   getOffices,
   getParty,
   getDocketEntry,

--- a/common/src/cams/test-utilities/mock-user.ts
+++ b/common/src/cams/test-utilities/mock-user.ts
@@ -1,4 +1,4 @@
-import { USTP_OFFICE_DATA_MAP, USTP_OFFICES_ARRAY } from '../courts';
+import { USTP_OFFICE_DATA_MAP, USTP_OFFICES_ARRAY } from '../offices';
 import { CamsRole } from '../roles';
 import { CamsUser } from '../users';
 

--- a/common/src/cams/users.ts
+++ b/common/src/cams/users.ts
@@ -1,4 +1,4 @@
-import { UstpOfficeDetails } from './courts';
+import { UstpOfficeDetails } from './offices';
 import { CamsRole } from './roles';
 
 export type CamsUserReference = {

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.test.tsx
@@ -5,8 +5,7 @@ import CaseDetailScreen from '../CaseDetailScreen';
 import { MockData } from '@common/cams/test-utilities/mock-data';
 import { ResourceActions } from '@common/cams/actions';
 import { CaseDetail } from '@common/cams/cases';
-import { MockInstance } from 'vitest';
-import { copyCaseNumber } from '@/lib/utils/caseNumber';
+import * as caseNumber from '@/lib/utils/caseNumber';
 
 function basicRender(caseDetail: ResourceActions<CaseDetail>, isLoading: boolean) {
   render(
@@ -119,39 +118,16 @@ describe('Case Detail Header tests', () => {
   });
 
   describe('Testing the clipboard with caseId', () => {
-    let writeTextMock: MockInstance<(data: string) => Promise<void>> = vi
-      .fn()
-      .mockResolvedValue('');
-
-    beforeEach(() => {
-      if (!navigator.clipboard) {
-        Object.assign(navigator, {
-          clipboard: {
-            writeText: writeTextMock,
-          },
-        });
-      } else {
-        writeTextMock = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
-      }
-    });
-
     test('clicking copy button should write caseId to clipboard', async () => {
+      const copySpy = vi.spyOn(caseNumber, 'copyCaseNumber').mockImplementation(vi.fn());
+
       basicRender(testCaseDetail, false);
 
       const caseIdCopyButton = document.querySelector('#header-case-id');
 
       fireEvent.click(caseIdCopyButton!);
 
-      expect(writeTextMock).toHaveBeenCalledWith(testCaseDetail.caseId);
-    });
-
-    test('should only copy to clipboard if we have a valid case number', () => {
-      copyCaseNumber('abcdefg#!@#$%');
-      expect(writeTextMock).not.toHaveBeenCalled();
-
-      copyCaseNumber(testCaseDetail.caseId);
-      expect(writeTextMock).toHaveBeenCalledWith(testCaseDetail.caseId);
-      expect(writeTextMock).toHaveBeenCalledTimes(1);
+      expect(copySpy).toHaveBeenCalledWith(testCaseDetail.caseId);
     });
   });
 });

--- a/user-interface/src/data-verification/DataVerificationScreen.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import DataVerificationScreen, { officeSorter } from './DataVerificationScreen';
+import DataVerificationScreen, { courtSorter } from './DataVerificationScreen';
 import { BrowserRouter } from 'react-router-dom';
 import { formatDate } from '@/lib/utils/datetime';
 import {
@@ -8,7 +8,7 @@ import {
   ConsolidationOrder,
   isConsolidationOrder,
 } from '@common/cams/orders';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 import Api2 from '@/lib/models/api2';
 import MockData from '@common/cams/test-utilities/mock-data';
@@ -30,7 +30,7 @@ describe('Review Orders screen', () => {
   });
 
   test('should sort offices', () => {
-    const testOffices: OfficeDetails[] = [
+    const testOffices: CourtDivisionDetails[] = [
       {
         courtDivisionCode: '001',
         groupDesignator: 'AA',
@@ -80,7 +80,7 @@ describe('Review Orders screen', () => {
         regionName: 'NEW YORK',
       },
     ];
-    const expectedOffices: OfficeDetails[] = [
+    const expectedOffices: CourtDivisionDetails[] = [
       {
         courtDivisionCode: '001',
         groupDesignator: 'AA',
@@ -130,8 +130,8 @@ describe('Review Orders screen', () => {
         regionName: 'NEW YORK',
       },
     ];
-    const actualOffices = testOffices.sort(officeSorter);
-    expect(actualOffices).toEqual<OfficeDetails[]>(expectedOffices);
+    const actualOffices = testOffices.sort(courtSorter);
+    expect(actualOffices).toEqual<CourtDivisionDetails[]>(expectedOffices);
   });
 
   test('should toggle filter button', async () => {

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -16,7 +16,7 @@ import {
   isConsolidationOrder,
   isTransferOrder,
 } from '@common/cams/orders';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import useFeatureFlags, { CONSOLIDATIONS_ENABLED } from '../lib/hooks/UseFeatureFlags';
 import { sortDates } from '@/lib/utils/datetime';
 import { useApi2 } from '@/lib/hooks/UseApi2';
@@ -27,7 +27,7 @@ import { CamsRole } from '@common/cams/roles';
 import LocalStorage from '@/lib/utils/local-storage';
 import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 
-export function officeSorter(a: OfficeDetails, b: OfficeDetails) {
+export function courtSorter(a: CourtDivisionDetails, b: CourtDivisionDetails) {
   const aKey = a.courtName + '-' + a.courtDivisionName;
   const bKey = b.courtName + '-' + b.courtDivisionName;
   if (aKey === bKey) return 0;
@@ -39,7 +39,7 @@ export default function DataVerificationScreen() {
   const [statusFilter, setStatusFilter] = useState<OrderStatus[]>(['pending']);
   const [typeFilter, setTypeFilter] = useState<OrderType[]>(['transfer', 'consolidation']);
   const [regionsMap, setRegionsMap] = useState<Map<string, string>>(new Map());
-  const [officesList, setOfficesList] = useState<Array<OfficeDetails>>([]);
+  const [courts, setCourts] = useState<Array<CourtDivisionDetails>>([]);
   const [orderList, setOrderList] = useState<Array<Order>>([]);
   const [isOrderListLoading, setIsOrderListLoading] = useState(false);
   const alertRef = useRef<AlertRefType>(null);
@@ -75,16 +75,16 @@ export default function DataVerificationScreen() {
       });
   }
 
-  async function getOffices() {
+  async function getCourts() {
     api
-      .getOffices()
+      .getCourts()
       .then((response) => {
-        const officeList = (response as ResponseBody<OfficeDetails[]>).data;
-        setOfficesList(officeList.sort(officeSorter));
+        const courts = (response as ResponseBody<CourtDivisionDetails[]>).data;
+        setCourts(courts.sort(courtSorter));
         setRegionsMap(
-          officeList.reduce((regionsMap, office) => {
-            if (!regionsMap.has(office.regionId)) {
-              regionsMap.set(office.regionId, office.regionName);
+          courts.reduce((regionsMap, court) => {
+            if (!regionsMap.has(court.regionId)) {
+              regionsMap.set(court.regionId, court.regionName);
             }
             return regionsMap;
           }, new Map()),
@@ -148,7 +148,7 @@ export default function DataVerificationScreen() {
 
   useEffect(() => {
     getOrders();
-    getOffices();
+    getCourts();
   }, []);
 
   let visibleItemCount = 0;
@@ -173,7 +173,7 @@ export default function DataVerificationScreen() {
           key={`accordion-${order.id}`}
           order={order}
           regionsMap={regionsMap}
-          officesList={officesList}
+          courts={courts}
           orderType={orderType}
           statusType={orderStatusType}
           onOrderUpdate={handleTransferOrderUpdate}
@@ -184,7 +184,7 @@ export default function DataVerificationScreen() {
           key={`accordion-${order.id}`}
           order={order}
           regionsMap={regionsMap}
-          officesList={officesList}
+          courts={courts}
           orderType={orderType}
           statusType={orderStatusType}
           onOrderUpdate={handleConsolidationOrderUpdate}

--- a/user-interface/src/data-verification/TransferOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/TransferOrderAccordion.test.tsx
@@ -6,7 +6,7 @@ import { TransferOrderAccordion, TransferOrderAccordionProps } from './TransferO
 import { describe } from 'vitest';
 import { orderType, orderStatusType } from '@/lib/utils/labels';
 import { MockData } from '@common/cams/test-utilities/mock-data';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { TransferOrder } from '@common/cams/orders';
 
 vi.mock('../lib/components/CamsSelect', () => import('../lib/components/CamsSelect.mock'));
@@ -44,7 +44,7 @@ describe('TransferOrderAccordion', () => {
   let order: TransferOrder;
   const regionMap = new Map();
   regionMap.set('02', 'NEW YORK');
-  const testOffices: OfficeDetails[] = [
+  const testOffices: CourtDivisionDetails[] = [
     {
       courtDivisionCode: '001',
       groupDesignator: 'AA',
@@ -86,7 +86,7 @@ describe('TransferOrderAccordion', () => {
   function renderWithProps(props?: Partial<TransferOrderAccordionProps>) {
     const defaultProps: TransferOrderAccordionProps = {
       order: order,
-      officesList: testOffices,
+      courts: testOffices,
       orderType,
       statusType: orderStatusType,
       onOrderUpdate: () => {},

--- a/user-interface/src/data-verification/TransferOrderAccordion.tsx
+++ b/user-interface/src/data-verification/TransferOrderAccordion.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import { Accordion } from '@/lib/components/uswds/Accordion';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { TransferOrder } from '@common/cams/orders';
 import { formatDate } from '@/lib/utils/datetime';
 import { getCaseNumber } from '@/lib/utils/caseNumber';
@@ -17,7 +17,7 @@ export interface TransferOrderAccordionProps {
   order: TransferOrder;
   statusType: Map<string, string>;
   orderType: Map<string, string>;
-  officesList: Array<OfficeDetails>;
+  courts: Array<CourtDivisionDetails>;
   regionsMap: Map<string, string>;
   onOrderUpdate: (alertDetails: AlertDetails, order?: TransferOrder) => void;
   onExpand?: (id: string) => void;
@@ -26,7 +26,7 @@ export interface TransferOrderAccordionProps {
 }
 
 export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
-  const { order, hidden, statusType, orderType, officesList, expandedId, onExpand } = props;
+  const { order, hidden, statusType, orderType, courts, expandedId, onExpand } = props;
   const [expanded, setExpanded] = useState<boolean>(false);
 
   const pendingTransferOrderRef = useRef<PendingTransferOrderImperative>(null);
@@ -90,7 +90,7 @@ export function TransferOrderAccordion(props: TransferOrderAccordionProps) {
               <PendingTransferOrder
                 order={order}
                 onOrderUpdate={props.onOrderUpdate}
-                officesList={officesList}
+                officesList={courts}
                 ref={pendingTransferOrderRef}
               />
             )}

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
@@ -7,7 +7,7 @@ import {
   ConsolidationOrderAccordionProps,
 } from '@/data-verification/consolidation/ConsolidationOrderAccordion';
 import { MockData } from '@common/cams/test-utilities/mock-data';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { formatDate } from '@/lib/utils/datetime';
 import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 import { getCaseNumber } from '@/lib/utils/caseNumber';
@@ -46,7 +46,7 @@ describe('ConsolidationOrderAccordion tests', () => {
   const order: ConsolidationOrder = MockData.getConsolidationOrder({
     override: { courtDivisionCode: '081' },
   });
-  const offices: OfficeDetails[] = MockData.getOffices();
+  const offices: CourtDivisionDetails[] = MockData.getCourts();
   const regionMap = new Map();
 
   const onOrderUpdateMockFunc = vi.fn();
@@ -76,7 +76,7 @@ describe('ConsolidationOrderAccordion tests', () => {
   function renderWithProps(props?: Partial<ConsolidationOrderAccordionProps>) {
     const defaultProps: ConsolidationOrderAccordionProps = {
       order,
-      officesList: offices,
+      courts: offices,
       orderType,
       statusType: orderStatusType,
       onOrderUpdate: onOrderUpdateMockFunc,

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
@@ -1,7 +1,7 @@
 import { formatDate } from '@/lib/utils/datetime';
 import { useEffect } from 'react';
 import { ConsolidationOrder } from '@common/cams/orders';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import './ConsolidationOrderAccordion.scss';
 import { getOfficeList } from '@/data-verification/dataVerificationHelper';
 import { getUniqueDivisionCodeOrUndefined } from '@/data-verification/consolidation/consolidationOrderAccordionUtils';
@@ -20,7 +20,7 @@ export interface ConsolidationOrderAccordionProps {
   order: ConsolidationOrder;
   statusType: Map<string, string>;
   orderType: Map<string, string>;
-  officesList: Array<OfficeDetails>;
+  courts: Array<CourtDivisionDetails>;
   regionsMap: Map<string, string>;
   onOrderUpdate: OnOrderUpdate;
   onExpand?: (id: string) => void;
@@ -61,9 +61,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     confirmationModal: consolidationControls.confirmationModal,
     divisionCode: getUniqueDivisionCodeOrUndefined(consolidationStore.order.childCases),
     expandedAccordionId: expandedId!,
-    filteredOfficeRecords: getOfficeList(
-      consolidationStore.filteredOfficesList ?? props.officesList,
-    ),
+    filteredOfficeRecords: getOfficeList(consolidationStore.filteredOfficesList ?? props.courts),
     formattedOrderFiledDate: formatDate(consolidationStore.order.orderDate),
     foundValidCaseNumber: consolidationStore.foundValidCaseNumber,
     hidden: hidden ?? false,

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderModal.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderModal.test.tsx
@@ -95,7 +95,7 @@ describe('ConsolidationOrderModalComponent', () => {
   test('should allow user to approve a consolidation', async () => {
     const id = 'test';
     const childCases = MockData.buildArray(MockData.getCaseSummary, 2);
-    const courts = MockData.getOffices().slice(0, 3);
+    const courts = MockData.getCourts().slice(0, 3);
 
     const leadCase = MockData.getCaseSummary();
     const consolidationType = 'substantive';

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderModal.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderModal.tsx
@@ -8,7 +8,7 @@ import { CaseAssignment } from '@common/cams/assignments';
 import { ConsolidationOrderCase, ConsolidationType, OrderStatus } from '@common/cams/orders';
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import './ConsolidationOrderModal.scss';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
 export type ConfirmActionPendingResults = {
   status: 'pending';
@@ -32,7 +32,7 @@ export interface ConsolidationOrderModalProps {
   id: string;
   onCancel: () => void;
   onConfirm: (results: ConfirmActionResults) => void;
-  courts?: OfficeDetails[];
+  courts?: CourtDivisionDetails[];
 }
 
 export type ShowOptionParams = {

--- a/user-interface/src/data-verification/consolidation/consolidationStore.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationStore.ts
@@ -1,12 +1,12 @@
 import { ConsolidationOrder, ConsolidationOrderCase, ConsolidationType } from '@common/cams/orders';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
 interface ConsolidationStore {
   consolidationType: ConsolidationType | null;
   setConsolidationType(val: ConsolidationType | null): void;
 
-  filteredOfficesList: OfficeDetails[] | null;
-  setFilteredOfficesList(officesList: OfficeDetails[] | null): void;
+  filteredOfficesList: CourtDivisionDetails[] | null;
+  setFilteredOfficesList(officesList: CourtDivisionDetails[] | null): void;
 
   foundValidCaseNumber: boolean;
   setFoundValidCaseNumber(val: boolean): void;

--- a/user-interface/src/data-verification/consolidation/consolidationStoreMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationStoreMock.ts
@@ -1,11 +1,11 @@
 import { ConsolidationOrderAccordionProps } from '@/data-verification/consolidation/ConsolidationOrderAccordion';
-import { filterCourtByDivision, OfficeDetails } from '@common/cams/courts';
+import { filterCourtByDivision, CourtDivisionDetails } from '@common/cams/courts';
 import { ConsolidationStore } from '@/data-verification/consolidation/consolidationStore';
 import { ConsolidationOrder, ConsolidationOrderCase, ConsolidationType } from '@common/cams/orders';
 
 export class ConsolidationStoreMock implements ConsolidationStore {
   consolidationType: ConsolidationType | null = null;
-  filteredOfficesList: OfficeDetails[] | null;
+  filteredOfficesList: CourtDivisionDetails[] | null;
   foundValidCaseNumber: boolean = false;
   isProcessing: boolean = false;
   isDataEnhanced: boolean = false;
@@ -19,7 +19,7 @@ export class ConsolidationStoreMock implements ConsolidationStore {
   selectedCases: ConsolidationOrderCase[] = [];
   showLeadCaseForm: boolean = false;
 
-  constructor(props: ConsolidationOrderAccordionProps, officesList: OfficeDetails[]) {
+  constructor(props: ConsolidationOrderAccordionProps, officesList: CourtDivisionDetails[]) {
     this.filteredOfficesList = filterCourtByDivision(props.order.courtDivisionCode, officesList);
     this.order = props.order;
   }
@@ -28,7 +28,7 @@ export class ConsolidationStoreMock implements ConsolidationStore {
     this.consolidationType = newType;
   };
 
-  setFilteredOfficesList = (val: OfficeDetails[]): void => {
+  setFilteredOfficesList = (val: CourtDivisionDetails[]): void => {
     this.filteredOfficesList = val;
   };
 

--- a/user-interface/src/data-verification/consolidation/consolidationStoreReact.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationStoreReact.ts
@@ -1,15 +1,15 @@
 import { useState } from 'react';
 import { ConsolidationOrder, ConsolidationOrderCase, ConsolidationType } from '@common/cams/orders';
-import { filterCourtByDivision, OfficeDetails } from '@common/cams/courts';
+import { filterCourtByDivision, CourtDivisionDetails } from '@common/cams/courts';
 import { ConsolidationOrderAccordionProps } from '@/data-verification/consolidation/ConsolidationOrderAccordion';
 import { ConsolidationStore } from '@/data-verification/consolidation/consolidationStore';
 
 export function useConsolidationStoreReact(
   props: ConsolidationOrderAccordionProps,
-  officesList: OfficeDetails[],
+  officesList: CourtDivisionDetails[],
 ): ConsolidationStore {
   const [consolidationType, setConsolidationType] = useState<ConsolidationType | null>(null);
-  const [filteredOfficesList, setFilteredOfficesList] = useState<OfficeDetails[] | null>(
+  const [filteredOfficesList, setFilteredOfficesList] = useState<CourtDivisionDetails[] | null>(
     filterCourtByDivision(props.order.courtDivisionCode, officesList),
   );
   const [foundValidCaseNumber, setFoundValidCaseNumber] = useState<boolean>(false);

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
@@ -54,7 +54,7 @@ describe('Consolidation UseCase tests', () => {
       order: mockOrder,
       statusType: orderStatusType,
       orderType: orderType,
-      officesList: MockData.getOffices(),
+      courts: MockData.getCourts(),
       regionsMap: new Map(),
       onOrderUpdate: onOrderUpdateSpy,
       onExpand,

--- a/user-interface/src/data-verification/dataVerificationHelper.test.ts
+++ b/user-interface/src/data-verification/dataVerificationHelper.test.ts
@@ -1,10 +1,10 @@
 import { describe } from 'vitest';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { getOfficeList } from './dataVerificationHelper';
 
 describe('data verification helper tests', () => {
   test('should properly map court information for selection', () => {
-    const offices: OfficeDetails[] = [
+    const offices: CourtDivisionDetails[] = [
       {
         officeName: '',
         officeCode: '',
@@ -43,7 +43,7 @@ describe('data verification helper tests', () => {
   });
 
   test('should get office select options', () => {
-    const testOffices: OfficeDetails[] = [
+    const testOffices: CourtDivisionDetails[] = [
       {
         courtDivisionCode: '001',
         groupDesignator: 'AA',

--- a/user-interface/src/data-verification/dataVerificationHelper.ts
+++ b/user-interface/src/data-verification/dataVerificationHelper.ts
@@ -1,6 +1,6 @@
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
-export function getOfficeList(officesList: OfficeDetails[]) {
+export function getOfficeList(officesList: CourtDivisionDetails[]) {
   const mapOutput = officesList.map((court) => {
     return {
       value: court.courtDivisionCode,

--- a/user-interface/src/data-verification/transfer/PendingTransferOrder.test.tsx
+++ b/user-interface/src/data-verification/transfer/PendingTransferOrder.test.tsx
@@ -1,4 +1,4 @@
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { TransferOrder } from '@common/cams/orders';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe } from 'vitest';
@@ -23,7 +23,7 @@ const mockGetTransferredCaseSuggestionsEmpty = { data: [] };
 
 const regionMap = new Map();
 regionMap.set('02', 'NEW YORK');
-const testOffices: OfficeDetails[] = [
+const testOffices: CourtDivisionDetails[] = [
   {
     courtDivisionCode: '001',
     groupDesignator: 'AA',

--- a/user-interface/src/data-verification/transfer/PendingTransferOrder.tsx
+++ b/user-interface/src/data-verification/transfer/PendingTransferOrder.tsx
@@ -13,7 +13,7 @@ import {
 } from './TransferConfirmationModal';
 import Button, { ButtonRef, UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import { getCaseNumber } from '@/lib/utils/caseNumber';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { SuggestedTransferCases, SuggestedTransferCasesImperative } from './SuggestedTransferCases';
 import { FromCaseSummary } from './FromCaseSummary';
 import { useApi2 } from '@/lib/hooks/UseApi2';
@@ -27,7 +27,7 @@ export type PendingTransferOrderProps = {
   order: TransferOrder;
   onOrderUpdate: (alertDetails: AlertDetails, order?: TransferOrder) => void;
   // TODO: This is a lot of prop drilling. Maybe add a custom hook???
-  officesList: Array<OfficeDetails>;
+  officesList: Array<CourtDivisionDetails>;
 };
 
 export function getOrderTransferFromOrder(order: TransferOrder): FlexibleTransferOrderAction {

--- a/user-interface/src/data-verification/transfer/SuggestedTransferCases.test.tsx
+++ b/user-interface/src/data-verification/transfer/SuggestedTransferCases.test.tsx
@@ -7,7 +7,7 @@ import {
   SuggestedTransferCasesProps,
 } from './SuggestedTransferCases';
 import { OrderStatus, TransferOrder } from '@common/cams/orders';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import { MockData } from '@common/cams/test-utilities/mock-data';
 import { CaseDocketEntry, CaseSummary } from '@common/cams/cases';
@@ -15,7 +15,7 @@ import { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { getCaseNumber } from '@/lib/utils/caseNumber';
 import Api2 from '@/lib/models/api2';
 
-const testOffices: OfficeDetails[] = [
+const testOffices: CourtDivisionDetails[] = [
   {
     courtDivisionCode: '001',
     groupDesignator: 'AA',

--- a/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
+++ b/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import { CaseSummary } from '@common/cams/cases';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { CaseTable, CaseTableImperative } from './CaseTable';
 import Alert, { AlertDetails, UswdsAlertStyle } from '@/lib/components/uswds/Alert';
@@ -24,7 +24,7 @@ enum ValidationStates {
 
 export type SuggestedTransferCasesProps = {
   order: TransferOrder;
-  officesList: OfficeDetails[];
+  officesList: CourtDivisionDetails[];
   onCaseSelection: (bCase: CaseSummary | null) => void;
   onAlert: (alertDetails: AlertDetails) => void;
   onInvalidCaseNumber: () => void;
@@ -40,7 +40,7 @@ function _SuggestedTransferCases(
     ValidationStates.notValidated,
   );
   const [newCaseSummary, setNewCaseSummary] = useState<CaseSummary | null>(null);
-  const [newCaseDivision, setNewCaseDivision] = useState<OfficeDetails | null>(null);
+  const [newCaseDivision, setNewCaseDivision] = useState<CourtDivisionDetails | null>(null);
   const [newCaseNumber, setNewCaseNumber] = useState<string | null>(
     order.docketSuggestedCaseNumber || null,
   );

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -1,6 +1,7 @@
 import { CaseAssignment, StaffAssignmentAction } from '@common/cams/assignments';
 import { CaseBasics, CaseDetail, CaseDocket, CaseSummary } from '@common/cams/cases';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
+import { UstpOfficeDetails } from '@common/cams/offices';
 import { Consolidation } from '@common/cams/events';
 import {
   ConsolidationOrder,
@@ -18,8 +19,9 @@ import { ObjectKeyVal } from '../type-declarations/basic';
 import { ResponseBody } from '@common/api/response';
 import LocalStorage from '../utils/local-storage';
 import Api from './api';
-import MockApi from '../testing/mock-api2';
+import MockApi2 from '../testing/mock-api2';
 import LocalCache from '../utils/local-cache';
+import { DAY } from '../utils/datetime';
 
 interface ApiClient {
   headers: Record<string, string>;
@@ -220,6 +222,11 @@ async function getCaseHistory(caseId: string) {
   return api().get<CaseHistory[]>(`/cases/${caseId}/history`);
 }
 
+async function getCourts() {
+  const path = `/courts`;
+  return withCache({ key: path, ttl: DAY }).get<CourtDivisionDetails[]>(path);
+}
+
 async function getMe() {
   return api().get<CamsSession>(`/me`);
 }
@@ -230,7 +237,8 @@ async function getOfficeAttorneys(officeCode: string) {
 }
 
 async function getOffices() {
-  return api().get<OfficeDetails[]>(`/offices`);
+  const path = `/offices`;
+  return withCache({ key: path, ttl: DAY }).get<UstpOfficeDetails[]>(path);
 }
 
 async function getOrders() {
@@ -275,6 +283,7 @@ export const _Api2 = {
   getCaseAssignments,
   getCaseAssociations,
   getCaseHistory,
+  getCourts,
   getMe,
   getOfficeAttorneys,
   getOffices,
@@ -287,6 +296,6 @@ export const _Api2 = {
   searchCases,
 };
 
-export const Api2 = import.meta.env['CAMS_PA11Y'] === 'true' ? MockApi : _Api2;
+export const Api2 = import.meta.env['CAMS_PA11Y'] === 'true' ? MockApi2 : _Api2;
 
 export default Api2;

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -9,7 +9,7 @@ import { AttorneyUser } from '@common/cams/users';
 import { CaseAssignment, StaffAssignmentAction } from '@common/cams/assignments';
 import { CaseHistory } from '@common/cams/history';
 import { CamsSession } from '@common/cams/session';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import {
   ConsolidationOrder,
   ConsolidationOrderActionApproval,
@@ -18,13 +18,14 @@ import {
   Order,
 } from '@common/cams/orders';
 import { CasesSearchPredicate } from '@common/api/search';
+import { USTP_OFFICES_ARRAY, UstpOfficeDetails } from '@common/cams/offices';
 
 const caseDocketEntries = MockData.buildArray(MockData.getDocketEntry, 5);
 const caseActions = [Actions.ManageAssignments];
 const caseDetails = MockData.getCaseDetail({
   override: { _actions: caseActions, chapter: '15' },
 });
-const offices = MockData.getOffices().slice(0, 5);
+const courts = MockData.getCourts().slice(0, 5);
 
 // Consolidated Lead Case
 const consolidationLeadCaseId = '999-99-00001';
@@ -161,7 +162,11 @@ async function get<T = unknown>(path: string): Promise<ResponseBody<T>> {
     };
   } else if (path.match(/\/offices/)) {
     response = {
-      data: offices,
+      data: USTP_OFFICES_ARRAY,
+    };
+  } else if (path.match(/\/courts/)) {
+    response = {
+      data: courts,
     };
   } else if (path.match(/\/me/)) {
     response = {
@@ -226,12 +231,16 @@ async function getCaseHistory(caseId: string): Promise<ResponseBody<CaseHistory[
   return get<CaseHistory[]>(`/cases/${caseId}/history`);
 }
 
+async function getCourts(): Promise<ResponseBody<CourtDivisionDetails[]>> {
+  return get<CourtDivisionDetails[]>(`/courts`);
+}
+
 async function getMe(): Promise<ResponseBody<CamsSession>> {
   return get<CamsSession>(`/me`);
 }
 
-async function getOffices(): Promise<ResponseBody<OfficeDetails[]>> {
-  return get<OfficeDetails[]>(`/offices`);
+async function getOffices(): Promise<ResponseBody<UstpOfficeDetails[]>> {
+  return get<UstpOfficeDetails[]>(`/offices`);
 }
 
 async function getOrders(): Promise<ResponseBody<Order[]>> {
@@ -274,6 +283,7 @@ export const MockApi2 = {
   getCaseAssignments,
   getCaseAssociations,
   getCaseHistory,
+  getCourts,
   getMe,
   getOffices,
   getOrders,

--- a/user-interface/src/lib/utils/datetime.ts
+++ b/user-interface/src/lib/utils/datetime.ts
@@ -49,3 +49,9 @@ export function sortDatesReverse(dateA: Date | string, dateB: Date | string): nu
   // newest date first
   return sortDates(dateA, dateB) * -1;
 }
+
+// Time units expressed in seconds:
+export const SECOND = 1;
+export const MINUTE = 60;
+export const HOUR = 3600;
+export const DAY = 86400;

--- a/user-interface/src/lib/utils/local-cache.ts
+++ b/user-interface/src/lib/utils/local-cache.ts
@@ -1,10 +1,12 @@
+import { HOUR } from './datetime';
+
 type Cachable<T = unknown> = {
   expiresAfter: number;
   value: T;
 };
 
 const NAMESPACE = 'cams:cache:';
-const DEFAULT_TTL = 3600000; // 60 minutes
+const DEFAULT_TTL = HOUR;
 const canCache = !!window.localStorage && import.meta.env['CAMS_DISABLE_LOCAL_CACHE'] !== 'true';
 
 function isCacheEnabled() {

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -429,7 +429,7 @@ describe('search screen', () => {
   });
 
   test('should show an error alert if offices cannot be retrieved from API', async () => {
-    vi.spyOn(Api2, 'getOffices')
+    vi.spyOn(Api2, 'getCourts')
       .mockRejectedValueOnce({
         message: 'some error',
       })

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -4,12 +4,12 @@ import {
   DEFAULT_SEARCH_LIMIT,
   DEFAULT_SEARCH_OFFSET,
 } from '@common/api/search';
-import { OfficeDetails } from '@common/cams/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import CaseNumberInput from '@/lib/components/CaseNumberInput';
 import { useApi2 } from '@/lib/hooks/UseApi2';
 import { ComboBoxRef, InputRef } from '@/lib/type-declarations/input-fields';
 import { getOfficeList } from '@/data-verification/dataVerificationHelper';
-import { officeSorter } from '@/data-verification/DataVerificationScreen';
+import { courtSorter } from '@/data-verification/DataVerificationScreen';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import './SearchScreen.scss';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
@@ -27,7 +27,7 @@ export default function SearchScreen() {
   });
 
   const [chapterList, setChapterList] = useState<ComboOption[]>([]);
-  const [officesList, setOfficesList] = useState<Array<OfficeDetails>>([]);
+  const [officesList, setOfficesList] = useState<Array<CourtDivisionDetails>>([]);
 
   const caseNumberInputRef = useRef<InputRef>(null);
   const courtSelectionRef = useRef<ComboBoxRef>(null);
@@ -46,11 +46,11 @@ export default function SearchScreen() {
     setChapterList(chapterArray);
   }
 
-  async function getOffices() {
+  async function getCourts() {
     api
-      .getOffices()
+      .getCourts()
       .then((response) => {
-        setOfficesList(response.data.sort(officeSorter));
+        setOfficesList(response.data.sort(courtSorter));
       })
       .catch(() => {
         globalAlert?.error('Cannot load office list');
@@ -126,7 +126,7 @@ export default function SearchScreen() {
   }
 
   useEffect(() => {
-    getOffices();
+    getCourts();
     getChapters();
   }, []);
 


### PR DESCRIPTION
# Purpose

Many places where we were getting office details were actually needing court division details.

# Major Changes

- Replace old OfficeDetails with CourtDivision.
- Add new courts endpoint to get CourtDivisionDetails where USTP office information was being retrieved but we really needed court division.

# Testing/Validation

Automated tests and builds pass.