### PR TITLE
Ignore specific typescript errors in tests

### DIFF
--- a/user-interface/src/login/broadcast-logout.test.ts
+++ b/user-interface/src/login/broadcast-logout.test.ts
@@ -21,6 +21,7 @@ describe('Broadcast Logout', () => {
     const closeSpy = vi.spyOn(BroadcastChannelHumble.prototype, 'close').mockReturnValue();
 
     Object.defineProperty(global, 'window', Object.create(window));
+    // @ts-expect-error `location` is a readonly property. As this is just a test, we do not care.
     global.window.location = {
       host: 'some-host',
       protocol: 'http:',

--- a/user-interface/src/login/http401-logout.test.ts
+++ b/user-interface/src/login/http401-logout.test.ts
@@ -35,10 +35,12 @@ describe('Login HTTP 401 handler', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
+      // @ts-expect-error `location` is a readonly property. As this is just a test, we do not care.
       window.location = { ...mockLocation };
     });
 
     afterAll(() => {
+      // @ts-expect-error `location` is a readonly property. As this is just a test, we do not care.
       window.location = originalLocation;
     });
 

--- a/user-interface/src/login/inactive-logout.test.ts
+++ b/user-interface/src/login/inactive-logout.test.ts
@@ -43,10 +43,12 @@ describe('Login Inactive Logout', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
+      // @ts-expect-error `location` is a readonly property. As this is just a test, we do not care.
       window.location = { ...mockLocation };
     });
 
     afterAll(() => {
+      // @ts-expect-error `location` is a readonly property. As this is just a test, we do not care.
       window.location = originalLocation;
     });
 

--- a/user-interface/src/login/session-end-logout.test.ts
+++ b/user-interface/src/login/session-end-logout.test.ts
@@ -34,6 +34,7 @@ describe('Session End Logout tests', () => {
   const logoutUri = protocol + '//' + host + LOGOUT_PATH;
 
   beforeEach(() => {
+    // @ts-expect-error `location` is a readonly property. As this is just a test, we do not care.
     window.location = { ...mockLocation };
   });
 


### PR DESCRIPTION
# Purpose

The latest typescript version introduced some type problems in frontend tests.

# Major Changes

For now we just add an `@ts-expect-error` comment to places we modify the dom location.

# Testing/Validation

The build works.

# Notes

We may want to consider finding a way to test without having to modify this readonly property so that we do not continue to have to add this comment in our tests.

## Summary by Sourcery

Tests:
- Adds @ts-expect-error comments to tests that modify the readonly location property.