### PR TITLE
CAMS-476 - Add broadcast logout functionality

### DIFF
--- a/user-interface/src/lib/humble/broadcast-channel-humble.ts
+++ b/user-interface/src/lib/humble/broadcast-channel-humble.ts
@@ -1,0 +1,19 @@
+export class BroadcastChannelHumble {
+  private channel: BroadcastChannel;
+
+  constructor(channelName: string) {
+    this.channel = new BroadcastChannel(channelName);
+  }
+
+  onMessage(handler: (event: MessageEvent) => void) {
+    this.channel.onmessage = handler;
+  }
+
+  postMessage(message: unknown) {
+    this.channel.postMessage(message);
+  }
+
+  close() {
+    this.channel.close();
+  }
+}

--- a/user-interface/src/login/Login.tsx
+++ b/user-interface/src/login/Login.tsx
@@ -21,6 +21,7 @@ import ApiConfiguration from '@/configuration/apiConfiguration';
 import { CamsUser } from '@common/cams/users';
 import { CamsSession } from '@common/cams/session';
 import { SUPERUSER } from '@common/cams/test-utilities/mock-user';
+import { initializeBroadcastLogout } from '@/login/broadcast-logout';
 
 export type LoginProps = PropsWithChildren & {
   provider?: LoginProvider;
@@ -42,6 +43,7 @@ export function Login(props: LoginProps): React.ReactNode {
 
   addApiAfterHook(http401Hook);
   initializeInactiveLogout();
+  initializeBroadcastLogout();
 
   const session: CamsSession | null = LocalStorage.getSession();
   if (session) {

--- a/user-interface/src/login/SessionEnd.tsx
+++ b/user-interface/src/login/SessionEnd.tsx
@@ -5,6 +5,7 @@ import Button from '@/lib/components/uswds/Button';
 import { LocalStorage } from '@/lib/utils/local-storage';
 import { LOGIN_PATH, LOGOUT_SESSION_END_PATH } from './login-library';
 import { BlankPage } from './BlankPage';
+import { broadcastLogout } from '@/login/broadcast-logout';
 
 export function SessionEnd() {
   const location = useLocation();
@@ -16,6 +17,7 @@ export function SessionEnd() {
 
   LocalStorage.removeSession();
   LocalStorage.removeAck();
+  broadcastLogout();
 
   useEffect(() => {
     if (location.pathname !== LOGOUT_SESSION_END_PATH) {

--- a/user-interface/src/login/broadcast-logout.test.ts
+++ b/user-interface/src/login/broadcast-logout.test.ts
@@ -10,7 +10,7 @@ describe('Broadcast Logout', () => {
     const postMessageSpy = vi
       .spyOn(BroadcastChannelHumble.prototype, 'postMessage')
       .mockReturnValue();
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     let onMessageFn: Function = vi.fn();
     const onMessageSpy = vi
       .spyOn(BroadcastChannelHumble.prototype, 'onMessage')

--- a/user-interface/src/login/broadcast-logout.test.ts
+++ b/user-interface/src/login/broadcast-logout.test.ts
@@ -1,4 +1,63 @@
-// TODO: Need to write a humble object that proxies the BroadcastChanner API so we can test.
+import { BroadcastChannelHumble } from '@/lib/humble/broadcast-channel-humble';
+import { broadcastLogout, initializeBroadcastLogout } from '@/login/broadcast-logout';
+
 describe('Broadcast Logout', () => {
-  test('should call postMessage', () => {});
+  test('should handle broadcast-logout properly', () => {
+    const postMessageSpy = vi
+      .spyOn(BroadcastChannelHumble.prototype, 'postMessage')
+      .mockReturnValue();
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    let onMessageFn: Function = vi.fn();
+    const onMessageSpy = vi
+      .spyOn(BroadcastChannelHumble.prototype, 'onMessage')
+      .mockImplementation((arg) => {
+        onMessageFn = arg;
+      });
+
+    const closeSpy = vi.spyOn(BroadcastChannelHumble.prototype, 'close').mockReturnValue();
+
+    global.window = Object.create(window);
+    global.window.location = {
+      ancestorOrigins: {
+        length: 1,
+        contains: vi.fn(),
+        item: vi.fn(() => ''),
+        [Symbol.iterator]: function (): ArrayIterator<string> {
+          throw new Error('Function not implemented.');
+        },
+      },
+      hash: '',
+      host: 'some-host',
+      hostname: '',
+      href: '',
+      origin: 'http://dummy.com',
+      pathname: '',
+      port: '',
+      protocol: 'http:',
+      search: '',
+      assign: function (url: string | URL): void {
+        console.log('URL::::::: ' + url);
+        return;
+      },
+      reload: function (): void {
+        throw new Error('Function not implemented.');
+      },
+      replace: function (_url: string | URL): void {
+        throw new Error('Function not implemented.');
+      },
+    };
+    vi.spyOn(global.window.location, 'assign');
+    const expectedUrl =
+      global.window.location.protocol + '//' + global.window.location.host + '/logout';
+
+    initializeBroadcastLogout();
+    broadcastLogout();
+    expect(postMessageSpy).toHaveBeenCalledWith('I am testing this');
+    expect(onMessageSpy).toHaveBeenCalledWith(expect.any(Function));
+    expect(onMessageFn).toEqual(expect.any(Function));
+    onMessageFn();
+    expect(closeSpy).toHaveBeenCalled();
+    expect(global.window.location.assign).toHaveBeenCalledWith(expectedUrl);
+    //TODO: find a way to actually have the postMessage event be handled
+  });
 });

--- a/user-interface/src/login/broadcast-logout.test.ts
+++ b/user-interface/src/login/broadcast-logout.test.ts
@@ -1,5 +1,9 @@
 import { BroadcastChannelHumble } from '@/lib/humble/broadcast-channel-humble';
-import { broadcastLogout, handleLogout, initializeBroadcastLogout } from '@/login/broadcast-logout';
+import {
+  broadcastLogout,
+  handleLogoutBroadcast,
+  initializeBroadcastLogout,
+} from '@/login/broadcast-logout';
 
 describe('Broadcast Logout', () => {
   test('should handle broadcast-logout properly', () => {
@@ -33,8 +37,8 @@ describe('Broadcast Logout', () => {
     expect(postMessageSpy).toHaveBeenCalledWith('Logout all windows');
 
     // Validate initializeBroadcastLogout function
-    expect(onMessageSpy).toHaveBeenCalledWith(handleLogout);
-    expect(onMessageFn).toEqual(handleLogout);
+    expect(onMessageSpy).toHaveBeenCalledWith(handleLogoutBroadcast);
+    expect(onMessageFn).toEqual(handleLogoutBroadcast);
 
     // Validate handleLogout function
     onMessageFn();

--- a/user-interface/src/login/broadcast-logout.test.ts
+++ b/user-interface/src/login/broadcast-logout.test.ts
@@ -1,0 +1,4 @@
+// TODO: Need to write a humble object that proxies the BroadcastChanner API so we can test.
+describe('Broadcast Logout', () => {
+  test('should call postMessage', () => {});
+});

--- a/user-interface/src/login/broadcast-logout.ts
+++ b/user-interface/src/login/broadcast-logout.ts
@@ -3,7 +3,7 @@ import { LOGOUT_PATH } from '@/login/login-library';
 
 let channel: BroadcastChannelHumble;
 
-export function handleLogout() {
+export function handleLogoutBroadcast() {
   const { host, protocol } = window.location;
   const logoutUri = protocol + '//' + host + LOGOUT_PATH;
   window.location.assign(logoutUri);
@@ -12,7 +12,7 @@ export function handleLogout() {
 
 export function initializeBroadcastLogout() {
   channel = new BroadcastChannelHumble('CAMS_logout');
-  channel.onMessage(handleLogout);
+  channel.onMessage(handleLogoutBroadcast);
 }
 
 export function broadcastLogout() {

--- a/user-interface/src/login/broadcast-logout.ts
+++ b/user-interface/src/login/broadcast-logout.ts
@@ -1,8 +1,9 @@
+import { BroadcastChannelHumble } from '@/lib/humble/broadcast-channel-humble';
 import { LOGOUT_PATH } from '@/login/login-library';
 
-let channel: BroadcastChannel;
+let channel: BroadcastChannelHumble;
 
-function handleLogout() {
+export function handleLogout() {
   const { host, protocol } = window.location;
   const logoutUri = protocol + '//' + host + LOGOUT_PATH;
   window.location.assign(logoutUri);
@@ -10,10 +11,10 @@ function handleLogout() {
 }
 
 export function initializeBroadcastLogout() {
-  channel = new BroadcastChannel('CAMS_logout');
-  channel.onmessage = handleLogout;
+  channel = new BroadcastChannelHumble('CAMS_logout');
+  channel.onMessage(handleLogout);
 }
 
 export function broadcastLogout() {
-  channel?.postMessage('');
+  channel?.postMessage('I am testing this');
 }

--- a/user-interface/src/login/broadcast-logout.ts
+++ b/user-interface/src/login/broadcast-logout.ts
@@ -16,5 +16,5 @@ export function initializeBroadcastLogout() {
 }
 
 export function broadcastLogout() {
-  channel?.postMessage('I am testing this');
+  channel?.postMessage('Logout all windows');
 }

--- a/user-interface/src/login/broadcast-logout.ts
+++ b/user-interface/src/login/broadcast-logout.ts
@@ -1,0 +1,19 @@
+import { LOGOUT_PATH } from '@/login/login-library';
+
+let channel: BroadcastChannel;
+
+function handleLogout() {
+  const { host, protocol } = window.location;
+  const logoutUri = protocol + '//' + host + LOGOUT_PATH;
+  window.location.assign(logoutUri);
+  channel?.close();
+}
+
+export function initializeBroadcastLogout() {
+  channel = new BroadcastChannel('CAMS_logout');
+  channel.onmessage = handleLogout;
+}
+
+export function broadcastLogout() {
+  channel?.postMessage('');
+}

--- a/user-interface/vitest.config.mts
+++ b/user-interface/vitest.config.mts
@@ -27,6 +27,7 @@ export default defineConfig({
         '**/data-verification/consolidation/ConsolidationOrderAccordionView.tsx',
         '**/data-verification/consolidation/*Mock.ts',
         '**/*.d.ts',
+        '**/**humble.ts',
         ...coverageConfigDefaults.exclude,
       ],
       thresholds: {


### PR DESCRIPTION
# Purpose

Logout of all windows/tabs when a user logs out of the app in a tab/window.

# Major Changes

- Added event listener to broadcast channel in each window/tab.
- Broadcast logout event over the channel to all windows/tabs.

# Testing/Validation

- Manual testing
- Humble object unit testing
