### PR TITLE
Add testing library linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
           -   eslint-plugin-jsx-a11y
           -   eslint-plugin-prettier
           -   eslint-plugin-react
+          -   eslint-plugin-testing-library
           -   '@eslint/js'
           -   typescript
           -   typescript-eslint

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -1,11 +1,11 @@
 import eslintTsConfig from '../common/eslint-ts.config.mjs';
-import eslintJestConfig from '../common/eslint-jest.config.mjs';
+import eslintTestConfig from '../common/eslint-test.config.mjs';
 
 const codeConfig = eslintTsConfig.map((configObject) => ({
   files: ['**/*.ts'],
   ...configObject,
 }));
-const testConfig = eslintJestConfig.map((configObject) => ({
+const testConfig = eslintTestConfig.map((configObject) => ({
   files: ['**/*.test.ts'],
   ...configObject,
 }));

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -12,7 +12,7 @@ const testConfig = eslintTestConfig.map((configObject) => ({
 
 const backendEslintConfig = [
   {
-    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*'],
+    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*', '**/coverage/**/*'],
   },
   ...codeConfig,
   ...testConfig,

--- a/common/eslint-test.config.mjs
+++ b/common/eslint-test.config.mjs
@@ -11,7 +11,7 @@ const jest = require('eslint-plugin-jest');
  * This ConfigArray is intended to be the base eslint configuration for all JavaScript
  * family test files (e.g. `.test.[j|t]s`, `.test.[j|t]sx`) that are tested with Jest.
  */
-const eslintJestConfig = tsEslint.config(
+const eslintTestConfig = tsEslint.config(
   eslintTsConfig,
   {
     plugins: jest.configs['flat/recommended']['plugins'],
@@ -35,4 +35,4 @@ const eslintJestConfig = tsEslint.config(
   },
 );
 
-export default eslintJestConfig;
+export default eslintTestConfig;

--- a/common/eslint.config.mjs
+++ b/common/eslint.config.mjs
@@ -12,7 +12,7 @@ const testConfig = eslintTestConfig.map((configObject) => ({
 
 const commonEslintConfig = [
   {
-    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*'],
+    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*', '**/coverage/**/*'],
   },
   ...codeConfig,
   ...testConfig,

--- a/common/eslint.config.mjs
+++ b/common/eslint.config.mjs
@@ -1,11 +1,11 @@
 import eslintTsConfig from './eslint-ts.config.mjs';
-import eslintJestConfig from './eslint-jest.config.mjs';
+import eslintTestConfig from './eslint-test.config.mjs';
 
 const codeConfig = eslintTsConfig.map((configObject) => ({
   files: ['**/*.ts'],
   ...configObject,
 }));
-const testConfig = eslintJestConfig.map((configObject) => ({
+const testConfig = eslintTestConfig.map((configObject) => ({
   files: ['**/*.test.ts'],
   ...configObject,
 }));

--- a/dev-tools/eslint.config.mjs
+++ b/dev-tools/eslint.config.mjs
@@ -1,11 +1,11 @@
 import eslintTsConfig from '../common/eslint-ts.config.mjs';
-import eslintJestConfig from '../common/eslint-jest.config.mjs';
+import eslintTestConfig from '../common/eslint-test.config.mjs';
 
 const codeConfig = eslintTsConfig.map((configObject) => ({
   files: ['**/*.ts'],
   ...configObject,
 }));
-const testConfig = eslintJestConfig.map((configObject) => ({
+const testConfig = eslintTestConfig.map((configObject) => ({
   files: ['**/*.test.ts'],
   ...configObject,
 }));

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,7 +32,7 @@ const jsConfig = eslintJsConfig.map((configObject) => ({
 
 const eslintConfig = [
   {
-    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*'],
+    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*', '**/coverage/**/*'],
   },
   ...frontendSourceConfig,
   ...frontendTestConfig,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,13 @@
 import frontendEslintConfig from './user-interface/eslint.config.mjs';
 import eslintJsConfig from './common/eslint-js.config.mjs';
 import eslintTsConfig from './common/eslint-ts.config.mjs';
-import eslintJestConfig from './common/eslint-jest.config.mjs';
+import eslintTestConfig from './common/eslint-test.config.mjs';
 
 const frontendSourceConfig = frontendEslintConfig.map((configObject) => ({
   files: ['user-interface/**/*.ts', 'user-interface/**/*.tsx'],
   ...configObject,
 }));
-const vitestConfig = frontendEslintConfig.map((configObject) => ({
+const frontendTestConfig = frontendEslintConfig.map((configObject) => ({
   files: ['user-interface/**/*.test.ts', 'user-interface/**/*.test.tsx'],
   ...configObject,
 }));
@@ -15,7 +15,7 @@ const sourceConfig = eslintTsConfig.map((configObject) => ({
   files: ['backend/**/*.ts', 'common/**/*.ts', 'dev-tools/**/*.ts', 'test/e2e/**/*.ts'],
   ...configObject,
 }));
-const jestConfig = eslintJestConfig.map((configObject) => ({
+const testConfig = eslintTestConfig.map((configObject) => ({
   files: [
     'backend/**/*.test.ts',
     'common/**/*.test.ts',
@@ -34,9 +34,9 @@ const eslintConfig = [
     ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*'],
   },
   ...frontendSourceConfig,
-  ...vitestConfig,
+  ...frontendTestConfig,
   ...sourceConfig,
-  ...jestConfig,
+  ...testConfig,
   ...jsConfig,
 ];
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,14 @@
-import frontendEslintConfig from './user-interface/eslint.config.mjs';
 import eslintJsConfig from './common/eslint-js.config.mjs';
 import eslintTsConfig from './common/eslint-ts.config.mjs';
 import eslintTestConfig from './common/eslint-test.config.mjs';
+import eslintUiTestConfig from './user-interface/eslint-ui-test.config.mjs';
+import eslintUiConfig from './user-interface/eslint-ui.config.mjs';
 
-const frontendSourceConfig = frontendEslintConfig.map((configObject) => ({
+const frontendSourceConfig = eslintUiConfig.map((configObject) => ({
   files: ['user-interface/**/*.ts', 'user-interface/**/*.tsx'],
   ...configObject,
 }));
-const frontendTestConfig = frontendEslintConfig.map((configObject) => ({
+const frontendTestConfig = eslintUiTestConfig.map((configObject) => ({
   files: ['user-interface/**/*.test.ts', 'user-interface/**/*.test.tsx'],
   ...configObject,
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.37.3",
+        "eslint-plugin-testing-library": "^7.1.1",
         "prettier": "^3.4.2",
         "react": "^18.3.1",
         "typescript": "^5.7.2",
@@ -3015,6 +3016,23 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.1.1.tgz",
+      "integrity": "sha512-nszC833aZPwB6tik1nMkbFqmtgIXTT0sfJEYs0zMBKMlkQ4to2079yUV96SvmLh00ovSBJI4pgcBC1TiIP8mXg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.15.0",
+        "@typescript-eslint/utils": "^8.15.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+        "pnpm": "^9.14.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.37.3",
         "prettier": "^3.4.2",
+        "react": "^18.3.1",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.2"
       }
@@ -5732,6 +5733,18 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.3",
+    "eslint-plugin-testing-library": "^7.1.1",
     "prettier": "^3.4.2",
     "react": "^18.3.1",
     "typescript": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.3",
     "prettier": "^3.4.2",
+    "react": "^18.3.1",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.2"
   }

--- a/test/e2e/eslint.config.mjs
+++ b/test/e2e/eslint.config.mjs
@@ -12,7 +12,7 @@ const testConfig = eslintTestConfig.map((configObject) => ({
 
 const e2eEslintConfig = [
   {
-    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*'],
+    ignores: ['**/node_modules/**/*', '**/playwright-report/**/*', '**/test-results/**/*'],
   },
   ...codeConfig,
   ...testConfig,

--- a/test/e2e/eslint.config.mjs
+++ b/test/e2e/eslint.config.mjs
@@ -1,11 +1,11 @@
 import eslintTsConfig from '../../common/eslint-ts.config.mjs';
-import eslintJestConfig from '../../common/eslint-jest.config.mjs';
+import eslintTestConfig from '../../common/eslint-test.config.mjs';
 
 const codeConfig = eslintTsConfig.map((configObject) => ({
   files: ['**/*.ts'],
   ...configObject,
 }));
-const testConfig = eslintJestConfig.map((configObject) => ({
+const testConfig = eslintTestConfig.map((configObject) => ({
   files: ['**/*.test.ts'],
   ...configObject,
 }));

--- a/user-interface/eslint-ui-test.config.mjs
+++ b/user-interface/eslint-ui-test.config.mjs
@@ -1,0 +1,31 @@
+import eslintUiConfig from './eslint-ui.config.mjs';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+const tsEslint = require('typescript-eslint');
+const testingLibrary = require('eslint-plugin-testing-library');
+
+/**
+ * eslintUiTestConfig
+ *
+ * This ConfigArray is intended to be the eslint configuration for TypeScript
+ * family test files (e.g. `.test.ts`, `.test.tsx`).
+ */
+const eslintUiTestConfig = tsEslint.config(
+  eslintUiConfig,
+  {
+    plugins: testingLibrary.configs['flat/react']['plugins'],
+  },
+  {
+    files: ['**/*.test.ts', '**/*.test.tsx'],
+    rules: {
+      'testing-library/no-dom-import': 'error',
+      'testing-library/no-unnecessary-act': 'error',
+      'testing-library/await-async-events': 'error',
+      'testing-library/no-manual-cleanup': 'error',
+      'testing-library/no-node-access': 'off',
+    },
+  },
+);
+
+export default eslintUiTestConfig;

--- a/user-interface/eslint-ui-test.config.mjs
+++ b/user-interface/eslint-ui-test.config.mjs
@@ -19,11 +19,28 @@ const eslintUiTestConfig = tsEslint.config(
   {
     files: ['**/*.test.ts', '**/*.test.tsx'],
     rules: {
-      'testing-library/no-dom-import': 'error',
-      'testing-library/no-unnecessary-act': 'error',
       'testing-library/await-async-events': 'error',
+      'testing-library/await-async-queries': 'error',
+      'testing-library/await-async-utils': 'warn', // default: error
+      'testing-library/no-await-sync-events': 'error',
+      'testing-library/no-await-sync-queries': 'error',
+      'testing-library/no-container': 'warn', // default: error
+      'testing-library/no-debugging-utils': 'warn',
+      'testing-library/no-dom-import': 'error',
+      'testing-library/no-global-regexp-flag-in-query': 'error',
       'testing-library/no-manual-cleanup': 'error',
-      'testing-library/no-node-access': 'off',
+      'testing-library/no-node-access': 'off', // default: error
+      'testing-library/no-promise-in-fire-event': 'error',
+      'testing-library/no-render-in-lifecycle': 'warn', // default: error
+      'testing-library/no-unnecessary-act': 'error',
+      'testing-library/no-wait-for-multiple-assertions': 'warn', // default: error
+      'testing-library/no-wait-for-side-effects': 'warn', // default: error
+      'testing-library/no-wait-for-snapshot': 'error',
+      'testing-library/prefer-find-by': 'error',
+      'testing-library/prefer-presence-queries': 'warn', // default: error
+      'testing-library/prefer-query-by-disappearance': 'error',
+      'testing-library/prefer-screen-queries': 'warn', // default: error
+      'testing-library/render-result-naming-convention': 'error',
     },
   },
 );

--- a/user-interface/eslint-ui-test.config.mjs
+++ b/user-interface/eslint-ui-test.config.mjs
@@ -1,5 +1,6 @@
 import eslintUiConfig from './eslint-ui.config.mjs';
 import { createRequire } from 'module';
+
 const require = createRequire(import.meta.url);
 
 const tsEslint = require('typescript-eslint');
@@ -11,38 +12,33 @@ const testingLibrary = require('eslint-plugin-testing-library');
  * This ConfigArray is intended to be the eslint configuration for TypeScript
  * family test files (e.g. `.test.ts`, `.test.tsx`).
  */
-const eslintUiTestConfig = tsEslint.config(
-  eslintUiConfig,
-  {
-    plugins: testingLibrary.configs['flat/react']['plugins'],
+const eslintUiTestConfig = tsEslint.config(eslintUiConfig, {
+  plugins: testingLibrary.configs['flat/react']['plugins'],
+  files: ['**/*.test.ts', '**/*.test.tsx'],
+  rules: {
+    'testing-library/await-async-events': 'error',
+    'testing-library/await-async-queries': 'error',
+    'testing-library/await-async-utils': 'warn', // default: error
+    'testing-library/no-await-sync-events': 'error',
+    'testing-library/no-await-sync-queries': 'error',
+    'testing-library/no-container': 'warn', // default: error
+    'testing-library/no-debugging-utils': 'warn',
+    'testing-library/no-dom-import': 'error',
+    'testing-library/no-global-regexp-flag-in-query': 'error',
+    'testing-library/no-manual-cleanup': 'error',
+    'testing-library/no-node-access': 'off', // default: error
+    'testing-library/no-promise-in-fire-event': 'error',
+    'testing-library/no-render-in-lifecycle': 'warn', // default: error
+    'testing-library/no-unnecessary-act': 'error',
+    'testing-library/no-wait-for-multiple-assertions': 'warn', // default: error
+    'testing-library/no-wait-for-side-effects': 'warn', // default: error
+    'testing-library/no-wait-for-snapshot': 'error',
+    'testing-library/prefer-find-by': 'error',
+    'testing-library/prefer-presence-queries': 'warn', // default: error
+    'testing-library/prefer-query-by-disappearance': 'error',
+    'testing-library/prefer-screen-queries': 'warn', // default: error
+    'testing-library/render-result-naming-convention': 'error',
   },
-  {
-    files: ['**/*.test.ts', '**/*.test.tsx'],
-    rules: {
-      'testing-library/await-async-events': 'error',
-      'testing-library/await-async-queries': 'error',
-      'testing-library/await-async-utils': 'warn', // default: error
-      'testing-library/no-await-sync-events': 'error',
-      'testing-library/no-await-sync-queries': 'error',
-      'testing-library/no-container': 'warn', // default: error
-      'testing-library/no-debugging-utils': 'warn',
-      'testing-library/no-dom-import': 'error',
-      'testing-library/no-global-regexp-flag-in-query': 'error',
-      'testing-library/no-manual-cleanup': 'error',
-      'testing-library/no-node-access': 'off', // default: error
-      'testing-library/no-promise-in-fire-event': 'error',
-      'testing-library/no-render-in-lifecycle': 'warn', // default: error
-      'testing-library/no-unnecessary-act': 'error',
-      'testing-library/no-wait-for-multiple-assertions': 'warn', // default: error
-      'testing-library/no-wait-for-side-effects': 'warn', // default: error
-      'testing-library/no-wait-for-snapshot': 'error',
-      'testing-library/prefer-find-by': 'error',
-      'testing-library/prefer-presence-queries': 'warn', // default: error
-      'testing-library/prefer-query-by-disappearance': 'error',
-      'testing-library/prefer-screen-queries': 'warn', // default: error
-      'testing-library/render-result-naming-convention': 'error',
-    },
-  },
-);
+});
 
 export default eslintUiTestConfig;

--- a/user-interface/eslint-ui.config.mjs
+++ b/user-interface/eslint-ui.config.mjs
@@ -1,0 +1,24 @@
+import eslintTsConfig from '../common/eslint-ts.config.mjs';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+const tsEslint = require('typescript-eslint');
+const jsxA11y = require('eslint-plugin-jsx-a11y');
+const reactPlugin = require('eslint-plugin-react');
+const reactVersionConfig = { settings: { react: { version: 'detect' } } };
+
+/**
+ * eslintUiConfig
+ *
+ * This ConfigArray is intended to be the eslint configuration for non-test TypeScript
+ * family files (e.g. `.ts`, `.tsx`) in the frontend project.
+ */
+const eslintUiConfig = tsEslint.config(
+  reactVersionConfig,
+  eslintTsConfig,
+  jsxA11y['flatConfigs']['recommended'],
+  reactPlugin.configs.flat.recommended,
+  reactPlugin.configs.flat['jsx-runtime'],
+);
+
+export default eslintUiConfig;

--- a/user-interface/eslint.config.mjs
+++ b/user-interface/eslint.config.mjs
@@ -1,18 +1,21 @@
-import eslintTsConfig from '../common/eslint-ts.config.mjs';
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
+import eslintUiConfig from './eslint-ui.config.mjs';
+import eslintUiTestConfig from './eslint-ui-test.config.mjs';
 
-const tsEslint = require('typescript-eslint');
-const jsxA11y = require('eslint-plugin-jsx-a11y');
-const reactPlugin = require('eslint-plugin-react');
-const reactVersionConfig = { settings: { react: { version: 'detect' } } };
+const codeConfig = eslintUiConfig.map((configObject) => ({
+  files: ['**/*.ts', '**/*.tsx'],
+  ...configObject,
+}));
+const testConfig = eslintUiTestConfig.map((configObject) => ({
+  files: ['**/*.test.ts', '**/*.test.tsx'],
+  ...configObject,
+}));
 
-const frontendEslintConfig = tsEslint.config(
-  reactVersionConfig,
-  eslintTsConfig,
-  jsxA11y['flatConfigs']['recommended'],
-  reactPlugin.configs.flat.recommended,
-  reactPlugin.configs.flat['jsx-runtime'],
-);
+const frontendEslintConfig = [
+  {
+    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*'],
+  },
+  ...codeConfig,
+  ...testConfig,
+];
 
 export default frontendEslintConfig;

--- a/user-interface/eslint.config.mjs
+++ b/user-interface/eslint.config.mjs
@@ -12,7 +12,7 @@ const testConfig = eslintUiTestConfig.map((configObject) => ({
 
 const frontendEslintConfig = [
   {
-    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*'],
+    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*', '**/coverage/**/*'],
   },
   ...codeConfig,
   ...testConfig,

--- a/user-interface/package-lock.json
+++ b/user-interface/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^5.1.0",
+        "eslint-plugin-testing-library": "^7.1.1",
         "jsdom": "^25.0.1",
         "pa11y-ci": "^3.1.0",
         "prettier": "^3.4.2",
@@ -5114,6 +5115,23 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.1.1.tgz",
+      "integrity": "sha512-nszC833aZPwB6tik1nMkbFqmtgIXTT0sfJEYs0zMBKMlkQ4to2079yUV96SvmLh00ovSBJI4pgcBC1TiIP8mXg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.15.0",
+        "@typescript-eslint/utils": "^8.15.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+        "pnpm": "^9.14.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/user-interface/package.json
+++ b/user-interface/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.3",
     "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-testing-library": "^7.1.1",
     "jsdom": "^25.0.1",
     "pa11y-ci": "^3.1.0",
     "prettier": "^3.4.2",

--- a/user-interface/src/data-verification/DataVerificationScreen.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import DataVerificationScreen from './DataVerificationScreen';
 import { BrowserRouter } from 'react-router-dom';
 import { formatDate } from '@/lib/utils/datetime';
@@ -45,17 +45,13 @@ describe('Review Orders screen', () => {
     });
     const approvedOrderFilter = screen.getByTestId(`order-status-filter-approved`);
 
-    act(() => {
-      fireEvent.click(approvedOrderFilter);
-    });
+    await fireEvent.click(approvedOrderFilter);
 
     await waitFor(() => {
       expect(approvedOrderFilter).toHaveClass('active');
     });
 
-    act(() => {
-      fireEvent.click(approvedOrderFilter);
-    });
+    await fireEvent.click(approvedOrderFilter);
 
     await waitFor(() => {
       expect(approvedOrderFilter).toHaveClass('inactive');
@@ -85,8 +81,8 @@ describe('Review Orders screen', () => {
 
     const approvedOrderFilter = screen.getByTestId(`order-status-filter-approved`);
     const rejectedOrderFilter = screen.getByTestId(`order-status-filter-rejected`);
-    fireEvent.click(approvedOrderFilter);
-    fireEvent.click(rejectedOrderFilter);
+    await fireEvent.click(approvedOrderFilter);
+    await fireEvent.click(rejectedOrderFilter);
 
     for (const order of ordersResponse.data) {
       await waitFor(async () => {
@@ -158,11 +154,11 @@ describe('Review Orders screen', () => {
       expect(loadingSpinner).not.toBeInTheDocument();
     });
     const pendingOrderFilter = screen.getByTestId(`order-status-filter-pending`);
-    fireEvent.click(pendingOrderFilter);
+    await fireEvent.click(pendingOrderFilter);
     const consolidationOrderFilter = screen.getByTestId(`order-status-filter-consolidation`);
-    fireEvent.click(consolidationOrderFilter);
+    await fireEvent.click(consolidationOrderFilter);
     const transferOrderFilter = screen.getByTestId(`order-status-filter-transfer`);
-    fireEvent.click(transferOrderFilter);
+    await fireEvent.click(transferOrderFilter);
 
     await waitFor(() => {
       const alert = screen.queryByTestId('alert-too-many-filters');
@@ -202,8 +198,8 @@ describe('Review Orders screen', () => {
 
     const approvedOrderFilter = screen.getByTestId(`order-status-filter-approved`);
     const rejectedOrderFilter = screen.getByTestId(`order-status-filter-rejected`);
-    fireEvent.click(approvedOrderFilter);
-    fireEvent.click(rejectedOrderFilter);
+    await fireEvent.click(approvedOrderFilter);
+    await fireEvent.click(rejectedOrderFilter);
 
     for (const order of transferOrders) {
       await waitFor(() => {
@@ -286,8 +282,8 @@ describe('Review Orders screen', () => {
       rejectFilter = screen.getByTestId(`order-status-filter-rejected`);
     });
 
-    fireEvent.click(approveFilter!);
-    fireEvent.click(rejectFilter!);
+    await fireEvent.click(approveFilter!);
+    await fireEvent.click(rejectFilter!);
 
     await waitFor(() => {
       // Check if all the orders are listed by default.
@@ -303,7 +299,7 @@ describe('Review Orders screen', () => {
       transferFilter = screen.getByTestId(`order-status-filter-transfer`);
       expect(transferFilter).toBeInTheDocument();
     });
-    fireEvent.click(transferFilter!);
+    await fireEvent.click(transferFilter!);
 
     // make sure only consolidations are visible
     await waitFor(async () => {
@@ -322,8 +318,8 @@ describe('Review Orders screen', () => {
     // deselect consolidation filter and select transfer filter
     const consolidationFilter = screen.getByTestId(`order-status-filter-consolidation`);
     expect(consolidationFilter).toBeInTheDocument();
-    fireEvent.click(transferFilter!);
-    fireEvent.click(consolidationFilter);
+    await fireEvent.click(transferFilter!);
+    await fireEvent.click(consolidationFilter);
 
     // make sure only transfers are visible
     for (const order of transferOrders) {

--- a/user-interface/src/data-verification/DataVerificationScreen.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.test.tsx
@@ -45,13 +45,13 @@ describe('Review Orders screen', () => {
     });
     const approvedOrderFilter = screen.getByTestId(`order-status-filter-approved`);
 
-    await fireEvent.click(approvedOrderFilter);
+    fireEvent.click(approvedOrderFilter);
 
     await waitFor(() => {
       expect(approvedOrderFilter).toHaveClass('active');
     });
 
-    await fireEvent.click(approvedOrderFilter);
+    fireEvent.click(approvedOrderFilter);
 
     await waitFor(() => {
       expect(approvedOrderFilter).toHaveClass('inactive');
@@ -81,8 +81,8 @@ describe('Review Orders screen', () => {
 
     const approvedOrderFilter = screen.getByTestId(`order-status-filter-approved`);
     const rejectedOrderFilter = screen.getByTestId(`order-status-filter-rejected`);
-    await fireEvent.click(approvedOrderFilter);
-    await fireEvent.click(rejectedOrderFilter);
+    fireEvent.click(approvedOrderFilter);
+    fireEvent.click(rejectedOrderFilter);
 
     for (const order of ordersResponse.data) {
       await waitFor(async () => {
@@ -154,11 +154,11 @@ describe('Review Orders screen', () => {
       expect(loadingSpinner).not.toBeInTheDocument();
     });
     const pendingOrderFilter = screen.getByTestId(`order-status-filter-pending`);
-    await fireEvent.click(pendingOrderFilter);
+    fireEvent.click(pendingOrderFilter);
     const consolidationOrderFilter = screen.getByTestId(`order-status-filter-consolidation`);
-    await fireEvent.click(consolidationOrderFilter);
+    fireEvent.click(consolidationOrderFilter);
     const transferOrderFilter = screen.getByTestId(`order-status-filter-transfer`);
-    await fireEvent.click(transferOrderFilter);
+    fireEvent.click(transferOrderFilter);
 
     await waitFor(() => {
       const alert = screen.queryByTestId('alert-too-many-filters');
@@ -198,8 +198,8 @@ describe('Review Orders screen', () => {
 
     const approvedOrderFilter = screen.getByTestId(`order-status-filter-approved`);
     const rejectedOrderFilter = screen.getByTestId(`order-status-filter-rejected`);
-    await fireEvent.click(approvedOrderFilter);
-    await fireEvent.click(rejectedOrderFilter);
+    fireEvent.click(approvedOrderFilter);
+    fireEvent.click(rejectedOrderFilter);
 
     for (const order of transferOrders) {
       await waitFor(() => {
@@ -282,8 +282,8 @@ describe('Review Orders screen', () => {
       rejectFilter = screen.getByTestId(`order-status-filter-rejected`);
     });
 
-    await fireEvent.click(approveFilter!);
-    await fireEvent.click(rejectFilter!);
+    fireEvent.click(approveFilter!);
+    fireEvent.click(rejectFilter!);
 
     await waitFor(() => {
       // Check if all the orders are listed by default.
@@ -299,7 +299,7 @@ describe('Review Orders screen', () => {
       transferFilter = screen.getByTestId(`order-status-filter-transfer`);
       expect(transferFilter).toBeInTheDocument();
     });
-    await fireEvent.click(transferFilter!);
+    fireEvent.click(transferFilter!);
 
     // make sure only consolidations are visible
     await waitFor(async () => {
@@ -318,8 +318,8 @@ describe('Review Orders screen', () => {
     // deselect consolidation filter and select transfer filter
     const consolidationFilter = screen.getByTestId(`order-status-filter-consolidation`);
     expect(consolidationFilter).toBeInTheDocument();
-    await fireEvent.click(transferFilter!);
-    await fireEvent.click(consolidationFilter);
+    fireEvent.click(transferFilter!);
+    fireEvent.click(consolidationFilter);
 
     // make sure only transfers are visible
     for (const order of transferOrders) {

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderModal.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderModal.test.tsx
@@ -50,9 +50,9 @@ describe('ConsolidationOrderModalComponent', () => {
     const onCancelSpy = vitest.fn();
 
     // Render and activate the modal.
-    const ref = renderModalWithProps({ id, onConfirm: onConfirmSpy, onCancel: onCancelSpy });
+    const view = renderModalWithProps({ id, onConfirm: onConfirmSpy, onCancel: onCancelSpy });
     await waitFor(() => {
-      ref.current?.show({ status: 'rejected', cases });
+      view.current?.show({ status: 'rejected', cases });
     });
 
     // Check heading
@@ -81,7 +81,7 @@ describe('ConsolidationOrderModalComponent', () => {
     });
 
     await waitFor(() => {
-      ref.current?.show({ status: 'rejected', cases });
+      view.current?.show({ status: 'rejected', cases });
     });
     const cancelButton = screen.getByTestId(`button-${id}-cancel-button`);
     expect(cancelButton).toBeVisible();
@@ -113,9 +113,9 @@ describe('ConsolidationOrderModalComponent', () => {
     vi.spyOn(Api2, 'getCaseAssignments').mockResolvedValue(assignmentResponse);
 
     // Render and activate the modal.
-    const ref = renderModalWithProps({ id, courts });
+    const view = renderModalWithProps({ id, courts });
     await waitFor(() => {
-      ref.current?.show({ status: 'approved', cases: childCases, leadCase, consolidationType });
+      view.current?.show({ status: 'approved', cases: childCases, leadCase, consolidationType });
     });
 
     const modal = screen.getByTestId('modal-test');
@@ -153,7 +153,7 @@ describe('ConsolidationOrderModalComponent', () => {
     });
 
     await waitFor(() => {
-      ref.current?.show({ status: 'approved', cases: childCases });
+      view.current?.show({ status: 'approved', cases: childCases });
     });
     const cancelButton = screen.getByTestId(`button-${id}-cancel-button`);
     expect(cancelButton).toBeVisible();
@@ -166,10 +166,10 @@ describe('ConsolidationOrderModalComponent', () => {
     const id = 'test';
     const cases = MockData.buildArray(MockData.getCaseSummary, 2);
 
-    const ref = renderModalWithProps({ id });
+    const view = renderModalWithProps({ id });
 
     await waitFor(() => {
-      ref.current?.show({ status: 'rejected', cases });
+      view.current?.show({ status: 'rejected', cases });
     });
 
     const button = screen.queryByTestId(`button-${id}-cancel-button`);

--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -449,7 +449,7 @@ describe('test cams combobox', () => {
     await userEvent.type(inputField, 'test test');
 
     inputField.focus();
-    userEvent.tab();
+    await userEvent.tab();
 
     await waitFor(() => {
       expect(inputField.value).toEqual('');

--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -153,7 +153,7 @@ describe('test cams combobox', () => {
 
     await userEvent.click(pillBox!.children[0]);
 
-    waitFor(() => {
+    await waitFor(() => {
       pillBox = document.querySelector(`#${comboboxId}-pill-box`);
       expect(pillBox!.children.length).toEqual(0);
     });

--- a/user-interface/src/lib/components/uswds/DatePicker.test.tsx
+++ b/user-interface/src/lib/components/uswds/DatePicker.test.tsx
@@ -30,73 +30,73 @@ describe('Test DatePicker component', async () => {
     return ref.current!;
   }
 
-  test('should clear when clearValue() is called', () => {
+  test('should clear when clearValue() is called', async () => {
     const initialValue = '2024-01-01';
 
-    const ref = renderWithProps({ value: initialValue });
+    const view = renderWithProps({ value: initialValue });
 
     const datePicker = screen.getByTestId(DEFAULT_ID);
     const step1 = datePicker.attributes.getNamedItem('value')?.value;
     expect(step1).toEqual(initialValue);
 
-    ref.clearValue();
-    waitFor(() => {
+    view.clearValue();
+    await waitFor(() => {
       const step2 = datePicker.attributes.getNamedItem('value')?.value;
       expect(step2).toEqual('');
     });
   });
 
-  test('should set the value when setValue() is called', () => {
+  test('should set the value when setValue() is called', async () => {
     const initialValue = '2024-01-01';
     const updatedValue = '2024-01-02';
 
-    const ref = renderWithProps({ value: initialValue });
+    const view = renderWithProps({ value: initialValue });
 
     const datePicker = screen.getByTestId(DEFAULT_ID);
     const step1 = datePicker.attributes.getNamedItem('value')?.value;
     expect(step1).toEqual(initialValue);
 
-    ref.setValue(updatedValue);
-    waitFor(() => {
+    view.setValue(updatedValue);
+    await waitFor(() => {
       const step2 = datePicker.attributes.getNamedItem('value')?.value;
       expect(step2).toEqual(updatedValue);
     });
   });
 
-  test('should reset when resetValue() is called', () => {
+  test('should reset when resetValue() is called', async () => {
     const initialValue = '2024-01-01';
     const updatedValue = '2024-01-02';
-    const ref = renderWithProps({ value: initialValue });
+    const view = renderWithProps({ value: initialValue });
 
     const datePicker = screen.getByTestId(DEFAULT_ID);
     const step1 = datePicker.attributes.getNamedItem('value')?.value;
     expect(step1).toEqual(initialValue);
 
-    ref.setValue(updatedValue);
-    waitFor(() => {
+    view.setValue(updatedValue);
+    await waitFor(() => {
       const step2 = datePicker.attributes.getNamedItem('value')?.value;
       expect(step2).toEqual(updatedValue);
     });
 
-    ref.resetValue();
-    waitFor(() => {
+    view.resetValue();
+    await waitFor(() => {
       const step3 = datePicker.attributes.getNamedItem('value')?.value;
       expect(step3).toEqual(initialValue);
     });
   });
 
   test('should be disabled when disable() is called', async () => {
-    const ref = renderWithProps();
+    const view = renderWithProps();
 
     const datePicker = screen.getByTestId(DEFAULT_ID);
     expect(datePicker).toBeEnabled();
 
-    ref.disable(true);
+    view.disable(true);
     await waitFor(() => {
       expect(datePicker).not.toBeEnabled();
     });
 
-    ref.disable(false);
+    view.disable(false);
     await waitFor(() => {
       expect(datePicker).toBeEnabled();
     });

--- a/user-interface/src/lib/utils/caseNumber.test.ts
+++ b/user-interface/src/lib/utils/caseNumber.test.ts
@@ -42,17 +42,17 @@ describe('Testing the clipboard with caseId', () => {
 
   test('clicking copy button should write caseId to clipboard', async () => {
     copyCaseNumber(testCaseDetail.caseId);
-    waitFor(() => {
+    await waitFor(() => {
       expect(writeTextMock).toHaveBeenCalledWith(testCaseDetail.caseId);
     });
   });
 
-  test('should only copy to clipboard if we have a valid case number', () => {
+  test('should only copy to clipboard if we have a valid case number', async () => {
     copyCaseNumber('abcdefg#!@#$%');
     expect(writeTextMock).not.toHaveBeenCalled();
 
     copyCaseNumber(testCaseDetail.caseId);
-    waitFor(() => {
+    await waitFor(() => {
       expect(writeTextMock).toHaveBeenCalledWith(testCaseDetail.caseId);
       expect(writeTextMock).toHaveBeenCalledTimes(1);
     });

--- a/user-interface/src/test/staff-assignment.test.tsx
+++ b/user-interface/src/test/staff-assignment.test.tsx
@@ -32,14 +32,14 @@ describe('Staff assignment', () => {
     let firstCaseAssignmentButton;
     await waitFor(async () => {
       // TODO: Can we use a better selector than test ID since it is closer to an implementation detail than a descriptive label?
-      firstCaseAssignmentButton = await screen.queryByTestId('open-modal-button-0');
+      firstCaseAssignmentButton = screen.queryByTestId('open-modal-button-0');
       expect(firstCaseAssignmentButton).toBeInTheDocument();
     });
     fireEvent.click(firstCaseAssignmentButton!);
 
     await waitFor(async () => {
       // TODO: Can we use a better selector than test ID since it is closer to an implementation detail than a descriptive label?
-      const attorneyListTbody = await screen.queryByTestId('case-load-table-body');
+      const attorneyListTbody = screen.queryByTestId('case-load-table-body');
       expect(attorneyListTbody).toBeInTheDocument();
       const attorneyNames = [...attorneyListTbody!.childNodes].map((row) => row.textContent);
       expect(attorneyNames.length).toBeGreaterThan(1);


### PR DESCRIPTION
# Purpose

We want to use the `testing-library` package as intended most of the time.

# Major Changes

- Add the eslint plugin provided by the package authors.
  - Configure the default rules leaving some turned off for further consideration before enabling.
  - Correct new linting errors.

# Testing/Validation

Automated tests still pass.

# Future Work

We could still add the [vitest plugin](https://www.npmjs.com/package/@vitest/eslint-plugin).