### PR TITLE
CAMS-497: Set upsert flag on session repo replaceOne method

### DIFF
--- a/backend/lib/adapters/gateways/mongo/user-session-cache.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/user-session-cache.mongo.repository.test.ts
@@ -83,6 +83,7 @@ describe('User session cache Cosmos repository tests', () => {
         signature: expect.anything(),
         ttl: expect.any(Number),
       }),
+      true,
     );
     const maxTtl = Math.floor(camsJwtClaims.exp - Date.now() / 1000);
     expect(argument.ttl).toBeLessThan(maxTtl + 1);

--- a/backend/lib/adapters/gateways/mongo/user-session-cache.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/user-session-cache.mongo.repository.ts
@@ -89,7 +89,7 @@ export class UserSessionCacheMongoRepository
         ttl,
       };
       const adapter = this.getAdapter<CachedCamsSession>();
-      await adapter.replaceOne(query, cached);
+      await adapter.replaceOne(query, cached, true);
       return session;
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);


### PR DESCRIPTION
# Problem

User sessions are not being persisted.

# Solution

We call the `replaceOne` method with the `upsert` flag set to true.

# Testing/Validation

Updated test.
