### PR TITLE
CAMS-496: Do not call insertMany for empty or falsy list

### DIFF
--- a/backend/lib/adapters/gateways/mongo/consolidations.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/consolidations.mongo.repository.test.ts
@@ -104,6 +104,23 @@ describe('Consolidations Repository tests', () => {
     expect(createManySpy).toHaveBeenCalledWith(consolidationOrders);
   });
 
+  const createManyEmptyCases = [
+    ['empty', []],
+    ['undefined', undefined],
+    ['null', null],
+  ];
+  test.each(createManyEmptyCases)(
+    'should not call insertMany with %s list',
+    async (_caseName: string, list: []) => {
+      const createManySpy = jest
+        .spyOn(MongoCollectionAdapter.prototype, 'insertMany')
+        .mockRejectedValue('This should not throw.');
+      await repo.createMany(list);
+
+      expect(createManySpy).not.toHaveBeenCalled();
+    },
+  );
+
   describe('error handling', () => {
     const error = new Error('some error');
     const camsError = getCamsError(error, 'COSMOS_DB_REPOSITORY_CONSOLIDATION_ORDERS');

--- a/backend/lib/adapters/gateways/mongo/consolidations.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/consolidations.mongo.repository.ts
@@ -67,6 +67,7 @@ export default class ConsolidationOrdersMongoRepository<T extends CamsDocument =
   }
 
   public async createMany(list: T[]): Promise<void> {
+    if (!list || !list.length) return;
     try {
       await this.getAdapter<T>().insertMany(list);
     } catch (originalError) {


### PR DESCRIPTION
# Problem

During order sync, we call `insertMany` from the Mongo adapter for consolidations even if there is nothing to insert.

# Solution

Bail early if the list is empty, undefined, or null.

# Testing/Validation

Added automated tests.