### PR TITLE
CAMS-508 Filter closed cases on "my cases"

### DIFF
--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
@@ -30,13 +30,13 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
         throw new Error('Trying to paginate for a query that is not a pagination query');
       }
 
-      const aggregationResult = await this.collectionHumble.aggregate(mongoQuery);
-      const totalCountPromise = this.collectionHumble.countDocuments(countQuery);
-
       const aggregationItem: CamsPaginationResponse<T> = {
         metadata: { total: 0 },
         data: [],
       };
+
+      const aggregationResult = await this.collectionHumble.aggregate(mongoQuery);
+      aggregationItem.metadata.total = await this.collectionHumble.countDocuments(countQuery);
 
       for await (const result of aggregationResult) {
         for (const doc of result.data) {
@@ -44,7 +44,6 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
         }
       }
 
-      aggregationItem.metadata.total = await totalCountPromise;
       return aggregationItem;
     } catch (originalError) {
       throw this.handleError(

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -334,6 +334,7 @@ export default function DataVerificationScreen() {
     </MainContent>
   );
 }
+
 interface FilterProps<T extends string> {
   label: string;
   filterType: T;

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -342,6 +342,12 @@ interface FilterProps<T extends string> {
   callback: (filterString: T) => void;
 }
 
+function generateTooltip(label: string, isActive: boolean) {
+  const base = `${label} ${isActive ? 'shown' : 'hidden'}.`.toLowerCase();
+  const tooltip = base.slice(0, 1).toUpperCase() + base.slice(1);
+  return tooltip;
+}
+
 function Filter<T extends string>(props: FilterProps<T>) {
   const { label, filterType, filters, callback } = props;
   return (
@@ -352,6 +358,7 @@ function Filter<T extends string>(props: FilterProps<T>) {
       aria-checked={filters.includes(filterType) ? true : false}
       onClick={() => callback(filterType)}
       data-testid={`order-status-filter-${filterType}`}
+      title={generateTooltip(label, filters.includes(filterType))}
     >
       {label}
       <Icon name="check" className={filters.includes(filterType) ? 'active' : ''}></Icon>

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.scss
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.scss
@@ -1,0 +1,37 @@
+.toggle-button {
+  display: inline-flex;
+  flex-flow: row;
+  flex-direction: row;
+
+  button {
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 1.5rem;
+    margin-right: 0.5rem;
+    padding: 0rem 0.5rem 0.125rem 0.5rem;
+    border-radius: 0.125rem;
+    text-decoration: none;
+    color: white;
+  }
+
+  :hover {
+    cursor: pointer;
+  }
+
+  .inactive {
+    background: #5c5c5c;
+    font-weight: normal;
+    svg {
+      display: none;
+      padding-left: 0.125rem;
+    }
+  }
+
+  .active {
+    background: #0050d8;
+    font-weight: bold;
+    svg {
+      display: inline;
+    }
+  }
+}

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.scss
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.scss
@@ -1,37 +1,38 @@
-.toggle-button {
+button.toggle-button {
   display: inline-flex;
   flex-flow: row;
   flex-direction: row;
 
-  button {
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 1.5rem;
-    margin-right: 0.5rem;
-    padding: 0rem 0.5rem 0.125rem 0.5rem;
-    border-radius: 0.125rem;
-    text-decoration: none;
-    color: white;
-  }
+  align-items: center;
+  justify-content: center;
 
-  :hover {
-    cursor: pointer;
-  }
+  margin-right: 0.5rem;
+  padding: 0rem 0.5rem 0.125rem 0.5rem;
+  border-radius: 0.125rem;
 
-  .inactive {
-    background: #5c5c5c;
-    font-weight: normal;
-    svg {
-      display: none;
-      padding-left: 0.125rem;
-    }
-  }
+  cursor: pointer;
+  text-decoration: none;
+  color: white;
+}
 
-  .active {
-    background: #0050d8;
-    font-weight: bold;
-    svg {
-      display: inline;
-    }
+button.toggle-button.inactive {
+  background: #5c5c5c;
+  font-weight: normal;
+  svg {
+    display: none;
+    padding-left: 0.125rem;
   }
+}
+
+button.toggle-button.active {
+  background: #0050d8;
+  font-weight: bold;
+  svg {
+    display: inline;
+  }
+}
+
+button.toggle-button:hover {
+  text-decoration: none;
+  color: white;
 }

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.test.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.test.tsx
@@ -9,6 +9,7 @@ describe('ToggleButton', () => {
         id="test-button"
         label="Test Button"
         ariaLabel="Test Button"
+        tooltipLabel="Test Button"
         isActive={false}
         onToggle={() => false}
       />,
@@ -18,6 +19,7 @@ describe('ToggleButton', () => {
     expect(button).toHaveClass('inactive');
     expect(button).toHaveAttribute('aria-checked', 'false');
     expect(button).toHaveTextContent('Test Button');
+    expect(button).toHaveAttribute('title', 'Test Button');
   });
 
   test('should render with active state', () => {
@@ -26,6 +28,7 @@ describe('ToggleButton', () => {
         id="test-button"
         label="Test Button"
         ariaLabel="Test Button"
+        tooltipLabel="Test Button"
         isActive={true}
         onToggle={() => true}
       />,
@@ -44,6 +47,7 @@ describe('ToggleButton', () => {
         id="test-button"
         label="Test Button"
         ariaLabel="Test Button"
+        tooltipLabel="Test Button"
         isActive={false}
         onToggle={onToggle}
       />,
@@ -68,6 +72,7 @@ describe('ToggleButton', () => {
         id="test-button"
         label={{ active: 'Active Label', inactive: 'Inactive Label' }}
         ariaLabel={{ active: 'Active Aria Label', inactive: 'Inactive Aria Label' }}
+        tooltipLabel={{ active: 'Active Tooltip', inactive: 'Inactive Tooltip' }}
         isActive={false}
         onToggle={() => false}
       />,
@@ -76,11 +81,13 @@ describe('ToggleButton', () => {
     const button = screen.getByRole('switch');
     expect(button).toHaveClass('inactive');
     expect(button).toHaveAttribute('aria-label', 'Inactive Aria Label');
+    expect(button).toHaveAttribute('title', 'Inactive Tooltip');
     expect(button).toHaveTextContent('Inactive Label');
 
     await userEvent.click(button);
     expect(button).toHaveClass('active');
     expect(button).toHaveAttribute('aria-label', 'Active Aria Label');
+    expect(button).toHaveAttribute('title', 'Active Tooltip');
     expect(button).toHaveTextContent('Active Label');
   });
 
@@ -91,6 +98,7 @@ describe('ToggleButton', () => {
         id="test-button"
         label={staticLabel}
         ariaLabel={staticLabel}
+        tooltipLabel={staticLabel}
         isActive={false}
         onToggle={() => false}
       />,
@@ -99,11 +107,13 @@ describe('ToggleButton', () => {
     const button = screen.getByRole('switch');
     expect(button).toHaveClass('inactive');
     expect(button).toHaveAttribute('aria-label', staticLabel);
+    expect(button).toHaveAttribute('title', staticLabel);
     expect(button).toHaveTextContent(staticLabel);
 
     await userEvent.click(button);
     expect(button).toHaveClass('active');
     expect(button).toHaveAttribute('aria-label', staticLabel);
+    expect(button).toHaveAttribute('title', staticLabel);
     expect(button).toHaveTextContent(staticLabel);
   });
 
@@ -113,6 +123,7 @@ describe('ToggleButton', () => {
         id="test-button"
         label="Test Button"
         ariaLabel="Test Button"
+        tooltipLabel="Test Button"
         isActive={false}
         onToggle={() => false}
       />,
@@ -126,6 +137,7 @@ describe('ToggleButton', () => {
         id="test-button"
         label="Test Button"
         ariaLabel="Test Button"
+        tooltipLabel="Test Button"
         isActive={true}
         onToggle={() => true}
       />,

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.test.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ToggleButton from './ToggleButton';
+
+describe('ToggleButton', () => {
+  test('should render with inactive state', () => {
+    render(
+      <ToggleButton
+        id="test-button"
+        label="Test Button"
+        ariaLabel="Test Button"
+        isActive={false}
+        onToggle={() => false}
+      />,
+    );
+
+    const button = screen.getByRole('switch');
+    expect(button).toHaveClass('inactive');
+    expect(button).toHaveAttribute('aria-checked', 'false');
+    expect(button).toHaveTextContent('Test Button');
+  });
+
+  test('should render with active state', () => {
+    render(
+      <ToggleButton
+        id="test-button"
+        label="Test Button"
+        ariaLabel="Test Button"
+        isActive={true}
+        onToggle={() => true}
+      />,
+    );
+
+    const button = screen.getByRole('switch');
+    expect(button).toHaveClass('active');
+    expect(button).toHaveAttribute('aria-checked', 'true');
+    expect(button).toHaveTextContent('Test Button');
+  });
+
+  test('should toggle state on click', () => {
+    const onToggle = vi.fn();
+    render(
+      <ToggleButton
+        id="test-button"
+        label="Test Button"
+        ariaLabel="Test Button"
+        isActive={false}
+        onToggle={onToggle}
+      />,
+    );
+
+    const button = screen.getByRole('switch');
+    fireEvent.click(button);
+
+    expect(button).toHaveClass('active');
+    expect(button).toHaveAttribute('aria-checked', 'true');
+    expect(onToggle).toHaveBeenCalledWith(true);
+
+    fireEvent.click(button);
+    expect(button).toHaveClass('inactive');
+    expect(button).toHaveAttribute('aria-checked', 'false');
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  test('should render with ModeLabel', () => {
+    render(
+      <ToggleButton
+        id="test-button"
+        label={{ active: 'Active Label', inactive: 'Inactive Label' }}
+        ariaLabel={{ active: 'Active Aria Label', inactive: 'Inactive Aria Label' }}
+        isActive={false}
+        onToggle={() => false}
+      />,
+    );
+
+    const button = screen.getByRole('switch');
+    expect(button).toHaveClass('inactive');
+    expect(button).toHaveAttribute('aria-label', 'Inactive Aria Label');
+    expect(button).toHaveTextContent('Inactive Label');
+
+    fireEvent.click(button);
+    expect(button).toHaveClass('active');
+    expect(button).toHaveAttribute('aria-label', 'Active Aria Label');
+    expect(button).toHaveTextContent('Active Label');
+  });
+
+  test('should render with static string labels', () => {
+    const staticLabel = 'Foo Bar';
+    render(
+      <ToggleButton
+        id="test-button"
+        label={staticLabel}
+        ariaLabel={staticLabel}
+        isActive={false}
+        onToggle={() => false}
+      />,
+    );
+
+    const button = screen.getByRole('switch');
+    expect(button).toHaveClass('inactive');
+    expect(button).toHaveAttribute('aria-label', staticLabel);
+    expect(button).toHaveTextContent(staticLabel);
+
+    fireEvent.click(button);
+    expect(button).toHaveClass('active');
+    expect(button).toHaveAttribute('aria-label', staticLabel);
+    expect(button).toHaveTextContent(staticLabel);
+  });
+
+  test('should update state from props', () => {
+    const { rerender } = render(
+      <ToggleButton
+        id="test-button"
+        label="Test Button"
+        ariaLabel="Test Button"
+        isActive={false}
+        onToggle={() => false}
+      />,
+    );
+
+    let button = screen.getByRole('switch');
+    expect(button).toHaveClass('inactive');
+
+    rerender(
+      <ToggleButton
+        id="test-button"
+        label="Test Button"
+        ariaLabel="Test Button"
+        isActive={true}
+        onToggle={() => true}
+      />,
+    );
+
+    button = screen.getByRole('switch');
+    expect(button).toHaveClass('active');
+  });
+});

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.test.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ToggleButton from './ToggleButton';
 
 describe('ToggleButton', () => {
@@ -36,7 +37,7 @@ describe('ToggleButton', () => {
     expect(button).toHaveTextContent('Test Button');
   });
 
-  test('should toggle state on click', () => {
+  test('should toggle state on click', async () => {
     const onToggle = vi.fn();
     render(
       <ToggleButton
@@ -49,19 +50,19 @@ describe('ToggleButton', () => {
     );
 
     const button = screen.getByRole('switch');
-    fireEvent.click(button);
+    await userEvent.click(button);
 
     expect(button).toHaveClass('active');
     expect(button).toHaveAttribute('aria-checked', 'true');
     expect(onToggle).toHaveBeenCalledWith(true);
 
-    fireEvent.click(button);
+    await userEvent.click(button);
     expect(button).toHaveClass('inactive');
     expect(button).toHaveAttribute('aria-checked', 'false');
     expect(onToggle).toHaveBeenCalledWith(false);
   });
 
-  test('should render with ModeLabel', () => {
+  test('should render with ModeLabel', async () => {
     render(
       <ToggleButton
         id="test-button"
@@ -77,13 +78,13 @@ describe('ToggleButton', () => {
     expect(button).toHaveAttribute('aria-label', 'Inactive Aria Label');
     expect(button).toHaveTextContent('Inactive Label');
 
-    fireEvent.click(button);
+    await userEvent.click(button);
     expect(button).toHaveClass('active');
     expect(button).toHaveAttribute('aria-label', 'Active Aria Label');
     expect(button).toHaveTextContent('Active Label');
   });
 
-  test('should render with static string labels', () => {
+  test('should render with static string labels', async () => {
     const staticLabel = 'Foo Bar';
     render(
       <ToggleButton
@@ -100,7 +101,7 @@ describe('ToggleButton', () => {
     expect(button).toHaveAttribute('aria-label', staticLabel);
     expect(button).toHaveTextContent(staticLabel);
 
-    fireEvent.click(button);
+    await userEvent.click(button);
     expect(button).toHaveClass('active');
     expect(button).toHaveAttribute('aria-label', staticLabel);
     expect(button).toHaveTextContent(staticLabel);

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import Icon from '../../uswds/Icon';
+import './ToggleButton.scss';
+
+type ModeLabel = {
+  active: string;
+  inactive: string;
+};
+
+function isModeLabel(obj: unknown): obj is ModeLabel {
+  return obj !== null && typeof obj === 'object' && 'active' in obj && 'inactive' in obj;
+}
+
+function getLabel(label: string | ModeLabel, isActive: boolean) {
+  if (isModeLabel(label)) {
+    return isActive ? label.active : label.inactive;
+  } else {
+    return label;
+  }
+}
+
+type ToggleButtonProps = {
+  id: string;
+  label: string | ModeLabel;
+  ariaLabel: string | ModeLabel;
+  isActive: boolean;
+  onToggle: () => void;
+};
+
+function ToggleButton(props: ToggleButtonProps) {
+  const [isActive, setIsActive] = useState(props.isActive);
+
+  function handleToggle() {
+    setIsActive(!isActive);
+    if (props.onToggle) {
+      props.onToggle();
+    }
+  }
+
+  const arialLabel = getLabel(props.ariaLabel, isActive);
+  const label = getLabel(props.label, isActive);
+
+  return (
+    <div className="toggle-button">
+      <button
+        id={props.id}
+        data-testid={props.id}
+        role="switch"
+        className={`${isActive ? 'active' : 'inactive'} usa-tag--big usa-button--unstyled`}
+        aria-label={arialLabel}
+        aria-checked={isActive}
+        onClick={handleToggle}
+      >
+        {label}
+        <Icon name="check"></Icon>
+      </button>
+    </div>
+  );
+}
+
+export default ToggleButton;

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
@@ -2,16 +2,16 @@ import { useEffect, useState } from 'react';
 import Icon from '../../uswds/Icon';
 import './ToggleButton.scss';
 
-type ModeLabel = {
+type ToggleLabel = {
   active: string;
   inactive: string;
 };
 
-function isModeLabel(obj: unknown): obj is ModeLabel {
+function isModeLabel(obj: unknown): obj is ToggleLabel {
   return obj !== null && typeof obj === 'object' && 'active' in obj && 'inactive' in obj;
 }
 
-function getLabel(label: string | ModeLabel, isActive: boolean) {
+function getLabel(label: string | ToggleLabel, isActive: boolean) {
   if (isModeLabel(label)) {
     return isActive ? label.active : label.inactive;
   } else {
@@ -21,8 +21,9 @@ function getLabel(label: string | ModeLabel, isActive: boolean) {
 
 type ToggleButtonProps = {
   id: string;
-  label: string | ModeLabel;
-  ariaLabel: string | ModeLabel;
+  label: string | ToggleLabel;
+  ariaLabel: string | ToggleLabel;
+  tooltipLabel: string | ToggleLabel;
   isActive: boolean;
   onToggle: (isActive: boolean) => boolean;
 };
@@ -41,6 +42,7 @@ function ToggleButton(props: ToggleButtonProps) {
 
   const ariaLabel = getLabel(props.ariaLabel, isActive);
   const label = getLabel(props.label, isActive);
+  const tooltip = getLabel(props.tooltipLabel, isActive);
 
   return (
     <button
@@ -51,6 +53,7 @@ function ToggleButton(props: ToggleButtonProps) {
       aria-label={ariaLabel}
       aria-checked={isActive}
       onClick={handleToggle}
+      title={tooltip}
     >
       {label}
       <Icon name="check"></Icon>

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
@@ -37,7 +37,7 @@ function ToggleButton(props: ToggleButtonProps) {
     }
   }
 
-  const arialLabel = getLabel(props.ariaLabel, isActive);
+  const ariaLabel = getLabel(props.ariaLabel, isActive);
   const label = getLabel(props.label, isActive);
 
   return (
@@ -46,7 +46,7 @@ function ToggleButton(props: ToggleButtonProps) {
       data-testid={props.id}
       role="switch"
       className={`toggle-button ${isActive ? 'active' : 'inactive'} usa-tag--big usa-button--unstyled`}
-      aria-label={arialLabel}
+      aria-label={ariaLabel}
       aria-checked={isActive}
       onClick={handleToggle}
     >

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
@@ -32,9 +32,7 @@ function ToggleButton(props: ToggleButtonProps) {
 
   function handleToggle() {
     setIsActive(!isActive);
-    if (props.onToggle) {
-      props.onToggle(!isActive);
-    }
+    props.onToggle(!isActive);
   }
 
   useEffect(() => {

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Icon from '../../uswds/Icon';
 import './ToggleButton.scss';
 
@@ -36,6 +36,10 @@ function ToggleButton(props: ToggleButtonProps) {
       props.onToggle(!isActive);
     }
   }
+
+  useEffect(() => {
+    setIsActive(props.isActive);
+  }, [props.isActive]);
 
   const ariaLabel = getLabel(props.ariaLabel, isActive);
   const label = getLabel(props.label, isActive);

--- a/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
+++ b/user-interface/src/lib/components/cams/ToggleButton/ToggleButton.tsx
@@ -24,7 +24,7 @@ type ToggleButtonProps = {
   label: string | ModeLabel;
   ariaLabel: string | ModeLabel;
   isActive: boolean;
-  onToggle: () => void;
+  onToggle: (isActive: boolean) => boolean;
 };
 
 function ToggleButton(props: ToggleButtonProps) {
@@ -33,7 +33,7 @@ function ToggleButton(props: ToggleButtonProps) {
   function handleToggle() {
     setIsActive(!isActive);
     if (props.onToggle) {
-      props.onToggle();
+      props.onToggle(!isActive);
     }
   }
 
@@ -41,20 +41,18 @@ function ToggleButton(props: ToggleButtonProps) {
   const label = getLabel(props.label, isActive);
 
   return (
-    <div className="toggle-button">
-      <button
-        id={props.id}
-        data-testid={props.id}
-        role="switch"
-        className={`${isActive ? 'active' : 'inactive'} usa-tag--big usa-button--unstyled`}
-        aria-label={arialLabel}
-        aria-checked={isActive}
-        onClick={handleToggle}
-      >
-        {label}
-        <Icon name="check"></Icon>
-      </button>
-    </div>
+    <button
+      id={props.id}
+      data-testid={props.id}
+      role="switch"
+      className={`toggle-button ${isActive ? 'active' : 'inactive'} usa-tag--big usa-button--unstyled`}
+      aria-label={arialLabel}
+      aria-checked={isActive}
+      onClick={handleToggle}
+    >
+      {label}
+      <Icon name="check"></Icon>
+    </button>
   );
 }
 

--- a/user-interface/src/my-cases/MyCasesScreen.scss
+++ b/user-interface/src/my-cases/MyCasesScreen.scss
@@ -10,4 +10,54 @@
     position: absolute;
     margin-top: 1.5rem;
   }
+  .case-status {
+    span,
+    .filter {
+      display: inline-block;
+      color: white;
+      padding: 0rem 0.5rem 0.125rem 0.5rem;
+      border-radius: 0.125rem;
+      text-decoration: none;
+    }
+    .filter {
+      display: inline-flex;
+      align-items: center;
+      flex-flow: row;
+      flex-direction: row;
+      justify-content: center;
+      svg {
+        display: none;
+        padding-left: 0.125rem;
+      }
+    }
+    .filter {
+      margin-bottom: 1.5rem;
+    }
+    .case-status-container {
+      display: inline-block;
+      flex-flow: row;
+    }
+    .show-closed-cases {
+      background: #0050d8;
+    }
+    .show-closed-cases .inactive {
+      background: #5c5c5c;
+    }
+    .filter {
+      margin-right: 0.5rem;
+    }
+    .filter:hover {
+      cursor: pointer;
+    }
+    .inactive {
+      background: #5c5c5c;
+      font-weight: normal;
+    }
+    .active {
+      font-weight: bold;
+      svg.active {
+        display: inline;
+      }
+    }
+  }
 }

--- a/user-interface/src/my-cases/MyCasesScreen.scss
+++ b/user-interface/src/my-cases/MyCasesScreen.scss
@@ -1,15 +1,18 @@
-.screen-heading {
-  display: block;
-  position: relative;
+.my-cases {
+  .screen-heading {
+    display: block;
+    position: relative;
 
-  h1 {
-    display: inline-block;
-    margin-right: 1rem;
+    h1 {
+      display: inline-block;
+      margin-right: 1rem;
+    }
+    .usa-button {
+      position: absolute;
+      margin-top: 1.5rem;
+    }
   }
-  .usa-button {
-    position: absolute;
-    margin-top: 1.5rem;
-  }
+
   .case-status {
     span,
     .filter {

--- a/user-interface/src/my-cases/MyCasesScreen.scss
+++ b/user-interface/src/my-cases/MyCasesScreen.scss
@@ -14,53 +14,14 @@
   }
 
   .case-status {
-    span,
-    .filter {
+    margin-bottom: 1.5rem;
+
+    span {
       display: inline-block;
       color: white;
       padding: 0rem 0.5rem 0.125rem 0.5rem;
       border-radius: 0.125rem;
       text-decoration: none;
-    }
-    .filter {
-      display: inline-flex;
-      align-items: center;
-      flex-flow: row;
-      flex-direction: row;
-      justify-content: center;
-      svg {
-        display: none;
-        padding-left: 0.125rem;
-      }
-    }
-    .filter {
-      margin-bottom: 1.5rem;
-    }
-    .case-status-container {
-      display: inline-block;
-      flex-flow: row;
-    }
-    .show-closed-cases {
-      background: #0050d8;
-    }
-    .show-closed-cases .inactive {
-      background: #5c5c5c;
-    }
-    .filter {
-      margin-right: 0.5rem;
-    }
-    .filter:hover {
-      cursor: pointer;
-    }
-    .inactive {
-      background: #5c5c5c;
-      font-weight: normal;
-    }
-    .active {
-      font-weight: bold;
-      svg.active {
-        display: inline;
-      }
     }
   }
 }

--- a/user-interface/src/my-cases/MyCasesScreen.test.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.test.tsx
@@ -36,6 +36,24 @@ describe('MyCasesScreen', () => {
     expect(modal).toBeInTheDocument();
   });
 
+  test('should toggle closed cases toggle', async () => {
+    render(
+      <BrowserRouter>
+        <MyCasesScreen></MyCasesScreen>
+      </BrowserRouter>,
+    );
+
+    const toggle = screen.getByTestId('closed-cases-toggle');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveClass('inactive');
+    fireEvent.click(toggle!);
+
+    expect(toggle).toHaveClass('active');
+    fireEvent.click(toggle!);
+
+    expect(toggle).toHaveClass('inactive');
+  });
+
   test('should render a list of cases assigned to a user', async () => {
     const expectedData = MockData.buildArray(MockData.getSyncedCase, 3);
     vi.spyOn(Api2, 'searchCases').mockResolvedValue({

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -68,7 +68,7 @@ export const MyCasesScreen = () => {
             <div className="case-status-container">
               <div>
                 <ToggleButton
-                  id="foobar"
+                  id="closed-cases-toggle"
                   ariaLabel={{ active: 'Hide closed cases.', inactive: 'Show closed cases.' }}
                   isActive={false}
                   label="Closed Cases"

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -69,7 +69,11 @@ export const MyCasesScreen = () => {
               <div>
                 <ToggleButton
                   id="closed-cases-toggle"
-                  ariaLabel={{ active: 'Hide closed cases.', inactive: 'Show closed cases.' }}
+                  ariaLabel={'Show closed cases.'}
+                  tooltipLabel={{
+                    active: 'Closed cases shown.',
+                    inactive: 'Closed cases hidden.',
+                  }}
                   isActive={false}
                   label="Closed Cases"
                   onToggle={handleShowClosedCasesToggle}

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -16,7 +16,7 @@ import './MyCasesScreen.scss';
 import ScreenInfoButton from '@/lib/components/cams/ScreenInfoButton';
 import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
 import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
-import Icon from '@/lib/components/uswds/Icon';
+import ToggleButton from '@/lib/components/cams/ToggleButton/ToggleButton';
 
 export const MyCasesScreen = () => {
   const screenTitle = 'My Cases';
@@ -66,7 +66,7 @@ export const MyCasesScreen = () => {
           <div className="filters case-status">
             <div className="case-status-container">
               <div>
-                <button
+                {/* <button
                   className={`filter show-closed-cases${doShowClosedCases ? ' active' : ' inactive'} usa-tag--big usa-button--unstyled`}
                   aria-label={`${doShowClosedCases ? 'Hide' : 'Show'} closed cases.`}
                   role="switch"
@@ -76,7 +76,14 @@ export const MyCasesScreen = () => {
                 >
                   Closed Cases
                   <Icon name="check" className={doShowClosedCases ? 'active' : ''}></Icon>
-                </button>
+                </button> */}
+                <ToggleButton
+                  id="foobar"
+                  ariaLabel={{ active: 'Hide closed cases.', inactive: 'Show closed cases.' }}
+                  isActive={false}
+                  label="Closed Cases"
+                  onToggle={handleShowClosedCasesToggle}
+                />
               </div>
             </div>
           </div>

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -35,7 +35,7 @@ export const MyCasesScreen = () => {
     offset: DEFAULT_SEARCH_OFFSET,
     assignments: [getCamsUserReference(session.user)],
     excludeChildConsolidations: true,
-    excludeClosedCases: doShowClosedCases,
+    excludeClosedCases: !doShowClosedCases,
   };
 
   const infoModalActionButtonGroup = {

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import Modal from '@/lib/components/uswds/modal/Modal';
 import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
@@ -16,6 +16,7 @@ import './MyCasesScreen.scss';
 import ScreenInfoButton from '@/lib/components/cams/ScreenInfoButton';
 import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
 import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
+import Icon from '@/lib/components/uswds/Icon';
 
 export const MyCasesScreen = () => {
   const screenTitle = 'My Cases';
@@ -23,16 +24,18 @@ export const MyCasesScreen = () => {
   const infoModalRef = useRef(null);
   const infoModalId = 'info-modal';
   const session = LocalStorage.getSession();
+  const [doShowClosedCases, setDoShowClosedCases] = useState(false);
 
   if (!session || !session.user.offices) {
+    // TODO: This renders a blank pane with no notice to the user. Maybe this should at least return a <Stop> component with a message.
     return <></>;
   }
-
   const searchPredicate: CasesSearchPredicate = {
     limit: DEFAULT_SEARCH_LIMIT,
     offset: DEFAULT_SEARCH_OFFSET,
     assignments: [getCamsUserReference(session.user)],
     excludeChildConsolidations: true,
+    excludeClosedCases: doShowClosedCases,
   };
 
   const infoModalActionButtonGroup = {
@@ -44,6 +47,10 @@ export const MyCasesScreen = () => {
     },
   };
 
+  function handleShowClosedCasesToggle() {
+    setDoShowClosedCases(!doShowClosedCases);
+  }
+
   return (
     <MainContent className="my-cases case-list">
       <DocumentTitle name="My Cases" />
@@ -54,6 +61,26 @@ export const MyCasesScreen = () => {
             <h1 data-testid="case-list-heading">{screenTitle}</h1>
             <ScreenInfoButton infoModalRef={infoModalRef} modalId={infoModalId} />
           </div>
+
+          <h3>Filters</h3>
+          <div className="filters case-status">
+            <div className="case-status-container">
+              <div>
+                <button
+                  className={`filter show-closed-cases${doShowClosedCases ? ' active' : ' inactive'} usa-tag--big usa-button--unstyled`}
+                  aria-label={`${doShowClosedCases ? 'Hide' : 'Show'} closed cases.`}
+                  role="switch"
+                  aria-checked={doShowClosedCases}
+                  onClick={handleShowClosedCasesToggle}
+                  data-testid="show-closed-cases-toggle"
+                >
+                  Closed Cases
+                  <Icon name="check" className={doShowClosedCases ? 'active' : ''}></Icon>
+                </button>
+              </div>
+            </div>
+          </div>
+
           <SearchResults
             id="search-results"
             searchPredicate={searchPredicate}

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -47,8 +47,9 @@ export const MyCasesScreen = () => {
     },
   };
 
-  function handleShowClosedCasesToggle() {
-    setDoShowClosedCases(!doShowClosedCases);
+  function handleShowClosedCasesToggle(isActive: boolean) {
+    setDoShowClosedCases(isActive);
+    return isActive;
   }
 
   return (
@@ -66,17 +67,6 @@ export const MyCasesScreen = () => {
           <div className="filters case-status">
             <div className="case-status-container">
               <div>
-                {/* <button
-                  className={`filter show-closed-cases${doShowClosedCases ? ' active' : ' inactive'} usa-tag--big usa-button--unstyled`}
-                  aria-label={`${doShowClosedCases ? 'Hide' : 'Show'} closed cases.`}
-                  role="switch"
-                  aria-checked={doShowClosedCases}
-                  onClick={handleShowClosedCasesToggle}
-                  data-testid="show-closed-cases-toggle"
-                >
-                  Closed Cases
-                  <Icon name="check" className={doShowClosedCases ? 'active' : ''}></Icon>
-                </button> */}
                 <ToggleButton
                   id="foobar"
                   ariaLabel={{ active: 'Hide closed cases.', inactive: 'Show closed cases.' }}

--- a/user-interface/src/search-results/SearchResults.tsx
+++ b/user-interface/src/search-results/SearchResults.tsx
@@ -129,6 +129,7 @@ export function SearchResults(props: SearchResultsProps) {
     search();
   }, [searchPredicate]);
 
+  const totalCount = searchResults?.pagination?.totalCount ?? 0;
   return (
     <div {...otherProps} className="search-results">
       {alertInfo && (
@@ -172,7 +173,7 @@ export function SearchResults(props: SearchResultsProps) {
             scrollable="true"
             uswdsStyle={['striped']}
             title="search results."
-            caption={`Search yielded ${new Intl.NumberFormat('en-US').format(searchResults?.pagination?.totalCount ?? 0)} results.`}
+            caption={`Search yielded ${new Intl.NumberFormat('en-US').format(totalCount)} ${totalCount === 1 ? 'result' : 'results'}.`}
           >
             <Header id={id} labels={searchResultsHeaderLabels} />
             <TableBody id={id}>


### PR DESCRIPTION
# Purpose

Toggle between showing and hiding closed cases on the My Cases screen. Default to hiding cases.

# Major Changes

- Added a new ToggleButton component
- Added a "Closed Cases" toggle button to the My Cases screen.
- Mapped the toggle to the `excludeClosedCases` flag on the search predicate.

# Testing/Validation

- Manual testing

# Definition of Done:

- [x] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed - More important code doesn’t directly depend on less important code
- [x] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

New Features:
- Adds a toggle button to the My Cases screen to allow users to filter closed cases.