### PR TITLE
CAMS-421: Scrub potential tax identifiers from message

### DIFF
--- a/backend/lib/adapters/services/logger.service.test.ts
+++ b/backend/lib/adapters/services/logger.service.test.ts
@@ -1,5 +1,6 @@
 import { LoggerImpl } from './logger.service';
 import { randomUUID } from 'crypto';
+import MockData from '../../../../common/src/cams/test-utilities/mock-data';
 
 describe('Basic logger service tests', () => {
   let mockLog;
@@ -66,22 +67,28 @@ describe('Basic logger service tests', () => {
   });
 
   test('should not log properties similar to disallowed properties', async () => {
-    logger.info('FOO-MODULE_NAME', 'test message', {
-      sSN: '111-11-1111',
-      tAxid: '11-1111111',
-      prop1: 'foo',
-      prop2: 'bar',
-      prop3: {
-        ssn: '123-45-6789',
-        prop3a: 'foo-a',
-        prop3b: {
-          taxID: '33-3333333',
-          prop3aa: 'test',
+    logger.info(
+      'FOO-MODULE_NAME',
+      `test message 123456789 ${MockData.randomEin()} ${MockData.randomSsn()}`,
+      {
+        sSN: MockData.randomSsn(),
+        tAxid: MockData.randomEin(),
+        prop1: 'foo',
+        prop2: 'bar',
+        prop3: {
+          ssn: MockData.randomSsn(),
+          prop3a: 'foo-a',
+          prop3b: {
+            taxID: MockData.randomEin(),
+            prop3aa: 'test',
+          },
+          itin: MockData.randomSsn(),
+          ein: MockData.randomEin(),
         },
       },
-    });
+    );
     expect(mockLog).toHaveBeenCalledWith(
-      `[INFO] [FOO-MODULE_NAME] [INVOCATION ${invocationId}] test message {"prop1":"foo","prop2":"bar","prop3":{"prop3a":"foo-a","prop3b":{"prop3aa":"test"}}}`,
+      `[INFO] [FOO-MODULE_NAME] [INVOCATION ${invocationId}] test message [REDACTED] [REDACTED] [REDACTED] {"prop1":"foo","prop2":"bar","prop3":{"prop3a":"foo-a","prop3b":{"prop3aa":"test"}}}`,
     );
   });
 });

--- a/backend/lib/adapters/services/logger.service.ts
+++ b/backend/lib/adapters/services/logger.service.ts
@@ -4,7 +4,7 @@ import { LoggerHelper } from '../types/basic';
 type LoggerProvider = Console['log'];
 type LogType = 'debug' | 'info' | 'warn' | 'error';
 
-const disallowedProperties = ['ssn', 'taxId'];
+const disallowedProperties = ['ssn', 'taxId', 'ein', 'itin'];
 
 export class LoggerImpl implements LoggerHelper {
   private readonly provider: LoggerProvider;
@@ -20,7 +20,7 @@ export class LoggerImpl implements LoggerHelper {
   }
 
   private logMessage(logType: LogType, moduleName: string, message: string, data?: unknown) {
-    const logString = `[${logType.toUpperCase()}] [${moduleName}] [INVOCATION ${this.invocationId}] ${message} ${
+    const logString = `[${logType.toUpperCase()}] [${moduleName}] [INVOCATION ${this.invocationId}] ${this.scrubMessage(message)} ${
       undefined != data
         ? JSON.stringify(data, (key, value) => {
             let disallowed = false;
@@ -34,6 +34,11 @@ export class LoggerImpl implements LoggerHelper {
         : ''
     }`;
     this.provider(this.sanitize(logString.trim()));
+  }
+
+  private scrubMessage(message: string) {
+    const piiRegex = /\b\d{3}[- ]?\d{2}[- ]?\d{4}\b|\b\d{2}[- ]?\d{7}\b/gm;
+    return message.replace(piiRegex, '[REDACTED]');
   }
 
   info(moduleName: string, message: string, data?: unknown) {

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -676,7 +676,9 @@ function getCaseSyncEvent(override: Partial<CaseSyncEvent>) {
 
 export const MockData = {
   randomCaseId,
+  randomEin,
   randomOffice,
+  randomSsn,
   randomUstpOffice,
   getAttorneyAssignment,
   getCaseNote,


### PR DESCRIPTION
# Purpose

We want to prevent PII from being logged in the `message` parameter of the logger functions.

# Major Changes

- Add scrubbing of the `message` parameter which uses a regex/replace to identify potential tax identifiers and replace them with `[REDACTED]`.
- Add `ein` and `itin` to the disallowed list just in case these are ever encountered in data we are logging.

# Testing/Validation

- Updated automated tests.

# Notes

I was considering adding a maximum length of the message string to prevent us from putting entire objects in the message. This is not strictly necessary given the new scrubbing, but realistically the message should not be a stringified json object. We can do this with the future ticket to clean up logging if we choose to.