### PR TITLE
Skip attempt to truncate migration table

### DIFF
--- a/backend/function-apps/dataflows/import/migrate-cases.ts
+++ b/backend/function-apps/dataflows/import/migrate-cases.ts
@@ -40,7 +40,7 @@ const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
 const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 const GET_CASEIDS_TO_MIGRATE = buildFunctionName(MODULE_NAME, 'getCaseIdsToMigrate');
 const LOAD_MIGRATION_TABLE = buildFunctionName(MODULE_NAME, 'loadMigrationTable');
-const EMPTY_MIGRATION_TABLE = buildFunctionName(MODULE_NAME, 'emptyMigrationTable');
+// const EMPTY_MIGRATION_TABLE = buildFunctionName(MODULE_NAME, 'emptyMigrationTable');
 
 /**
  * handleStart
@@ -51,8 +51,8 @@ const EMPTY_MIGRATION_TABLE = buildFunctionName(MODULE_NAME, 'emptyMigrationTabl
  * @param {InvocationContext} context
  */
 async function handleStart(_ignore: StartMessage, context: InvocationContext) {
-  const isEmpty = await emptyMigrationTable(context);
-  if (!isEmpty) return;
+  // const isEmpty = await emptyMigrationTable(context);
+  // if (!isEmpty) return;
 
   const count = await loadMigrationTable(context);
 
@@ -113,18 +113,18 @@ async function loadMigrationTable(invocationContext: InvocationContext) {
  *
  * @param invocationContext
  */
-async function emptyMigrationTable(invocationContext: InvocationContext) {
-  const context = await ContextCreator.getApplicationContext({ invocationContext });
-  const result = await MigrateCases.emptyMigrationTable(context);
-  if (result.error) {
-    invocationContext.extraOutputs.set(
-      DLQ,
-      buildQueueError(result.error, MODULE_NAME, EMPTY_MIGRATION_TABLE),
-    );
-    return false;
-  }
-  return true;
-}
+// async function emptyMigrationTable(invocationContext: InvocationContext) {
+//   const context = await ContextCreator.getApplicationContext({ invocationContext });
+//   const result = await MigrateCases.emptyMigrationTable(context);
+//   if (result.error) {
+//     invocationContext.extraOutputs.set(
+//       DLQ,
+//       buildQueueError(result.error, MODULE_NAME, EMPTY_MIGRATION_TABLE),
+//     );
+//     return false;
+//   }
+//   return true;
+// }
 
 /**
  * getCaseIdsToMigrate


### PR DESCRIPTION
# Purpose

The production service account cannot truncate the migration table.

# Major Changes

We skip the attempt to truncate the migration table.

# Testing/Validation

Automated tests still pass. This is just housekeeping that will have to be performed manually.
