### PR TITLE
CAMS-478 - Prefetch office staff and cache on login

### DIFF
--- a/backend/functions/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
@@ -62,7 +62,11 @@ describe('offices repo', () => {
       .mockResolvedValue('inserted-id');
 
     await repo.putOfficeStaff(officeCode, session.user);
-    expect(replaceOneSpy).toHaveBeenCalledWith(expect.anything(), staff, true);
+    expect(replaceOneSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      { ...staff, updatedOn: expect.anything() },
+      true,
+    );
   });
 
   describe('error handling', () => {

--- a/user-interface/src/login/Session.test.tsx
+++ b/user-interface/src/login/Session.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import * as reactRouter from 'react-router';
 import { CamsSession } from '@common/cams/session';
@@ -6,12 +6,15 @@ import LocalStorage from '@/lib/utils/local-storage';
 import { LOGIN_PATHS, LOGIN_SUCCESS_PATH } from './login-library';
 import { Session, SessionProps } from './Session';
 import { MockData } from '@common/cams/test-utilities/mock-data';
+import Api2 from '@/lib/models/api2';
+import { USTP_OFFICE_DATA_MAP } from '@common/cams/offices';
 
 describe('Session', () => {
   const testSession: CamsSession = {
     user: {
       id: 'mockId',
       name: 'Mock User',
+      offices: [USTP_OFFICE_DATA_MAP.get('USTP_CAMS_Region_2_Office_Manhattan')!],
     },
     provider: 'mock',
     accessToken: MockData.getJwt(),
@@ -33,6 +36,14 @@ describe('Session', () => {
       </BrowserRouter>,
     );
   }
+
+  test('should prefetch office staff for each division the user is assigned to', () => {
+    const getOfficeAttorneys = vi.spyOn(Api2, 'getOfficeAttorneys');
+    renderWithProps();
+    waitFor(() => {
+      expect(getOfficeAttorneys).toHaveBeenCalledTimes(testSession.user.offices!.length);
+    });
+  });
 
   test('should write the session to local storage', () => {
     const setSession = vi.spyOn(LocalStorage, 'setSession');

--- a/user-interface/src/login/Session.tsx
+++ b/user-interface/src/login/Session.tsx
@@ -21,6 +21,12 @@ export function useStateAndActions() {
     errorMessage: '',
   });
 
+  function postLoginTasks(session: CamsSession) {
+    session.user.offices?.forEach((office) => {
+      Api2.getOfficeAttorneys(office.officeCode);
+    });
+  }
+
   function getMe() {
     if (state.isLoaded) return;
     const newState = { ...state };
@@ -28,6 +34,7 @@ export function useStateAndActions() {
       .then((response) => {
         const session = response.data;
         LocalStorage.setSession(session);
+        postLoginTasks(session);
         newState.isLoaded = true;
       })
       .catch((error) => {


### PR DESCRIPTION
# Purpose

Preload office staff on login

# Major Changes

* Async called get office staff endpoint upon login in Session component
 
# Testing/Validation

Unit tests


