### PR TITLE
CAMS-302: Only use default flag values for testing

### DIFF
--- a/backend/lib/adapters/utils/feature-flag.ts
+++ b/backend/lib/adapters/utils/feature-flag.ts
@@ -1,10 +1,10 @@
 import * as ld from '@launchdarkly/node-server-sdk';
 import { ApplicationConfiguration } from '../../configs/application-configuration';
-import { defaultFeatureFlags } from '../../../../common/src/feature-flags';
+import { testFeatureFlags } from '../../../../common/src/feature-flags';
 import { FeatureFlagSet } from '../types/basic';
 
 export async function getFeatureFlags(config: ApplicationConfiguration): Promise<FeatureFlagSet> {
-  if (!config.featureFlagKey) return defaultFeatureFlags;
+  if (!config.featureFlagKey) return testFeatureFlags;
 
   const client = ld.init(config.featureFlagKey, {
     baseUri: 'https://clientsdk.launchdarkly.us',

--- a/common/src/feature-flags.test.ts
+++ b/common/src/feature-flags.test.ts
@@ -1,7 +1,7 @@
-import { defaultFeatureFlags } from './feature-flags';
+import { testFeatureFlags } from './feature-flags';
 
 describe('feature flag tests', () => {
   test('should return a map of flag names', () => {
-    expect(Object.keys(defaultFeatureFlags)).toBeTruthy();
+    expect(Object.keys(testFeatureFlags)).toBeTruthy();
   });
 });

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -7,7 +7,7 @@ export interface FeatureFlagSet {
   [key: string]: boolean | string | number;
 }
 
-export const defaultFeatureFlags: FeatureFlagSet = {
+export const testFeatureFlags: FeatureFlagSet = {
   'chapter-twelve-enabled': true,
   'chapter-eleven-enabled': true,
   'transfer-orders-enabled': true,

--- a/user-interface/src/lib/hooks/UseFeatureFlags.test.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.test.ts
@@ -1,5 +1,5 @@
 import * as sdk from 'launchdarkly-react-client-sdk';
-import { FeatureFlagSet, defaultFeatureFlags } from '@common/feature-flags';
+import { FeatureFlagSet, testFeatureFlags } from '@common/feature-flags';
 import * as config from '../../configuration/featureFlagConfiguration';
 import useFeatureFlags from './UseFeatureFlags';
 
@@ -11,7 +11,13 @@ const remoteFeatureFlags: FeatureFlagSet = {
 };
 
 describe('useFeatureFlag hook', () => {
-  beforeEach(() => {});
+  beforeEach(() => {
+    vi.stubEnv('CAMS_PA11Y', 'false');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
   test('should use defaults when an api key is not available', () => {
     vi.spyOn(config, 'getFeatureFlagConfiguration').mockReturnValue({
@@ -20,7 +26,7 @@ describe('useFeatureFlag hook', () => {
       useCamelCaseFlagKeys: false,
     });
     const featureFlags = useFeatureFlags();
-    expect(featureFlags).toEqual(defaultFeatureFlags);
+    expect(featureFlags).toEqual({});
   });
 
   test('should use defaults when an no flags are returned from the service', () => {
@@ -31,7 +37,7 @@ describe('useFeatureFlag hook', () => {
       useCamelCaseFlagKeys: false,
     });
     const featureFlags = useFeatureFlags();
-    expect(featureFlags).toEqual(defaultFeatureFlags);
+    expect(featureFlags).toEqual({});
   });
 
   test('should use flags returned from the service', () => {
@@ -43,5 +49,18 @@ describe('useFeatureFlag hook', () => {
     });
     const featureFlags = useFeatureFlags();
     expect(featureFlags).toEqual(remoteFeatureFlags);
+  });
+
+  test('should use default true flags when CAMS_PA11Y is true', () => {
+    vi.stubEnv('CAMS_PA11Y', 'true');
+
+    vi.spyOn(sdk, 'useFlags').mockRejectedValue(new Error('this should not be called'));
+    vi.spyOn(config, 'getFeatureFlagConfiguration').mockReturnValue({
+      clientId: BOGUS_CLIENT_ID,
+      useExternalProvider: true,
+      useCamelCaseFlagKeys: false,
+    });
+    const featureFlags = useFeatureFlags();
+    expect(featureFlags).toEqual(testFeatureFlags);
   });
 });

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -1,6 +1,6 @@
 import { useFlags } from 'launchdarkly-react-client-sdk';
-import { defaultFeatureFlags, FeatureFlagSet } from '@common/feature-flags';
-import { getFeatureFlagConfiguration } from '../../configuration/featureFlagConfiguration';
+import { FeatureFlagSet, testFeatureFlags } from '@common/feature-flags';
+import { getFeatureFlagConfiguration } from '@/configuration/featureFlagConfiguration';
 
 export const CHAPTER_ELEVEN_ENABLED = 'chapter-eleven-enabled';
 export const CHAPTER_TWELVE_ENABLED = 'chapter-twelve-enabled';
@@ -12,10 +12,9 @@ export const PRIVILEGED_IDENTITY_MANAGEMENT = 'privileged-identity-management';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();
-  if (!config.clientId) return defaultFeatureFlags;
+  if (import.meta.env['CAMS_PA11Y'] === 'true') return testFeatureFlags;
+  if (!config.clientId) return {};
 
   const featureFlags = useFlags();
-  return !featureFlags || Object.keys(featureFlags).length === 0
-    ? defaultFeatureFlags
-    : featureFlags;
+  return !featureFlags || Object.keys(featureFlags).length === 0 ? {} : featureFlags;
 }


### PR DESCRIPTION
# Purpose

We do not want to default to features being turned on simply to ensure that a11y tests can validate features that are behind flags.

# Major Changes

- Only return feature flag values as true by default if we are testing.

# Testing/Validation

- Updated automated tests.
- Validated locally in the following scenarios:
  - Valid client id for Launch Darkly.
  - Invalid client id for Launch Darkly.
  - `CAMS_PA11Y` set to true.
  - `CAMS_PA11Y` set to false and no client id for Launch Darkly.

# Notes

This will also prevent the behavior we see on refresh where a Case Assignment Manager who refreshes the screen while viewing the Staff Assignment screen will see chapter 11 cases despite that feature flag being turned off.