### PR TITLE
CAMS-421 Protect import HTTP triggers with API key

### DIFF
--- a/backend/function-apps/dataflows/dataflows-common.test.ts
+++ b/backend/function-apps/dataflows/dataflows-common.test.ts
@@ -1,0 +1,55 @@
+import { HttpRequest } from '@azure/functions';
+import { isAuthorized } from './dataflows-common';
+
+describe('Dataflows Common', () => {
+  describe('isAuthorized', () => {
+    const RIGHT = 'this-is-a-key';
+    const WRONG = 'this-is-a-bad-key';
+
+    const env = process.env;
+    beforeAll(() => {
+      process.env = {
+        ADMIN_KEY: RIGHT,
+      };
+    });
+
+    afterAll(() => {
+      process.env = env;
+    });
+
+    test('should return true', async () => {
+      const request = {
+        headers: new Map<string, string>([['Authorization', `ApiKey ${RIGHT}`]]),
+      } as unknown as HttpRequest;
+      expect(isAuthorized(request)).toBeTruthy();
+    });
+
+    test('should return false when authorization header is missing', async () => {
+      const request = {
+        headers: new Map<string, string>(),
+      } as unknown as HttpRequest;
+      expect(isAuthorized(request)).toBeFalsy();
+    });
+
+    test('should return false when authorization header scheme is missing', async () => {
+      const request = {
+        headers: new Map<string, string>([['Authorization', RIGHT]]),
+      } as unknown as HttpRequest;
+      expect(isAuthorized(request)).toBeFalsy();
+    });
+
+    test('should return false when authorization header scheme is incorrect', async () => {
+      const request = {
+        headers: new Map<string, string>([['Authorization', `Bearer ${RIGHT}`]]),
+      } as unknown as HttpRequest;
+      expect(isAuthorized(request)).toBeFalsy();
+    });
+
+    test('should return false when api key does not match', async () => {
+      const request = {
+        headers: new Map<string, string>([['Authorization', `ApiKey ${WRONG}`]]),
+      } as unknown as HttpRequest;
+      expect(isAuthorized(request)).toBeFalsy();
+    });
+  });
+});

--- a/backend/function-apps/dataflows/dataflows-common.ts
+++ b/backend/function-apps/dataflows/dataflows-common.ts
@@ -1,0 +1,7 @@
+import { HttpRequest } from '@azure/functions';
+
+export function isAuthorized(request: HttpRequest) {
+  const header = request.headers.get('Authorization');
+  const parts = header ? header.split(' ') : ['', ''];
+  return process.env.ADMIN_KEY && parts[0] === 'ApiKey' && parts[1] === process.env.ADMIN_KEY;
+}

--- a/backend/function-apps/dataflows/migration/client/acms-migration-trigger.function.ts
+++ b/backend/function-apps/dataflows/migration/client/acms-migration-trigger.function.ts
@@ -4,9 +4,10 @@ import { HttpRequest, HttpResponse, InvocationContext } from '@azure/functions';
 import { MAIN_ORCHESTRATOR } from '../migration';
 import { TriggerRequest } from '../../../../lib/use-cases/acms-orders/acms-orders';
 import { BadRequestError } from '../../../../lib/common-errors/bad-request';
-import { UnauthorizedError } from '../../../../lib/common-errors/unauthorized-error';
 import { toAzureError } from '../../../azure/functions';
 import ContextCreator from '../../../azure/application-context-creator';
+import { isAuthorized } from '../../dataflows-common';
+import { UnauthorizedError } from '../../../../lib/common-errors/unauthorized-error';
 
 dotenv.config();
 
@@ -17,6 +18,10 @@ export default async function httpStart(
   context: InvocationContext,
 ): Promise<HttpResponse> {
   try {
+    if (!isAuthorized(request)) {
+      throw new UnauthorizedError(MODULE_NAME);
+    }
+
     const client = df.getClient(context);
     let params: TriggerRequest;
     if (request.body) {
@@ -27,13 +32,6 @@ export default async function httpStart(
       throw new BadRequestError(MODULE_NAME, { message: 'Missing or malformed request body.' });
     }
 
-    if (params.apiKey !== process.env.ADMIN_KEY) {
-      throw new UnauthorizedError(MODULE_NAME, {
-        message: 'API key was missing or did not match.',
-      });
-    }
-
-    delete params.apiKey;
     const instanceId: string = await client.startNew(MAIN_ORCHESTRATOR, {
       input: params,
     });
@@ -45,10 +43,5 @@ export default async function httpStart(
 }
 
 function isTriggerRequest(request: unknown): request is TriggerRequest {
-  return (
-    typeof request === 'object' &&
-    'apiKey' in request &&
-    'chapters' in request &&
-    'divisionCodes' in request
-  );
+  return typeof request === 'object' && 'chapters' in request && 'divisionCodes' in request;
 }

--- a/backend/lib/adapters/types/http.d.ts
+++ b/backend/lib/adapters/types/http.d.ts
@@ -28,7 +28,3 @@ export type CamsHttpRequest<B = unknown> = {
   params: CamsDict;
   body?: B;
 };
-
-export type AdminRequestBody = {
-  apiKey: string;
-};

--- a/backend/lib/use-cases/acms-orders/acms-orders.ts
+++ b/backend/lib/use-cases/acms-orders/acms-orders.ts
@@ -7,7 +7,6 @@ import { CaseConsolidationHistory } from '../../../../common/src/cams/history';
 import { ACMS_SYSTEM_USER_REFERENCE } from '../../../../common/src/cams/auditable';
 import { getCamsError } from '../../common-errors/error-utilities';
 import { CamsError } from '../../common-errors/cams-error';
-import { AdminRequestBody } from '../../adapters/types/http';
 
 const MODULE_NAME = 'ACMS_ORDERS_USE_CASE';
 
@@ -16,7 +15,7 @@ export type AcmsBounds = {
   chapters: string[];
 };
 
-export type TriggerRequest = AcmsBounds & AdminRequestBody;
+export type TriggerRequest = AcmsBounds;
 
 export type AcmsPredicate = {
   divisionCode: string;


### PR DESCRIPTION
# Purpose

Ensure import triggers are not maliciously triggered.

# Major Changes

Added guards to triggers to return Unauthorized response if called without a correct API key.

# Testing/Validation

Unit test coverage for the isAuthorized function.
