### PR TITLE
CAMS-421 enabled MongoRetryableWrites on cosmos account

### DIFF
--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-account.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-account.bicep
@@ -138,6 +138,10 @@ resource account 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
       {
         name: 'EnableUniqueCompoundNestedDocs'
       }
+      {
+        name: 'EnableMongoRetryableWrites'
+      }
+
     ]
     publicNetworkAccess: 'Enabled'
     isVirtualNetworkFilterEnabled: allowAllNetworks ? false : true

--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-account.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-account.bicep
@@ -141,7 +141,6 @@ resource account 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
       {
         name: 'EnableMongoRetryableWrites'
       }
-
     ]
     publicNetworkAccess: 'Enabled'
     isVirtualNetworkFilterEnabled: allowAllNetworks ? false : true


### PR DESCRIPTION
# Purpose

When running the migration in production, a user entering the application caused the write/update operations to fail within the migration with the Error from cosmos '500 - Request rate is large'. We are capping out the number of available RUs for the cosmos db during the migration operation. to help assist this we are going to enable Mongo Retryable Writes and other possibilities.

# Major Changes

- enable Retryable writes

# Testing/Validation

- deployed 

# Notes

Still researching