### PR TITLE
CAMS-542 add 'id' index to cases collection for Case Note performance

### DIFF
--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
@@ -206,6 +206,11 @@ resource casesCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases
         }
         {
           key: {
+            keys: ['id']
+          }
+        }
+        {
+          key: {
             keys: ['caseId']
           }
         }


### PR DESCRIPTION
Jira ticket: CAMS-542

# Purpose

Performance when updating large case notes seems degraded

# Major Changes

-  add 'id' index to cases collection for Case Note performance

# Testing/Validation

- deploy in USTP environment to test

# Notes

N/A

# Definition of Done:

- [ ] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed - More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

Enhancements:
- Create an additional index on the 'id' field in the Cosmos DB cases collection to optimize query performance