### PR TITLE
CAMS-421 Return ACMS caseId for caseIds to sync

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -486,12 +486,13 @@ export default class CasesDxtrGateway implements CasesInterface {
 
     const query = `
       SELECT
-        CONCAT(C.CS_DIV, '-', C.CASE_ID) AS caseId,
+        CONCAT(CS_DIV.CS_DIV_ACMS, '-', C.CASE_ID) AS caseId,
         MAX(T.TX_ID) as maxTxId
       FROM AO_TX T
       JOIN AO_CS C ON C.CS_CASEID = T.CS_CASEID AND C.COURT_ID = T.COURT_ID
+      JOIN AO_CS_DIV AS CS_DIV ON C.CS_DIV = CS_DIV.CS_DIV
       WHERE T.TX_ID > @txId
-      GROUP BY C.CS_DIV, C.CASE_ID
+      GROUP BY CS_DIV.CS_DIV_ACMS, C.CASE_ID
       ORDER BY MAX(T.TX_ID) DESC
     `;
 


### PR DESCRIPTION
# Purpose

Use ACMS caseIds for case sync

# Major Changes

Altered SQL query in DXTR to use the ACMS division code from AO_CS_DIV when constructing caseIds.

# Testing/Validation

Manual
