### PR TITLE
CAMS-440: Added help document to user dropdown menu

### DIFF
--- a/user-interface/src/lib/components/Header.tsx
+++ b/user-interface/src/lib/components/Header.tsx
@@ -42,6 +42,11 @@ function mapNavState(path: string) {
 
 const userMenuItems: MenuItem[] = [
   {
+    label: 'Help',
+    address: 'https://doj365.sharepoint.us/sites/USTP-OIT/SitePages/CAMS.aspx',
+    target: 'cams_help',
+  },
+  {
     label: 'Logout',
     address: LOGOUT_PATH,
   },

--- a/user-interface/src/lib/components/cams/DropdownMenu/DropdownMenu.tsx
+++ b/user-interface/src/lib/components/cams/DropdownMenu/DropdownMenu.tsx
@@ -8,6 +8,7 @@ export type MenuItem = {
   address: string;
   title?: string;
   className?: string;
+  target?: string;
 };
 
 export type DropdownMenuProps = {
@@ -145,6 +146,7 @@ export function DropdownMenu(props: DropdownMenuProps) {
               data-testid={`menu-item-${id}-${idx}`}
               className="usa-nav-link"
               title={item.title ?? ''}
+              target={item.target}
               onKeyDown={handleSubItemKeyDown}
             >
               {item.label}


### PR DESCRIPTION
# Purpose

Add Help menu link to document to the user dropdown menu

# Major Changes

Added link to menu with cams_help browser tab target.  Link goes to sharepoint site.

# Testing/Validation

No testing needed.  Already covered.  Manual testing works.


# Definition of Done:

n/a