### PR TITLE
CAMS-421 Upgrade case sync to use last sync date

### DIFF
--- a/backend/function-apps/dataflows/import/migrate-cases.ts
+++ b/backend/function-apps/dataflows/import/migrate-cases.ts
@@ -17,6 +17,7 @@ import ExportAndLoadCase from '../../../lib/use-cases/dataflows/export-and-load-
 import { isNotFoundError } from '../../../lib/common-errors/not-found-error';
 import ApplicationContextCreator from '../../azure/application-context-creator';
 import { UnknownError } from '../../../lib/common-errors/unknown-error';
+import { getTodaysIsoDate } from '../../../../common/src/date-helper';
 
 const MODULE_NAME = 'MIGRATE-CASES';
 const PAGE_SIZE = 100;
@@ -236,7 +237,7 @@ async function getCaseIdsToMigrate(
  */
 async function storeRuntimeState(invocationContext: InvocationContext) {
   const appContext = await ContextCreator.getApplicationContext({ invocationContext });
-  return CasesRuntimeState.storeRuntimeState(appContext);
+  return CasesRuntimeState.storeRuntimeState(appContext, getTodaysIsoDate());
 }
 
 export function setupMigrateCases() {

--- a/backend/function-apps/dataflows/import/sync-cases.ts
+++ b/backend/function-apps/dataflows/import/sync-cases.ts
@@ -49,7 +49,10 @@ const TIMER_TRIGGER = buildFunctionName(MODULE_NAME, 'timerTrigger');
 async function handleStart(startMessage: StartMessage, invocationContext: InvocationContext) {
   try {
     const context = await ContextCreator.getApplicationContext({ invocationContext });
-    const { events, lastTxId } = await SyncCases.getCaseIds(context, startMessage['lastTxId']);
+    const { events, lastSyncDate } = await SyncCases.getCaseIds(
+      context,
+      startMessage['lastSyncDate'],
+    );
 
     if (!events.length) return;
 
@@ -64,7 +67,7 @@ async function handleStart(startMessage: StartMessage, invocationContext: Invoca
     }
     invocationContext.extraOutputs.set(PAGE, pages);
 
-    await CasesRuntimeState.storeRuntimeState(context, lastTxId);
+    await CasesRuntimeState.storeRuntimeState(context, lastSyncDate);
   } catch (originalError) {
     invocationContext.extraOutputs.set(
       DLQ,

--- a/backend/lib/adapters/gateways/cases.local.gateway.ts
+++ b/backend/lib/adapters/gateways/cases.local.gateway.ts
@@ -1,8 +1,4 @@
-import {
-  CasesInterface,
-  CasesSyncMeta,
-  TransactionIdRangeForDate,
-} from '../../use-cases/cases/cases.interface';
+import { CasesInterface, TransactionIdRangeForDate } from '../../use-cases/cases/cases.interface';
 import { ApplicationContext } from '../types/basic';
 import { GatewayHelper } from './gateway-helper';
 import { getMonthDayYearStringFromDate } from '../utils/date-helper';
@@ -124,10 +120,10 @@ export class CasesLocalGateway implements CasesInterface {
     }
   }
 
-  public async getCaseIdsAndMaxTxIdToSync(
+  public async getUpdatedCaseIds(
     _applicationContext: ApplicationContext,
-    _lastTxId: string,
-  ): Promise<CasesSyncMeta> {
+    _start: string,
+  ): Promise<string[]> {
     throw new Error('Not implemented');
   }
 

--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -493,7 +493,7 @@ export default class CasesDxtrGateway implements CasesInterface {
       SELECT CONCAT(CS_DIV.CS_DIV_ACMS, '-', C.CASE_ID) AS caseId
       FROM AO_CS C
       JOIN AO_CS_DIV AS CS_DIV ON C.CS_DIV = CS_DIV.CS_DIV
-      WHERE C.LAST_UPDATE_DATE > '@start'
+      WHERE C.LAST_UPDATE_DATE > @start
     `;
 
     const queryResult: QueryResults = await executeQuery(

--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -1,7 +1,6 @@
 import * as mssql from 'mssql';
 import {
   CasesInterface,
-  CasesSyncMeta,
   TransactionIdRangeForDate,
 } from '../../../use-cases/cases/cases.interface';
 import { ApplicationContext } from '../../types/basic';
@@ -30,6 +29,7 @@ const orderToTransferCode = 'CTO';
 const NOT_FOUND = -1;
 
 type RawCaseIdAndMaxId = { caseId: string; maxTxId: number };
+type CaseIdRecord = { caseId: string };
 
 export function getCaseIdParts(caseId: string) {
   const parts = caseId.split('-');
@@ -472,58 +472,45 @@ export default class CasesDxtrGateway implements CasesInterface {
     return bCase;
   }
 
-  async getCaseIdsAndMaxTxIdToSync(
-    context: ApplicationContext,
-    lastTxId: string,
-  ): Promise<CasesSyncMeta> {
-    const input: DbTableFieldSpec[] = [];
-
-    input.push({
-      name: 'txId',
-      type: mssql.BigInt,
-      value: parseInt(lastTxId),
+  /**
+   * getUpdatedCaseIds
+   *
+   * Gets the case ids for all cases with LAST_UPDATE_DATE values greater than the provided date.
+   * 2025-02-23 06:35:30.453
+   *
+   * @param {string} start The date and time to begin checking for LAST_UPDATE_DATE values.
+   * @returns {string[]} A list of case ids for updated cases.
+   */
+  async getUpdatedCaseIds(context: ApplicationContext, start: string): Promise<string[]> {
+    const params: DbTableFieldSpec[] = [];
+    params.push({
+      name: 'start',
+      type: mssql.DateTime,
+      value: start,
     });
 
     const query = `
-      SELECT
-        CONCAT(CS_DIV.CS_DIV_ACMS, '-', C.CASE_ID) AS caseId,
-        MAX(T.TX_ID) as maxTxId
-      FROM AO_TX T
-      JOIN AO_CS C ON C.CS_CASEID = T.CS_CASEID AND C.COURT_ID = T.COURT_ID
+      SELECT CONCAT(CS_DIV.CS_DIV_ACMS, '-', C.CASE_ID) AS caseId
+      FROM AO_CS C
       JOIN AO_CS_DIV AS CS_DIV ON C.CS_DIV = CS_DIV.CS_DIV
-      WHERE T.TX_ID > @txId
-      GROUP BY CS_DIV.CS_DIV_ACMS, C.CASE_ID
-      ORDER BY MAX(T.TX_ID) DESC
+      WHERE C.LAST_UPDATE_DATE > '@start'
     `;
 
     const queryResult: QueryResults = await executeQuery(
       context,
       context.config.dxtrDbConfig,
       query,
-      input,
+      params,
     );
 
-    const results = handleQueryResult<RawCaseIdAndMaxId[]>(
+    const results = handleQueryResult<CaseIdRecord[]>(
       context,
       queryResult,
       MODULE_NAME,
-      this.caseIdsAndMaxTxIdCallback,
+      this.getUpdatedCaseIdsCallback,
     );
 
-    let meta: CasesSyncMeta;
-    if (results.length) {
-      meta = {
-        caseIds: results.map((bCase) => bCase.caseId),
-        lastTxId: results[0].maxTxId.toString(),
-      };
-    } else {
-      meta = {
-        caseIds: [],
-        lastTxId,
-      };
-    }
-
-    return meta;
+    return results.map((record) => record.caseId);
   }
 
   private async queryCase(
@@ -901,5 +888,11 @@ export default class CasesDxtrGateway implements CasesInterface {
     applicationContext.logger.debug(MODULE_NAME, `Results received from DXTR`);
 
     return (queryResult.results as mssql.IResult<RawCaseIdAndMaxId[]>).recordset;
+  }
+
+  getUpdatedCaseIdsCallback(applicationContext: ApplicationContext, queryResult: QueryResults) {
+    applicationContext.logger.debug(MODULE_NAME, `Results received from DXTR`);
+
+    return (queryResult.results as mssql.IResult<CaseIdRecord[]>).recordset;
   }
 }

--- a/backend/lib/use-cases/cases/cases.interface.d.ts
+++ b/backend/lib/use-cases/cases/cases.interface.d.ts
@@ -26,7 +26,7 @@ export interface CasesInterface {
 
   getSuggestedCases(applicationContext: ApplicationContext, caseId: string): Promise<CaseSummary[]>;
 
-  getUpdatedCaseIds(applicationContext: ApplicationContext, caseId: string): Promise<string[]>;
+  getUpdatedCaseIds(applicationContext: ApplicationContext, start: string): Promise<string[]>;
 
   findTransactionIdRangeForDate(
     context: ApplicationContext,

--- a/backend/lib/use-cases/cases/cases.interface.d.ts
+++ b/backend/lib/use-cases/cases/cases.interface.d.ts
@@ -26,10 +26,7 @@ export interface CasesInterface {
 
   getSuggestedCases(applicationContext: ApplicationContext, caseId: string): Promise<CaseSummary[]>;
 
-  getCaseIdsAndMaxTxIdToSync(
-    applicationContext: ApplicationContext,
-    lastTxId: string,
-  ): Promise<CasesSyncMeta>;
+  getUpdatedCaseIds(applicationContext: ApplicationContext, caseId: string): Promise<string[]>;
 
   findTransactionIdRangeForDate(
     context: ApplicationContext,

--- a/backend/lib/use-cases/dataflows/cases-runtime-state.test.ts
+++ b/backend/lib/use-cases/dataflows/cases-runtime-state.test.ts
@@ -1,7 +1,6 @@
 import { ApplicationContext } from '../../adapters/types/basic';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
-import { CasesLocalGateway } from '../../adapters/gateways/cases.local.gateway';
 import { CasesSyncState } from '../gateways.types';
 import CasesRuntimeState from './cases-runtime-state';
 
@@ -16,85 +15,27 @@ describe('storeRuntimeState tests', () => {
     jest.restoreAllMocks();
   });
 
-  test('should persist a new sync state when transaction id is not provided', async () => {
-    jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(undefined);
-    const upsertSpy = jest
-      .spyOn(MockMongoRepository.prototype, 'upsert')
-      .mockResolvedValue(undefined);
-    const txId = '1001';
-    jest.spyOn(CasesLocalGateway.prototype, 'findMaxTransactionId').mockResolvedValue(txId);
-
-    await CasesRuntimeState.storeRuntimeState(context);
-    expect(upsertSpy).toHaveBeenCalledWith({ documentType: 'CASES_SYNC_STATE', txId });
-  });
-
   test('should persist a new sync state', async () => {
     jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(undefined);
     const upsertSpy = jest
       .spyOn(MockMongoRepository.prototype, 'upsert')
       .mockResolvedValue(undefined);
 
-    const txId = '1001';
-    await CasesRuntimeState.storeRuntimeState(context, txId);
+    const lastSyncDate = new Date().toISOString();
+    await CasesRuntimeState.storeRuntimeState(context, lastSyncDate);
     expect(upsertSpy).toHaveBeenCalledWith({
       documentType: 'CASES_SYNC_STATE',
-      txId,
+      lastSyncDate,
     });
-  });
-
-  test('should persist a higher transaction id', async () => {
-    const original: CasesSyncState = {
-      documentType: 'CASES_SYNC_STATE',
-      txId: '1000',
-    };
-    jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(original);
-    const upsertSpy = jest
-      .spyOn(MockMongoRepository.prototype, 'upsert')
-      .mockResolvedValue(undefined);
-
-    const txId = '1001';
-    await CasesRuntimeState.storeRuntimeState(context, txId);
-    expect(upsertSpy).toHaveBeenCalledWith({ ...original, txId });
-  });
-
-  test('should not persist a lower transaction id', async () => {
-    const original: CasesSyncState = {
-      documentType: 'CASES_SYNC_STATE',
-      txId: '1000',
-    };
-    jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(original);
-    const upsertSpy = jest
-      .spyOn(MockMongoRepository.prototype, 'upsert')
-      .mockRejectedValue(new Error('this should not be called'));
-
-    const txId = '1';
-    await CasesRuntimeState.storeRuntimeState(context, txId);
-    expect(upsertSpy).not.toHaveBeenCalled();
   });
 
   test('should throw CamsError', async () => {
     const original: CasesSyncState = {
       documentType: 'CASES_SYNC_STATE',
-      txId: '1000',
+      lastSyncDate: '1000',
     };
     jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(original);
     jest.spyOn(MockMongoRepository.prototype, 'upsert').mockRejectedValue(new Error('some error'));
     await expect(CasesRuntimeState.storeRuntimeState(context, '1001')).resolves.toBeUndefined();
-  });
-
-  test('should throw error if gateway throws', async () => {
-    jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(undefined);
-    jest
-      .spyOn(CasesLocalGateway.prototype, 'findMaxTransactionId')
-      .mockRejectedValue(new Error('some error'));
-
-    await expect(CasesRuntimeState.storeRuntimeState(context)).resolves.toBeUndefined();
-  });
-
-  test('should throw error if max transaction id cannot be determined', async () => {
-    jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(undefined);
-    jest.spyOn(CasesLocalGateway.prototype, 'findMaxTransactionId').mockResolvedValue(undefined);
-
-    await expect(CasesRuntimeState.storeRuntimeState(context)).resolves.toBeUndefined();
   });
 });

--- a/backend/lib/use-cases/dataflows/cases-runtime-state.test.ts
+++ b/backend/lib/use-cases/dataflows/cases-runtime-state.test.ts
@@ -15,27 +15,43 @@ describe('storeRuntimeState tests', () => {
     jest.restoreAllMocks();
   });
 
-  test('should persist a new sync state', async () => {
+  test('should persist a new sync state and log', async () => {
     jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(undefined);
     const upsertSpy = jest
       .spyOn(MockMongoRepository.prototype, 'upsert')
       .mockResolvedValue(undefined);
 
     const lastSyncDate = new Date().toISOString();
+    const errorLogSpy = jest.spyOn(context.logger, 'camsError');
+    const infoLogSpy = jest.spyOn(context.logger, 'info');
     await CasesRuntimeState.storeRuntimeState(context, lastSyncDate);
     expect(upsertSpy).toHaveBeenCalledWith({
       documentType: 'CASES_SYNC_STATE',
       lastSyncDate,
     });
+    expect(errorLogSpy).not.toHaveBeenCalled();
+    expect(infoLogSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Wrote runtime state: '),
+      expect.anything(),
+    );
   });
 
-  test('should throw CamsError', async () => {
+  test('should log CamsError', async () => {
     const original: CasesSyncState = {
       documentType: 'CASES_SYNC_STATE',
       lastSyncDate: '1000',
     };
     jest.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(original);
     jest.spyOn(MockMongoRepository.prototype, 'upsert').mockRejectedValue(new Error('some error'));
+    const errorLogSpy = jest.spyOn(context.logger, 'camsError');
+    const infoLogSpy = jest.spyOn(context.logger, 'info');
     await expect(CasesRuntimeState.storeRuntimeState(context, '1001')).resolves.toBeUndefined();
+    expect(errorLogSpy).toHaveBeenCalled();
+    expect(infoLogSpy).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Wrote runtime state: '),
+      expect.anything(),
+    );
   });
 });

--- a/backend/lib/use-cases/dataflows/cases-runtime-state.ts
+++ b/backend/lib/use-cases/dataflows/cases-runtime-state.ts
@@ -1,34 +1,19 @@
 import { ApplicationContext } from '../../adapters/types/basic';
-import Factory, { getCasesGateway } from '../../factory';
-import { UnknownError } from '../../common-errors/unknown-error';
+import Factory from '../../factory';
 import { CasesSyncState } from '../gateways.types';
 import { getCamsError } from '../../common-errors/error-utilities';
 
 const MODULE_NAME = 'CASE-RUNTIME-STATE';
 
-async function storeRuntimeState(context: ApplicationContext, lastTxId?: string) {
+async function storeRuntimeState(context: ApplicationContext, lastSyncDate: string) {
   const runtimeStateRepo = Factory.getCasesSyncStateRepo(context);
   try {
-    const syncState = await runtimeStateRepo.read('CASES_SYNC_STATE');
-    context.logger.info(MODULE_NAME, `Retrieved runtime state: ${syncState}.`);
-    if (!lastTxId) {
-      const gateway = getCasesGateway(context);
-      lastTxId = await gateway.findMaxTransactionId(context);
-      if (!lastTxId) {
-        throw new UnknownError(MODULE_NAME, {
-          message: 'Failed to determine the maximum transaction id.',
-        });
-      }
-    }
-    if (!syncState || lastTxId > syncState.txId) {
-      const newSyncState: CasesSyncState = {
-        ...syncState,
-        documentType: 'CASES_SYNC_STATE',
-        txId: lastTxId,
-      };
-      await runtimeStateRepo.upsert(newSyncState);
-      context.logger.info(MODULE_NAME, `Wrote runtime state: ${newSyncState}.`);
-    }
+    const newSyncState: CasesSyncState = {
+      documentType: 'CASES_SYNC_STATE',
+      lastSyncDate,
+    };
+    await runtimeStateRepo.upsert(newSyncState);
+    context.logger.info(MODULE_NAME, `Wrote runtime state: ${newSyncState}.`);
   } catch (originalError) {
     const error = getCamsError(
       originalError,

--- a/backend/lib/use-cases/dataflows/cases-runtime-state.ts
+++ b/backend/lib/use-cases/dataflows/cases-runtime-state.ts
@@ -13,7 +13,7 @@ async function storeRuntimeState(context: ApplicationContext, lastSyncDate: stri
       lastSyncDate,
     };
     await runtimeStateRepo.upsert(newSyncState);
-    context.logger.info(MODULE_NAME, `Wrote runtime state: ${newSyncState}.`);
+    context.logger.info(MODULE_NAME, `Wrote runtime state: `, newSyncState);
   } catch (originalError) {
     const error = getCamsError(
       originalError,

--- a/backend/lib/use-cases/dataflows/sync-cases.ts
+++ b/backend/lib/use-cases/dataflows/sync-cases.ts
@@ -5,13 +5,13 @@ import { getCamsError } from '../../common-errors/error-utilities';
 import { CasesSyncState } from '../gateways.types';
 import { randomUUID } from 'node:crypto';
 import { CamsError } from '../../common-errors/cams-error';
+import { getIsoDate } from '../../../../common/src/date-helper';
 
 const MODULE_NAME = 'SYNC-CASES-USE-CASE';
 
 async function getCaseIds(context: ApplicationContext, lastSyncDate?: string) {
   try {
-    const now = new Date().toISOString();
-
+    const now = getIsoDate(new Date());
     let syncState: CasesSyncState;
     if (lastSyncDate) {
       syncState = {
@@ -26,7 +26,9 @@ async function getCaseIds(context: ApplicationContext, lastSyncDate?: string) {
 
     const casesGateway = getCasesGateway(context);
     const start = syncState.lastSyncDate;
-    if (!start) throw new CamsError(MODULE_NAME);
+    if (!start) {
+      throw new CamsError(MODULE_NAME);
+    }
     const caseIds = await casesGateway.getUpdatedCaseIds(context, syncState.lastSyncDate);
 
     const events: CaseSyncEvent[] = caseIds.map((caseId) => {

--- a/backend/lib/use-cases/dataflows/sync-cases.ts
+++ b/backend/lib/use-cases/dataflows/sync-cases.ts
@@ -4,7 +4,6 @@ import Factory, { getCasesGateway } from '../../factory';
 import { getCamsError } from '../../common-errors/error-utilities';
 import { CasesSyncState } from '../gateways.types';
 import { randomUUID } from 'node:crypto';
-import { CamsError } from '../../common-errors/cams-error';
 
 const MODULE_NAME = 'SYNC-CASES-USE-CASE';
 
@@ -25,10 +24,6 @@ async function getCaseIds(context: ApplicationContext, lastSyncDate?: string) {
     }
 
     const casesGateway = getCasesGateway(context);
-    const start = syncState.lastSyncDate;
-    if (!start) {
-      throw new CamsError(MODULE_NAME);
-    }
     const caseIds = await casesGateway.getUpdatedCaseIds(context, syncState.lastSyncDate);
 
     const events: CaseSyncEvent[] = caseIds.map((caseId) => {

--- a/backend/lib/use-cases/dataflows/sync-cases.ts
+++ b/backend/lib/use-cases/dataflows/sync-cases.ts
@@ -5,13 +5,13 @@ import { getCamsError } from '../../common-errors/error-utilities';
 import { CasesSyncState } from '../gateways.types';
 import { randomUUID } from 'node:crypto';
 import { CamsError } from '../../common-errors/cams-error';
-import { getIsoDate } from '../../../../common/src/date-helper';
 
 const MODULE_NAME = 'SYNC-CASES-USE-CASE';
 
 async function getCaseIds(context: ApplicationContext, lastSyncDate?: string) {
   try {
-    const now = getIsoDate(new Date());
+    const now = new Date().toISOString();
+
     let syncState: CasesSyncState;
     if (lastSyncDate) {
       syncState = {

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -177,7 +177,7 @@ export type OrderSyncState = RuntimeState & {
 
 export type CasesSyncState = RuntimeState & {
   documentType: 'CASES_SYNC_STATE';
-  lastSyncDate?: string;
+  lastSyncDate: string;
 };
 
 export type OfficeStaffSyncState = RuntimeState & {

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -177,7 +177,7 @@ export type OrderSyncState = RuntimeState & {
 
 export type CasesSyncState = RuntimeState & {
   documentType: 'CASES_SYNC_STATE';
-  txId: string;
+  lastSyncDate?: string;
 };
 
 export type OfficeStaffSyncState = RuntimeState & {

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -15,5 +15,4 @@ export const testFeatureFlags: FeatureFlagSet = {
   'case-search-enabled': true,
   'case-notes-enabled': true,
   'privileged-identity-management': true,
-  'enhanced-case-sync': true,
 };

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -12,7 +12,6 @@ export const testFeatureFlags: FeatureFlagSet = {
   'chapter-eleven-enabled': true,
   'transfer-orders-enabled': true,
   'consolidations-enabled': true,
-  'case-search-enabled': true,
   'case-notes-enabled': true,
   'privileged-identity-management': true,
 };

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -15,4 +15,5 @@ export const testFeatureFlags: FeatureFlagSet = {
   'case-search-enabled': true,
   'case-notes-enabled': true,
   'privileged-identity-management': true,
+  'enhanced-case-sync': true,
 };

--- a/ops/cloud-deployment/lib/storage/storage-queues.bicep
+++ b/ops/cloud-deployment/lib/storage/storage-queues.bicep
@@ -1,7 +1,5 @@
 param storageAccountName string
 
-param migrationTaskName string = 'migration-task'
-
 resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
   name: storageAccountName
 }
@@ -14,37 +12,4 @@ resource storageAccountQueueServices 'Microsoft.Storage/storageAccounts/queueSer
       corsRules: []
     }
   }
-}
-
-resource migrationBaseQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = {
-  parent: storageAccountQueueServices
-  name: migrationTaskName
-  properties: {
-    metadata: {}
-  }
-  dependsOn: [
-    storageAccount
-  ]
-}
-
-resource migrationFailureQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = {
-  parent: storageAccountQueueServices
-  name: '${migrationTaskName}-fail'
-  properties: {
-    metadata: {}
-  }
-  dependsOn: [
-    storageAccount
-  ]
-}
-
-resource migrationSuccessQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = {
-  parent: storageAccountQueueServices
-  name: '${migrationTaskName}-success'
-  properties: {
-    metadata: {}
-  }
-  dependsOn: [
-    storageAccount
-  ]
 }

--- a/user-interface/src/lib/components/Header.test.tsx
+++ b/user-interface/src/lib/components/Header.test.tsx
@@ -15,7 +15,6 @@ describe('Header', () => {
   });
   vi.spyOn(FeatureFlags, 'default').mockReturnValue({
     'transfer-orders-enabled': true,
-    'case-search-enabled': true,
   });
 
   beforeEach(() => {


### PR DESCRIPTION
# Purpose

Upgrade case sync to use new sync date in DXTR

# Major Changes

Replaced sync case ID query using the AO_TX with new query to update date in AO_CS.
Stored last sync date in case sync runtime state.

# Testing/Validation

* Unit tests
* Manual testing

# Definition of Done:

- [X] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [X] Dependency rule followed - More important code doesn’t directly depend on less important code
- [X] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

Updates the case synchronization process to use the last synchronization date instead of the last transaction ID. This change improves the efficiency and accuracy of case synchronization by focusing on changes since the last successful sync.

Enhancements:
- Replaces the case ID query using the AO_TX table with a new query that updates the date in the AO_CS table.
- Stores the last sync date in the case sync runtime state.
- Updates the sync cases use case to retrieve case IDs based on the last sync date.
- Removes the retrieval of max transaction ID from the CasesLocalGateway as it is no longer needed.
- Updates the CasesSyncState type to use lastSyncDate instead of txId.
- Updates the sync cases function app to pass the lastSyncDate to the getCaseIds use case and store the lastSyncDate in the runtime state.