### PR TITLE
Azcli fix

### DIFF
--- a/.github/workflows/reusable-database-deploy.yml
+++ b/.github/workflows/reusable-database-deploy.yml
@@ -57,7 +57,7 @@ jobs:
         uses: azure/cli@v2
         id: e2eDbExists
         with:
-          azcliversion: 2.62
+          azcliversion: 2.62.0
           inlineScript: |
             cmd="az cosmosdb mongodb database exists --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} -n ${{ steps.generateE2eName.outputs.e2eDatabaseName }} -g ${{ secrets.AZURE_RG }} -o tsv"
             echo $cmd

--- a/.github/workflows/reusable-database-deploy.yml
+++ b/.github/workflows/reusable-database-deploy.yml
@@ -20,7 +20,7 @@ on:
         type: string
     outputs:
       e2eCosmosDbExists:
-        description: "Does E2E Cosmos DB Already Exists before deployment"
+        description: 'Does E2E Cosmos DB Already Exists before deployment'
         value: ${{ jobs.deploy-db.outputs.e2eCosmosDbExists }}
 
 jobs:
@@ -43,19 +43,26 @@ jobs:
           secret: ${{ secrets.PGP_SIGNING_PASSPHRASE }}
           op: decode
           in: ${{ inputs.azResourceGrpNetworkEncrypted }}
-
-      - name: Check if E2E CosmosDb exists ##Check if E2E DB exists determining if the DB needs data seeded downstream
-        id: e2eDbExists
+      - name: Generate E2E name
+        id: generateE2eName
         run: |
           e2eDatabaseName="${{ secrets.AZ_COSMOS_DATABASE_NAME }}-e2e"
           if [[ ${{ inputs.ghaEnvironment }} != "Main-Gov" ]]; then
             echo "Adding suffix to database name"
             e2eDatabaseName="${e2eDatabaseName}-${{ inputs.environmentHash }}"
           fi
-          cmd="az cosmosdb mongodb database exists --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} -n $e2eDatabaseName -g ${{ secrets.AZURE_RG }} -o tsv"
-          echo $cmd
-          e2eCosmosDbExists=$($cmd)
-          echo "e2eCosmosDbExists=${e2eCosmosDbExists}" >> $GITHUB_OUTPUT
+          echo "e2eDatabaseName=${e2eDatabaseName}" >> $GITHUB_OUTPUT
+
+      - name: Check if E2E CosmosDb exists
+        uses: azure/cli@v2
+        id: e2eDbExists
+        with:
+          azcliversion: 2.62
+          inlineScript: |
+            cmd="az cosmosdb mongodb database exists --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} -n ${{ steps.generateE2eName.outputs.e2eDatabaseName }} -g ${{ secrets.AZURE_RG }} -o tsv"
+            echo $cmd
+            e2eCosmosDbExists=$($cmd)
+            echo "e2eCosmosDbExists=${e2eCosmosDbExists}" >> $GITHUB_OUTPUT
 
       - name: Deploy Cosmos MongoDB
         id: azure-mongodb-deploy


### PR DESCRIPTION
# Problem

AZCLI is having issues with version compatibilities on their templates. they seem to have done a release for azure cloud that is not available in the AZ CLI for Azure Government. I used an azcli step within the problem step. If we need this elsewhere we can use it there too and rip out what we need once they finish updates.

# Solution

- used an azcli GHA step targeting a working version of AZ CLI with the working cosmos libraries for Azure Gov

# Testing/Validation

Ran through pipeline to validate changes

# Other Changes

- in the future we will likely want to remove this functionality once the latest version of these are changed, but we also need to be cognizant of this in the future when using the AZ CLI in the pipeline.
