### PR TITLE
converted delete branch resources to azcli task

### DIFF
--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Delete Branch Resources
         uses: azure/cli@v2
-        id: deleteBranchREsourcues
+        id: deleteBranchResourcues
         with:
           azcliversion: 2.62.0
           inlineScript: |

--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       hashId:
-        description: "Hash id of target branch deployment"
-        default: ""
+        description: 'Hash id of target branch deployment'
+        default: ''
         type: string
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: ${{ inputs.hashId != ''  || github.event.ref_type == 'branch' }}
-    environment: "Develop"
+    environment: 'Develop'
     outputs:
       executeCleanup: ${{ steps.check.outputs.executeCleanup }}
       targetBranchHashId: ${{ steps.check.outputs.targetBranchHashId }}
@@ -64,20 +64,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check]
     if: needs.check.outputs.executeCleanup == 'true'
-    environment: "Develop"
+    environment: 'Develop'
     env:
-      environment: "Develop"
+      environment: 'Develop'
 
     steps:
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
       - uses: actions/checkout@v3
-      - run: |
-          ./ops/scripts/utility/az-delete-branch-resources.sh \
-          --app-resource-group=${{ secrets.AZ_APP_RG }} \
-          --db-account=${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \
-          --db-resource-group=${{ secrets.AZURE_RG }} \
-          --network-resource-group=${{ secrets.AZ_NETWORK_RG }} \
-          --short-hash=${{ needs.check.outputs.targetBranchHashId }}
+      - name: Delete Branch Resources
+        uses: azure/cli@v2
+        id: deleteBranchREsourcues
+        with:
+          azcliversion: 2.62.0
+          inlineScript: |
+            ./ops/scripts/utility/az-delete-branch-resources.sh \
+            --app-resource-group=${{ secrets.AZ_APP_RG }} \
+            --db-account=${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \
+            --db-resource-group=${{ secrets.AZURE_RG }} \
+            --network-resource-group=${{ secrets.AZ_NETWORK_RG }} \
+            --short-hash=${{ needs.check.outputs.targetBranchHashId }}

--- a/.github/workflows/reusable-database-deploy.yml
+++ b/.github/workflows/reusable-database-deploy.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@main
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}


### PR DESCRIPTION
# Problem

The branch resource cleanup also needed to transition to an azcli step. it was failing because of AZCLI commands within a script executing actions on cosmosdb

# Solution

- convert deletion step of branch cleanup to azcli action

# Testing/Validation

ran through pipeline

# Other Changes


