### PR TITLE
CAMS-421 Find AO_TX transaction ID range by date

### DIFF
--- a/backend/lib/adapters/gateways/cases.local.gateway.ts
+++ b/backend/lib/adapters/gateways/cases.local.gateway.ts
@@ -1,4 +1,8 @@
-import { CasesInterface, CasesSyncMeta } from '../../use-cases/cases/cases.interface';
+import {
+  CasesInterface,
+  CasesSyncMeta,
+  TransactionIdRangeForDate,
+} from '../../use-cases/cases/cases.interface';
 import { ApplicationContext } from '../types/basic';
 import { GatewayHelper } from './gateway-helper';
 import { getMonthDayYearStringFromDate } from '../utils/date-helper';
@@ -124,6 +128,13 @@ export class CasesLocalGateway implements CasesInterface {
     _applicationContext: ApplicationContext,
     _lastTxId: string,
   ): Promise<CasesSyncMeta> {
+    throw new Error('Not implemented');
+  }
+
+  public async findTransactionIdRangeForDate(
+    _context: ApplicationContext,
+    _findDate: string,
+  ): Promise<TransactionIdRangeForDate> {
     throw new Error('Not implemented');
   }
 }

--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
@@ -1,6 +1,6 @@
 import CasesDxtrGateway, { getCaseIdParts } from './cases.dxtr.gateway';
 import * as database from '../../utils/database';
-import { QueryResults } from '../../types/database';
+import { DbTableFieldSpec, QueryResults } from '../../types/database';
 import { CaseDetail } from '../../../../../common/src/cams/cases';
 import * as featureFlags from '../../utils/feature-flag';
 import { CamsError } from '../../../common-errors/cams-error';
@@ -9,6 +9,7 @@ import { CASE_SUMMARIES } from '../../../testing/mock-data/case-summaries.mock';
 import { DEBTORS } from '../../../testing/mock-data/debtors.mock';
 import { MockData } from '../../../../../common/src/cams/test-utilities/mock-data';
 import { createMockApplicationContext } from '../../../testing/testing-utilities';
+import { TransactionIdRangeForDate } from '../../../use-cases/cases/cases.interface';
 
 const dxtrDatabaseName = 'some-database-name';
 
@@ -804,5 +805,97 @@ describe('Test DXTR Gateway', () => {
       const result = await testCasesDxtrGateway.getCaseIdsAndMaxTxIdToSync(applicationContext, '0');
       expect(result).toEqual(expectedReturn);
     });
+  });
+
+  describe('findTransactionIdRangeForDate', () => {
+    const dateRangeMock = (_context, _config, query: string, params: DbTableFieldSpec[]) => {
+      const mockTxMap = new Map<number, string>([
+        [100, '2024-01-01'],
+        [101, '2024-01-01'],
+        [102, '2024-01-01'],
+        [103, '2024-02-01'],
+        [104, '2024-02-01'],
+        [105, '2024-03-01'],
+        [106, '2024-03-01'],
+        [107, '2024-03-01'],
+        [108, '2024-03-01'],
+        [109, '2024-04-01'],
+        [110, '2024-05-01'],
+      ]);
+
+      let recordset = [];
+
+      if (query.includes('MAX_TX_ID')) {
+        recordset = [{ MAX_TX_ID: 110 }];
+      }
+
+      if (query.includes('MIN_TX_ID')) {
+        recordset = [{ MIN_TX_ID: 100 }];
+      }
+
+      if (query.includes('TX_DATE')) {
+        const txId = params[0].value as number;
+        if (mockTxMap.has(txId)) {
+          const TX_DATE = mockTxMap.get(txId);
+          recordset = [{ TX_DATE }];
+        }
+      }
+
+      const results: QueryResults = {
+        success: true,
+        results: {
+          recordset,
+        },
+        message: '',
+      };
+
+      return Promise.resolve(results);
+    };
+
+    const boundTestCase = [
+      [
+        '1990-01-01',
+        {
+          findDate: '1990-01-01',
+          found: false,
+        },
+      ],
+      [
+        '2070-01-01',
+        {
+          findDate: '2070-01-01',
+          found: false,
+        },
+      ],
+      [
+        '2024-03-01',
+        {
+          findDate: '2024-03-01',
+          found: true,
+          start: 105,
+          end: 108,
+        },
+      ],
+      [
+        '2024-04-01',
+        {
+          findDate: '2024-04-01',
+          found: true,
+          start: 109,
+          end: 109,
+        },
+      ],
+    ];
+    test.each(boundTestCase)(
+      'should find the transaction id bounds in the AO_TX table for %s',
+      async (findDate: string, expected: TransactionIdRangeForDate) => {
+        querySpy.mockImplementation(dateRangeMock);
+        const actual = await testCasesDxtrGateway.findTransactionIdRangeForDate(
+          applicationContext,
+          findDate,
+        );
+        expect(actual).toEqual(expected);
+      },
+    );
   });
 });

--- a/backend/lib/testing/isolated-integration/test-dxtr-tx-bisect.ts
+++ b/backend/lib/testing/isolated-integration/test-dxtr-tx-bisect.ts
@@ -1,0 +1,49 @@
+import * as dotenv from 'dotenv';
+import { InvocationContext } from '@azure/functions';
+import { LoggerImpl } from '../../adapters/services/logger.service';
+import ContextCreator from '../../../function-apps/azure/application-context-creator';
+import Factory from '../../factory';
+
+dotenv.config({ path: '../../../.env' });
+
+const MODULE_NAME = 'ITEST';
+
+// NOTE: Disable "type": "module" in the common package.json temporarily to get past the CommonJS/require() issue.
+
+async function testBisect() {
+  const context = await ContextCreator.getApplicationContext({
+    invocationContext: new InvocationContext(),
+    logger: new LoggerImpl('dxtr-tx-bisect'),
+  });
+
+  function log(...values: unknown[]) {
+    values.forEach((value) => {
+      if (typeof value === 'object') {
+        context.logger.info(MODULE_NAME, JSON.stringify(value, null, 0));
+      } else {
+        context.logger.info(MODULE_NAME, String(value));
+      }
+    });
+  }
+
+  try {
+    const gateway = Factory.getCasesGateway(context);
+    const dates = ['2016-03-16', '2015-03-16', '2016-03-03', '1990-01-01', '2070-01-01'];
+    // const dates = ['2016-03-16']; /// 10609 - 10615
+    for (const date of dates) {
+      const answer = await gateway.findTransactionIdRangeForDate(context, date);
+      log(answer);
+    }
+  } catch (error) {
+    context.logger.error(MODULE_NAME, error);
+  } finally {
+    log('Done.', '\n');
+  }
+}
+
+if (require.main === module) {
+  (async () => {
+    await testBisect();
+    process.exit(0);
+  })();
+}

--- a/backend/lib/use-cases/cases/cases.interface.d.ts
+++ b/backend/lib/use-cases/cases/cases.interface.d.ts
@@ -7,6 +7,13 @@ export type CasesSyncMeta = {
   lastTxId: string;
 };
 
+type TransactionIdRangeForDate = {
+  findDate: string;
+  found: boolean;
+  end?: number;
+  start?: number;
+};
+
 export interface CasesInterface {
   getCaseDetail(applicationContext: ApplicationContext, caseId: string): Promise<CaseDetail>;
 
@@ -23,4 +30,9 @@ export interface CasesInterface {
     applicationContext: ApplicationContext,
     lastTxId: string,
   ): Promise<CasesSyncMeta>;
+
+  findTransactionIdRangeForDate(
+    context: ApplicationContext,
+    findDate: string,
+  ): Promise<TransactionIdRangeForDate>;
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -71,6 +71,7 @@
     "dependency-cruiser:ci": "npx depcruise --output-type err-long function-apps/api/attorneys case-assignments case-docket case-history case-summary cases consolidations healthcheck offices orders orders-manual-sync orders-sync ../lib ",
     "itest:okta-group-api": "CAMS_LOGIN_PROVIDER=okta npx ts-node lib/testing/isolated-integration/test-okta-group-api.ts",
     "itest:acms-migration": "CAMS_LOGIN_PROVIDER=mock npx ts-node lib/testing/isolated-integration/test-acms-migration.ts",
-    "itest:export-office-csv": "CAMS_LOGIN_PROVIDER=okta npx ts-node ../lib/testing/isolated-integration/export-office-csv.ts"
+    "itest:export-office-csv": "CAMS_LOGIN_PROVIDER=okta npx ts-node lib/testing/isolated-integration/export-office-csv.ts",
+    "itest:dxtr-tx-bisect": "npx ts-node lib/testing/isolated-integration/test-dxtr-tx-bisect.ts"
   }
 }


### PR DESCRIPTION
# Purpose

Find AO_TX transaction ID range by date

# Major Changes

Added binary search of the AO_TX table to find starting and ending TX_ID bounds by ISO date string.

# Testing/Validation

Manual testing

