### PR TITLE
CAMS-492 Case Search Bug

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -321,11 +321,8 @@ export default class CasesDxtrGateway implements CasesInterface {
       for (const chapter of predicate.chapters) {
         chapters.push(chapter);
       }
-    } else {
-      chapters.push('15');
+      conditions.push(`cs.CS_CHAPTER IN ('${chapters.join("', '")}')`);
     }
-
-    conditions.push(`cs.CS_CHAPTER IN ('${chapters.join("', '")}')`);
 
     const CASE_SEARCH_QUERY_PREDICATE =
       conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';


### PR DESCRIPTION
Jira ticket: CAMS-492

# Problem

Case search only worked with chapter 15 cases properly, because by default we pushed chapter 15 into the predicate

# Solution

- modified query params to only push  chapters when we have predicate.chapters available


# Testing/Validation

ran locally

# Other Changes

 we might want to push a default set of chapters as the params rather than not querying for them at all like ['7', '9', '11', '12', '13', '15'] 
