### PR TITLE
CAMS-512: Properly identify user's offices

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
@@ -52,7 +52,7 @@ function toUstpOfficeDetails(flatOfficeDetails: DxtrFlatOfficeDetails[]): UstpOf
       current = {
         officeCode: ustpOfficeCode,
         officeName: getOfficeName(flatOffice.courtDivisionCode),
-        idpGroupId: ustpOfficeCode.replace(/_/g, ' '),
+        idpGroupName: ustpOfficeCode.replace(/_/g, ' '),
         groups: [],
         regionId: parseInt(flatOffice.regionId).toString(),
         regionName: flatOffice.regionName,

--- a/backend/lib/adapters/gateways/okta/okta-user-group-gateway.test.ts
+++ b/backend/lib/adapters/gateways/okta/okta-user-group-gateway.test.ts
@@ -224,10 +224,10 @@ describe('OktaGroupGateway', () => {
   describe('getUserById tests', () => {
     let context: ApplicationContext;
     const manhattanOffice: UstpOfficeDetails = {
-      officeCode: 'USTP CAMS Region 2 Office Manhattan',
+      officeCode: 'USTP_CAMS_Region_2_Office_Manhattan',
       officeName: 'Manhattan',
       groups: [],
-      idpGroupId: randomUUID(),
+      idpGroupName: 'USTP CAMS Region 2 Office Manhattan',
       regionId: '02',
       regionName: 'Region 2',
     };
@@ -247,7 +247,7 @@ describe('OktaGroupGateway', () => {
         name: 'USTP CAMS Region 2 Office Manhattan',
       };
       const groupTwo: IdpGroup = {
-        id: manhattanOffice.idpGroupId,
+        id: manhattanOffice.idpGroupName,
         name: 'USTP CAMS Trial Attorney',
       };
       jest.spyOn(MockOfficesGateway.prototype, 'getOffices').mockResolvedValue([manhattanOffice]);

--- a/backend/lib/adapters/gateways/okta/okta-user-group-gateway.ts
+++ b/backend/lib/adapters/gateways/okta/okta-user-group-gateway.ts
@@ -142,16 +142,14 @@ class OktaUserGroupGateway implements UserGroupGateway {
     try {
       const user = await this.oktaHumble.getUser({ userId: id });
       const groups = await this.oktaHumble.listUserGroups({ userId: id });
-      const groupIds = [];
       const groupNames = [];
       for await (const oktaGroup of groups) {
-        groupIds.push(oktaGroup.id);
         groupNames.push(oktaGroup.name);
       }
       const camsUser = {
         id: user.id,
         name: user.name,
-        offices: await UsersHelpers.getOfficesFromGroupNames(context, groupIds),
+        offices: await UsersHelpers.getOfficesFromGroupNames(context, groupNames),
         roles: UsersHelpers.getRolesFromGroupNames(groupNames),
       };
       context.logger.info(MODULE_NAME, `Retrieved ${id}`, camsUser);

--- a/backend/lib/testing/analysis/acms-dxtr-divisions/compare-divisions.ts
+++ b/backend/lib/testing/analysis/acms-dxtr-divisions/compare-divisions.ts
@@ -319,7 +319,7 @@ export function ustpOfficeToDivision(ustp: UstpOfficeDetails): DxtrRegionDivisio
         dxtrJudicialDistrictName: division.court.courtName,
         dxtrDivisionCode: division.divisionCode,
         dxtrDivisionName: division.courtOffice.courtOfficeName,
-        oktaGroupName: ustp.idpGroupId,
+        oktaGroupName: ustp.idpGroupName,
         camsOfficeCode: ustp.officeCode,
         ustpOfficeName: ustp.officeName,
       });

--- a/backend/lib/testing/analysis/export-office-csv.ts
+++ b/backend/lib/testing/analysis/export-office-csv.ts
@@ -20,7 +20,7 @@ function officesToCsv(offices: UstpOfficeDetails[]) {
   const records: string[] = offices
     .map((office) => [
       office.officeCode,
-      office.idpGroupId,
+      office.idpGroupName,
       office.officeName,
       office.regionId,
       office.regionName,

--- a/backend/lib/testing/mock-gateways/mock-user-group-gateway.ts
+++ b/backend/lib/testing/mock-gateways/mock-user-group-gateway.ts
@@ -30,14 +30,14 @@ LocalStorageGateway.getRoleMapping().forEach((camsRole, groupName) => {
 MOCKED_USTP_OFFICES_ARRAY.forEach((office) => {
   const group: CamsUserGroup = {
     id: randomUUID(),
-    name: office.idpGroupId,
+    name: office.idpGroupName,
   };
 
   group.users = MockUsers.filter(
-    (user) => !!user.user.offices.find((office) => office.idpGroupId === office.idpGroupId),
+    (user) => !!user.user.offices.find((office) => office.idpGroupName === office.idpGroupName),
   ).map((user) => getCamsUserReference(user.user));
 
-  camsUserGroups.set(office.idpGroupId, group);
+  camsUserGroups.set(office.idpGroupName, group);
 });
 
 export class MockUserGroupGateway implements UserGroupGateway {

--- a/backend/lib/use-cases/admin/admin.test.ts
+++ b/backend/lib/use-cases/admin/admin.test.ts
@@ -217,7 +217,7 @@ describe('Admin Use Case', () => {
 
   test('should return a list of valid IdP groups names', async () => {
     const roleGroups = Array.from(LocalStorageGateway.getRoleMapping().keys());
-    const officeGroups = MOCKED_USTP_OFFICES_ARRAY.map((office) => office.idpGroupId);
+    const officeGroups = MOCKED_USTP_OFFICES_ARRAY.map((office) => office.idpGroupName);
 
     const actual = await useCase.getRoleAndOfficeGroupNames(context);
 

--- a/backend/lib/use-cases/admin/admin.ts
+++ b/backend/lib/use-cases/admin/admin.ts
@@ -40,7 +40,7 @@ export class AdminUseCase {
         const officeGateway = getOfficesGateway(context);
 
         const offices = await officeGateway.getOffices(context);
-        const officeGroups = offices.map((office) => office.idpGroupId);
+        const officeGroups = offices.map((office) => office.idpGroupName);
         const roleGroups = Array.from(LocalStorageGateway.getRoleMapping().keys());
 
         this.roleAndOfficeGroupNames = {

--- a/backend/lib/use-cases/offices/offices.ts
+++ b/backend/lib/use-cases/offices/offices.ts
@@ -55,7 +55,7 @@ export class OfficesUseCase {
     const offices = await officesGateway.getOffices(context);
     const groupToRoleMap = storage.getRoleMapping();
     const groupToOfficeMap = offices.reduce((acc, office) => {
-      acc.set(office.idpGroupId, office);
+      acc.set(office.idpGroupName, office);
       return acc;
     }, new Map<string, UstpOfficeDetails>());
 

--- a/backend/lib/use-cases/users/users.helpers.test.ts
+++ b/backend/lib/use-cases/users/users.helpers.test.ts
@@ -16,10 +16,10 @@ describe('UsersHelpers tests', () => {
   const expiredDate = MockData.someDateBeforeThisDate(today);
   const unexpiredDate = MockData.someDateAfterThisDate(today);
   const manhattanOffice = MOCKED_USTP_OFFICES_ARRAY.find(
-    (office) => office.idpGroupId === 'USTP CAMS Region 2 Office Manhattan',
+    (office) => office.idpGroupName === 'USTP CAMS Region 2 Office Manhattan',
   );
   const wilmingtonOffice = MOCKED_USTP_OFFICES_ARRAY.find(
-    (office) => office.idpGroupId === 'USTP CAMS Region 3 Office Wilmington',
+    (office) => office.idpGroupName === 'USTP CAMS Region 3 Office Wilmington',
   );
 
   beforeEach(async () => {
@@ -124,7 +124,7 @@ describe('UsersHelpers tests', () => {
       id: idpUser.id,
       name: idpUser.name,
       claims: {
-        groups: ['USTP CAMS Case Assignment Manager', wilmingtonOffice.idpGroupId],
+        groups: ['USTP CAMS Case Assignment Manager', wilmingtonOffice.idpGroupName],
       },
       expires: unexpiredDate,
     };
@@ -165,7 +165,7 @@ describe('UsersHelpers tests', () => {
       id: idpUser.id,
       name: idpUser.name,
       claims: {
-        groups: ['USTP CAMS Case Assignment Manager', wilmingtonOffice.idpGroupId],
+        groups: ['USTP CAMS Case Assignment Manager', wilmingtonOffice.idpGroupName],
       },
       expires: MockData.someDateAfterThisDate(new Date().toISOString()),
     };
@@ -196,7 +196,7 @@ describe('UsersHelpers tests', () => {
       id: idpUser.id,
       name: idpUser.name,
       claims: {
-        groups: ['USTP CAMS Case Assignment Manager', wilmingtonOffice.idpGroupId],
+        groups: ['USTP CAMS Case Assignment Manager', wilmingtonOffice.idpGroupName],
       },
       expires: MockData.someDateAfterThisDate(new Date().toISOString()),
     };

--- a/backend/lib/use-cases/users/users.helpers.ts
+++ b/backend/lib/use-cases/users/users.helpers.ts
@@ -75,7 +75,7 @@ async function getOfficesFromGroupNames(
 ): Promise<UstpOfficeDetails[]> {
   const officesGateway = getOfficesGateway(context);
   const ustpOffices = await officesGateway.getOffices(context);
-  return ustpOffices.filter((office) => idpGroups.includes(office.idpGroupId));
+  return ustpOffices.filter((office) => idpGroups.includes(office.idpGroupName));
 }
 
 const UsersHelpers = {

--- a/common/src/cams/courts.test.ts
+++ b/common/src/cams/courts.test.ts
@@ -116,7 +116,7 @@ describe('common court library tests', () => {
 
 const seattleOffice = {
   officeCode: 'USTP_CAMS_Region_18_Office_Seattle',
-  idpGroupId: 'USTP CAMS Region 18 Office Seattle',
+  idpGroupName: 'USTP CAMS Region 18 Office Seattle',
   officeName: 'Seattle',
   groups: [
     {

--- a/common/src/cams/offices.ts
+++ b/common/src/cams/offices.ts
@@ -2,10 +2,10 @@ import { Staff } from './users';
 
 //TODO: Some of these probably do not belong here
 export type UstpOfficeDetails = {
-  officeCode: string; // Active Directory Group name (for now)
+  officeCode: string; // Active Directory Group name (for now) e.g. USTP_CAMS_My_Group_Name
   officeName: string; // https://www.justice.gov/ust/us-trustee-regions-and-offices and dxtr.constants.ts
   groups: UstpGroup[];
-  idpGroupId: string; // Okta
+  idpGroupName: string; // Okta group name e.g. USTP CAMS My Group Name
   regionId: string; // DXTR AO_REGION
   regionName: string; // DXTR AO_REGION
   state?: string; // https://www.justice.gov/ust/us-trustee-regions-and-offices
@@ -40,7 +40,7 @@ export type CourtOffice = {
 export const MOCKED_USTP_OFFICES_ARRAY: UstpOfficeDetails[] = [
   {
     officeCode: 'USTP_CAMS_Region_18_Office_Seattle',
-    idpGroupId: 'USTP CAMS Region 18 Office Seattle',
+    idpGroupName: 'USTP CAMS Region 18 Office Seattle',
     officeName: 'Seattle',
     groups: [
       {
@@ -115,7 +115,7 @@ export const MOCKED_USTP_OFFICES_ARRAY: UstpOfficeDetails[] = [
   },
   {
     officeCode: 'USTP_CAMS_Region_3_Office_Wilmington',
-    idpGroupId: 'USTP CAMS Region 3 Office Wilmington',
+    idpGroupName: 'USTP CAMS Region 3 Office Wilmington',
     officeName: 'Wilmington',
     groups: [
       {
@@ -137,7 +137,7 @@ export const MOCKED_USTP_OFFICES_ARRAY: UstpOfficeDetails[] = [
   },
   {
     officeCode: 'USTP_CAMS_Region_2_Office_Manhattan',
-    idpGroupId: 'USTP CAMS Region 2 Office Manhattan',
+    idpGroupName: 'USTP CAMS Region 2 Office Manhattan',
     officeName: 'Manhattan',
     groups: [
       {
@@ -167,7 +167,7 @@ export const MOCKED_USTP_OFFICES_ARRAY: UstpOfficeDetails[] = [
   },
   {
     officeCode: 'USTP_CAMS_Region_2_Office_Buffalo',
-    idpGroupId: 'USTP CAMS Region 2 Office Buffalo',
+    idpGroupName: 'USTP CAMS Region 2 Office Buffalo',
     officeName: 'Buffalo',
     groups: [
       {

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -562,7 +562,7 @@ function getRole(): string {
 }
 
 function getRoleAndOfficeGroupNames(): RoleAndOfficeGroupNames {
-  const offices = MockData.getOffices().map((office) => office.idpGroupId);
+  const offices = MockData.getOffices().map((office) => office.idpGroupName);
   return {
     roles: buildArray(getRole, 5),
     offices,


### PR DESCRIPTION
# Problem

User's assigned offices are not being added to their session.

# Solution

Use the Okta group name rather than identifier to match offices.

# Testing/Validation

Ran locally against dev instance of Okta and updated tests. Will validated in staging prior to production deployment.
