### PR TITLE
CAMS-422 added arg to exclude child cases on MyCasesScreen

### DIFF
--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -36,6 +36,7 @@ export const MyCasesScreen = () => {
     limit: DEFAULT_SEARCH_LIMIT,
     offset: DEFAULT_SEARCH_OFFSET,
     assignments: [getCamsUserReference(session.user)],
+    excludeChildConsolidations: true,
   };
 
   const infoModalActionButtonGroup = {


### PR DESCRIPTION
Jira ticket: CAMS-421

# Purpose

Prevent cases that are a child of a consolidation from coming back on the My Cases Screen

# Major Changes

- Added argument for data call to excludeChildConsolidations to My Cases Screen

# Testing/Validation

- Deployed environment

# Notes

N/A

## Summary by Sourcery

Bug Fixes:
- Excludes child cases of consolidations from appearing on the My Cases screen.