### PR TITLE
Cams 514 reenable veracode sca scans on all commits

### DIFF
--- a/.github/workflows/reusable-sca-scan.yml
+++ b/.github/workflows/reusable-sca-scan.yml
@@ -6,6 +6,9 @@ on:
       path:
         required: true
         type: string
+      artifactname:
+        required: true
+        type: string
 
 jobs:
   sca-scan:

--- a/.github/workflows/reusable-sca-scan.yml
+++ b/.github/workflows/reusable-sca-scan.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   sca-scan:
-    if: (github.ref == 'refs/heads/dependency-updates-auto')
     runs-on: ubuntu-latest
     name: SCA Scan ${{ inputs.path }}
 

--- a/.github/workflows/reusable-sca-scan.yml
+++ b/.github/workflows/reusable-sca-scan.yml
@@ -26,3 +26,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           create-issues: false
           path: ${{ inputs.path }}
+          artifactname: ${{ inputs.artifactname }}

--- a/.github/workflows/reusable-sca-scan.yml
+++ b/.github/workflows/reusable-sca-scan.yml
@@ -29,3 +29,4 @@ jobs:
           create-issues: false
           path: ${{ inputs.path }}
           artifactname: ${{ inputs.artifactname }}
+          debug: true

--- a/.github/workflows/reusable-sca-scan.yml
+++ b/.github/workflows/reusable-sca-scan.yml
@@ -29,4 +29,3 @@ jobs:
           create-issues: false
           path: ${{ inputs.path }}
           artifactname: ${{ inputs.artifactname }}
-          debug: true

--- a/.github/workflows/reusable-sca-scan.yml
+++ b/.github/workflows/reusable-sca-scan.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
           SRCCLR_REGION: ${{ secrets.SRCCLR_REGION }}
-        uses: veracode/veracode-sca@v2.1.12
+        uses: veracode/veracode-sca@artifactname
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           create-issues: false

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -7,30 +7,35 @@ jobs:
     uses: ./.github/workflows/reusable-sca-scan.yml
     with:
       path: user-interface
+      artifactname: ui
     secrets: inherit # pragma: allowlist secret
 
   sca-scan-backend-lib:
     uses: ./.github/workflows/reusable-sca-scan.yml
     with:
       path: backend
+      artifactname: backend
     secrets: inherit # pragma: allowlist secret
 
   sca-scan-backend-api:
     uses: ./.github/workflows/reusable-sca-scan.yml
     with:
       path: backend/function-apps/api
+      artifactname: backend-api
     secrets: inherit # pragma: allowlist secret
 
   sca-scan-backend-migration:
     uses: ./.github/workflows/reusable-sca-scan.yml
     with:
       path: backend/function-apps/migration
+      artifactname: backend-migration
     secrets: inherit # pragma: allowlist secret
 
   sca-scan-common:
     uses: ./.github/workflows/reusable-sca-scan.yml
     with:
       path: common
+      artifactname: common
     secrets: inherit # pragma: allowlist secret
 
   sast-pipeline-scan:


### PR DESCRIPTION
# Purpose

Reenable the veracode SCA scan steps

# Major Changes

- Veracode action version
- names of artifacts

# Testing/Validation

Ran action several times to make sure it would complete successfully

# Notes

I'm not sure if the version `artifactname` needs to be kept or if we can resume using the normal versioning convention. Will follow-up with support.