### PR TITLE
CAMS-421 Handle missing TX join

### DIFF
--- a/backend/lib/adapters/gateways/debtor-type-gateway.test.ts
+++ b/backend/lib/adapters/gateways/debtor-type-gateway.test.ts
@@ -6,7 +6,7 @@ describe('Debtor Type Name gateway', () => {
     expect(debtorTypeName).toEqual('Corporate Business');
   });
   test('should return an unknown label for an invalid ID', () => {
-    const debtorTypeName = getDebtorTypeLabel('ZZ');
-    expect(debtorTypeName).toEqual('Debtor type information is not available.');
+    expect(getDebtorTypeLabel('ZZ')).toEqual('Not Available');
+    expect(getDebtorTypeLabel(null)).toEqual('Not Available');
   });
 });

--- a/backend/lib/adapters/gateways/debtor-type-gateway.test.ts
+++ b/backend/lib/adapters/gateways/debtor-type-gateway.test.ts
@@ -6,7 +6,7 @@ describe('Debtor Type Name gateway', () => {
     expect(debtorTypeName).toEqual('Corporate Business');
   });
   test('should return an unknown label for an invalid ID', () => {
-    expect(getDebtorTypeLabel('ZZ')).toEqual('Not Available');
-    expect(getDebtorTypeLabel(null)).toEqual('Not Available');
+    expect(getDebtorTypeLabel('ZZ')).toEqual('Debtor Type Not Available');
+    expect(getDebtorTypeLabel(null)).toEqual('Debtor Type Not Available');
   });
 });

--- a/backend/lib/adapters/gateways/debtor-type-gateway.ts
+++ b/backend/lib/adapters/gateways/debtor-type-gateway.ts
@@ -9,5 +9,5 @@ const debtorTypeLabelMap = new Map<string, string>([
 ]);
 
 export function getDebtorTypeLabel(id: string | null): string {
-  return debtorTypeLabelMap.has(id) ? debtorTypeLabelMap.get(id) : 'Not Available';
+  return debtorTypeLabelMap.has(id) ? debtorTypeLabelMap.get(id) : 'Debtor Type Not Available';
 }

--- a/backend/lib/adapters/gateways/debtor-type-gateway.ts
+++ b/backend/lib/adapters/gateways/debtor-type-gateway.ts
@@ -8,7 +8,6 @@ const debtorTypeLabelMap = new Map<string, string>([
   ['PB', 'Partnership Business'],
 ]);
 
-export function getDebtorTypeLabel(id: string | undefined): string {
-  if (debtorTypeLabelMap.has(id)) return debtorTypeLabelMap.get(id);
-  return 'Debtor type information is not available.';
+export function getDebtorTypeLabel(id: string | null): string {
+  return debtorTypeLabelMap.has(id) ? debtorTypeLabelMap.get(id) : 'Not Available';
 }

--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -574,13 +574,13 @@ export default class CasesDxtrGateway implements CasesInterface {
         JOIN [dbo].[AO_REGION] AS R ON grp_des.REGION_ID = R.REGION_ID
         JOIN (
           SELECT DISTINCT
-          T1.COURT_ID,
-          T1.CS_CASEID,
-          substring(REC,108,2) AS petitionCode,
-          substring(REC,34,2) AS debtorTypeCode
+          C1.COURT_ID,
+          C1.CS_CASEID,
+          substring(T1.REC,108,2) AS petitionCode,
+          substring(T1.REC,34,2) AS debtorTypeCode
           FROM [dbo].[AO_CS] AS C1
           JOIN [dbo].[AO_CS_DIV] AS C2 ON C1.CS_DIV = C2.CS_DIV
-          JOIN [dbo].[AO_TX] AS T1 ON T1.CS_CASEID=C1.CS_CASEID AND T1.COURT_ID=C1.COURT_ID AND T1.TX_TYPE='1' AND T1.TX_CODE='1'
+          LEFT JOIN [dbo].[AO_TX] AS T1 ON T1.CS_CASEID=C1.CS_CASEID AND T1.COURT_ID=C1.COURT_ID AND T1.TX_TYPE='1' AND T1.TX_CODE='1'
           WHERE C1.CASE_ID = @dxtrCaseId
           AND C2.CS_DIV_ACMS = @courtDiv
         ) AS TX ON TX.COURT_ID=CS.COURT_ID AND TX.CS_CASEID=CS.CS_CASEID

--- a/backend/lib/adapters/gateways/petition-gateway.test.ts
+++ b/backend/lib/adapters/gateways/petition-gateway.test.ts
@@ -20,7 +20,7 @@ describe('Petition Type Label gateway', () => {
         isTransfer: false,
         isVoluntary: false,
         petitionCode: petitionCode ?? '',
-        petitionLabel: 'Not Available',
+        petitionLabel: 'Petition Not Available',
       };
       expect(getPetitionInfo(petitionCode)).toEqual(expected);
     });

--- a/backend/lib/adapters/gateways/petition-gateway.test.ts
+++ b/backend/lib/adapters/gateways/petition-gateway.test.ts
@@ -14,15 +14,15 @@ describe('Petition Type Label gateway', () => {
     expect(debtorTypeName).toEqual(expected);
   });
 
-  test('should return an unknown label for an invalid ID', () => {
-    const petitionCode = 'ZZ';
-    const debtorTypeName = getPetitionInfo(petitionCode);
-    const expected: PetitionInfo = {
-      isTransfer: false,
-      isVoluntary: false,
-      petitionCode,
-      petitionLabel: '',
-    };
-    expect(debtorTypeName).toEqual(expected);
+  test('should return an not available label for an invalid ID', () => {
+    ['ZZ', null].forEach((petitionCode) => {
+      const expected: PetitionInfo = {
+        isTransfer: false,
+        isVoluntary: false,
+        petitionCode: petitionCode ?? '',
+        petitionLabel: 'Not Available',
+      };
+      expect(getPetitionInfo(petitionCode)).toEqual(expected);
+    });
   });
 });

--- a/backend/lib/adapters/gateways/petition-gateway.ts
+++ b/backend/lib/adapters/gateways/petition-gateway.ts
@@ -21,7 +21,7 @@ export function getPetitionInfo(petitionCode: string | null): PetitionInfo {
     petitionCode: petitionCode ?? '',
     petitionLabel: petitionLabelMap.has(petitionCode)
       ? petitionLabelMap.get(petitionCode)
-      : 'Not Available',
+      : 'Petition Not Available',
     isVoluntary: voluntaryCodes.includes(petitionCode),
     isTransfer: transferCodes.includes(petitionCode),
   };

--- a/backend/lib/adapters/gateways/petition-gateway.ts
+++ b/backend/lib/adapters/gateways/petition-gateway.ts
@@ -16,10 +16,12 @@ export interface PetitionInfo {
   isTransfer: boolean;
 }
 
-export function getPetitionInfo(petitionCode: string | undefined): PetitionInfo {
+export function getPetitionInfo(petitionCode: string | null): PetitionInfo {
   return {
-    petitionCode,
-    petitionLabel: petitionLabelMap.has(petitionCode) ? petitionLabelMap.get(petitionCode) : '',
+    petitionCode: petitionCode ?? '',
+    petitionLabel: petitionLabelMap.has(petitionCode)
+      ? petitionLabelMap.get(petitionCode)
+      : 'Not Available',
     isVoluntary: voluntaryCodes.includes(petitionCode),
     isTransfer: transferCodes.includes(petitionCode),
   };


### PR DESCRIPTION
# Purpose

Sync cases without petition or debtor types

# Major Changes

* Left join on the AO_TX table so case summaries are returned even if the type=1, code=1 TX records are absent.
* Update the label mappings to handle null codes for petition and debtor type codes.

# Testing/Validation

* Unit testing
* Manual testing
