### PR TITLE
CAMS-502: Properly handle modified result for upserts

### DIFF
--- a/backend/lib/adapters/gateways/mongo/case-assignment.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/case-assignment.mongo.repository.test.ts
@@ -33,7 +33,9 @@ describe('case assignment repo tests', () => {
     test('should update assignment', async () => {
       const fakeAttorney = MockData.getAttorneyUser();
       const assignment = MockData.getAttorneyAssignment({ name: fakeAttorney.name });
-      jest.spyOn(MongoCollectionAdapter.prototype, 'replaceOne').mockResolvedValue(assignment.id);
+      jest
+        .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')
+        .mockResolvedValue({ id: assignment.id, modifiedCount: 1, upsertedCount: 0 });
       const actual = await repo.update(assignment);
       expect(actual).toEqual(assignment.id);
     });

--- a/backend/lib/adapters/gateways/mongo/case-assignment.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/case-assignment.mongo.repository.ts
@@ -52,7 +52,10 @@ export class CaseAssignmentMongoRepository
   async update(caseAssignment: CaseAssignment): Promise<string> {
     const query = equals<CaseAssignment['id']>('id', caseAssignment.id);
     try {
-      return await this.getAdapter<CaseAssignment>().replaceOne(query, caseAssignment);
+      const result = await this.getAdapter<CaseAssignment>().replaceOne(query, caseAssignment);
+      if (result.modifiedCount > 0) {
+        return result.id;
+      }
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME, 'Unable to update assignment.');
     }

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
@@ -12,7 +12,7 @@ import { closeDeferred } from '../../../deferrable/defer-close';
 import { createAuditRecord } from '../../../../../common/src/cams/auditable';
 import { getCamsError } from '../../../common-errors/error-utilities';
 import { CamsSession } from '../../../../../common/src/cams/session';
-import { DEFAULT_STAFF_TTL } from '../../../use-cases/admin/admin';
+import { DEFAULT_STAFF_TTL } from '../../../use-cases/offices/offices';
 
 describe('offices repo', () => {
   let context: ApplicationContext;
@@ -64,7 +64,7 @@ describe('offices repo', () => {
     });
     const replaceOneSpy = jest
       .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')
-      .mockResolvedValue('inserted-id');
+      .mockResolvedValue({ id: 'inserted-id', modifiedCount: 1, upsertedCount: 0 });
 
     await repo.putOfficeStaff(officeCode, session.user);
     expect(replaceOneSpy).toHaveBeenCalledWith(

--- a/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.ts
@@ -35,8 +35,10 @@ export class RuntimeStateMongoRepository<T extends RuntimeState>
     try {
       const query = QueryBuilder.build(equals('documentType', data.documentType));
       const adapter = this.getAdapter<T>();
-      const id = await adapter.replaceOne(query, data, true);
-      return { ...data, id } as T;
+      const result = await adapter.replaceOne(query, data, true);
+      if (result.modifiedCount + result.upsertedCount > 0) {
+        return { ...data, id: result.id } as T;
+      }
     } catch (e) {
       throw getCamsError(e, MODULE_NAME);
     }

--- a/backend/lib/adapters/gateways/mongo/user-session-cache.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/user-session-cache.mongo.repository.test.ts
@@ -68,7 +68,7 @@ describe('User session cache Cosmos repository tests', () => {
     const camsJwtClaims = jwt.decode(newSession.accessToken) as CamsJwtClaims;
     const insertOne = jest
       .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')
-      .mockResolvedValue('oid-guid');
+      .mockResolvedValue({ id: 'oid-guid', modifiedCount: 1, upsertedCount: 0 });
     const tokenParts = newSession.accessToken.split('.');
     const signature = tokenParts[2];
     const expectedQuery = QueryBuilder.build(equals('signature', signature));

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
@@ -136,10 +136,18 @@ describe('Mongo adapter', () => {
       matchedCount: 1,
       modifiedCount: 1,
       upsertedId: _id,
+      upsertedCount: 0,
     });
+
+    const expected = {
+      id: testObject.id,
+      modifiedCount: 1,
+      upsertedCount: 0,
+    };
+
     const result = await adapter.replaceOne(testQuery, testObject);
-    expect(result).not.toEqual(_id);
-    expect(result).toEqual(testObject.id);
+    expect(result).not.toEqual({ ...expected, id: _id });
+    expect(result).toEqual(expected);
   });
 
   test('should throw an error calling replaceOne for a nonexistent record and upsert=false', async () => {
@@ -189,9 +197,16 @@ describe('Mongo adapter', () => {
       upsertedCount: 1,
       upsertedId: _id,
     });
+
+    const expected = {
+      id: testObject.id,
+      modifiedCount: 0,
+      upsertedCount: 1,
+    };
+
     const result = await adapter.replaceOne(testQuery, testObject, true);
-    expect(result).toEqual(testObject.id);
-    expect(result).not.toEqual(_id);
+    expect(result).toEqual(expected);
+    expect(result).not.toEqual({ ...expected, id: _id });
   });
 
   const upsertFailureCases = [

--- a/backend/lib/controllers/admin/admin.controller.test.ts
+++ b/backend/lib/controllers/admin/admin.controller.test.ts
@@ -36,15 +36,18 @@ describe('Admin controller tests', () => {
 
   test('should return 201 for successful addition of staff', async () => {
     const context = await createMockApplicationContext();
+    const id = 'user-idp-id';
     context.request.method = 'POST';
     context.request.params.procedure = 'createStaff';
     context.request.body = {
       officeCode: 'TEST_OFFICE_GROUP',
-      id: 'user-okta-id',
+      id,
       name: 'Last, First',
       roles: [CamsRole.CaseAssignmentManager],
     };
-    jest.spyOn(AdminUseCase.prototype, 'addOfficeStaff').mockResolvedValue();
+    jest
+      .spyOn(AdminUseCase.prototype, 'addOfficeStaff')
+      .mockResolvedValue({ id, modifiedCount: 0, upsertedCount: 1 });
     const response = await controller.handleRequest(context);
     expect(response).toEqual({ statusCode: 201 });
   });

--- a/backend/lib/controllers/admin/admin.controller.ts
+++ b/backend/lib/controllers/admin/admin.controller.ts
@@ -27,8 +27,8 @@ export class AdminController implements CamsController {
         return { statusCode: 204 };
       } else if (procedure === createStaff && context.request.method === 'POST') {
         const requestBody: CreateStaffRequestBody = context.request.body as CreateStaffRequestBody;
-        await useCase.addOfficeStaff(context, requestBody);
-        return { statusCode: 201 };
+        const result = await useCase.addOfficeStaff(context, requestBody);
+        return { statusCode: result.upsertedCount === 1 ? 201 : 204 };
       } else if (procedure === deleteStaff && context.request.method === 'DELETE') {
         await useCase.deleteStaff(
           context,

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -56,6 +56,7 @@ let orderSyncStateRepo: RuntimeStateRepository<OrderSyncState>;
 let officeStaffSyncStateRepo: RuntimeStateRepository<OfficeStaffSyncState>;
 
 let mockOrdersRepository: MockMongoRepository;
+let mockOfficesRepository: MockMongoRepository;
 let mockConsolidationsRepository: MockMongoRepository;
 let mockCasesRepository: MockMongoRepository;
 let mockUserSessionCacheRepository: MockMongoRepository;
@@ -116,10 +117,10 @@ export const getOfficesGateway = (context: ApplicationContext): OfficesGateway =
 
 export const getOfficesRepository = (context: ApplicationContext): OfficesRepository => {
   if (context.config.get('dbMock')) {
-    if (!mockOrdersRepository) {
-      mockOrdersRepository = MockMongoRepository.getInstance(context);
+    if (!mockOfficesRepository) {
+      mockOfficesRepository = MockMongoRepository.getInstance(context);
     }
-    return mockOrdersRepository;
+    return mockOfficesRepository;
   }
   const repo = OfficesMongoRepository.getInstance(context);
   deferRelease(repo, context);

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -46,6 +46,7 @@ import { RuntimeStateMongoRepository } from './adapters/gateways/mongo/runtime-s
 import { UserSessionCacheMongoRepository } from './adapters/gateways/mongo/user-session-cache.mongo.repository';
 import { AcmsGatewayImpl } from './adapters/gateways/acms/acms.gateway';
 import { deferRelease } from './deferrable/defer-release';
+import { MockOfficesRepository } from './testing/mock-gateways/mock.offices.repository';
 
 let casesGateway: CasesInterface;
 let ordersGateway: OrdersGateway;
@@ -56,7 +57,6 @@ let orderSyncStateRepo: RuntimeStateRepository<OrderSyncState>;
 let officeStaffSyncStateRepo: RuntimeStateRepository<OfficeStaffSyncState>;
 
 let mockOrdersRepository: MockMongoRepository;
-let mockOfficesRepository: MockMongoRepository;
 let mockConsolidationsRepository: MockMongoRepository;
 let mockCasesRepository: MockMongoRepository;
 let mockUserSessionCacheRepository: MockMongoRepository;
@@ -116,11 +116,8 @@ export const getOfficesGateway = (context: ApplicationContext): OfficesGateway =
 };
 
 export const getOfficesRepository = (context: ApplicationContext): OfficesRepository => {
-  if (context.config.get('dbMock')) {
-    if (!mockOfficesRepository) {
-      mockOfficesRepository = MockMongoRepository.getInstance(context);
-    }
-    return mockOfficesRepository;
+  if (context.config.authConfig.provider === 'mock') {
+    return MockOfficesRepository;
   }
   const repo = OfficesMongoRepository.getInstance(context);
   deferRelease(repo, context);

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -54,7 +54,7 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
-  putOfficeStaff(..._ignore): Promise<void> {
+  putOfficeStaff(..._ignore): Promise<any> {
     throw new Error('Method not implemented.');
   }
 

--- a/backend/lib/testing/mock-gateways/mock.offices.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock.offices.repository.ts
@@ -1,8 +1,11 @@
 import { TRIAL_ATTORNEYS } from '../../../../common/src/cams/test-utilities/attorneys.mock';
+import { CamsUserReference } from '../../../../common/src/cams/users';
 
 export const MockOfficesRepository = {
   release: () => {},
-  putOfficeStaff: (_officeCode, _user) => Promise.resolve(),
+  putOfficeStaff: (_officeCode: string, user: CamsUserReference, _ttl?: number) =>
+    Promise.resolve({ id: user.id, modifiedCount: 1, upsertedCount: 1 }),
+  findAndDeleteStaff: (_officeCode: string, _id: string) => Promise.resolve(),
   getOfficeAttorneys: () => {
     return Promise.resolve(TRIAL_ATTORNEYS);
   },

--- a/backend/lib/use-cases/admin/admin.test.ts
+++ b/backend/lib/use-cases/admin/admin.test.ts
@@ -1,12 +1,12 @@
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { AdminUseCase, CreateStaffRequestBody } from './admin';
 import { DEFAULT_STAFF_TTL } from '../offices/offices';
-import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import MockData from '../../../../common/src/cams/test-utilities/mock-data';
 import { CamsRole } from '../../../../common/src/cams/roles';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { CamsError } from '../../common-errors/cams-error';
 import { Staff } from '../../../../common/src/cams/users';
+import { MockOfficesRepository } from '../../testing/mock-gateways/mock.offices.repository';
 
 describe('Test Migration Admin Use Case', () => {
   let context: ApplicationContext;
@@ -42,7 +42,7 @@ describe('Test Migration Admin Use Case', () => {
     async (_caseName: string, ttl: number, expectedTtl: number) => {
       const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
       const createSpy = jest
-        .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
+        .spyOn(MockOfficesRepository, 'putOfficeStaff')
         .mockResolvedValue({ id: user.id, modifiedCount: 0, upsertedCount: 1 });
 
       const expectedUser: Staff = {
@@ -63,7 +63,7 @@ describe('Test Migration Admin Use Case', () => {
   test('should add to camsStack upon create error', async () => {
     const message = 'Some error occurred.';
     jest
-      .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
+      .spyOn(MockOfficesRepository, 'putOfficeStaff')
       .mockRejectedValue(new CamsError(module, { message }));
 
     const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
@@ -86,9 +86,7 @@ describe('Test Migration Admin Use Case', () => {
   });
 
   test('should remove office staff entry', async () => {
-    const deleteSpy = jest
-      .spyOn(MockMongoRepository.prototype, 'findAndDeleteStaff')
-      .mockResolvedValue();
+    const deleteSpy = jest.spyOn(MockOfficesRepository, 'findAndDeleteStaff').mockResolvedValue();
 
     await useCase.deleteStaff(context, testOffice, 'John Doe');
     expect(deleteSpy).toHaveBeenCalledWith(testOffice, 'John Doe');
@@ -97,7 +95,7 @@ describe('Test Migration Admin Use Case', () => {
   test('should add to camsStack upon delete error', async () => {
     const message = 'Some error occurred.';
     jest
-      .spyOn(MockMongoRepository.prototype, 'findAndDeleteStaff')
+      .spyOn(MockOfficesRepository, 'findAndDeleteStaff')
       .mockRejectedValue(new CamsError(module, { message }));
 
     await expect(useCase.deleteStaff(context, testOffice, 'John Doe')).rejects.toThrow(

--- a/backend/lib/use-cases/admin/admin.test.ts
+++ b/backend/lib/use-cases/admin/admin.test.ts
@@ -1,5 +1,6 @@
 import { createMockApplicationContext } from '../../testing/testing-utilities';
-import { AdminUseCase, CreateStaffRequestBody, DEFAULT_STAFF_TTL } from './admin';
+import { AdminUseCase, CreateStaffRequestBody } from './admin';
+import { DEFAULT_STAFF_TTL } from '../offices/offices';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import MockData from '../../../../common/src/cams/test-utilities/mock-data';
 import { CamsRole } from '../../../../common/src/cams/roles';
@@ -39,11 +40,11 @@ describe('Test Migration Admin Use Case', () => {
   test.each(successCases)(
     'should create new office staff entry with %s ttl provided',
     async (_caseName: string, ttl: number, expectedTtl: number) => {
+      const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
       const createSpy = jest
         .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
-        .mockResolvedValue();
+        .mockResolvedValue({ id: user.id, modifiedCount: 0, upsertedCount: 1 });
 
-      const user = MockData.getCamsUser({ roles: [CamsRole.CaseAssignmentManager] });
       const expectedUser: Staff = {
         id: user.id,
         name: user.name,

--- a/backend/lib/use-cases/admin/admin.ts
+++ b/backend/lib/use-cases/admin/admin.ts
@@ -2,9 +2,10 @@ import { ApplicationContext } from '../../adapters/types/basic';
 import Factory from '../../factory';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
 import { Staff } from '../../../../common/src/cams/users';
+import { UpsertResult } from '../gateways.types';
+import { DEFAULT_STAFF_TTL } from '../offices/offices';
 
 const MODULE_NAME = 'ADMIN-USE-CASE';
-export const DEFAULT_STAFF_TTL = 60 * 60 * 23; // Set to 23 hours until we figure out issue with upsert
 
 export type CreateStaffRequestBody = Staff & {
   officeCode: string;
@@ -35,7 +36,7 @@ export class AdminUseCase {
   public async addOfficeStaff(
     context: ApplicationContext,
     requestBody: CreateStaffRequestBody,
-  ): Promise<void> {
+  ): Promise<UpsertResult> {
     const officesRepo = Factory.getOfficesRepository(context);
     const ttl = requestBody.ttl ?? DEFAULT_STAFF_TTL;
     const userWithRoles: Staff = {
@@ -45,7 +46,7 @@ export class AdminUseCase {
     };
 
     try {
-      await officesRepo.putOfficeStaff(requestBody.officeCode, userWithRoles, ttl);
+      return await officesRepo.putOfficeStaff(requestBody.officeCode, userWithRoles, ttl);
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         camsStackInfo: { module: MODULE_NAME, message: 'Failed to create staff document.' },

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -21,6 +21,14 @@ import { CamsSession } from '../../../common/src/cams/session';
 import { ConditionOrConjunction, Sort } from '../query/query-builder';
 import { AcmsConsolidation, AcmsPredicate } from './acms-orders/acms-orders';
 
+export type ReplaceResult = {
+  id: string;
+  modifiedCount: number;
+  upsertedCount: number;
+};
+
+export type UpsertResult = ReplaceResult;
+
 export interface Releasable {
   release: () => void;
 }
@@ -121,7 +129,7 @@ export interface CasesRepository extends Releasable {
 
 export interface OfficesRepository extends Releasable {
   getOfficeAttorneys(officeCode: string): Promise<AttorneyUser[]>;
-  putOfficeStaff(officeCode: string, user: CamsUserReference, ttl?: number): Promise<void>;
+  putOfficeStaff(officeCode: string, user: CamsUserReference, ttl?: number): Promise<ReplaceResult>;
   findAndDeleteStaff(officeCode: string, id: string): Promise<void>;
 }
 
@@ -149,7 +157,11 @@ export interface DocumentCollectionAdapter<T> {
   find: (query: ConditionOrConjunction, sort?: Sort) => Promise<T[]>;
   findOne: (query: ConditionOrConjunction) => Promise<T>;
   getAll: (sort?: Sort) => Promise<T[]>;
-  replaceOne: (query: ConditionOrConjunction, item: unknown, upsert?: boolean) => Promise<string>;
+  replaceOne: (
+    query: ConditionOrConjunction,
+    item: unknown,
+    upsert?: boolean,
+  ) => Promise<ReplaceResult>;
   insertOne: (item: unknown) => Promise<string>;
   insertMany: (items: unknown[]) => Promise<string[]>;
   deleteOne: (query: ConditionOrConjunction) => Promise<number>;

--- a/backend/lib/use-cases/offices/offices.test.ts
+++ b/backend/lib/use-cases/offices/offices.test.ts
@@ -172,9 +172,9 @@ describe('offices use case tests', () => {
 
     const putSpy = jest
       .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
-      .mockResolvedValueOnce()
+      .mockResolvedValueOnce({ id: users[1].id, modifiedCount: 1, upsertedCount: 0 })
       .mockRejectedValueOnce(new Error('some unknown error'))
-      .mockResolvedValue();
+      .mockResolvedValue({ id: users[3].id, modifiedCount: 0, upsertedCount: 1 });
     const stateRepoSpy = jest.spyOn(MockMongoRepository.prototype, 'upsert').mockResolvedValue('');
     const logSpy = jest.spyOn(applicationContext.logger, 'info').mockImplementation(() => {});
 

--- a/backend/lib/use-cases/offices/offices.test.ts
+++ b/backend/lib/use-cases/offices/offices.test.ts
@@ -11,6 +11,7 @@ import { TRIAL_ATTORNEYS } from '../../../../common/src/cams/test-utilities/atto
 import AttorneysList from '../attorneys';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import { CamsRole } from '../../../../common/src/cams/roles';
+import { MockOfficesRepository } from '../../testing/mock-gateways/mock.offices.repository';
 
 describe('offices use case tests', () => {
   let applicationContext: ApplicationContext;
@@ -171,7 +172,7 @@ describe('offices use case tests', () => {
       );
 
     const putSpy = jest
-      .spyOn(MockMongoRepository.prototype, 'putOfficeStaff')
+      .spyOn(MockOfficesRepository, 'putOfficeStaff')
       .mockResolvedValueOnce({ id: users[1].id, modifiedCount: 1, upsertedCount: 0 })
       .mockRejectedValueOnce(new Error('some unknown error'))
       .mockResolvedValue({ id: users[3].id, modifiedCount: 0, upsertedCount: 1 });

--- a/backend/lib/use-cases/offices/offices.ts
+++ b/backend/lib/use-cases/offices/offices.ts
@@ -14,6 +14,7 @@ import AttorneysList from '../attorneys';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
 
 const MODULE_NAME = 'OFFICES_USE_CASE';
+export const DEFAULT_STAFF_TTL = 60 * 60 * 25;
 
 export class OfficesUseCase {
   public async getOffices(context: ApplicationContext): Promise<UstpOfficeDetails[]> {


### PR DESCRIPTION
# Problem

Upserts that modify documents are incorrectly identified as having failed.

# Solution

Properly identify modified count as an indicator of success for upserts. Extend the ttl back out past 24 hours to ensure that documents exist at least until the next sync runs.

# Testing/Validation

Updated all related automated tests. Also exercised the endpoint to ensure that upserts and replacements work.