### PR TITLE
CAMS-492: Only get chapter 15 and enabled chapters

### DIFF
--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.test.tsx
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.test.tsx
@@ -43,7 +43,7 @@ describe('StaffAssignmentScreen', () => {
       limit: DEFAULT_SEARCH_LIMIT,
       offset: DEFAULT_SEARCH_OFFSET,
       divisionCodes: getCourtDivisionCodes(user),
-      chapters: expect.arrayContaining(['15']),
+      chapters: ['15'],
     };
 
     const SearchResults = vi

--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.test.tsx
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.test.tsx
@@ -13,17 +13,26 @@ import { SearchResultsProps } from '@/search-results/SearchResults';
 import { CamsRole } from '@common/cams/roles';
 import { BrowserRouter } from 'react-router-dom';
 import { getCourtDivisionCodes } from '@common/cams/users';
+import { FeatureFlagSet } from '@common/feature-flags';
+import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 
 describe('StaffAssignmentScreen', () => {
+  let mockFeatureFlags: FeatureFlagSet;
+
   beforeEach(() => {
     vi.stubEnv('CAMS_PA11Y', 'true');
+    mockFeatureFlags = {
+      'chapter-eleven-enabled': false,
+      'chapter-twelve-enabled': false,
+    };
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
-  test('should render a list of cases assigned to a case assignment manager', async () => {
+  test('should render a list of chapter 15 cases for a case assignment manager to review', async () => {
     const user = testingUtilities.setUserWithRoles([CamsRole.CaseAssignmentManager]);
 
     vi.spyOn(Api2, 'searchCases').mockResolvedValue({
@@ -34,6 +43,50 @@ describe('StaffAssignmentScreen', () => {
       limit: DEFAULT_SEARCH_LIMIT,
       offset: DEFAULT_SEARCH_OFFSET,
       divisionCodes: getCourtDivisionCodes(user),
+      chapters: expect.arrayContaining(['15']),
+    };
+
+    const SearchResults = vi
+      .spyOn(searchResultsModule, 'default')
+      .mockImplementation((_props: SearchResultsProps) => {
+        return <></>;
+      });
+
+    render(
+      <BrowserRouter>
+        <StaffAssignmentScreen></StaffAssignmentScreen>
+      </BrowserRouter>,
+    );
+
+    expect(SearchResults).toHaveBeenCalledWith(
+      {
+        id: 'search-results',
+        noResultsMessage: 'No cases currently assigned.',
+        searchPredicate: expectedPredicate,
+        header: expect.anything(),
+        row: expect.anything(),
+      },
+      {},
+    );
+  });
+
+  test('should render a list of chapter 11, 12, and 15 cases for a case assignment manager to review', async () => {
+    mockFeatureFlags = {
+      'chapter-eleven-enabled': true,
+      'chapter-twelve-enabled': true,
+    };
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+    const user = testingUtilities.setUserWithRoles([CamsRole.CaseAssignmentManager]);
+
+    vi.spyOn(Api2, 'searchCases').mockResolvedValue({
+      data: MockData.buildArray(MockData.getCaseBasics, 3),
+    });
+
+    const expectedPredicate: CasesSearchPredicate = {
+      limit: DEFAULT_SEARCH_LIMIT,
+      offset: DEFAULT_SEARCH_OFFSET,
+      divisionCodes: getCourtDivisionCodes(user),
+      chapters: expect.arrayContaining(['11', '12', '15']),
     };
 
     const SearchResults = vi

--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.tsx
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.tsx
@@ -19,12 +19,25 @@ import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import ScreenInfoButton from '@/lib/components/cams/ScreenInfoButton';
 import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
 import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
+import useFeatureFlags, {
+  CHAPTER_ELEVEN_ENABLED,
+  CHAPTER_TWELVE_ENABLED,
+} from '@/lib/hooks/UseFeatureFlags';
+
+function getChapters(): string[] {
+  const chapters = ['15'];
+  const featureFlags = useFeatureFlags();
+  if (featureFlags[CHAPTER_ELEVEN_ENABLED]) chapters.push('11');
+  if (featureFlags[CHAPTER_TWELVE_ENABLED]) chapters.push('12');
+  return chapters;
+}
 
 function getPredicateByUserContext(user: CamsUser): CasesSearchPredicate {
   const predicate: CasesSearchPredicate = {
     limit: DEFAULT_SEARCH_LIMIT,
     offset: DEFAULT_SEARCH_OFFSET,
     divisionCodes: getCourtDivisionCodes(user),
+    chapters: getChapters(),
   };
 
   return predicate;


### PR DESCRIPTION
# Problem

The staff assignment screen should only look for cases for enabled chapters which means 15 by default and 11 and/or 12 if the feature flags are turned on.

# Solution

We modify the search predicate to only include chapter 15 by default and other chapters if enabled by feature flag.

# Testing/Validation

Automated tests modified to test this.