### PR TITLE
CAMS-500: enable roles in staging

### DIFF
--- a/backend/function-apps/api/admin/admin.function.ts
+++ b/backend/function-apps/api/admin/admin.function.ts
@@ -33,7 +33,7 @@ export default async function handler(
 }
 
 app.http('admin', {
-  methods: ['DELETE'],
+  methods: ['DELETE', 'POST'],
   authLevel: 'anonymous',
   handler,
   route: 'dev-tools/{procedure}',

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
@@ -106,7 +106,6 @@ describe('offices repo', () => {
       );
     });
 
-    // TODO: test error cases for findAndDeleteStaff
     test('should throw error for failure to delete', async () => {
       jest.spyOn(MongoCollectionAdapter.prototype, 'deleteOne').mockResolvedValue(0);
 

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
@@ -98,11 +98,16 @@ export class OfficesMongoRepository extends BaseMongoRepository implements Offic
       ),
     );
 
-    const deletedCount = await this.getAdapter<OfficeStaff>().deleteOne(query);
-    if (deletedCount === 0) {
-      throw new UnknownError(MODULE_NAME, { message: 'Failed to delete office staff.' });
-    } else if (deletedCount > 1) {
-      throw new UnknownError(MODULE_NAME, { message: 'Deleted more than one office staff.' });
+    try {
+      const deletedCount = await this.getAdapter<OfficeStaff>().deleteOne(query);
+      if (deletedCount === 0) {
+        throw new UnknownError(MODULE_NAME, { message: 'Failed to delete office staff.' });
+      } else if (deletedCount > 1) {
+        throw new UnknownError(MODULE_NAME, { message: 'Deleted more than one office staff.' });
+      }
+    } catch (originalError) {
+      const error = getCamsError(originalError, MODULE_NAME);
+      throw error;
     }
   }
 }

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
@@ -47,8 +47,11 @@ export class OfficesMongoRepository extends BaseMongoRepository implements Offic
     OfficesMongoRepository.dropInstance();
   }
 
-  async putOfficeStaff(officeCode: string, user: CamsUserReference): Promise<void> {
-    const ttl = 86400;
+  async putOfficeStaff(
+    officeCode: string,
+    user: CamsUserReference,
+    ttl: number = 86400,
+  ): Promise<void> {
     const staff = createAuditRecord<OfficeStaff>({
       id: user.id,
       documentType: 'OFFICE_STAFF',

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
@@ -89,11 +89,11 @@ export class OfficesMongoRepository extends BaseMongoRepository implements Offic
     }
   }
 
-  public async findAndDeleteStaff(_officeCode: string, _id: string): Promise<void> {
+  public async findAndDeleteStaff(officeCode: string, id: string): Promise<void> {
     const query = QueryBuilder.build(
       and(
-        equals<OfficeStaff['officeCode']>('officeCode', _officeCode),
-        equals<OfficeStaff['id']>('id', _id),
+        equals<OfficeStaff['officeCode']>('officeCode', officeCode),
+        equals<OfficeStaff['id']>('id', id),
         equals<OfficeStaff['documentType']>('documentType', 'OFFICE_STAFF'),
       ),
     );

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
@@ -87,4 +87,8 @@ export class OfficesMongoRepository extends BaseMongoRepository implements Offic
       throw getCamsError(originalError, MODULE_NAME);
     }
   }
+
+  public async findAndDeleteStaff(_officeCode: string, _id: string): Promise<void> {
+    throw new Error('Not implemented');
+  }
 }

--- a/backend/lib/controllers/admin/admin.controller.test.ts
+++ b/backend/lib/controllers/admin/admin.controller.test.ts
@@ -3,6 +3,7 @@ import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { AdminController } from './admin.controller';
 import { AdminUseCase } from '../../use-cases/admin/admin';
 import { UnknownError } from '../../common-errors/unknown-error';
+import { CamsRole } from '../../../../common/src/cams/roles';
 
 describe('Admin controller tests', () => {
   let controller: AdminController;
@@ -11,12 +12,41 @@ describe('Admin controller tests', () => {
     controller = new AdminController();
   });
 
-  test('should return 204 for successful deletion', async () => {
+  test('should return 204 for successful deletion of migrations', async () => {
     const context = await createMockApplicationContext();
+    context.request.method = 'DELETE';
     context.request.params.procedure = 'deleteMigrations';
     jest.spyOn(AdminUseCase.prototype, 'deleteMigrations').mockResolvedValue();
     const response = await controller.handleRequest(context);
     expect(response).toEqual({ statusCode: 204 });
+  });
+
+  test('should return 204 for successful deletion of staff', async () => {
+    const context = await createMockApplicationContext();
+    context.request.method = 'DELETE';
+    context.request.params.procedure = 'deleteStaff';
+    context.request.body = {
+      officeCode: 'TEST_OFFICE_GROUP',
+      id: 'user-okta-id',
+    };
+    jest.spyOn(AdminUseCase.prototype, 'deleteStaff').mockResolvedValue();
+    const response = await controller.handleRequest(context);
+    expect(response).toEqual({ statusCode: 204 });
+  });
+
+  test('should return 201 for successful addition of staff', async () => {
+    const context = await createMockApplicationContext();
+    context.request.method = 'POST';
+    context.request.params.procedure = 'createStaff';
+    context.request.body = {
+      officeCode: 'TEST_OFFICE_GROUP',
+      id: 'user-okta-id',
+      name: 'Last, First',
+      roles: [CamsRole.CaseAssignmentManager],
+    };
+    jest.spyOn(AdminUseCase.prototype, 'addOfficeStaff').mockResolvedValue();
+    const response = await controller.handleRequest(context);
+    expect(response).toEqual({ statusCode: 201 });
   });
 
   test('should throw bad request error when procedure does not equal deleteMigrations', async () => {
@@ -27,6 +57,7 @@ describe('Admin controller tests', () => {
 
   test('should throw camsError when useCase.deleteMigrations throws', async () => {
     const context = await createMockApplicationContext();
+    context.request.method = 'DELETE';
     context.request.params.procedure = 'deleteMigrations';
     jest
       .spyOn(AdminUseCase.prototype, 'deleteMigrations')

--- a/backend/lib/controllers/admin/admin.controller.ts
+++ b/backend/lib/controllers/admin/admin.controller.ts
@@ -1,11 +1,15 @@
 import { ApplicationContext } from '../../adapters/types/basic';
 import { CamsHttpResponseInit } from '../../adapters/utils/http-response';
 import { CamsController } from '../controller';
-import { AdminUseCase } from '../../use-cases/admin/admin';
+import { AdminUseCase, CreateStaffRequestBody } from '../../use-cases/admin/admin';
 import { getCamsError } from '../../common-errors/error-utilities';
 import { BadRequestError } from '../../common-errors/bad-request';
 
 const MODULE_NAME = 'ADMIN-CONTROLLER';
+const deleteMigrations = 'deleteMigrations';
+const deleteStaff = 'deleteStaff';
+const createStaff = 'createStaff';
+const SUPPORTED_PROCEDURES = [createStaff, deleteMigrations, deleteStaff];
 
 export class AdminController implements CamsController {
   public async handleRequest(
@@ -13,13 +17,26 @@ export class AdminController implements CamsController {
   ): Promise<CamsHttpResponseInit<object | undefined>> {
     const procedure = context.request.params.procedure;
     const useCase = new AdminUseCase();
-    if (procedure !== 'deleteMigrations') {
+    if (!SUPPORTED_PROCEDURES.includes(procedure)) {
       throw new BadRequestError(MODULE_NAME, { message: 'Procedure not found' });
     }
 
     try {
-      await useCase.deleteMigrations(context);
-      return { statusCode: 204 };
+      if (procedure === deleteMigrations && context.request.method === 'DELETE') {
+        await useCase.deleteMigrations(context);
+        return { statusCode: 204 };
+      } else if (procedure === createStaff && context.request.method === 'POST') {
+        const requestBody: CreateStaffRequestBody = context.request.body as CreateStaffRequestBody;
+        await useCase.addOfficeStaff(context, requestBody);
+        return { statusCode: 201 };
+      } else if (procedure === deleteStaff && context.request.method === 'DELETE') {
+        await useCase.deleteStaff(
+          context,
+          context.request.body['officeCode'],
+          context.request.body['id'],
+        );
+        return { statusCode: 204 };
+      }
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);
     }

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -44,7 +44,6 @@ import ConsolidationOrdersMongoRepository from './adapters/gateways/mongo/consol
 import { MockMongoRepository } from './testing/mock-gateways/mock-mongo.repository';
 import { RuntimeStateMongoRepository } from './adapters/gateways/mongo/runtime-state.mongo.repository';
 import { UserSessionCacheMongoRepository } from './adapters/gateways/mongo/user-session-cache.mongo.repository';
-import { MockOfficesRepository } from './testing/mock-gateways/mock.offices.repository';
 import { AcmsGatewayImpl } from './adapters/gateways/acms/acms.gateway';
 import { deferRelease } from './deferrable/defer-release';
 
@@ -116,8 +115,11 @@ export const getOfficesGateway = (context: ApplicationContext): OfficesGateway =
 };
 
 export const getOfficesRepository = (context: ApplicationContext): OfficesRepository => {
-  if (context.config.authConfig.provider === 'mock') {
-    return MockOfficesRepository;
+  if (context.config.get('dbMock')) {
+    if (!mockOrdersRepository) {
+      mockOrdersRepository = MockMongoRepository.getInstance(context);
+    }
+    return mockOrdersRepository;
   }
   const repo = OfficesMongoRepository.getInstance(context);
   deferRelease(repo, context);

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -46,6 +46,10 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
+  findAndDeleteStaff(..._ignore): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
   getOfficeAttorneys(..._ignore): Promise<any[]> {
     throw new Error('Method not implemented.');
   }

--- a/backend/lib/use-cases/admin/admin.test.ts
+++ b/backend/lib/use-cases/admin/admin.test.ts
@@ -1,10 +1,11 @@
 import { createMockApplicationContext } from '../../testing/testing-utilities';
-import { AdminUseCase } from './admin';
+import { AdminUseCase, CreateStaffRequestBody } from './admin';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import MockData from '../../../../common/src/cams/test-utilities/mock-data';
 import { CamsRole } from '../../../../common/src/cams/roles';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { CamsError } from '../../common-errors/cams-error';
+import { Staff } from '../../../../common/src/cams/users';
 
 describe('Test Migration Admin Use Case', () => {
   let context: ApplicationContext;
@@ -30,16 +31,33 @@ describe('Test Migration Admin Use Case', () => {
     );
   });
 
-  test('should create new office staff entry', async () => {
-    const createSpy = jest
-      .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
-      .mockResolvedValue();
+  const successCases = [
+    ['undefined', undefined, 86400],
+    ['-1', -1, -1],
+    ['3600', 3600, 3600],
+  ];
+  test.each(successCases)(
+    'should create new office staff entry with %s ttl provided',
+    async (_caseName: string, ttl: number, expectedTtl: number) => {
+      const createSpy = jest
+        .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
+        .mockResolvedValue();
 
-    const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
-    delete user.offices;
-    await useCase.addOfficeStaff(context, 'My_Test_Office', user, -1);
-    expect(createSpy).toHaveBeenCalled();
-  });
+      const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
+      const expectedUser: Staff = {
+        id: user.id,
+        name: user.name,
+        roles: user.roles,
+      };
+      const requestBody: CreateStaffRequestBody = {
+        officeCode: testOffice,
+        ttl,
+        ...expectedUser,
+      };
+      await useCase.addOfficeStaff(context, requestBody);
+      expect(createSpy).toHaveBeenCalledWith(testOffice, expectedUser, expectedTtl);
+    },
+  );
 
   test('should add to camsStack upon create error', async () => {
     const message = 'Some error occurred.';
@@ -48,8 +66,14 @@ describe('Test Migration Admin Use Case', () => {
       .mockRejectedValue(new CamsError(module, { message }));
 
     const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
-    delete user.offices;
-    await expect(useCase.addOfficeStaff(context, testOffice, user, -1)).rejects.toThrow(
+    const requestBody: CreateStaffRequestBody = {
+      officeCode: testOffice,
+      id: user.id,
+      name: user.name,
+      roles: user.roles,
+      ttl: -1,
+    };
+    await expect(useCase.addOfficeStaff(context, requestBody)).rejects.toThrow(
       expect.objectContaining({
         message,
         module,

--- a/backend/lib/use-cases/admin/admin.test.ts
+++ b/backend/lib/use-cases/admin/admin.test.ts
@@ -3,11 +3,21 @@ import { AdminUseCase } from './admin';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import MockData from '../../../../common/src/cams/test-utilities/mock-data';
 import { CamsRole } from '../../../../common/src/cams/roles';
+import { ApplicationContext } from '../../adapters/types/basic';
+import { CamsError } from '../../common-errors/cams-error';
 
 describe('Test Migration Admin Use Case', () => {
+  let context: ApplicationContext;
+  let useCase: AdminUseCase;
+  const module = 'TEST-MODULE';
+  const testOffice = 'TEST_OFFICE_GROUP';
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    useCase = new AdminUseCase();
+  });
+
   test('should record use case module on CAMS stack', async () => {
-    const context = await createMockApplicationContext();
-    const useCase = new AdminUseCase();
     await expect(useCase.deleteMigrations(context)).rejects.toThrow(
       expect.objectContaining({
         camsStack: [
@@ -21,14 +31,58 @@ describe('Test Migration Admin Use Case', () => {
   });
 
   test('should create new office staff entry', async () => {
-    const context = await createMockApplicationContext();
-    const useCase = new AdminUseCase();
     const createSpy = jest
       .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
       .mockResolvedValue();
 
     const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
+    delete user.offices;
     await useCase.addOfficeStaff(context, 'My_Test_Office', user, -1);
     expect(createSpy).toHaveBeenCalled();
+  });
+
+  test('should add to camsStack upon create error', async () => {
+    const message = 'Some error occurred.';
+    jest
+      .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
+      .mockRejectedValue(new CamsError(module, { message }));
+
+    const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
+    delete user.offices;
+    await expect(useCase.addOfficeStaff(context, testOffice, user, -1)).rejects.toThrow(
+      expect.objectContaining({
+        message,
+        module,
+        camsStack: expect.arrayContaining([
+          { module: expect.anything(), message: 'Failed to create staff document.' },
+        ]),
+      }),
+    );
+  });
+
+  test('should remove office staff entry', async () => {
+    const deleteSpy = jest
+      .spyOn(MockMongoRepository.prototype, 'findAndDeleteStaff')
+      .mockResolvedValue();
+
+    await useCase.deleteStaff(context, testOffice, 'John Doe');
+    expect(deleteSpy).toHaveBeenCalledWith(testOffice, 'John Doe');
+  });
+
+  test('should add to camsStack upon delete error', async () => {
+    const message = 'Some error occurred.';
+    jest
+      .spyOn(MockMongoRepository.prototype, 'findAndDeleteStaff')
+      .mockRejectedValue(new CamsError(module, { message }));
+
+    await expect(useCase.deleteStaff(context, testOffice, 'John Doe')).rejects.toThrow(
+      expect.objectContaining({
+        message,
+        module,
+        camsStack: expect.arrayContaining([
+          { module: expect.anything(), message: 'Failed to delete staff document.' },
+        ]),
+      }),
+    );
   });
 });

--- a/backend/lib/use-cases/admin/admin.test.ts
+++ b/backend/lib/use-cases/admin/admin.test.ts
@@ -1,5 +1,8 @@
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { AdminUseCase } from './admin';
+import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
+import MockData from '../../../../common/src/cams/test-utilities/mock-data';
+import { CamsRole } from '../../../../common/src/cams/roles';
 
 describe('Test Migration Admin Use Case', () => {
   test('should record use case module on CAMS stack', async () => {
@@ -15,5 +18,17 @@ describe('Test Migration Admin Use Case', () => {
         ],
       }),
     );
+  });
+
+  test('should create new office staff entry', async () => {
+    const context = await createMockApplicationContext();
+    const useCase = new AdminUseCase();
+    const createSpy = jest
+      .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
+      .mockResolvedValue();
+
+    const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
+    await useCase.addOfficeStaff(context, 'My_Test_Office', user, -1);
+    expect(createSpy).toHaveBeenCalled();
   });
 });

--- a/backend/lib/use-cases/admin/admin.ts
+++ b/backend/lib/use-cases/admin/admin.ts
@@ -1,6 +1,7 @@
 import { ApplicationContext } from '../../adapters/types/basic';
 import Factory from '../../factory';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
+import { Staff } from '../../../../common/src/cams/users';
 
 const MODULE_NAME = 'ADMIN-USE-CASE';
 
@@ -12,6 +13,23 @@ export class AdminUseCase {
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         camsStackInfo: { module: MODULE_NAME, message: 'Failed during migration deletion.' },
+      });
+    }
+  }
+
+  public async addOfficeStaff(
+    context: ApplicationContext,
+    officeCode: string,
+    userWithRoles: Staff,
+    ttl: number = 86400,
+  ): Promise<void> {
+    const officesRepo = Factory.getOfficesRepository(context);
+
+    try {
+      await officesRepo.putOfficeStaff(officeCode, userWithRoles, ttl);
+    } catch (originalError) {
+      throw getCamsErrorWithStack(originalError, MODULE_NAME, {
+        camsStackInfo: { module: MODULE_NAME, message: 'Failed to create document.' },
       });
     }
   }

--- a/backend/lib/use-cases/admin/admin.ts
+++ b/backend/lib/use-cases/admin/admin.ts
@@ -17,6 +17,15 @@ export class AdminUseCase {
     }
   }
 
+  /**
+   * addOfficeStaff
+   * @param {ApplicationContext} context Application context.
+   * @param {string} officeCode The AD Group for the office to add the user to.
+   * @param {Staff} userWithRoles User name, id, and list of roles.
+   * @param {number} [ttl=86400] Mongo-compliant time to live with a default of 24 hours. Use -1 for
+   * no ttl.
+   * @throws {CamsError} Throws a CamsError or any type that extends CamsError.
+   */
   public async addOfficeStaff(
     context: ApplicationContext,
     officeCode: string,
@@ -29,7 +38,23 @@ export class AdminUseCase {
       await officesRepo.putOfficeStaff(officeCode, userWithRoles, ttl);
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
-        camsStackInfo: { module: MODULE_NAME, message: 'Failed to create document.' },
+        camsStackInfo: { module: MODULE_NAME, message: 'Failed to create staff document.' },
+      });
+    }
+  }
+
+  public async deleteStaff(
+    context: ApplicationContext,
+    officeCode: string,
+    id: string,
+  ): Promise<void> {
+    const officesRepo = Factory.getOfficesRepository(context);
+
+    try {
+      await officesRepo.findAndDeleteStaff(officeCode, id);
+    } catch (originalError) {
+      throw getCamsErrorWithStack(originalError, MODULE_NAME, {
+        camsStackInfo: { module: MODULE_NAME, message: 'Failed to delete staff document.' },
       });
     }
   }

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -121,7 +121,7 @@ export interface CasesRepository extends Releasable {
 
 export interface OfficesRepository extends Releasable {
   getOfficeAttorneys(officeCode: string): Promise<AttorneyUser[]>;
-  putOfficeStaff(officeCode: string, user: CamsUserReference): Promise<void>;
+  putOfficeStaff(officeCode: string, user: CamsUserReference, ttl?: number): Promise<void>;
 }
 
 // TODO: Move these models to a top level models file?

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -122,6 +122,7 @@ export interface CasesRepository extends Releasable {
 export interface OfficesRepository extends Releasable {
   getOfficeAttorneys(officeCode: string): Promise<AttorneyUser[]>;
   putOfficeStaff(officeCode: string, user: CamsUserReference, ttl?: number): Promise<void>;
+  findAndDeleteStaff(officeCode: string, id: string): Promise<void>;
 }
 
 // TODO: Move these models to a top level models file?

--- a/backend/lib/use-cases/offices/offices.test.ts
+++ b/backend/lib/use-cases/offices/offices.test.ts
@@ -90,6 +90,7 @@ describe('offices use case tests', () => {
         release: () => {},
         putOfficeStaff: jest.fn(),
         getOfficeAttorneys: repoSpy,
+        findAndDeleteStaff: jest.fn(),
         close: jest.fn(),
       };
     });
@@ -117,6 +118,7 @@ describe('offices use case tests', () => {
         release: () => {},
         putOfficeStaff: jest.fn(),
         getOfficeAttorneys: repoSpy,
+        findAndDeleteStaff: jest.fn(),
         close: jest.fn(),
       };
     });

--- a/backend/lib/use-cases/offices/offices.test.ts
+++ b/backend/lib/use-cases/offices/offices.test.ts
@@ -10,7 +10,6 @@ import { USTP_OFFICES_ARRAY, UstpDivisionMeta } from '../../../../common/src/cam
 import { TRIAL_ATTORNEYS } from '../../../../common/src/cams/test-utilities/attorneys.mock';
 import AttorneysList from '../attorneys';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
-import { MockOfficesRepository } from '../../testing/mock-gateways/mock.offices.repository';
 import { CamsRole } from '../../../../common/src/cams/roles';
 
 describe('offices use case tests', () => {
@@ -170,7 +169,7 @@ describe('offices use case tests', () => {
       );
 
     const putSpy = jest
-      .spyOn(MockOfficesRepository, 'putOfficeStaff')
+      .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
       .mockResolvedValueOnce()
       .mockRejectedValueOnce(new Error('some unknown error'))
       .mockResolvedValue();


### PR DESCRIPTION
# Purpose

We need project team members to be able to validate privileged functionality in staging.

# Major Changes

Adds two new admin Functions to create and delete staff entries.

# Testing/Validation

- Automated tests added.
- Will verify with a dev deployment.

# Options

I think an admin portal would be really good to add. Currently these new functions would have to be run by someone with elevated access within the Azure Portal. An admin screen in CAMS could leverage role based access meaning non-developers would be able to run them.