### PR TITLE
Cosmos Database Deployment and bicep Updates

### DIFF
--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -13,7 +13,7 @@ jobs:
   list:
     runs-on: ubuntu-latest
     steps:
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -30,7 +30,7 @@ jobs:
       executeCleanup: ${{ steps.check.outputs.executeCleanup }}
       targetBranchHashId: ${{ steps.check.outputs.targetBranchHashId }}
     steps:
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/reusable-backend-slot.yml
+++ b/.github/workflows/reusable-backend-slot.yml
@@ -34,7 +34,7 @@ jobs:
     environment: ${{ inputs.ghaEnvironment }}
     steps:
       - uses: actions/checkout@v3
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/reusable-build-frontend.yml
+++ b/.github/workflows/reusable-build-frontend.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.nodeVersion }}
-          cache: "npm"
+          cache: 'npm'
           cache-dependency-path: user-interface/package-lock.json
 
       - name: Execute Build

--- a/.github/workflows/reusable-build-info.yml
+++ b/.github/workflows/reusable-build-info.yml
@@ -11,40 +11,40 @@ on:
         type: string
     outputs:
       stackName:
-        description: "Application name"
+        description: 'Application name'
         value: ${{ jobs.build-info.outputs.stackName }}
       webappName:
-        description: "Expected Web Application name [used for Azure Resource]"
+        description: 'Expected Web Application name [used for Azure Resource]'
         value: ${{ jobs.build-info.outputs.webappName }}
       apiFunctionName:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.apiFunctionName }}
       azResourceGrpAppEncrypted:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.azResourceGrpAppEncrypted }}
       azResourceGrpNetworkEncrypted:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.azResourceGrpNetworkEncrypted }}
       environmentHash:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.environmentHash }}
       migrationFunctionName:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.migrationFunctionName }}
       slotName:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.slotName }}
       deployVnet:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.deployVnet }}
       deployBicep:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.deployBicep }}
       initialDeployment:
-        description: ""
+        description: ''
         value: ${{ jobs.build-info.outputs.initialDeployment }}
       ghaEnvironment:
-        description: ""
+        description: ''
         value: ${{ inputs.environment }}
 
 jobs:
@@ -78,7 +78,7 @@ jobs:
           shortHash="${hash:0:6}"
           echo "environmentHash=${shortHash}" >> $GITHUB_OUTPUT
           echo "resourceGroupSuffix=-${shortHash}" >> $GITHUB_OUTPUT
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       deployBranch:
-        default: "false"
+        default: 'false'
         type: string
       deployBicep:
         required: true
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@main
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get source code
         uses: actions/checkout@v3
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/reusable-endpoint-test.yml
+++ b/.github/workflows/reusable-endpoint-test.yml
@@ -9,7 +9,7 @@ on:
       slotName:
         required: false
         type: string
-        default: "initial"
+        default: 'initial'
       webappName:
         required: true
         type: string
@@ -38,7 +38,7 @@ jobs:
       priority: 200
     steps:
       - uses: actions/checkout@v3
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/reusable-frontend-slot.yml
+++ b/.github/workflows/reusable-frontend-slot.yml
@@ -27,7 +27,7 @@ jobs:
     environment: ${{ inputs.ghaEnvironment }}
     steps:
       - uses: actions/checkout@v3
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           name: ${{ inputs.webappName }}-build
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -92,7 +92,7 @@ jobs:
         with:
           name: ${{ inputs.apiFunctionName }}-build
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -124,7 +124,7 @@ jobs:
         with:
           name: ${{ inputs.migrationFunctionName }}-build
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -162,12 +162,7 @@ jobs:
 
   execute-e2e-test:
     needs:
-      [
-        deploy-webapp-slot,
-        deploy-api-slot,
-        deploy-migration-slot,
-        endpoint-test-application-slot,
-      ]
+      [deploy-webapp-slot, deploy-api-slot, deploy-migration-slot, endpoint-test-application-slot]
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       apiFunctionName: ${{ inputs.apiFunctionName }}
@@ -183,19 +178,13 @@ jobs:
   swap-webapp-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs:
-      [
-        deploy-webapp-slot,
-        deploy-api-slot,
-        deploy-migration-slot,
-        execute-e2e-test,
-      ]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-migration-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       webappName: ${{ inputs.webappName }}
       slotName: ${{ inputs.slotName }}
     steps:
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -213,19 +202,13 @@ jobs:
   swap-nodeapi-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs:
-      [
-        deploy-webapp-slot,
-        deploy-api-slot,
-        deploy-migration-slot,
-        execute-e2e-test,
-      ]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-migration-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       apiFunctionName: ${{ inputs.apiFunctionName }}
       slotName: ${{ inputs.slotName }}
     steps:
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -243,18 +226,12 @@ jobs:
   swap-migration-app-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs:
-      [
-        deploy-webapp-slot,
-        deploy-api-slot,
-        deploy-migration-slot,
-        execute-e2e-test,
-      ]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-migration-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       slotName: ${{ inputs.slotName }}
     steps:
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -285,7 +262,7 @@ jobs:
       branchHashId: ${{ inputs.environmentHash }}
       ghaEnvironment: ${{ inputs.ghaEnvironment }}
       azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
-      slotName: "self"
+      slotName: 'self'
     secrets: inherit # pragma: allowlist secret
 
   enable-access:
@@ -296,7 +273,7 @@ jobs:
       webappName: ${{ inputs.webappName }}
       apiFunctionName: ${{ inputs.apiFunctionName }}
     steps:
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/sub-deploy-code.yml
+++ b/.github/workflows/sub-deploy-code.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           name: ${{ inputs.webappName }}-build
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -68,7 +68,7 @@ jobs:
         with:
           name: ${{ inputs.apiFunctionName }}-build
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -100,7 +100,7 @@ jobs:
         with:
           name: ${{ inputs.migrationFunctionName }}-build
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
@@ -131,7 +131,7 @@ jobs:
       branchHashId: ${{ inputs.environmentHash }}
       ghaEnvironment: ${{ inputs.ghaEnvironment }}
       azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
-      slotName: "initial"
+      slotName: 'initial'
     secrets: inherit # pragma: allowlist secret
 
   enable-access:
@@ -142,7 +142,7 @@ jobs:
       webappName: ${{ inputs.webappName }}
       apiFunctionName: ${{ inputs.apiFunctionName }}
     steps:
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Package source code for scan
         run: zip -r cams.zip . -i "./backend/*" -i "./user-interface/*" -i "./common/*"
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}

--- a/ops/cloud-deployment/ustp-cams-cosmos.bicep
+++ b/ops/cloud-deployment/ustp-cams-cosmos.bicep
@@ -5,6 +5,12 @@ param resourceGroupName string
 param accountName string
 @description('CosmosDb database name')
 param databaseName string
+
+@description('Cosmos E2E database name')
+param e2eDatabaseName string
+
+param deployE2eDatabase bool = false
+
 @description('List of container name and keys')
 param databaseCollections array = [] // See parameters.json file
 
@@ -104,4 +110,15 @@ module cosmosDiagnosticSetting './lib/app-insights/diagnostics-settings-cosmos.b
     database
     collections
   ]
+}
+
+module e2eDatabaseModule './ustp-cams-cosmos-e2e.bicep' = if(deployE2eDatabase){
+  name: '${accountName}-e2e-database-module'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    accountName: accountName
+    databaseName: e2eDatabaseName
+    resourceGroupName: resourceGroupName
+    databaseCollections: databaseCollections
+  }
 }

--- a/ops/cloud-deployment/ustp-cams-cosmos.bicep
+++ b/ops/cloud-deployment/ustp-cams-cosmos.bicep
@@ -80,6 +80,22 @@ module collections './lib/cosmos/mongo/cosmos-collections.bicep' = {
   ]
 }
 
+module e2eDatabase './ustp-cams-cosmos-e2e.bicep' = if(deployE2eDatabase){
+  name: '${accountName}-e2e-database-module'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    accountName: accountName
+    databaseName: e2eDatabaseName
+    resourceGroupName: resourceGroupName
+    databaseCollections: databaseCollections
+  }
+  dependsOn: [
+    account
+    collections
+    database
+  ]
+}
+
 module cosmosAvailabilityAlert './lib/monitoring-alerts/metrics-alert-rule.bicep' = if (createAlerts) {
   name: '${accountName}-availability-alert-module'
   params: {
@@ -96,6 +112,9 @@ module cosmosAvailabilityAlert './lib/monitoring-alerts/metrics-alert-rule.bicep
     actionGroupName: actionGroupName
     actionGroupResourceGroupName: actionGroupResourceGroupName
   }
+  dependsOn:[
+    e2eDatabase
+  ]
 }
 
 module cosmosDiagnosticSetting './lib/app-insights/diagnostics-settings-cosmos.bicep' = if (!empty(analyticsWorkspaceId)) {
@@ -107,18 +126,6 @@ module cosmosDiagnosticSetting './lib/app-insights/diagnostics-settings-cosmos.b
     accountName: accountName
   }
   dependsOn: [
-    database
-    collections
+    e2eDatabase
   ]
-}
-
-module e2eDatabaseModule './ustp-cams-cosmos-e2e.bicep' = if(deployE2eDatabase){
-  name: '${accountName}-e2e-database-module'
-  scope: resourceGroup(resourceGroupName)
-  params: {
-    accountName: accountName
-    databaseName: e2eDatabaseName
-    resourceGroupName: resourceGroupName
-    databaseCollections: databaseCollections
-  }
 }

--- a/ops/scripts/pipeline/az-cosmos-deploy.sh
+++ b/ops/scripts/pipeline/az-cosmos-deploy.sh
@@ -88,7 +88,7 @@ while [[ $# -gt 0 ]]; do
         ;;
 
     --e2eCosmosDbExists)
-        e2eCosmosDbExists="${2}"
+        e2eCosmosDbExists=$2
         shift 2
         ;;
 
@@ -98,6 +98,7 @@ while [[ $# -gt 0 ]]; do
         ;;
     esac
 done
+
 
 allowAllNetworks=false
 if [[ ${environment} != 'Main-Gov' ]]; then
@@ -109,28 +110,25 @@ if [[ ${environment} == 'Main-Gov' ]]; then
     createAlerts=true
 fi
 
-# Provision and configure primary Webapp Azure CosmosDb resource
+deployE2eDatabase=false
+# shellcheck disable=SC2086 # REASON: Qoutes render the e2eCosmosDbExists boolean unusable
+if [ ${e2eCosmosDbExists} != true ] && [ ${e2eCosmosDbExists} != "true" ]; then
+    deployE2eDatabase=true
+fi
+
+
+e2eDatabaseName="${database}-e2e"
+if [[ ${environment} != 'Main-Gov' ]]; then
+    e2eDatabaseName="${e2eDatabaseName}-${branchHashId}"
+fi
+
+
 # shellcheck disable=SC2086 # REASON: Qoutes render the CreateAlertsproperty unusable
 az deployment group create -w -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos.bicep \
     -p ./ops/cloud-deployment/params/ustp-cams-mongo-collections.parameters.json \
-    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}"
+    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}" e2eDatabaseName="${e2eDatabaseName}" deployE2eDatabase=$deployE2eDatabase
 
 # shellcheck disable=SC2086 # REASON: Qoutes render the CreateAlerts property unusable
 az deployment group create -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos.bicep \
     -p ./ops/cloud-deployment/params/ustp-cams-mongo-collections.parameters.json \
-    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}"
-
-# Provision and configure e2e CosmosDB databases and containers only if slot deployments occur and it doesnt already eist. Otherwise we do not need an e2e database.
-if [[ $e2eCosmosDbExists != 'true' && $e2eCosmosDbExists != true ]]; then
-    echo "Deploying Cosmos Database for E2E testing"
-    e2eDatabaseName="${database}-e2e"
-    if [[ ${environment} != 'Main-Gov' ]]; then
-        e2eDatabaseName="${e2eDatabaseName}-${branchHashId}"
-    fi
-    az deployment group create -w -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos-e2e.bicep \
-        -p ./ops/cloud-deployment/params/ustp-cams-mongo-collections.parameters.json \
-        -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${e2eDatabaseName}"
-    az deployment group create -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos-e2e.bicep \
-        -p ./ops/cloud-deployment/params/ustp-cams-mongo-collections.parameters.json \
-        -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${e2eDatabaseName}"
-fi
+    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}" e2eDatabaseName="${e2eDatabaseName}" deployE2eDatabase=$deployE2eDatabase

--- a/ops/scripts/pipeline/slots/az-func-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-func-slot-deploy.sh
@@ -52,7 +52,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # set rule_name in case of exit or other scenarios
-rule_name="agent-${app_name:0:26}" # rule name has a 32 character limit
+rule_name="agent-slot-${app_name:0:26}" # rule name has a 32 character limit
 
 function on_exit() {
     # always try to remove temporary access

--- a/ops/scripts/pipeline/slots/az-func-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-func-slot-deploy.sh
@@ -52,7 +52,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # set rule_name in case of exit or other scenarios
-rule_name="agent-slot-${app_name:0:26}" # rule name has a 32 character limit
+rule_name="agent-slot-${app_name:0:21}" # rule name has a 32 character limit
 
 function on_exit() {
     # always try to remove temporary access


### PR DESCRIPTION
# Purpose

when working with an error we were seeing related to deployment of the users collection, I noticed there was an opportunity to streamline the deployment workflow for the cosmos e2e database and push it into one template and simplify the process. to keep us up to date I also switched all of our az/login GHA usages to v2 instead of v1

# Major Changes

- update all azure/login@v1 to v2
- minimize and simplify cosmos database deployment bicep

# Testing/Validation

- ran through pipeline and tested deployment of database

# Notes

- I left branchHaseId in the cosmos deployment script for now to avoid having to update USTP but we can remove it and pass in the already generated name to the script if we choose to.

