### PR TITLE
Add Azure Portal url to CORS allowlist

### DIFF
--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -212,7 +212,7 @@ module ustpFunctions 'backend-api-deploy.bicep' = {
       sqlServerResourceGroupName: sqlServerResourceGroupName
       sqlServerIdentityName: sqlServerIdentityName
       sqlServerIdentityResourceGroupName: sqlServerIdentityResourceGroupName
-      apiCorsAllowOrigins: ['https://${webappName}.azurewebsites.us']
+      apiCorsAllowOrigins: ['https://${webappName}.azurewebsites.us','https://portal.azure.us']
       migrationCorsAllowOrigins: ['https://${webappName}.azurewebsites.us','https://portal.azure.us']
       allowVeracodeScan: allowVeracodeScan
       idKeyvaultAppConfiguration: idKeyvaultAppConfiguration


### PR DESCRIPTION
# Problem

We have to modify CORS settings and stop and start the Function App to trigger the sync.

# Solution

Add Azure Portal url to the CORS allowlist so that we can just trigger Functions when needed.
