### PR TITLE
CAMS-544: Use a better order for courts query

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
@@ -111,7 +111,7 @@ export default class OfficesDxtrGateway implements OfficesGateway {
     JOIN [dbo].[AO_GRP_DES] d on a.GRP_DES = d.GRP_DES
     JOIN [dbo].[AO_REGION] r on d.REGION_ID = r.REGION_ID
     WHERE a.[CS_DIV_ACMS] not in (${INVALID_DIVISION_CODES_SQL})
-    ORDER BY a.GRP_DES, a.OFFICE_CODE`;
+    ORDER BY a.STATE, c.COURT_NAME, b.OFFICE_NAME_DISPLAY`;
 
     const queryResult: QueryResults = await executeQuery(
       context,


### PR DESCRIPTION
# Purpose

The order of the courts in the district (division) filter on the search screen is difficult to use.

# Major Changes

Instead of ordering by group designator and office code—which the users do not see—we now order by state, then court name, then office name display.

# Testing/Validation

Validated the query results make sense.

# Definition of Done:

- [x] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed - More important code doesn’t directly depend on less important code
- [x] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

Enhancements:
- Modify the SQL query ordering to prioritize state, court name, and office name display for better readability and usability