### PR TITLE
CAMS-516 UseOutsideClick now acts on mousedown, not click

### DIFF
--- a/user-interface/src/lib/hooks/UseOutsideClick.ts
+++ b/user-interface/src/lib/hooks/UseOutsideClick.ts
@@ -1,5 +1,11 @@
 import React from 'react';
 
+// NOTE:  This hook acts on "mousedown" rather than "click" so that it does
+// not disturb other click events. For instance, if a comboBox dropdown
+// popup is open, and a user clicks on a button, we don't want to swallow
+// up the click event on the button, but do want to close the dropdown.
+// (That's quite a run-on sentence huah?) By handling a "mousedown", the click
+// is then handled by the button.
 export default function useOutsideClick(
   refs: Array<React.RefObject<HTMLElement>>,
   callback: (event: MouseEvent) => void,

--- a/user-interface/src/lib/hooks/UseOutsideClick.ts
+++ b/user-interface/src/lib/hooks/UseOutsideClick.ts
@@ -20,10 +20,10 @@ export default function useOutsideClick(
       if (fireCallback) callback(event);
     };
 
-    document.addEventListener('click', handleClick);
+    document.addEventListener('mousedown', handleClick);
 
     return () => {
-      document.removeEventListener('click', handleClick);
+      document.removeEventListener('mousedown', handleClick);
     };
   }, [refs]);
 


### PR DESCRIPTION
# Purpose

Bug Fix for -- comboBox outside click action was swallowing up the click event, such that if a user has the comboxOpen, and then clicks on a button, the comboBox closes but the button click is not handled.

# Major Changes

Adjusted the UseOutsideClick hook to handle a "mousedown" event rather than a "click" event.

# Testing/Validation

Manually tested using mouse and verified that keyboard interaction still works as expected.

