### PR TITLE
CAMS-522 fixed Regex on isValidUserInput 

### DIFF
--- a/backend/lib/controllers/case-notes/case.notes.controller.test.ts
+++ b/backend/lib/controllers/case-notes/case.notes.controller.test.ts
@@ -151,26 +151,26 @@ describe('Case note controller tests', () => {
     );
   });
 
-  const maliciousNote = "fetch('/api/data');";
+  // const maliciousNote = "fetch('/api/data');";
 
-  test('should throw error when XSS note content is provided', async () => {
-    jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();
-    applicationContext.request = mockCamsHttpRequest({
-      method: 'POST',
-      params: {
-        id: NORMAL_CASE_ID,
-      },
-      body: {
-        title: 'test note title',
-        content: maliciousNote,
-      },
-    });
+  // test('should throw error when XSS note content is provided', async () => {
+  //   jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();
+  //   applicationContext.request = mockCamsHttpRequest({
+  //     method: 'POST',
+  //     params: {
+  //       id: NORMAL_CASE_ID,
+  //     },
+  //     body: {
+  //       title: 'test note title',
+  //       content: maliciousNote,
+  //     },
+  //   });
 
-    const controller = new CaseNotesController(applicationContext);
-    await expect(controller.handleRequest(applicationContext)).rejects.toThrow(
-      'Note content contains invalid keywords.',
-    );
-  });
+  //   const controller = new CaseNotesController(applicationContext);
+  //   await expect(controller.handleRequest(applicationContext)).rejects.toThrow(
+  //     'Note content contains invalid keywords.',
+  //   );
+  // });
 
   const testMongoInjectedNotes = 'mongo.aggregate([{ key: 1 }]);';
 
@@ -192,24 +192,25 @@ describe('Case note controller tests', () => {
       'Note content contains invalid keywords.',
     );
   });
-  test('should throw error when XSS note title is provided', async () => {
-    jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();
-    applicationContext.request = mockCamsHttpRequest({
-      method: 'POST',
-      params: {
-        id: NORMAL_CASE_ID,
-      },
-      body: {
-        title: maliciousNote,
-        content: 'some test content.',
-      },
-    });
 
-    const controller = new CaseNotesController(applicationContext);
-    await expect(controller.handleRequest(applicationContext)).rejects.toThrow(
-      'Note title contains invalid keywords.',
-    );
-  });
+  // test('should throw error when XSS note title is provided', async () => {
+  //   jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();
+  //   applicationContext.request = mockCamsHttpRequest({
+  //     method: 'POST',
+  //     params: {
+  //       id: NORMAL_CASE_ID,
+  //     },
+  //     body: {
+  //       title: maliciousNote,
+  //       content: 'some test content.',
+  //     },
+  //   });
+
+  //   const controller = new CaseNotesController(applicationContext);
+  //   await expect(controller.handleRequest(applicationContext)).rejects.toThrow(
+  //     'Note title contains invalid keywords.',
+  //   );
+  // });
 
   test('should throw error when malicious mongo note title is provided', async () => {
     jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();

--- a/backend/lib/controllers/case-notes/case.notes.controller.test.ts
+++ b/backend/lib/controllers/case-notes/case.notes.controller.test.ts
@@ -151,26 +151,26 @@ describe('Case note controller tests', () => {
     );
   });
 
-  // const maliciousNote = "fetch('/api/data');";
+  const maliciousNote = "fetch('/api/data');";
 
-  // test('should throw error when XSS note content is provided', async () => {
-  //   jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();
-  //   applicationContext.request = mockCamsHttpRequest({
-  //     method: 'POST',
-  //     params: {
-  //       id: NORMAL_CASE_ID,
-  //     },
-  //     body: {
-  //       title: 'test note title',
-  //       content: maliciousNote,
-  //     },
-  //   });
+  test('should throw error when XSS note content is provided', async () => {
+    jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();
+    applicationContext.request = mockCamsHttpRequest({
+      method: 'POST',
+      params: {
+        id: NORMAL_CASE_ID,
+      },
+      body: {
+        title: 'test note title',
+        content: maliciousNote,
+      },
+    });
 
-  //   const controller = new CaseNotesController(applicationContext);
-  //   await expect(controller.handleRequest(applicationContext)).rejects.toThrow(
-  //     'Note content contains invalid keywords.',
-  //   );
-  // });
+    const controller = new CaseNotesController(applicationContext);
+    await expect(controller.handleRequest(applicationContext)).rejects.toThrow(
+      'Note content contains invalid keywords.',
+    );
+  });
 
   const testMongoInjectedNotes = 'mongo.aggregate([{ key: 1 }]);';
 
@@ -193,24 +193,24 @@ describe('Case note controller tests', () => {
     );
   });
 
-  // test('should throw error when XSS note title is provided', async () => {
-  //   jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();
-  //   applicationContext.request = mockCamsHttpRequest({
-  //     method: 'POST',
-  //     params: {
-  //       id: NORMAL_CASE_ID,
-  //     },
-  //     body: {
-  //       title: maliciousNote,
-  //       content: 'some test content.',
-  //     },
-  //   });
+  test('should throw error when XSS note title is provided', async () => {
+    jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();
+    applicationContext.request = mockCamsHttpRequest({
+      method: 'POST',
+      params: {
+        id: NORMAL_CASE_ID,
+      },
+      body: {
+        title: maliciousNote,
+        content: 'some test content.',
+      },
+    });
 
-  //   const controller = new CaseNotesController(applicationContext);
-  //   await expect(controller.handleRequest(applicationContext)).rejects.toThrow(
-  //     'Note title contains invalid keywords.',
-  //   );
-  // });
+    const controller = new CaseNotesController(applicationContext);
+    await expect(controller.handleRequest(applicationContext)).rejects.toThrow(
+      'Note title contains invalid keywords.',
+    );
+  });
 
   test('should throw error when malicious mongo note title is provided', async () => {
     jest.spyOn(CaseNotesUseCase.prototype, 'createCaseNote').mockResolvedValue();

--- a/common/src/cams/sanitization.test.ts
+++ b/common/src/cams/sanitization.test.ts
@@ -7,6 +7,7 @@ describe('Input sanitization tests', () => {
     ['This is a safe string.'],
     ["Let's fetch some data."],
     ['This is just a plain sentence.'],
+    ['If you have nothing better to do, Count (or Prince), something--something.'],
   ];
   test.each(validInputs)('should pass notes through', (input: string) => {
     const actual = isValidUserInput(input);
@@ -17,6 +18,7 @@ describe('Input sanitization tests', () => {
     ['<script></script>'],
     ['<script>foo</script>'],
     ["fetch('/api/data');"],
+    ["eval('/api/data');"],
     ["document.querySelector('#id');"],
     ["<script>alert('XSS');</script>"],
   ];

--- a/common/src/cams/sanitization.test.ts
+++ b/common/src/cams/sanitization.test.ts
@@ -17,11 +17,8 @@ describe('Input sanitization tests', () => {
     ['<script></script>'],
     ['<script>foo</script>'],
     ["<script>alert('XSS');</script>"],
-    ['Use setTimeout(() => {}, 1000);'],
-    ["document.querySelector('#id');"],
-    ["fetch('/api/data');"],
   ];
-  test.each(testXSSNotes)('should detech invalid strings', (input: string) => {
+  test.each(testXSSNotes)('should detect invalid strings', (input: string) => {
     const actual = isValidUserInput(input);
     expect(actual).toEqual(false);
   });

--- a/common/src/cams/sanitization.test.ts
+++ b/common/src/cams/sanitization.test.ts
@@ -16,6 +16,8 @@ describe('Input sanitization tests', () => {
   const testXSSNotes = [
     ['<script></script>'],
     ['<script>foo</script>'],
+    ["fetch('/api/data');"],
+    ["document.querySelector('#id');"],
     ["<script>alert('XSS');</script>"],
   ];
   test.each(testXSSNotes)('should detect invalid strings', (input: string) => {

--- a/common/src/cams/sanitization.ts
+++ b/common/src/cams/sanitization.ts
@@ -1,7 +1,9 @@
 const MONGO_CONSOLE_INJECTED_PATTERN = RegExp(
   /\b(?:db\.[a-zA-Z]+|mongo\.[a-zA-Z]+|(?:find|insert|update|delete|aggregate|create|drop|remove|replace|count|distinct|mapReduce|save)\b\s*(?:\(|{))/i,
 );
-const JAVASCRIPT_INJECTED_PATTERN = RegExp(/<script[\s\S]*?>[\s\S]*?<\/script>/i);
+const JAVASCRIPT_INJECTED_PATTERN = RegExp(
+  /(eval\s*\(.*?\)|window\.\w+|document.\.\w+|<script[\s\S]*?>[\s\S]*?<\/script>)/i,
+);
 const MONGO_QUERY_INJECTED_PATTERN = RegExp(
   /\$(eq|ne|gt|gte|lt|lte|in|nin|and|or|not|regex|exists|type|mod|text|where|all|elemMatch|size)/,
 );

--- a/common/src/cams/sanitization.ts
+++ b/common/src/cams/sanitization.ts
@@ -1,15 +1,17 @@
 const MONGO_CONSOLE_INJECTED_PATTERN = RegExp(
   /\b(?:db\.[a-zA-Z]+|mongo\.[a-zA-Z]+|(?:find|insert|update|delete|aggregate|create|drop|remove|replace|count|distinct|mapReduce|save)\b\s*(?:\(|{))/i,
 );
-// const JAVASCRIPT_INJECTED_PATTERN = RegExp(
-//   /\b(?:eval|Function|with|document\.|window\.|alert|prompt|confirm|fetch\s*\(|setTimeout|setInterval)|<script[\s\S]*?>[\s\S]*?<\/script>/i,
-// );
+const JAVASCRIPT_INJECTED_PATTERN = RegExp(/<script[\s\S]*?>[\s\S]*?<\/script>/i);
 const MONGO_QUERY_INJECTED_PATTERN = RegExp(
   /\$(eq|ne|gt|gte|lt|lte|in|nin|and|or|not|regex|exists|type|mod|text|where|all|elemMatch|size)/,
 );
 
 export function isValidUserInput(input: string) {
-  if (input.match(MONGO_CONSOLE_INJECTED_PATTERN) || input.match(MONGO_QUERY_INJECTED_PATTERN)) {
+  if (
+    input.match(MONGO_CONSOLE_INJECTED_PATTERN) ||
+    input.match(JAVASCRIPT_INJECTED_PATTERN) ||
+    input.match(MONGO_QUERY_INJECTED_PATTERN)
+  ) {
     return false;
   } else {
     return true;

--- a/common/src/cams/sanitization.ts
+++ b/common/src/cams/sanitization.ts
@@ -1,5 +1,5 @@
 const MONGO_CONSOLE_INJECTED_PATTERN = RegExp(
-  /\b(?:db\.[a-zA-Z]+|mongo\.[a-zA-Z]+|(?:find|insert|update|delete|aggregate|create|drop|remove|replace|count|distinct|mapReduce|save)\b\s*(?:\(|{))/i,
+  /\b(?:db\.[a-zA-Z]+|mongo\.[a-zA-Z]+|(?:find|insert|update|delete|aggregate|create|drop|remove|replace|count|distinct|mapReduce|save)\b\s*:\{})/i,
 );
 const JAVASCRIPT_INJECTED_PATTERN = RegExp(
   /<script\b[^>]*>[\s\S]*?<\/script>|fetch\s*\(.*?\)|eval\s*\(.*?\)|window\.[a-zA-Z_$][a-zA-Z0-9_$]*|document\.[a-zA-Z_$][a-zA-Z0-9_$]*/gi,

--- a/common/src/cams/sanitization.ts
+++ b/common/src/cams/sanitization.ts
@@ -2,7 +2,7 @@ const MONGO_CONSOLE_INJECTED_PATTERN = RegExp(
   /\b(?:db\.[a-zA-Z]+|mongo\.[a-zA-Z]+|(?:find|insert|update|delete|aggregate|create|drop|remove|replace|count|distinct|mapReduce|save)\b\s*(?:\(|{))/i,
 );
 const JAVASCRIPT_INJECTED_PATTERN = RegExp(
-  /\b(?:fetch\s*\(.*?\)|eval\s*\(.*?\)|window\.[a-zA-Z]+|document\.[a-zA-Z]+|(?:<script[\s\S]*?>[\s\S]*?<\/script>))/i,
+  /<script\b[^>]*>[\s\S]*?<\/script>|fetch\s*\(.*?\)|eval\s*\(.*?\)|window\.[a-zA-Z_$][a-zA-Z0-9_$]*|document\.[a-zA-Z_$][a-zA-Z0-9_$]*/gi,
 );
 const MONGO_QUERY_INJECTED_PATTERN = RegExp(
   /\$(eq|ne|gt|gte|lt|lte|in|nin|and|or|not|regex|exists|type|mod|text|where|all|elemMatch|size)/,

--- a/common/src/cams/sanitization.ts
+++ b/common/src/cams/sanitization.ts
@@ -1,19 +1,15 @@
 const MONGO_CONSOLE_INJECTED_PATTERN = RegExp(
   /\b(?:db\.[a-zA-Z]+|mongo\.[a-zA-Z]+|(?:find|insert|update|delete|aggregate|create|drop|remove|replace|count|distinct|mapReduce|save)\b\s*(?:\(|{))/i,
 );
-const JAVASCRIPT_INJECTED_PATTERN = RegExp(
-  /\b(?:eval|Function|with|document\.|window\.|alert|prompt|confirm|fetch\s*\(|setTimeout|setInterval)|<script[\s\S]*?>[\s\S]*?<\/script>/i,
-);
+// const JAVASCRIPT_INJECTED_PATTERN = RegExp(
+//   /\b(?:eval|Function|with|document\.|window\.|alert|prompt|confirm|fetch\s*\(|setTimeout|setInterval)|<script[\s\S]*?>[\s\S]*?<\/script>/i,
+// );
 const MONGO_QUERY_INJECTED_PATTERN = RegExp(
   /\$(eq|ne|gt|gte|lt|lte|in|nin|and|or|not|regex|exists|type|mod|text|where|all|elemMatch|size)/,
 );
 
 export function isValidUserInput(input: string) {
-  if (
-    input.match(MONGO_CONSOLE_INJECTED_PATTERN) ||
-    input.match(JAVASCRIPT_INJECTED_PATTERN) ||
-    input.match(MONGO_QUERY_INJECTED_PATTERN)
-  ) {
+  if (input.match(MONGO_CONSOLE_INJECTED_PATTERN) || input.match(MONGO_QUERY_INJECTED_PATTERN)) {
     return false;
   } else {
     return true;

--- a/common/src/cams/sanitization.ts
+++ b/common/src/cams/sanitization.ts
@@ -2,7 +2,7 @@ const MONGO_CONSOLE_INJECTED_PATTERN = RegExp(
   /\b(?:db\.[a-zA-Z]+|mongo\.[a-zA-Z]+|(?:find|insert|update|delete|aggregate|create|drop|remove|replace|count|distinct|mapReduce|save)\b\s*(?:\(|{))/i,
 );
 const JAVASCRIPT_INJECTED_PATTERN = RegExp(
-  /(eval\s*\(.*?\)|window\.\w+|document.\.\w+|<script[\s\S]*?>[\s\S]*?<\/script>)/i,
+  /\b(?:fetch\s*\(.*?\)|eval\s*\(.*?\)|window\.[a-zA-Z]+|document\.[a-zA-Z]+|(?:<script[\s\S]*?>[\s\S]*?<\/script>))/i,
 );
 const MONGO_QUERY_INJECTED_PATTERN = RegExp(
   /\$(eq|ne|gt|gte|lt|lte|in|nin|and|or|not|regex|exists|type|mod|text|where|all|elemMatch|size)/,

--- a/user-interface/src/lib/models/api2.test.ts
+++ b/user-interface/src/lib/models/api2.test.ts
@@ -235,16 +235,20 @@ describe('_Api2 functions', async () => {
     expect(postSpy).toHaveBeenCalledWith(path, cleanConsolidationOrder, {});
   });
 
-  test('should not call patchTransferOrderRejection with malicious input', () => {
+  test('should call patchTransferOrderRejection with purified malicious input', () => {
     const postSpy = vi.spyOn(api.default, 'patch').mockResolvedValue({ data: '' });
     const dirtyTransferOrder: TransferOrderActionRejection = {
       ...MockData.getTransferOrder(),
       status: 'rejected',
       reason: inputBlockedFromApi,
     };
-
+    const purifiedTransferOrder = { ...dirtyTransferOrder, reason: '' };
     api2.Api2.patchTransferOrderRejection(dirtyTransferOrder);
-    expect(postSpy).not.toHaveBeenCalled();
+    expect(postSpy).toHaveBeenCalledWith(
+      `/orders/${dirtyTransferOrder.id}`,
+      purifiedTransferOrder,
+      {},
+    );
   });
 
   test('should call patchTransferOrderRejection with non-malicious input', () => {

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -295,9 +295,11 @@ async function patchTransferOrderApproval(data: Partial<FlexibleTransferOrderAct
 }
 
 async function patchTransferOrderRejection(data: Partial<TransferOrderActionRejection>) {
-  if (data.reason && isValidUserInput(data.reason)) {
+  if (data.reason) {
     data.reason = sanitizeText(data.reason);
-    await api().patch<TransferOrder, FlexibleTransferOrderAction>(`/orders/${data.id}`, data);
+    if (isValidUserInput(data.reason)) {
+      await api().patch<TransferOrder, FlexibleTransferOrderAction>(`/orders/${data.id}`, data);
+    }
   }
 }
 
@@ -309,12 +311,14 @@ async function putConsolidationOrderApproval(data: ConsolidationOrderActionAppro
 }
 
 async function putConsolidationOrderRejection(data: ConsolidationOrderActionRejection) {
-  if (data.reason && isValidUserInput(data.reason)) {
+  if (data.reason) {
     data.reason = sanitizeText(data.reason);
-    return api().put<ConsolidationOrder[], ConsolidationOrderActionRejection>(
-      '/consolidations/reject',
-      data,
-    );
+    if (isValidUserInput(data.reason)) {
+      return api().put<ConsolidationOrder[], ConsolidationOrderActionRejection>(
+        '/consolidations/reject',
+        data,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Jira ticket: CAMS-522

# Problem

We were seeing an issue where normal words were being rejected and not saved with notes. 

# Solution

- The JAVACSRIPT regex was causing issues within the sanitization. I temporarily commented it out until we figure out what we actually want to put there.
- The rejection post calls were also doing an odd order of operations for valid user input and sanitization that was oppposite of the way we really wanted. So That was fixed as well
# Testing/Validation

- updated unit tests validating the change
- ran locally and verified

# Other Changes

to get this nailed down we just need to decide what goes into the JAVASCRIPT regex and wrap up the tests for it
