### PR TITLE
CAMS-484 corrected param name

### DIFF
--- a/ops/scripts/pipeline/slots/az-slot-start-stop-operations.sh
+++ b/ops/scripts/pipeline/slots/az-slot-start-stop-operations.sh
@@ -13,7 +13,7 @@ operation='start'
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-    -g | --resource-group)
+    -g | --resourceGroup)
         app_rg="${2}"
         shift 2
         ;;


### PR DESCRIPTION
Jira ticket: CAMS-484

# Problem

improperly named resourceGroup parameter for slot operations script

# Solution

renamed resource-group parameter to resourceGroup

# Testing/Validation

ran it locally

# Other Changes

N/A
