### PR TITLE
CAMS-451 corrected middleware Ips for cosmos

### DIFF
--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-account.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-account.bicep
@@ -89,19 +89,16 @@ var azureIpArray = [for item in allowedIps:{
 // Enable Azure Portal access
 var azureIpRules = concat(azureIpArray,[
   {
-    ipAddressOrRange: '0.0.0.0'
+    ipAddressOrRange: '52.244.134.181'
+  }
+  {
+    ipAddressOrRange: '52.244.176.112'
   }
   {
     ipAddressOrRange: '52.247.148.42'
   }
   {
     ipAddressOrRange: '52.247.163.6'
-  }
-  {
-    ipAddressOrRange: '52.244.134.181'
-  }
-  {
-    ipAddressOrRange: '52.247.176.112'
   }
 ])
 


### PR DESCRIPTION
Jira ticket: CAMS-451

# Purpose

add azure portal access to cosmos during deployment

# Major Changes

 corrected cosmos middleware Ips and removed 0.0.0.0 for security

# Testing/Validation

deploy*


