### PR TITLE
default e2e db name to empty string to prevent failure in USTP

### DIFF
--- a/ops/cloud-deployment/ustp-cams-cosmos.bicep
+++ b/ops/cloud-deployment/ustp-cams-cosmos.bicep
@@ -7,7 +7,7 @@ param accountName string
 param databaseName string
 
 @description('Cosmos E2E database name')
-param e2eDatabaseName string
+param e2eDatabaseName string = ''
 
 param deployE2eDatabase bool = false
 
@@ -80,7 +80,7 @@ module collections './lib/cosmos/mongo/cosmos-collections.bicep' = {
   ]
 }
 
-module e2eDatabase './ustp-cams-cosmos-e2e.bicep' = if(deployE2eDatabase){
+module e2eDatabase './ustp-cams-cosmos-e2e.bicep' = if(deployE2eDatabase && !empty(e2eDatabaseName)){
   name: '${accountName}-e2e-database-module'
   scope: resourceGroup(resourceGroupName)
   params: {


### PR DESCRIPTION
# Problem

We needed to default the value for cosmosE2eDatabaseName so we did not require the param in USTP yet

# Solution

default param to empty string in bicep

# Testing/Validation

N/A

# Other Changes

N/A 

# Notes

-once we implement E2E testing in USTP this will change
