### PR TITLE
CAMS-283: e2e documentation

### DIFF
--- a/docs/operations/_sidebar.md
+++ b/docs/operations/_sidebar.md
@@ -1,6 +1,7 @@
 <!-- docs/operations/_sidebar.md -->
 
-* [< Back](/)
-* [Deployment](/operations/deployment.md)
-* [Scripts](/operations/scripts.md)
-* [Slots](/operations/slots.md)
+- [< Back](/)
+- [Deployment](/operations/deployment.md)
+- [Scripts](/operations/scripts.md)
+- [Slots](/operations/slots.md)
+- [E2E Tests](/operations/e2e-tests.md)

--- a/docs/operations/e2e-tests.md
+++ b/docs/operations/e2e-tests.md
@@ -4,11 +4,11 @@
 
 To run E2E tests on the CAMS app from your local machine, you will require a .env file within the test/e2e/ directory with the following contents:
 
-`authFile="playwright/.auth/user.json"
-TARGET_HOST=http://localhost:3000
-CAMS_LOGIN_PROVIDER = 'mock | okta | none'
-OKTA_USER_NAME=<if provide is okta>
-OKTA_PASSWORD=<if provider is okta>`
+- `authFile="playwright/.auth/user.json"`
+- `TARGET_HOST=http://localhost:3000`
+- `CAMS_LOGIN_PROVIDER = "mock | okta | none"`
+- `OKTA_USER_NAME=<if provide is okta>`
+- `OKTA_PASSWORD=<if provider is okta>`
 
 ## Installation
 
@@ -16,7 +16,22 @@ In order to run playwright locally you will need to install playwright with the 
 
 `npx playwright install --with-deps`
 
-## Running against Local Host
+## Running E2E Tests
+
+### Setup for running against locally hosted application
 
 - When running playwright against the locally hosted application, you will wnt to ensure the NodeApi is running against a clean e2e database or the database needed for testing
+- run the application locally [Running](../running.md)
 - ensure your test/e2e/ .env file has `TARGET_HOST=http://localhost:3000`
+- ensure your test/e2e/ .env file has `CAMS_LOGIN_PROVIDER=mock`
+
+### Running against Deployed Environment
+
+- ensure your test/e2e/ .env file has `TARGET_HOST=https://<targetEnvironmentUrl>`
+- ensure `CAMS_LOGIN_PROVIDER=<targetEnvironmentLoginProvider>`
+- ensure `OKTA_USER_NAME=<targetEnvUser> OKTA_PASSWORD=<targetEnvUserPass>` are set for the proper environment
+
+### Executing the Tests
+
+- Run Headless: within test/e2e/ `npm run headless`
+- Run with playwright UI: within test/e2e/ `npm run ui`

--- a/docs/operations/e2e-tests.md
+++ b/docs/operations/e2e-tests.md
@@ -1,0 +1,22 @@
+# End-2-End Tests
+
+## .env file
+
+To run E2E tests on the CAMS app from your local machine, you will require a .env file within the test/e2e/ directory with the following contents:
+
+`authFile="playwright/.auth/user.json"
+TARGET_HOST=http://localhost:3000
+CAMS_LOGIN_PROVIDER = 'mock | okta | none'
+OKTA_USER_NAME=<if provide is okta>
+OKTA_PASSWORD=<if provider is okta>`
+
+## Installation
+
+In order to run playwright locally you will need to install playwright with the project dependencies. That can be done from your terminal within the test/e2e/ directory:
+
+`npx playwright install --with-deps`
+
+## Running against Local Host
+
+- When running playwright against the locally hosted application, you will wnt to ensure the NodeApi is running against a clean e2e database or the database needed for testing
+- ensure your test/e2e/ .env file has `TARGET_HOST=http://localhost:3000`

--- a/docs/operations/e2e-tests.md
+++ b/docs/operations/e2e-tests.md
@@ -20,8 +20,9 @@ In order to run playwright locally you will need to install playwright with the 
 
 ### Setup for running against locally hosted application
 
-- When running playwright against the locally hosted application, you will want to ensure the NodeApi is running against a clean e2e database or the database needed for testing. `COSMOS_DATABASE_NAME=cams-e2e-<envHash>`
-- run the application locally [Running](../running.md)
+- When running playwright against the locally hosted application, you will want to ensure the NodeApi is running against a clean e2e database or the database needed for testing, and has the following .env values within backend/function : `COSMOS_DATABASE_NAME=cams-e2e-<envHash> CAMS_LOGIN_PROVIDER=mock`
+- Within the user-interface/.env file you will need `CAMS_LOGIN_PROVIDER=mock`
+- For other configuration and to run the application locally [See Running...](../running.md)
 - ensure your test/e2e/ .env file has `TARGET_HOST=http://localhost:3000`
 - ensure your test/e2e/ .env file has `CAMS_LOGIN_PROVIDER=mock`
 

--- a/docs/operations/e2e-tests.md
+++ b/docs/operations/e2e-tests.md
@@ -20,7 +20,7 @@ In order to run playwright locally you will need to install playwright with the 
 
 ### Setup for running against locally hosted application
 
-- When running playwright against the locally hosted application, you will wnt to ensure the NodeApi is running against a clean e2e database or the database needed for testing
+- When running playwright against the locally hosted application, you will wnt to ensure the NodeApi is running against a clean e2e database or the database needed for testing. `COSMOS_DATABASE_NAME=cams-e2e-<envHash>`
 - run the application locally [Running](../running.md)
 - ensure your test/e2e/ .env file has `TARGET_HOST=http://localhost:3000`
 - ensure your test/e2e/ .env file has `CAMS_LOGIN_PROVIDER=mock`

--- a/docs/operations/e2e-tests.md
+++ b/docs/operations/e2e-tests.md
@@ -7,7 +7,7 @@ To run E2E tests on the CAMS app from your local machine, you will require a .en
 - `authFile="playwright/.auth/user.json"`
 - `TARGET_HOST=http://localhost:3000`
 - `CAMS_LOGIN_PROVIDER = "mock | okta | none"`
-- `OKTA_USER_NAME=<if provide is okta>`
+- `OKTA_USER_NAME=<if provider is okta>`
 - `OKTA_PASSWORD=<if provider is okta>`
 
 ## Installation

--- a/docs/operations/e2e-tests.md
+++ b/docs/operations/e2e-tests.md
@@ -20,7 +20,7 @@ In order to run playwright locally you will need to install playwright with the 
 
 ### Setup for running against locally hosted application
 
-- When running playwright against the locally hosted application, you will wnt to ensure the NodeApi is running against a clean e2e database or the database needed for testing. `COSMOS_DATABASE_NAME=cams-e2e-<envHash>`
+- When running playwright against the locally hosted application, you will want to ensure the NodeApi is running against a clean e2e database or the database needed for testing. `COSMOS_DATABASE_NAME=cams-e2e-<envHash>`
 - run the application locally [Running](../running.md)
 - ensure your test/e2e/ .env file has `TARGET_HOST=http://localhost:3000`
 - ensure your test/e2e/ .env file has `CAMS_LOGIN_PROVIDER=mock`


### PR DESCRIPTION
# Purpose

Provide developers documentation for running e2e tests locally

# Major Changes

- added e2e-tests.md outlining running end to end tests locally

# Testing/Validation

N/A

