### PR TITLE
CAMS-451 setup bicep to take an array of networks

### DIFF
--- a/.github/workflows/reusable-database-deploy.yml
+++ b/.github/workflows/reusable-database-deploy.yml
@@ -59,13 +59,13 @@ jobs:
       - name: Deploy database
         id: azure-db-deploy
         run: |
-          allowedSubnet=$(az network vnet subnet show -g ${{ steps.rgNetwork.outputs.out }} --vnet-name ${{ vars.AZ_NETWORK_VNET_NAME }} -n snet-${{ inputs.apiName }} --query id -o tsv)
+          allowedNetworks=$(az network vnet subnet list -g ${{ steps.rgNetwork.outputs.out }} --vnet-name ${{ vars.AZ_NETWORK_VNET_NAME }} --query "[?name=='snet-${{ inputs.apiName }}'].id" -o json)
           ./ops/scripts/pipeline/az-cosmos-deploy.sh \
             -g ${{ secrets.AZURE_RG }} \
             --accountName ${{ secrets.AZ_COSMOS_ACCOUNT_NAME }} \
             --databaseName ${{ secrets.AZ_COSMOS_DATABASE_NAME }} \
             --environmentName ${{ inputs.ghaEnvironment }} \
-            --allowedSubnet ${allowedSubnet} \
+            --allowedNetworks $allowedNetworks \
             --analyticsWorkspaceId ${{ secrets.AZ_ANALYTICS_WORKSPACE_ID }} \
             --actionGroupResourceGroup ${{ secrets.AZ_ANALYTICS_RG }} \
             --actionGroupName ${{ secrets.AZ_ACTION_GROUP_NAME }} \

--- a/ops/cloud-deployment/lib/cosmos/cosmos-account.bicep
+++ b/ops/cloud-deployment/lib/cosmos/cosmos-account.bicep
@@ -59,7 +59,7 @@ param backupRetentionIntervalInHours int = 8
 param backupStorageRedundancy string = 'Geo'
 
 @description('List of allowed subnet resource ids')
-param allowedSubnets array = []
+param allowedNetworks array = []
 
 @description('WARNING: Set CosmosDb account for public access for all. Should be only enable for development environment.')
 param allowAllNetworks bool = false
@@ -80,7 +80,7 @@ var azureIpRules = [
   }
 ]
 
-var allowedSubnetList = [for item in allowedSubnets: {
+var allowedNetworkList = [for item in allowedNetworks: {
   id: item
   ignoreMissingVNetServiceEndpoint: false
 }]
@@ -106,7 +106,7 @@ resource account 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
     ]
     publicNetworkAccess: 'Enabled'
     isVirtualNetworkFilterEnabled: allowAllNetworks ? false : true
-    virtualNetworkRules: allowAllNetworks ? [] : allowedSubnetList
+    virtualNetworkRules: allowAllNetworks ? [] : allowedNetworkList
     ipRules: allowAllNetworks ? [] : azureIpRules
     backupPolicy: {
       type: 'Periodic'

--- a/ops/cloud-deployment/ustp-cams-cosmos.bicep
+++ b/ops/cloud-deployment/ustp-cams-cosmos.bicep
@@ -9,10 +9,7 @@ param databaseName string
 param databaseContainers array = [] // See parameters.json file
 
 @description('Allowed subnet resource id')
-param allowedSubnet string = ''
-
-@description('Allowed subnet resource id')
-param allowedSubnetUstp string = ''
+param allowedNetworks array = []
 
 @description('The resource Id of the workspace.')
 param analyticsWorkspaceId string = ''
@@ -37,7 +34,7 @@ module account './lib/cosmos/cosmos-account.bicep' = {
   params: {
     accountName: accountName
     location: location
-    allowedSubnets: empty(allowedSubnetUstp) ? [allowedSubnet] :  [allowedSubnet, allowedSubnetUstp]
+    allowedNetworks: allowedNetworks
     allowAllNetworks: allowAllNetworks
   }
 }

--- a/ops/scripts/pipeline/az-cosmos-deploy.sh
+++ b/ops/scripts/pipeline/az-cosmos-deploy.sh
@@ -41,8 +41,8 @@ while [[ $# -gt 0 ]]; do
         shift 2
         ;;
 
-    --allowedSubnet)
-        allowedSubnet="${2}"
+    --allowedNetworks)
+        allowedNetworks="${2}"
         shift 2
         ;;
 
@@ -90,10 +90,10 @@ fi
 # Provision and configure primary Webapp Azure CosmosDb resource
 az deployment group create -w -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos.bicep \
     -p ./ops/cloud-deployment/params/ustp-cams-cosmos-containers.parameters.json \
-    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedSubnet="${allowedSubnet}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks=${allowAllNetworks} createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}"
+    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks=${allowAllNetworks} createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}"
 az deployment group create -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos.bicep \
     -p ./ops/cloud-deployment/params/ustp-cams-cosmos-containers.parameters.json \
-    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedSubnet="${allowedSubnet}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks=${allowAllNetworks} createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}"
+    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks=${allowAllNetworks} createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}"
 
 # Provision and configure e2e CosmosDB databases and containers only if slot deployments occur and it doesnt already eist. Otherwise we do not need an e2e database.
 if [[ $e2eCosmosDbExists != 'true' && $e2eCosmosDbExists != true ]]; then


### PR DESCRIPTION
Jira ticket: CAMS-451

# Purpose

Allow USTP to keep access to cosmos from a list of networks

# Major Changes

- updated bicep to take an array
- updated scripts and workflow to accomodate for the array

# Testing/Validation

- ran the script locally against a newly created db

# Notes

This will only work if the service endpoint for Cosmosdb is configured on the subnet or vnet you are allowing access

# Definition of Done:

- [ ] Acceptance criteria met - The system meets all acceptance criteria
- [ ] Feature toggles created - Features that are deployed but not released have toggles
- [ ] Design QA passed - All visual UI looks and works the way it’s supposed to
- [ ] Usability validated - Team ensures the working code is easy to use
- [ ] Accessibility tests passed - System passes automated and manual accessibility tests and supports applicable devices
- [ ] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [ ] Dependency Rule followed - More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain
- [ ] Source code merged - Code has been merged into the main branch
- [ ] 90% unit test coverage achieved - Automated test coverage tools indicate coverage of >= 90%
- [ ] Code reviewed - Code is reviewed by at least two other team members before being merged
- [ ] Code quality checks passed - Code passes all automated quality checks
- [ ] Security scans passed - Code passes expected scans for vulnerabilities and compliance issues
- [ ] Threat model updated - The threat model incorporates new threats and remediations
- [ ] Build process updated - Automated build process include code supporting the user story
- [ ] Load/performance tests passed - Performance tests include the functionality of the user story
- [ ] Documents are updated - All required documentation is up to date and version controlled
- [ ] Code is deployed - Code is deployed to the highest production like environment
