### PR TITLE
CAMS-288 Staff assignment filter

### DIFF
--- a/backend/function-apps/dataflows/dataflows-common.test.ts
+++ b/backend/function-apps/dataflows/dataflows-common.test.ts
@@ -1,12 +1,27 @@
-import { HttpRequest } from '@azure/functions';
-import { buildFunctionName, isAuthorized } from './dataflows-common';
+import { HttpRequest, InvocationContext, StorageQueueOutput, Timer } from '@azure/functions';
+import {
+  buildFunctionName,
+  buildHttpTrigger,
+  buildQueueName,
+  buildStartQueueHttpTrigger,
+  buildStartQueueTimerTrigger,
+  isAuthorized,
+} from './dataflows-common';
 
 describe('Dataflows Common', () => {
-  describe('buildUniqueName', () => {
-    test('should concatenate arguments with a hyphen delimter', () => {
+  describe('buildFunctionName', () => {
+    test('should return a function name according to our naming convention', () => {
       expect(buildFunctionName()).toEqual('');
-      expect(buildFunctionName('one')).toEqual('one');
-      expect(buildFunctionName('two', 'three')).toEqual('two-three');
+      expect(buildFunctionName('ONE_FOO')).toEqual('ONE-FOO');
+      expect(buildFunctionName('TWO', 'THREE_four')).toEqual('TWO-THREE-four');
+    });
+  });
+
+  describe('buildQueueName', () => {
+    test('should return a queue name conforming to StorageAccount queue name constraints', () => {
+      expect(buildQueueName()).toEqual('');
+      expect(buildQueueName('ONE')).toEqual('one');
+      expect(buildQueueName('TWO', 'THREE')).toEqual('two-three');
     });
   });
 
@@ -14,7 +29,7 @@ describe('Dataflows Common', () => {
     const RIGHT = 'this-is-a-key';
     const WRONG = 'this-is-a-bad-key';
 
-    const env = process.env;
+    const { env } = process;
     beforeAll(() => {
       process.env = {
         ADMIN_KEY: RIGHT,
@@ -58,6 +73,70 @@ describe('Dataflows Common', () => {
         headers: new Map<string, string>([['Authorization', `ApiKey ${WRONG}`]]),
       } as unknown as HttpRequest;
       expect(isAuthorized(request)).toBeFalsy();
+    });
+  });
+
+  describe('buildHttpTrigger', () => {
+    test('should return a http trigger that executes the function passed to the build function', async () => {
+      const invocationContext = {
+        log: jest.fn(),
+      } as unknown as InvocationContext;
+
+      const fnArgumentSpy = jest.fn();
+      const trigger = buildHttpTrigger('TEST', fnArgumentSpy);
+
+      const goodRequest = {
+        headers: new Map<string, string>([['Authorization', `ApiKey ${process.env.ADMIN_KEY}`]]),
+      } as unknown as HttpRequest;
+      await trigger(goodRequest, invocationContext);
+      expect(fnArgumentSpy).toHaveBeenCalledWith(invocationContext, goodRequest);
+
+      fnArgumentSpy.mockClear();
+      const badRequest = {
+        headers: new Map<string, string>(),
+      } as unknown as HttpRequest;
+      await trigger(badRequest, invocationContext);
+      expect(fnArgumentSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buildStartQueueTimerTrigger', () => {
+    test('should return a timer trigger that puts a message on a given start queue', async () => {
+      const setSpy = jest.fn();
+      const invocationContext = {
+        extraOutputs: {
+          set: setSpy,
+        },
+      } as unknown as InvocationContext;
+
+      const storageQueue = {} as unknown as StorageQueueOutput;
+      const trigger = buildStartQueueTimerTrigger('TEST', storageQueue);
+
+      const timer = {} as unknown as Timer;
+      await trigger(timer, invocationContext);
+
+      expect(setSpy).toHaveBeenCalledWith(storageQueue, {});
+    });
+  });
+
+  describe('buildStartQueueHttpTrigger', () => {
+    test('should return a http trigger that puts a message on a given start queue', async () => {
+      const setSpy = jest.fn();
+      const invocationContext = {
+        log: jest.fn(),
+        extraOutputs: {
+          set: setSpy,
+        },
+      } as unknown as InvocationContext;
+
+      const storageQueue = {} as unknown as StorageQueueOutput;
+      const trigger = buildStartQueueHttpTrigger('TEST', storageQueue);
+
+      const goodRequest = {
+        headers: new Map<string, string>([['Authorization', `ApiKey ${process.env.ADMIN_KEY}`]]),
+      } as unknown as HttpRequest;
+      await trigger(goodRequest, invocationContext);
+      expect(setSpy).toHaveBeenCalledWith(storageQueue, {});
     });
   });
 });

--- a/backend/function-apps/dataflows/dataflows-common.ts
+++ b/backend/function-apps/dataflows/dataflows-common.ts
@@ -79,8 +79,7 @@ export function buildHttpTrigger(
         throw new ForbiddenError(moduleName);
       }
 
-      const result = await fn(context, request);
-      context.debug(result);
+      await fn(context, request);
 
       return new HttpResponse(toAzureSuccess({ statusCode: 201 }));
     } catch (error) {

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.test.ts
@@ -57,6 +57,24 @@ describe('offices repo', () => {
     expect(attorneys).toEqual(attorneyUsers);
   });
 
+  test('getOfficeAssignments', async () => {
+    // const assigments = MockData.buildArray(MockData.getCamsUserReference, 3);
+    const assigments = []; // pass for now.
+    const officeCode = 'office_code';
+    // const findSpy = jest
+    //   .spyOn(MongoCollectionAdapter.prototype, 'find')
+    //   .mockResolvedValue(assigments);
+
+    // const query = and(
+    //   doc('documentType').equals('OFFICE_STAFF'),
+    //   doc('roles').contains([CamsRole.TrialAttorney]),
+    //   doc('officeCode').equals(officeCode),
+    // );
+    const actual = await repo.getOfficeAssignments(officeCode);
+    // expect(findSpy).toHaveBeenCalledWith(query);
+    expect(actual).toEqual(assigments);
+  });
+
   test('putOfficeStaff', async () => {
     const staff = createAuditRecord<OfficeStaff>({
       id: session.user.id,

--- a/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/offices.mongo.repository.ts
@@ -32,14 +32,17 @@ export class OfficesMongoRepository extends BaseMongoRepository implements Offic
   }
 
   public static getInstance(context: ApplicationContext) {
-    if (!OfficesMongoRepository.instance)
+    if (!OfficesMongoRepository.instance) {
       OfficesMongoRepository.instance = new OfficesMongoRepository(context);
+    }
     OfficesMongoRepository.referenceCount++;
     return OfficesMongoRepository.instance;
   }
 
   public static dropInstance() {
-    if (OfficesMongoRepository.referenceCount > 0) OfficesMongoRepository.referenceCount--;
+    if (OfficesMongoRepository.referenceCount > 0) {
+      OfficesMongoRepository.referenceCount--;
+    }
     if (OfficesMongoRepository.referenceCount < 1) {
       OfficesMongoRepository.instance.client.close().then();
       OfficesMongoRepository.instance = null;
@@ -87,6 +90,25 @@ export class OfficesMongoRepository extends BaseMongoRepository implements Offic
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);
     }
+  }
+
+  async getOfficeAssignments(_officeCode: string): Promise<CamsUserReference[]> {
+    // TODO: Query the assigmnents collection for the unique set of attorneys assigned to the office's cases.
+
+    // const doc = using<OfficeStaff>();
+    // const query = and(
+    //   doc('documentType').equals('OFFICE_STAFF'),
+    //   doc('roles').contains([CamsRole.TrialAttorney]),
+    //   doc('officeCode').equals(officeCode),
+    // );
+
+    // try {
+    //   const result = await this.getAdapter<OfficeStaff>().find(query);
+    //   return result.map((doc) => getCamsUserReference(doc));
+    // } catch (originalError) {
+    //   throw getCamsError(originalError, MODULE_NAME);
+    // }
+    return [];
   }
 
   public async findAndDeleteStaff(officeCode: string, id: string): Promise<void> {

--- a/backend/lib/controllers/offices/offices.controller.test.ts
+++ b/backend/lib/controllers/offices/offices.controller.test.ts
@@ -5,6 +5,7 @@ import { COURT_DIVISIONS } from '../../../../common/src/cams/test-utilities/cour
 import { CamsError } from '../../common-errors/cams-error';
 import { mockCamsHttpRequest } from '../../testing/mock-data/cams-http-request-helper';
 import { UnknownError } from '../../common-errors/unknown-error';
+import MockData from '../../../../common/src/cams/test-utilities/mock-data';
 
 let getOffices = jest.fn();
 let getOfficeAttorneys = jest.fn();
@@ -118,10 +119,11 @@ describe('offices controller tests', () => {
   });
 
   test('should call getOfficeAssignments', async () => {
+    const assignments = [MockData.getCamsUser()];
     getOffices = jest
       .fn()
       .mockRejectedValue(new CamsError('TEST', { message: 'some known error' }));
-    getOfficeAssignments = jest.fn().mockResolvedValue([]);
+    getOfficeAssignments = jest.fn().mockResolvedValue(assignments);
 
     const officeCode = 'new-york';
     const subResource = 'assignments';
@@ -129,10 +131,10 @@ describe('offices controller tests', () => {
     applicationContext.request = camsHttpRequest;
 
     const controller = new OfficesController();
-    const attorneys = await controller.handleRequest(applicationContext);
-    expect(attorneys).toEqual(
+    const actual = await controller.handleRequest(applicationContext);
+    expect(actual).toEqual(
       expect.objectContaining({
-        body: { meta: expect.objectContaining({ self: expect.any(String) }), data: [] },
+        body: { meta: expect.objectContaining({ self: expect.any(String) }), data: assignments },
       }),
     );
     expect(getOffices).not.toHaveBeenCalled();

--- a/backend/lib/controllers/offices/offices.controller.test.ts
+++ b/backend/lib/controllers/offices/offices.controller.test.ts
@@ -8,6 +8,7 @@ import { UnknownError } from '../../common-errors/unknown-error';
 
 let getOffices = jest.fn();
 let getOfficeAttorneys = jest.fn();
+let getOfficeAssignments = jest.fn();
 const syncOfficeStaff = jest.fn();
 
 jest.mock('../../use-cases/offices/offices', () => {
@@ -16,6 +17,7 @@ jest.mock('../../use-cases/offices/offices', () => {
       return {
         getOffices,
         getOfficeAttorneys,
+        getOfficeAssignments,
         syncOfficeStaff,
       };
     }),
@@ -113,6 +115,28 @@ describe('offices controller tests', () => {
     );
     expect(getOffices).not.toHaveBeenCalled();
     expect(getOfficeAttorneys).toHaveBeenCalledWith(applicationContext, officeCode);
+  });
+
+  test('should call getOfficeAssignments', async () => {
+    getOffices = jest
+      .fn()
+      .mockRejectedValue(new CamsError('TEST', { message: 'some known error' }));
+    getOfficeAssignments = jest.fn().mockResolvedValue([]);
+
+    const officeCode = 'new-york';
+    const subResource = 'assignments';
+    const camsHttpRequest = mockCamsHttpRequest({ params: { officeCode, subResource } });
+    applicationContext.request = camsHttpRequest;
+
+    const controller = new OfficesController();
+    const attorneys = await controller.handleRequest(applicationContext);
+    expect(attorneys).toEqual(
+      expect.objectContaining({
+        body: { meta: expect.objectContaining({ self: expect.any(String) }), data: [] },
+      }),
+    );
+    expect(getOffices).not.toHaveBeenCalled();
+    expect(getOfficeAssignments).toHaveBeenCalledWith(applicationContext, officeCode);
   });
 
   test('should call getOffices', async () => {

--- a/backend/lib/controllers/offices/offices.controller.ts
+++ b/backend/lib/controllers/offices/offices.controller.ts
@@ -31,10 +31,12 @@ export class OfficesController implements CamsController, CamsTimerController {
     context: ApplicationContext,
   ): Promise<CamsHttpResponseInit<UstpOfficeDetails[] | CamsUserReference[]>> {
     try {
-      const params = context.request.params;
+      const { params } = context.request;
       let data;
       if (params?.officeCode && params?.subResource === 'attorneys') {
         data = await this.useCase.getOfficeAttorneys(context, params.officeCode);
+      } else if (params?.officeCode && params?.subResource === 'assignments') {
+        data = await this.useCase.getOfficeAssigments(context, params.officeCode);
       } else if (params?.officeCode && params?.subResource) {
         throw new BadRequestError(MODULE_NAME, {
           message: `Sub resource ${params?.subResource} is not supported.`,

--- a/backend/lib/controllers/offices/offices.controller.ts
+++ b/backend/lib/controllers/offices/offices.controller.ts
@@ -33,13 +33,13 @@ export class OfficesController implements CamsController, CamsTimerController {
     try {
       const { params } = context.request;
       let data;
-      if (params?.officeCode && params?.subResource === 'attorneys') {
+      if (params.officeCode && params.subResource === 'attorneys') {
         data = await this.useCase.getOfficeAttorneys(context, params.officeCode);
-      } else if (params?.officeCode && params?.subResource === 'assignments') {
+      } else if (params.officeCode && params.subResource === 'assignments') {
         data = await this.useCase.getOfficeAssignments(context, params.officeCode);
-      } else if (params?.officeCode && params?.subResource) {
+      } else if (params.officeCode && params.subResource) {
         throw new BadRequestError(MODULE_NAME, {
-          message: `Sub resource ${params?.subResource} is not supported.`,
+          message: `Sub resource ${params.subResource} is not supported.`,
         });
       } else {
         data = await this.useCase.getOffices(context);

--- a/backend/lib/controllers/offices/offices.controller.ts
+++ b/backend/lib/controllers/offices/offices.controller.ts
@@ -36,7 +36,7 @@ export class OfficesController implements CamsController, CamsTimerController {
       if (params?.officeCode && params?.subResource === 'attorneys') {
         data = await this.useCase.getOfficeAttorneys(context, params.officeCode);
       } else if (params?.officeCode && params?.subResource === 'assignments') {
-        data = await this.useCase.getOfficeAssigments(context, params.officeCode);
+        data = await this.useCase.getOfficeAssignments(context, params.officeCode);
       } else if (params?.officeCode && params?.subResource) {
         throw new BadRequestError(MODULE_NAME, {
           message: `Sub resource ${params?.subResource} is not supported.`,

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -59,6 +59,10 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
+  getOfficeAssignments(..._ignore): Promise<any[]> {
+    throw new Error('Method not implemented.');
+  }
+
   putOrExtendOfficeStaff(..._ignore): Promise<void> {
     throw new Error('Method not implemented.');
   }

--- a/backend/lib/testing/mock-gateways/mock.offices.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock.offices.repository.ts
@@ -11,4 +11,7 @@ export const MockOfficesRepository = {
   getOfficeAttorneys: () => {
     return Promise.resolve(TRIAL_ATTORNEYS);
   },
+  getOfficeAssignments(_officeCode: string): Promise<CamsUserReference[]> {
+    return Promise.resolve(TRIAL_ATTORNEYS);
+  },
 };

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -161,6 +161,7 @@ export interface OfficesRepository extends Releasable {
   getOfficeAttorneys(officeCode: string): Promise<AttorneyUser[]>;
   putOfficeStaff(officeCode: string, user: CamsUserReference, ttl?: number): Promise<ReplaceResult>;
   findAndDeleteStaff(officeCode: string, id: string): Promise<void>;
+  getOfficeAssignments(_officeCode: string): Promise<CamsUserReference[]>;
 }
 
 export interface UsersRepository extends Releasable {

--- a/backend/lib/use-cases/offices/offices.test.ts
+++ b/backend/lib/use-cases/offices/offices.test.ts
@@ -89,6 +89,7 @@ describe('offices use case tests', () => {
         getOfficeAttorneys: repoSpy,
         findAndDeleteStaff: jest.fn(),
         putOrExtendOfficeStaff: jest.fn(),
+        getOfficeAssignments: jest.fn(),
         close: jest.fn(),
       };
     });
@@ -96,6 +97,30 @@ describe('offices use case tests', () => {
 
     const officeCode = 'new-york';
     const officeAttorneys = await useCase.getOfficeAttorneys(applicationContext, officeCode);
+    expect(officeAttorneys).toEqual(mockAttorneys);
+    expect(repoSpy).toHaveBeenCalledWith(officeCode);
+    expect(attorneysSpy).not.toHaveBeenCalled();
+  });
+
+  test('should return assigned attorneys for office', async () => {
+    const useCase = new OfficesUseCase();
+    const mockAttorneys = [];
+    const repoSpy = jest.fn().mockResolvedValue(mockAttorneys);
+    jest.spyOn(factory, 'getOfficesRepository').mockImplementation(() => {
+      return {
+        release: () => {},
+        putOfficeStaff: jest.fn(),
+        getOfficeAttorneys: jest.fn(),
+        getOfficeAssignments: repoSpy,
+        findAndDeleteStaff: jest.fn(),
+        putOrExtendOfficeStaff: jest.fn(),
+        close: jest.fn(),
+      };
+    });
+    const attorneysSpy = jest.spyOn(AttorneysList.prototype, 'getAttorneyList');
+
+    const officeCode = 'new-york';
+    const officeAttorneys = await useCase.getOfficeAssigments(applicationContext, officeCode);
     expect(officeAttorneys).toEqual(mockAttorneys);
     expect(repoSpy).toHaveBeenCalledWith(officeCode);
     expect(attorneysSpy).not.toHaveBeenCalled();

--- a/backend/lib/use-cases/offices/offices.test.ts
+++ b/backend/lib/use-cases/offices/offices.test.ts
@@ -104,8 +104,8 @@ describe('offices use case tests', () => {
 
   test('should return assigned attorneys for office', async () => {
     const useCase = new OfficesUseCase();
-    const mockAttorneys = [];
-    const repoSpy = jest.fn().mockResolvedValue(mockAttorneys);
+    const expected = [MockData.getCamsUserReference()];
+    const repoSpy = jest.fn().mockResolvedValue(expected);
     jest.spyOn(factory, 'getOfficesRepository').mockImplementation(() => {
       return {
         release: () => {},
@@ -117,13 +117,11 @@ describe('offices use case tests', () => {
         close: jest.fn(),
       };
     });
-    const attorneysSpy = jest.spyOn(AttorneysList.prototype, 'getAttorneyList');
 
     const officeCode = 'new-york';
-    const officeAttorneys = await useCase.getOfficeAssigments(applicationContext, officeCode);
-    expect(officeAttorneys).toEqual(mockAttorneys);
+    const actual = await useCase.getOfficeAssigments(applicationContext, officeCode);
+    expect(actual).toEqual(expected);
     expect(repoSpy).toHaveBeenCalledWith(officeCode);
-    expect(attorneysSpy).not.toHaveBeenCalled();
   });
 
   test('should persist offices and continue trying after error', async () => {

--- a/backend/lib/use-cases/offices/offices.test.ts
+++ b/backend/lib/use-cases/offices/offices.test.ts
@@ -119,7 +119,7 @@ describe('offices use case tests', () => {
     });
 
     const officeCode = 'new-york';
-    const actual = await useCase.getOfficeAssigments(applicationContext, officeCode);
+    const actual = await useCase.getOfficeAssignments(applicationContext, officeCode);
     expect(actual).toEqual(expected);
     expect(repoSpy).toHaveBeenCalledWith(officeCode);
   });

--- a/backend/lib/use-cases/offices/offices.ts
+++ b/backend/lib/use-cases/offices/offices.ts
@@ -45,6 +45,14 @@ export class OfficesUseCase {
     return await repository.getOfficeAttorneys(officeCode);
   }
 
+  public async getOfficeAssigments(
+    context: ApplicationContext,
+    officeCode: string,
+  ): Promise<Staff[]> {
+    const repository = getOfficesRepository(context);
+    return await repository.getOfficeAssignments(officeCode);
+  }
+
   public async syncOfficeStaff(context: ApplicationContext): Promise<object> {
     const officesGateway = getOfficesGateway(context);
     const repository = getOfficesRepository(context);

--- a/backend/lib/use-cases/offices/offices.ts
+++ b/backend/lib/use-cases/offices/offices.ts
@@ -45,7 +45,7 @@ export class OfficesUseCase {
     return await repository.getOfficeAttorneys(officeCode);
   }
 
-  public async getOfficeAssigments(
+  public async getOfficeAssignments(
     context: ApplicationContext,
     officeCode: string,
   ): Promise<Staff[]> {
@@ -153,7 +153,9 @@ export function buildOfficeCode(regionId: string, courtDivisionCode: string): st
 }
 
 export function getOfficeName(divisionCode: string): string {
-  if (USTP_OFFICE_NAME_MAP.has(divisionCode)) return USTP_OFFICE_NAME_MAP.get(divisionCode);
+  if (USTP_OFFICE_NAME_MAP.has(divisionCode)) {
+    return USTP_OFFICE_NAME_MAP.get(divisionCode);
+  }
   return 'UNKNOWN_' + divisionCode;
 }
 


### PR DESCRIPTION
# Purpose

Filter cases on the staff assignment screen by a given staff user

# Major Changes

- Added new /offices/{officeId}/assignees endpoint

# Testing/Validation

- Unit tests

# Definition of Done:

- [ ] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed - More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

Adds a new endpoint to retrieve staff assignments for a given office.

New Features:
- Introduces the /offices/{officeId}/assignees endpoint to fetch staff assignments for an office.

Tests:
- Adds unit tests for the new endpoint and related functionality.