### PR TITLE
CAMS-461 cleanup helper script

### DIFF
--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -3,9 +3,6 @@ name: Clean up Flexion Azure Resources
 on:
   delete:
 
-  pull_request:
-    types: [closed]
-
   workflow_dispatch:
     inputs:
       hashId:

--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -1,8 +1,11 @@
 name: Clean up Flexion Azure Resources
 
 on:
+  delete:
+
   pull_request:
     types: [closed]
+
   workflow_dispatch:
     inputs:
       hashId:

--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -2,11 +2,10 @@ name: Clean up Flexion Azure Resources
 
 on:
   delete:
-
   workflow_dispatch:
     inputs:
       hashId:
-        description: "Hash id of target branch deployemnt"
+        description: "Hash id of target branch deployment"
         default: ""
         type: string
 

--- a/ops/scripts/utility/check-env-hashes.sh
+++ b/ops/scripts/utility/check-env-hashes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# A utility script useful for beginning dependency updates
+# A utility script useful for identifying deployed branch environments
 
 # Usage
 #   From the root directory, run the following command:
@@ -12,14 +12,17 @@
 Help()
 {
    # Display Help
-   echo "This script runs 'npm update' for all Node projects in the repository."
+   echo "This script prints branch names and their short hashes or checks a"
+   echo "known short hash against existing branches. Default lists remote"
+   echo "branches and their short hashes."
    echo
-   echo "Syntax: ./ops/scripts/utility/update-dependencies.sh [-c|h|r|u]"
+   echo "Syntax: ./ops/scripts/utility/check-env-hashes.sh [-l|h|r|e {hash}]"
    echo "options:"
    echo "l     Check local branches."
    echo "h     Print this Help and exit."
    echo "r     Check remote branches."
-   echo "e     Check against a specific known short hash. Example usage: -e 0a3de4"
+   echo "e     Check against a specific known short hash."
+   echo "      Example usage: -e 0a3de4"
    echo
 }
 

--- a/ops/scripts/utility/check-env-hashes.sh
+++ b/ops/scripts/utility/check-env-hashes.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# A utility script useful for beginning dependency updates
+
+# Usage
+#   From the root directory, run the following command:
+#     ./ops/scripts/utility/check-env-hashes.sh [-l|h|r|e {hash}]
+
+############################################################
+# Help                                                     #
+############################################################
+Help()
+{
+   # Display Help
+   echo "This script runs 'npm update' for all Node projects in the repository."
+   echo
+   echo "Syntax: ./ops/scripts/utility/update-dependencies.sh [-c|h|r|u]"
+   echo "options:"
+   echo "l     Check local branches."
+   echo "h     Print this Help and exit."
+   echo "r     Check remote branches."
+   echo "e     Check against a specific known short hash. Example usage: -e 0a3de4"
+   echo
+}
+
+############################################################
+############################################################
+# Main program                                             #
+############################################################
+############################################################
+LOCAL=true
+REMOTE=true
+while getopts ":hlre:" option; do
+  case $option in
+    h) # display help
+      Help
+      exit;;
+    l) # Local branches
+      LOCAL=true
+      REMOTE=false
+      ;;
+    r) # Remote branches
+      REMOTE=true
+      ;;
+    e) # Existing environment
+      inputHash=${OPTARG}
+      ;;
+    \?) # Invalid option
+      echo "Run with the '-h' option to see valid usage."
+      exit 1
+      ;;
+  esac
+done
+
+branches=()
+if [[ "$LOCAL" = "true" ]]; then
+  mapfile -t localBranches < <(git for-each-ref refs/heads --format='%(refname:short)')
+  branches+=("${localBranches[@]}")
+fi
+if [[ "$REMOTE" = "true" ]]; then
+  mapfile -t remoteBranches < <(git for-each-ref refs/remotes --format='%(refname:short)' | sed 's|^origin/||')
+  branches+=("${remoteBranches[@]}")
+fi
+
+found=false
+for branch in "${branches[@]}"; do
+  # Generate the SHA256 hash
+  hash=$(echo -n "$branch" | openssl sha256 | awk '{print $2}')
+  # Extract the first 6 characters of the hash
+  shortHash="${hash:0:6}"
+  if [[ -z "$inputHash" ]]; then
+    echo "Branch: \"$branch\", Short Hash: \"$shortHash\""
+  else
+    if [ "$shortHash" == "$inputHash" ]; then
+      echo "Matching branch found: $branch"
+      found=true
+      break
+    fi
+  fi
+done
+
+# If -e was used but no branch was found
+if [[ -n "$inputHash" && "$found" = "false" ]]; then
+    echo "No branch found with the short hash: $inputHash"
+    exit 0
+fi


### PR DESCRIPTION
# Purpose

It can be frustrating to figure out what branch a deployed environment belongs to for determining whether we still need it.

# Major Changes

Adds a utility script which can be used to find a deployed environment's branch by it's short hash.

# Testing/Validation

Ran the script, validating behavior using currently deployed branches.

# Notes

Further improvements might include things like taking multiple existing short hashes to find multiple branches in one run.
