### PR TITLE
CAMS-529 system maintenance banner

### DIFF
--- a/user-interface/src/lib/components/Header.tsx
+++ b/user-interface/src/lib/components/Header.tsx
@@ -199,7 +199,7 @@ export const Header = () => {
               inline={true}
               show={true}
             >
-              System performance may be degraded during the update until approximately 9:00 AM EST.
+              {flags[SYSTEM_MAINTENANCE_BANNER]}
             </Alert>
           </div>
           <div className="grid-col-1"></div>

--- a/user-interface/src/lib/components/Header.tsx
+++ b/user-interface/src/lib/components/Header.tsx
@@ -4,6 +4,7 @@ import './Header.scss';
 import useFeatureFlags, {
   PRIVILEGED_IDENTITY_MANAGEMENT,
   TRANSFER_ORDERS_ENABLED,
+  SYSTEM_MAINTENANCE_BANNER,
 } from '../hooks/UseFeatureFlags';
 import { Banner } from './uswds/Banner';
 import { useEffect, useState } from 'react';
@@ -12,6 +13,7 @@ import { CamsRole } from '@common/cams/roles';
 import Icon from './uswds/Icon';
 import { DropdownMenu, MenuItem } from './cams/DropdownMenu/DropdownMenu';
 import { ADMIN_PATH } from '@/admin/admin-config';
+import Alert, { UswdsAlertStyle } from './uswds/Alert';
 
 export enum NavState {
   DEFAULT,
@@ -186,6 +188,23 @@ export const Header = () => {
           </div>
         </div>
       </header>
+      {flags[SYSTEM_MAINTENANCE_BANNER] && (
+        <div className="system-maintenance-banner grid-row">
+          <div className="grid-col-1"></div>
+          <div className="grid-col-10">
+            <Alert
+              type={UswdsAlertStyle.Warning}
+              title="System maintenance"
+              slim={true}
+              inline={true}
+              show={true}
+            >
+              System performance may be degraded during the update until approximately 9:00 AM EST.
+            </Alert>
+          </div>
+          <div className="grid-col-1"></div>
+        </div>
+      )}
     </>
   );
 };

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -8,7 +8,7 @@ export const TRANSFER_ORDERS_ENABLED = 'transfer-orders-enabled';
 export const CONSOLIDATIONS_ENABLED = 'consolidations-enabled';
 export const CASE_NOTES_ENABLED = 'case-notes-enabled';
 export const PRIVILEGED_IDENTITY_MANAGEMENT = 'privileged-identity-management';
-export const SYSTEM_MAINTENANCE_BANNER = 'display-system-maintenance-banner';
+export const SYSTEM_MAINTENANCE_BANNER = 'system-maintenance-banner';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -8,6 +8,7 @@ export const TRANSFER_ORDERS_ENABLED = 'transfer-orders-enabled';
 export const CONSOLIDATIONS_ENABLED = 'consolidations-enabled';
 export const CASE_NOTES_ENABLED = 'case-notes-enabled';
 export const PRIVILEGED_IDENTITY_MANAGEMENT = 'privileged-identity-management';
+export const SYSTEM_MAINTENANCE_BANNER = 'display-system-maintenance-banner';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();


### PR DESCRIPTION

# Purpose

Admin users should have the ability to set a System Maintenance message and display a banner.

# Major Changes

This is handled with a flag.  To set a message, change the "Enabled" variation of the flag and then enable the flag to display the banner.

