### PR TITLE
CAMS-421 Scaling 

### DIFF
--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -55,8 +55,8 @@ param apiFunctionName string
 param apiFunctionSubnetId string
 
 param dataflowsFunctionName string
+
 param dataflowsFunctionSubnetId string
-param dataflowsFunctionInstanceCount int = 4
 
 param virtualNetworkResourceGroupName string
 
@@ -246,7 +246,6 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     httpsOnly: true
     virtualNetworkSubnetId: dataflowsFunctionSubnetId
     keyVaultReferenceIdentity: appConfigIdentity.id
-    minimumElasticInstanceCount: dataflowsFunctionInstanceCount
   }
   dependsOn: [
     appConfigIdentity

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -150,7 +150,7 @@ resource servicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   properties: {
     perSiteScaling: true
     elasticScaleEnabled: true
-    maximumElasticWorkerCount: 4
+    maximumElasticWorkerCount: 10
     isSpot: false
     reserved: true // set true for Linux
     isXenon: false
@@ -539,10 +539,10 @@ resource dataflowsFunctionConfig 'Microsoft.Web/sites/config@2023-12-01' = {
       allowedOrigins: dataflowsCorsAllowOrigins
     }
     numberOfWorkers: 1
-    alwaysOn: true
+    alwaysOn: false
     http20Enabled: true
     functionAppScaleLimit: 4
-    minimumElasticInstanceCount: 1
+    minimumElasticInstanceCount: 0
     publicNetworkAccess: 'Enabled'
     ipSecurityRestrictions: dataflowsIpSecurityRestrictionsRules
     ipSecurityRestrictionsDefaultAction: 'Deny'

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -223,6 +223,7 @@ resource apiFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     httpsOnly: true
     virtualNetworkSubnetId: apiFunctionSubnetId
     keyVaultReferenceIdentity: appConfigIdentity.id
+    minimumElasticInstanceCount: 1
   }
   dependsOn: [
     appConfigIdentity
@@ -254,6 +255,7 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
         maximumInstanceCount: 4
       }
     }
+    minimumElasticInstanceCount: 1
   }
   dependsOn: [
     appConfigIdentity

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -55,8 +55,8 @@ param apiFunctionName string
 param apiFunctionSubnetId string
 
 param dataflowsFunctionName string
-
 param dataflowsFunctionSubnetId string
+param dataflowsFunctionInstanceCount int = 4
 
 param virtualNetworkResourceGroupName string
 
@@ -246,6 +246,7 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     httpsOnly: true
     virtualNetworkSubnetId: dataflowsFunctionSubnetId
     keyVaultReferenceIdentity: appConfigIdentity.id
+    minimumElasticInstanceCount: dataflowsFunctionInstanceCount
   }
   dependsOn: [
     appConfigIdentity

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -245,16 +245,6 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     httpsOnly: true
     virtualNetworkSubnetId: dataflowsFunctionSubnetId
     keyVaultReferenceIdentity: appConfigIdentity.id
-    functionAppConfig: {
-      scaleAndConcurrency: {
-        alwaysReady: [
-          {
-            instanceCount: 1
-          }
-        ]
-        maximumInstanceCount: 4
-      }
-    }
     minimumElasticInstanceCount: 1
   }
   dependsOn: [

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -142,9 +142,28 @@ resource appConfigIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@202
   scope: resourceGroup(kvAppConfigResourceGroupName)
 }
 
-resource servicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
+resource apiServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   location: location
   name: planName
+  sku: planTypeToSkuMap[planType]
+  kind: 'linux'
+  properties: {
+    perSiteScaling: true
+    elasticScaleEnabled: true
+    maximumElasticWorkerCount: 10
+    isSpot: false
+    reserved: true // set true for Linux
+    isXenon: false
+    hyperV: false
+    targetWorkerCount: 0
+    targetWorkerSizeId: 0
+    zoneRedundant: false
+  }
+}
+
+resource dataflowsServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
+  location: location
+  name: '${planName}-dataflows'
   sku: planTypeToSkuMap[planType]
   kind: 'linux'
   properties: {
@@ -218,7 +237,7 @@ resource apiFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     userAssignedIdentities: userAssignedIdentities
   }
   properties: {
-    serverFarmId: servicePlan.id
+    serverFarmId: apiServicePlan.id
     enabled: true
     httpsOnly: true
     virtualNetworkSubnetId: apiFunctionSubnetId
@@ -239,7 +258,7 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     userAssignedIdentities: userAssignedIdentities
   }
   properties: {
-    serverFarmId: servicePlan.id
+    serverFarmId: dataflowsServicePlan.id
     enabled: true
     httpsOnly: true
     virtualNetworkSubnetId: dataflowsFunctionSubnetId

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -542,7 +542,7 @@ resource dataflowsFunctionConfig 'Microsoft.Web/sites/config@2023-12-01' = {
     alwaysOn: false
     http20Enabled: true
     functionAppScaleLimit: 4
-    minimumElasticInstanceCount: 0
+    minimumElasticInstanceCount: 1
     publicNetworkAccess: 'Enabled'
     ipSecurityRestrictions: dataflowsIpSecurityRestrictionsRules
     ipSecurityRestrictionsDefaultAction: 'Deny'

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -223,7 +223,6 @@ resource apiFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     httpsOnly: true
     virtualNetworkSubnetId: apiFunctionSubnetId
     keyVaultReferenceIdentity: appConfigIdentity.id
-    minimumElasticInstanceCount: 1
   }
   dependsOn: [
     appConfigIdentity
@@ -245,7 +244,6 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     httpsOnly: true
     virtualNetworkSubnetId: dataflowsFunctionSubnetId
     keyVaultReferenceIdentity: appConfigIdentity.id
-    minimumElasticInstanceCount: 1
   }
   dependsOn: [
     appConfigIdentity
@@ -511,8 +509,8 @@ resource apiFunctionConfig 'Microsoft.Web/sites/config@2023-12-01' = {
     numberOfWorkers: 1
     alwaysOn: true
     http20Enabled: true
-    functionAppScaleLimit: 0
-    minimumElasticInstanceCount: 0
+    functionAppScaleLimit: 1
+    minimumElasticInstanceCount: 1
     publicNetworkAccess: 'Enabled'
     ipSecurityRestrictions: ipSecurityRestrictionsRules
     ipSecurityRestrictionsDefaultAction: 'Deny'
@@ -543,8 +541,8 @@ resource dataflowsFunctionConfig 'Microsoft.Web/sites/config@2023-12-01' = {
     numberOfWorkers: 1
     alwaysOn: true
     http20Enabled: true
-    functionAppScaleLimit: 0
-    minimumElasticInstanceCount: 0
+    functionAppScaleLimit: 4
+    minimumElasticInstanceCount: 1
     publicNetworkAccess: 'Enabled'
     ipSecurityRestrictions: dataflowsIpSecurityRestrictionsRules
     ipSecurityRestrictionsDefaultAction: 'Deny'

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -60,7 +60,6 @@ param dataflowsFunctionSubnetId string
 
 param virtualNetworkResourceGroupName string
 
-
 param privateEndpointSubnetId string
 
 param mssqlRequestTimeout string
@@ -149,9 +148,9 @@ resource servicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   sku: planTypeToSkuMap[planType]
   kind: 'linux'
   properties: {
-    perSiteScaling: false
-    elasticScaleEnabled: false
-    maximumElasticWorkerCount: 1
+    perSiteScaling: true
+    elasticScaleEnabled: true
+    maximumElasticWorkerCount: 4
     isSpot: false
     reserved: true // set true for Linux
     isXenon: false
@@ -231,7 +230,6 @@ resource apiFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
   ]
 }
 
-
 resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
   name: dataflowsFunctionName
   location: location
@@ -246,6 +244,16 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     httpsOnly: true
     virtualNetworkSubnetId: dataflowsFunctionSubnetId
     keyVaultReferenceIdentity: appConfigIdentity.id
+    functionAppConfig: {
+      scaleAndConcurrency: {
+        alwaysReady: [
+          {
+            instanceCount: 1
+          }
+        ]
+        maximumInstanceCount: 4
+      }
+    }
   }
   dependsOn: [
     appConfigIdentity
@@ -255,7 +263,7 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
 
 //Create App Insights
 module apiFunctionAppInsights 'lib/app-insights/function-app-insights.bicep' = {
-  name:'appi-${apiFunctionName}-module'
+  name: 'appi-${apiFunctionName}-module'
   scope: resourceGroup()
   params: {
     actionGroupName: actionGroupName
@@ -271,7 +279,7 @@ module apiFunctionAppInsights 'lib/app-insights/function-app-insights.bicep' = {
 }
 
 module dataflowsFunctionAppInsights 'lib/app-insights/function-app-insights.bicep' = {
-  name:'appi-${dataflowsFunctionName}-module'
+  name: 'appi-${dataflowsFunctionName}-module'
   scope: resourceGroup()
   params: {
     actionGroupName: actionGroupName
@@ -399,12 +407,21 @@ var baseApplicationSettings = concat(
     ? [
         { name: 'MSSQL_USER', value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=MSSQL-USER)' }
         { name: 'MSSQL_PASS', value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=MSSQL-PASS)' }
-        { name: 'ACMS_MSSQL_USER', value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ACMS-MSSQL-USER)' }
-        { name: 'ACMS_MSSQL_PASS', value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ACMS-MSSQL-PASS)' }
+        {
+          name: 'ACMS_MSSQL_USER'
+          value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ACMS-MSSQL-USER)'
+        }
+        {
+          name: 'ACMS_MSSQL_PASS'
+          value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ACMS-MSSQL-PASS)'
+        }
       ]
     : [
         { name: 'MSSQL_PASS', value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=MSSQL-CLIENT-ID)' }
-        { name: 'ACMS_MSSQL_CLIENT_ID', value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ACMS-MSSQL-CLIENT-ID)'}
+        {
+          name: 'ACMS_MSSQL_CLIENT_ID'
+          value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ACMS-MSSQL-CLIENT-ID)'
+        }
       ]
 )
 
@@ -418,8 +435,8 @@ var dataflowsApplicationSettings = concat(
   ],
   baseApplicationSettings,
   createApplicationInsights
-  ? [{ name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: dataflowsFunctionAppInsights.outputs.connectionString }]
-  : []
+    ? [{ name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: dataflowsFunctionAppInsights.outputs.connectionString }]
+    : []
 )
 
 //API Function Application Settings
@@ -432,8 +449,8 @@ var apiApplicationSettings = concat(
   ],
   baseApplicationSettings,
   createApplicationInsights
-  ? [{ name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: apiFunctionAppInsights.outputs.connectionString }]
-  : []
+    ? [{ name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: apiFunctionAppInsights.outputs.connectionString }]
+    : []
 )
 
 var ipSecurityRestrictionsRules = concat(
@@ -539,15 +556,18 @@ resource dataflowsFunctionConfig 'Microsoft.Web/sites/config@2023-12-01' = {
     publicNetworkAccess: 'Enabled'
     ipSecurityRestrictions: dataflowsIpSecurityRestrictionsRules
     ipSecurityRestrictionsDefaultAction: 'Deny'
-    scmIpSecurityRestrictions: concat([
-      {
-        ipAddress: 'Any'
-        action: 'Deny'
-        priority: 2147483647
-        name: 'Deny all'
-        description: 'Deny all access'
-      }
-    ], middlewareIpSecurityRestrictionsRules)
+    scmIpSecurityRestrictions: concat(
+      [
+        {
+          ipAddress: 'Any'
+          action: 'Deny'
+          priority: 2147483647
+          name: 'Deny all'
+          description: 'Deny all access'
+        }
+      ],
+      middlewareIpSecurityRestrictionsRules
+    )
     scmIpSecurityRestrictionsDefaultAction: 'Deny'
     scmIpSecurityRestrictionsUseMain: false
     linuxFxVersion: linuxFxVersionMap['${functionsRuntime}']


### PR DESCRIPTION
# Purpose
- Merge these changes into the invocation hotfix so we can get these in together
allow scaling of the dataflows functionapp and separate the service plans.

# Major Changes

- changed the scaling of the dataflows functionapp to allow for more worker instances
- separated the service plans for the dataflows and api function apps

# Testing/Validation

- ran the deployment through.

# Notes

- we may need to possibly delete the old functionapp resources within USTP, but we will see once we get there
