### PR TITLE
Use existing shell script to delete database

### DIFF
--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -75,8 +75,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           ./ops/scripts/utility/az-delete-branch-resources.sh \
-          -b ${{ needs.check.outputs.targetBranchHashId }} \
-          -g ${{ secrets.AZ_APP_RG }} \
-          -n ${{ secrets.AZ_NETWORK_RG }} \
-          -r ${{ secrets.AZURE_RG }} \
-          -a ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }}
+          --app-resource-group=${{ secrets.AZ_APP_RG }} \
+          --db-account=${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \
+          --db-resource-group=${{ secrets.AZURE_RG }} \
+          --network-resource-group=${{ secrets.AZ_NETWORK_RG }} \
+          --short-hash=${{ needs.check.outputs.targetBranchHashId }}

--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -73,17 +73,10 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
       - uses: actions/checkout@v3
-      - name: Clean up e2e test database
-        run: |
-          echo "Adding suffix to database name.."
-          e2eDatabaseName="${{ secrets.AZ_COSMOS_DATABASE_NAME }}-e2e-${{ needs.check.outputs.targetBranchHashId }}"
-
-          az cosmosdb mongodb database delete \
-          --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \
-          --name "${e2eDatabaseName}" \
-          --resource-group  ${{ secrets.AZURE_RG }} \
-          --yes
-
-          echo "Finished Removing Database..."
-
-      - run: ./ops/scripts/utility/az-delete-branch-resources.sh ${{ needs.check.outputs.targetBranchHashId }} false
+      - run: |
+          ./ops/scripts/utility/az-delete-branch-resources.sh \
+          -b ${{ needs.check.outputs.targetBranchHashId }} \
+          -g ${{ secrets.AZ_APP_RG }} \
+          -n ${{ secrets.AZ_NETWORK_RG }} \
+          -r ${{ secrets.AZURE_RG }} \
+          -a ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }}

--- a/ops/scripts/utility/az-delete-branch-resources.sh
+++ b/ops/scripts/utility/az-delete-branch-resources.sh
@@ -105,6 +105,8 @@ if [[ ${rgAppExists} != "true" || ${rgNetExists} != "true" || ${dbExists} != "tr
     fi
 fi
 
+echo "Begin clean up of Azure resources for ${hash_id}."
+
 # Disconnect VNET integration from App Service components prior to deleting resources
 if [[ "${rgAppExists}" == "true" ]]; then
     echo "Start disconnecting VNET integration"

--- a/ops/scripts/utility/az-delete-branch-resources.sh
+++ b/ops/scripts/utility/az-delete-branch-resources.sh
@@ -122,12 +122,12 @@ fi
 
 # Delete by resource group
 if [[ "${rgAppExists}" == "true" ]]; then
-    echo "Start deleting resource group ${app_rg}"
+    echo "Start deleting app resource group ${app_rg}"
     az group delete -n "${app_rg}" --yes
 fi
 
 if [[ "${rgNetExists}" == "true" ]]; then
-    echo "Start deleting resource group ${network_rg}"
+    echo "Start deleting network resource group ${network_rg}"
     az group delete -n "${network_rg}" --yes
 fi
 

--- a/ops/scripts/utility/az-delete-branch-resources.sh
+++ b/ops/scripts/utility/az-delete-branch-resources.sh
@@ -13,7 +13,6 @@
 # 2   Required parameter not provided
 # 10+ Validation check errors
 
-
 ############################################################
 # Help                                                     #
 ############################################################
@@ -33,8 +32,6 @@ Help()
   exit 0
 }
 
-set -euo pipefail # ensure job step fails in CI pipeline when error occurs
-
 ############################################################
 # Error                                                    #
 ############################################################
@@ -45,6 +42,12 @@ function error() {
     exit "${code}"
 }
 
+############################################################
+############################################################
+# Main program                                             #
+############################################################
+############################################################
+set -euo pipefail # ensure job step fails in CI pipeline when error occurs
 ignore=false # if true, ignore validation
 
 # Parse named parameters

--- a/ops/scripts/utility/az-delete-branch-resources.sh
+++ b/ops/scripts/utility/az-delete-branch-resources.sh
@@ -136,5 +136,4 @@ if [[ "${dbExists}" == "true" ]]; then
   az cosmosdb mongodb database delete -g bankruptcy-oversight-support-systems -a cosmos-mongo-ustp-cams-dev -n "${e2e_db}" --yes
 fi
 
-
 echo "Completed resource clean up operations."

--- a/ops/scripts/utility/check-env-hashes.sh
+++ b/ops/scripts/utility/check-env-hashes.sh
@@ -2,10 +2,6 @@
 
 # A utility script useful for identifying deployed branch environments
 
-# Usage
-#   From the root directory, run the following command:
-#     ./ops/scripts/utility/check-env-hashes.sh [-l|h|r|e {hash}]
-
 ############################################################
 # Help                                                     #
 ############################################################
@@ -16,18 +12,29 @@ Help()
    echo "known short hash against existing branches. Default lists remote"
    echo "branches and their short hashes."
    echo
-   echo "Syntax: ./ops/scripts/utility/check-env-hashes.sh [-l|h|r|e {hash}]"
-   echo "options:"
-   echo "a     Database account name. Required unless using -e flag."
-   echo "d     Database resource group name. Required unless using -e flag."
-   echo "e     Check against a specific known short hash."
-   echo "g     App resource group name. Required unless using -e flag."
-   echo "h     Print this Help and exit."
-   echo "l     Check local branches."
-   echo "n     Network resource group name. Required unless using -e flag."
-   echo "r     Check remote branches."
-   echo "      Example usage: -e 0a3de4"
-   echo
+   echo "Usage: $0 [options]"
+     echo ""
+     echo "Options:"
+     echo "  --help                             Display this help message."
+     echo "  --app-resource-group-base=<rg>     Application resource group name. **REQUIRED**"
+     echo "  --db-account=<account>             Database account name. **REQUIRED**"
+     echo "  --db-resource-group=<rg>           Database resource group name. **REQUIRED**"
+     echo "  --network-resource-group-base=<rg> Network resource group name. **REQUIRED**"
+     echo "  --existing-hash=<hash>             Branch hash ID for a specific resource. **OPTIONAL**"
+     echo "  --local-branches                   Run against local branches. Overrides default behavior."
+     echo "  --remote-branches                  Run against remote branches. Default behavior. Flag is useful for running both local and remote."
+     echo ""
+     exit 0
+}
+
+############################################################
+# Error                                                    #
+############################################################
+function error() {
+    local msg=$1
+    local code=$2
+    echo "ERROR: ${msg}" >>/dev/stderr
+    exit "${code}"
 }
 
 ############################################################
@@ -37,39 +44,52 @@ Help()
 ############################################################
 LOCAL=true
 REMOTE=true
-while getopts ":a:d:e:g:hln:r" option; do
-  case $option in
-    a) # Database account name
-      db_account=${OPTARG}
-      ;;
-    d) # Database resource group name
-      db_rg=${OPTARG}
-      ;;
-    e) # Existing environment
-      inputHash=${OPTARG}
-      ;;
-    g) # App resource group base name
-      app_rg_base=${OPTARG}
-      ;;
-    h) # display help
+# Parse named parameters
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
       Help
-      exit;;
-    l) # Local branches
+      ;;
+    --app-resource-group-base=*)
+      app_rg_base="${1#*=}"
+      shift
+      ;;
+    --db-account=*)
+      db_account="${1#*=}"
+      shift
+      ;;
+    --db-resource-group=*)
+      db_rg="${1#*=}"
+      shift
+      ;;
+    --network-resource-group-base=*)
+      network_rg_base="${1#*=}"
+      shift
+      ;;
+    --existing-hash=*)
+      inputHash="${1#*=}"
+      shift
+      ;;
+    --local-branches)
       LOCAL=true
       REMOTE=false
+      shift
       ;;
-    n) # Network resource group base name
-      network_rg_base=${OPTARG}
-      ;;
-    r) # Remote branches
+    --remote-branches)
       REMOTE=true
+      shift
       ;;
-    \?) # Invalid option
-      echo "Run with the '-h' option to see valid usage."
+    *)
+      echo "Invalid option: $1"
+      echo "Run with '--help' to see valid usage."
       exit 1
       ;;
   esac
 done
+
+if [[ -z "${inputHash}" && ( -z "${app_rg_base}" || -z "${db_account}" || -z "${db_rg}" || -z "${network_rg_base}" ) ]]; then
+  error "Not all required parameters provided. Run this script with the --help flag for details." 2
+fi
 
 branches=()
 if [[ "$LOCAL" = "true" ]]; then
@@ -103,7 +123,7 @@ for branch in "${branches[@]}"; do
   fi
 done
 
-# If -e was used but no branch was found
+# If --existing-hash was used but no branch was found
 if [[ -n "$inputHash" && "$found" = "false" ]]; then
     echo "No branch found with the short hash: $inputHash"
     exit 0

--- a/ops/scripts/utility/check-env-hashes.sh
+++ b/ops/scripts/utility/check-env-hashes.sh
@@ -22,7 +22,7 @@ Help()
      echo "  --network-resource-group-base=<rg> Network resource group name. **REQUIRED**"
      echo "  --existing-hash=<hash>             Branch hash ID for a specific resource. **OPTIONAL**"
      echo "  --local-branches                   Run against local branches. Overrides default behavior."
-     echo "  --remote-branches                  Run against remote branches. Default behavior. Flag is useful for running both local and remote."
+     echo "  --remote-branches                  Run against remote branches. Default behavior. Needed only in conjunction with --local-branches."
      echo ""
      exit 0
 }


### PR DESCRIPTION
# Purpose

e2e test databases were not being deleted—or at least not always—when the clean up script was run.

# Major Changes

Modifies the clean up script to delete the e2e test database.

# Other Changes

Added logging of whether the resources exist to the check-env-hashed script.

# Testing/Validation

Ran locally as expected.
Ran the workflow against the deployed environment. https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/12381595212

# Notes

The number of required inputs is a bit high. We may want to find a way to support environment variables for local running.