### PR TITLE
Remove durable functions

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,6 @@
         "@okta/okta-sdk-nodejs": "^7.1.1",
         "applicationinsights": "^3.5.0",
         "dotenv": "^16.4.7",
-        "durable-functions": "^3.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.14.2",
         "mssql": "^10.0.4"
@@ -3965,17 +3964,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/azure-function-context-mock": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/azure-function-context-mock/-/azure-function-context-mock-0.0.7.tgz",
@@ -4609,15 +4597,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -4872,34 +4851,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/durable-functions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/durable-functions/-/durable-functions-3.1.0.tgz",
-      "integrity": "sha512-baSkW45/VrVvl1e27qvxEZX2z5vApiINaGUTIxx0c4H5E2Lr22QnogZrebqIhyfspZ466XKhp245nyS0HSkAYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/functions": "^4.0.0",
-        "axios": "^1.6.1",
-        "debug": "~2.6.9",
-        "lodash": "^4.17.15",
-        "moment": "^2.29.2",
-        "uuid": "~3.3.2",
-        "validator": "~13.7.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/durable-functions/node_modules/uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -5975,26 +5926,6 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -8442,15 +8373,6 @@
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
       "license": "MIT"
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/mongodb": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.14.2.tgz",
@@ -8506,12 +8428,6 @@
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/mssql": {
       "version": "10.0.4",
@@ -9278,12 +9194,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
       "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
       "license": "Apache-2.0"
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -10711,15 +10621,6 @@
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/walker": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,6 @@
     "@okta/okta-sdk-nodejs": "^7.1.1",
     "applicationinsights": "^3.5.0",
     "dotenv": "^16.4.7",
-    "durable-functions": "^3.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.14.2",
     "mssql": "^10.0.4"

--- a/docs/architecture/decision-records/Dataflows.md
+++ b/docs/architecture/decision-records/Dataflows.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The use of Durable Functions for long-running jobs was not meeting performance expectations.
+The use of Durable Functions for long-running jobs was not meeting performance expectations. Specifically, most of the compute time was spent on orchestration, moving tasks in and out of memory, but performing very few migrations.
 
 ## Decision
 

--- a/docs/architecture/decision-records/Dataflows.md
+++ b/docs/architecture/decision-records/Dataflows.md
@@ -1,0 +1,17 @@
+# Dataflows
+
+## Context
+
+The use of Durable Functions for long-running jobs was not meeting performance expectations.
+
+## Decision
+
+Azure Durable Functions are replaced by queues and queue triggers.
+
+## Status
+
+Supersedes [DurableFunction](./DurableFunction.md)
+
+## Consequences
+
+The architecture remains with the familiar paradigm but performs much better with messages on queues and queue triggers.

--- a/docs/architecture/decision-records/Dataflows.md
+++ b/docs/architecture/decision-records/Dataflows.md
@@ -10,7 +10,7 @@ Azure Durable Functions are replaced by queues and queue triggers.
 
 ## Status
 
-Supersedes [DurableFunction](./DurableFunction.md)
+Supersedes [DurableFunction](/architecture/decision-records/DurableFunction.md)
 
 ## Consequences
 

--- a/docs/architecture/decision-records/DurableFunction.md
+++ b/docs/architecture/decision-records/DurableFunction.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The architecture needs to support long running jobs related to data migration from source systems.
+The architecture needs to support long-running jobs related to data migration from source systems.
 
 ## Decision
 
@@ -11,9 +11,9 @@ common with the existing web API implemented as an Azure Function application.
 
 ## Status
 
-Accepted
+Superseded by [Dataflows](./Dataflows.md)
 
 ## Consequences
 
-The architecture uses a familiar programming paradigm across backend implmentations. It also shares
+The architecture uses a familiar programming paradigm across backend implementations. It also shares
 a common CI/CD pipeline with existing web API.

--- a/docs/architecture/decision-records/DurableFunction.md
+++ b/docs/architecture/decision-records/DurableFunction.md
@@ -11,7 +11,7 @@ common with the existing web API implemented as an Azure Function application.
 
 ## Status
 
-Superseded by [Dataflows](./Dataflows.md)
+Superseded by [Dataflows](/architecture/decision-records/Dataflows.md)
 
 ## Consequences
 

--- a/docs/architecture/decision-records/_sidebar.md
+++ b/docs/architecture/decision-records/_sidebar.md
@@ -9,7 +9,6 @@
 - [Backend Logging](/architecture/decision-records/BackendLogging.md)
 - [Dataflows](/architecture/decision-records/Dataflows.md)
 - [Deployment](/architecture/decision-records/Deployment.md)
-- [Durable Function](/architecture/decision-records/DurableFunction.md)
 - [Frontend Build Tooling](/architecture/decision-records/FrontendBuildTooling.md)
 - [Frontend Design System](/architecture/decision-records/FrontendDesignSystem.md)
 - [GitHub Actions](/architecture/decision-records/GithubActionWorkflow.md)

--- a/docs/architecture/decision-records/_sidebar.md
+++ b/docs/architecture/decision-records/_sidebar.md
@@ -7,6 +7,7 @@
 - [Authentication](/architecture/decision-records/Authentication.md)
 - [Azure Resource Manager](/architecture/decision-records/AzureResourceManager.md)
 - [Backend Logging](/architecture/decision-records/BackendLogging.md)
+- [Dataflows](/architecture/decision-records/Dataflows.md)
 - [Deployment](/architecture/decision-records/Deployment.md)
 - [Durable Function](/architecture/decision-records/DurableFunction.md)
 - [Frontend Build Tooling](/architecture/decision-records/FrontendBuildTooling.md)


### PR DESCRIPTION
# Purpose

Dependabot submitted a PR to override the version of `axios` used by `durable-functions` which was no longer in use.

# Major Changes

- Remove `durable-functions`.
- Update the ADRs.

# Testing/Validation

Validated the docs work correctly.

## Summary by Sourcery

Enhancements:
- Replaces Durable Functions with Dataflows for long-running jobs, utilizing queues and queue triggers to enhance performance.