### PR TITLE
CAMS-484 fixed ttl for office staff because we only run once a day

### DIFF
--- a/backend/functions/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
+++ b/backend/functions/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
@@ -49,7 +49,7 @@ describe('offices repo', () => {
     const session = await createMockApplicationContextSession();
     const officeCode = 'test_office_code';
 
-    const ttl = 4500;
+    const ttl = 86400;
     const staff = createAuditRecord<OfficeStaff>({
       id: session.user.id,
       documentType: 'OFFICE_STAFF',

--- a/backend/functions/lib/adapters/gateways/mongo/offices.mongo.repository.ts
+++ b/backend/functions/lib/adapters/gateways/mongo/offices.mongo.repository.ts
@@ -26,7 +26,7 @@ export class OfficesMongoRepository extends BaseMongoRepository implements Offic
   }
 
   async putOfficeStaff(officeCode: string, user: CamsUserReference): Promise<void> {
-    const ttl = 4500;
+    const ttl = 86400;
     const staff = createAuditRecord<OfficeStaff>({
       id: user.id,
       documentType: 'OFFICE_STAFF',


### PR DESCRIPTION
Jira ticket: CAMS-484

# Problem

TTL on office staff records not in alignment with once a day office-staff-sync runs

# Solution

- updated the ttl on office staff records to be 86400s or 1day

# Testing/Validation

-deployment*

# Other Changes

N/A
