### PR TITLE
updated SCA scan step version

### DIFF
--- a/.github/workflows/reusable-sca-scan.yml
+++ b/.github/workflows/reusable-sca-scan.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
           SRCCLR_REGION: ${{ secrets.SRCCLR_REGION }}
-        uses: veracode/veracode-sca@v2.1.6
+        uses: veracode/veracode-sca@v2.1.12
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           create-issues: false


### PR DESCRIPTION
# Problem

SCA scan started failing this morning seemingly because of versioning issues with Gov Cloud, Still need RCA

# Solution

- upgrade SCA scan step to 2.1.12

# Testing/Validation

pipeline validation

