### PR TITLE
Set default ttl to 23 hours temporarily

### DIFF
--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
@@ -12,6 +12,7 @@ import { closeDeferred } from '../../../deferrable/defer-close';
 import { createAuditRecord } from '../../../../../common/src/cams/auditable';
 import { getCamsError } from '../../../common-errors/error-utilities';
 import { CamsSession } from '../../../../../common/src/cams/session';
+import { DEFAULT_STAFF_TTL } from '../../../use-cases/admin/admin';
 
 describe('offices repo', () => {
   let context: ApplicationContext;
@@ -54,13 +55,12 @@ describe('offices repo', () => {
   });
 
   test('putOfficeStaff', async () => {
-    const ttl = 86400;
     const staff = createAuditRecord<OfficeStaff>({
       id: session.user.id,
       documentType: 'OFFICE_STAFF',
       officeCode,
       ...session.user,
-      ttl,
+      ttl: DEFAULT_STAFF_TTL,
     });
     const replaceOneSpy = jest
       .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
@@ -8,6 +8,7 @@ import { getCamsError, getCamsErrorWithStack } from '../../../common-errors/erro
 import { OfficesRepository } from '../../../use-cases/gateways.types';
 import { BaseMongoRepository } from './utils/base-mongo-repository';
 import { UnknownError } from '../../../common-errors/unknown-error';
+import { DEFAULT_STAFF_TTL } from '../../../use-cases/admin/admin';
 
 const MODULE_NAME: string = 'OFFICES_MONGO_REPOSITORY';
 const COLLECTION_NAME = 'offices';
@@ -51,7 +52,7 @@ export class OfficesMongoRepository extends BaseMongoRepository implements Offic
   async putOfficeStaff(
     officeCode: string,
     user: CamsUserReference,
-    ttl: number = 86400,
+    ttl: number = DEFAULT_STAFF_TTL,
   ): Promise<void> {
     const staff = createAuditRecord<OfficeStaff>({
       id: user.id,

--- a/backend/lib/use-cases/admin/admin.test.ts
+++ b/backend/lib/use-cases/admin/admin.test.ts
@@ -1,5 +1,5 @@
 import { createMockApplicationContext } from '../../testing/testing-utilities';
-import { AdminUseCase, CreateStaffRequestBody } from './admin';
+import { AdminUseCase, CreateStaffRequestBody, DEFAULT_STAFF_TTL } from './admin';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import MockData from '../../../../common/src/cams/test-utilities/mock-data';
 import { CamsRole } from '../../../../common/src/cams/roles';
@@ -32,7 +32,7 @@ describe('Test Migration Admin Use Case', () => {
   });
 
   const successCases = [
-    ['undefined', undefined, 86400],
+    ['undefined', undefined, DEFAULT_STAFF_TTL],
     ['-1', -1, -1],
     ['3600', 3600, 3600],
   ];

--- a/backend/lib/use-cases/admin/admin.ts
+++ b/backend/lib/use-cases/admin/admin.ts
@@ -4,6 +4,7 @@ import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
 import { Staff } from '../../../../common/src/cams/users';
 
 const MODULE_NAME = 'ADMIN-USE-CASE';
+export const DEFAULT_STAFF_TTL = 60 * 60 * 23; // Set to 23 hours until we figure out issue with upsert
 
 export type CreateStaffRequestBody = Staff & {
   officeCode: string;
@@ -36,7 +37,7 @@ export class AdminUseCase {
     requestBody: CreateStaffRequestBody,
   ): Promise<void> {
     const officesRepo = Factory.getOfficesRepository(context);
-    const ttl = requestBody.ttl ?? 86400;
+    const ttl = requestBody.ttl ?? DEFAULT_STAFF_TTL;
     const userWithRoles: Staff = {
       id: requestBody.id,
       name: requestBody.name,


### PR DESCRIPTION
# Problem

Upsert if failing for staff documents.

# Solution

We temporarily set the ttl to 23 hours so that the documents will be removed by the next night when the sync runs. This way each night at midnight eastern, the container should be empty and the sync should succeed.

# Testing/Validation

Updated automated tests.
