### PR TITLE
CAMS-288 Remove pagination from query builder

### DIFF
--- a/backend/lib/adapters/gateways/mongo/cases.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/cases.mongo.repository.test.ts
@@ -618,7 +618,7 @@ describe('Cases repository', () => {
     };
 
     jest
-      .spyOn(MongoCollectionAdapter.prototype, '_aggregate')
+      .spyOn(MongoCollectionAdapter.prototype, 'aggregate')
       .mockImplementation((...params: unknown[]) => {
         const _q = toMongoAggregate(params[0] as Pipeline);
         return Promise.resolve([]);

--- a/backend/lib/adapters/gateways/mongo/cases.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/cases.mongo.repository.test.ts
@@ -333,8 +333,8 @@ describe('Cases repository', () => {
         {
           stage: 'SORT',
           fields: [
-            expect.objectContaining({ field: { name: 'dateFiled' }, direction: 'DESCENDING' }),
-            expect.objectContaining({ field: { name: 'caseNumber' }, direction: 'DESCENDING' }),
+            { field: { name: 'dateFiled' }, direction: 'DESCENDING' },
+            { field: { name: 'caseNumber' }, direction: 'DESCENDING' },
           ],
         },
         {
@@ -381,8 +381,8 @@ describe('Cases repository', () => {
         {
           stage: 'SORT',
           fields: [
-            expect.objectContaining({ field: { name: 'dateFiled' }, direction: 'DESCENDING' }),
-            expect.objectContaining({ field: { name: 'caseNumber' }, direction: 'DESCENDING' }),
+            { field: { name: 'dateFiled' }, direction: 'DESCENDING' },
+            { field: { name: 'caseNumber' }, direction: 'DESCENDING' },
           ],
         },
         {
@@ -423,7 +423,7 @@ describe('Cases repository', () => {
       stages: [
         {
           stage: 'MATCH',
-          q: and(
+          ...and(
             doc('documentType').equals('SYNCED_CASE'),
             doc('caseId').contains(predicate.caseIds),
             doc('chapter').contains(predicate.chapters),
@@ -433,12 +433,12 @@ describe('Cases repository', () => {
         {
           stage: 'SORT',
           fields: [
-            expect.objectContaining({ field: { name: 'dateFiled' }, direction: 'DESCENDING' }),
-            expect.objectContaining({ field: { name: 'caseNumber' }, direction: 'DESCENDING' }),
+            { field: { name: 'dateFiled' }, direction: 'DESCENDING' },
+            { field: { name: 'caseNumber' }, direction: 'DESCENDING' },
           ],
         },
         {
-          stage: 'PAGE',
+          stage: 'PAGINATE',
           skip: predicate.offset,
           limit: predicate.limit,
         },

--- a/backend/lib/adapters/gateways/mongo/cases.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/cases.mongo.repository.test.ts
@@ -43,7 +43,7 @@ describe('Cases repository', () => {
     orderDate: '01/01/2024',
     documentType: 'TRANSFER_TO',
   };
-  const { and, paginate } = QueryBuilder;
+  const { and } = QueryBuilder;
 
   beforeEach(async () => {
     context = await createMockApplicationContext();
@@ -304,7 +304,7 @@ describe('Cases repository', () => {
     );
   });
 
-  test('should call paginatedFind without caseIds array in query', async () => {
+  test('should call paginate without caseIds array in query', async () => {
     const predicate: CasesSearchPredicate = {
       chapters: ['15'],
       excludeChildConsolidations: true,
@@ -316,27 +316,41 @@ describe('Cases repository', () => {
       data: [MockData.getSyncedCase({ override: { caseId: caseId1 } })],
     };
     const findSpy = jest
-      .spyOn(MongoCollectionAdapter.prototype, 'paginatedFind')
+      .spyOn(MongoCollectionAdapter.prototype, 'paginate')
       .mockResolvedValueOnce(expectedSyncedCaseArray);
     const result = await repo.searchCases(predicate);
     const doc = using<SyncedCase>();
-    const expectedQuery = paginate<SyncedCase>(
-      predicate.offset,
-      predicate.limit,
-      [and(doc('documentType').equals('SYNCED_CASE'), doc('chapter').contains(predicate.chapters))],
-      {
-        attributes: [
-          ['dateFiled', 'DESCENDING'],
-          ['caseNumber', 'DESCENDING'],
-        ],
-      },
-    );
+
+    const expectedQuery = {
+      stages: [
+        {
+          stage: 'MATCH',
+          ...and(
+            doc('documentType').equals('SYNCED_CASE'),
+            doc('chapter').contains(predicate.chapters),
+          ),
+        },
+        {
+          stage: 'SORT',
+          fields: [
+            expect.objectContaining({ field: { name: 'dateFiled' }, direction: 'DESCENDING' }),
+            expect.objectContaining({ field: { name: 'caseNumber' }, direction: 'DESCENDING' }),
+          ],
+        },
+        {
+          stage: 'PAGINATE',
+          skip: predicate.offset,
+          limit: predicate.limit,
+        },
+      ],
+    };
+
     expect(findSpy).toHaveBeenCalledWith(expectedQuery);
 
     expect(result).toEqual(expectedSyncedCaseArray);
   });
 
-  test('should call paginatedFind with caseIds array in query', async () => {
+  test('should call paginate with caseIds array in query', async () => {
     const predicate: CasesSearchPredicate = {
       chapters: ['15'],
       excludeChildConsolidations: true,
@@ -350,33 +364,40 @@ describe('Cases repository', () => {
       MockData.getSyncedCase({ override: { caseId: caseId2 } }),
     ];
     const findSpy = jest
-      .spyOn(MongoCollectionAdapter.prototype, 'paginatedFind')
+      .spyOn(MongoCollectionAdapter.prototype, 'paginate')
       .mockResolvedValue({ data: expectedSyncedCaseArray });
     const result = await repo.searchCases(predicate);
     const doc = using<SyncedCase>();
-    const expectedQuery = paginate<SyncedCase>(
-      predicate.offset,
-      predicate.limit,
-      [
-        and(
-          doc('documentType').equals('SYNCED_CASE'),
-          doc('caseId').contains(predicate.caseIds),
-          doc('chapter').contains(predicate.chapters),
-        ),
+    const expectedQuery = {
+      stages: [
+        {
+          stage: 'MATCH',
+          ...and(
+            doc('documentType').equals('SYNCED_CASE'),
+            doc('caseId').contains(predicate.caseIds),
+            doc('chapter').contains(predicate.chapters),
+          ),
+        },
+        {
+          stage: 'SORT',
+          fields: [
+            expect.objectContaining({ field: { name: 'dateFiled' }, direction: 'DESCENDING' }),
+            expect.objectContaining({ field: { name: 'caseNumber' }, direction: 'DESCENDING' }),
+          ],
+        },
+        {
+          stage: 'PAGINATE',
+          skip: predicate.offset,
+          limit: predicate.limit,
+        },
       ],
-      {
-        attributes: [
-          ['dateFiled', 'DESCENDING'],
-          ['caseNumber', 'DESCENDING'],
-        ],
-      },
-    );
+    };
     expect(findSpy).toHaveBeenCalledWith(expectedQuery);
 
     expect(result).toEqual({ data: expectedSyncedCaseArray });
   });
 
-  test('should call paginatedFind with caseIds array and excludedCaseIds in query', async () => {
+  test('should call paginate with caseIds array and excludedCaseIds in query', async () => {
     const excludedCaseIds = ['111-11-11111', '111-11-11112'];
     const predicate: CasesSearchPredicate = {
       chapters: ['15'],
@@ -392,35 +413,44 @@ describe('Cases repository', () => {
       MockData.getSyncedCase({ override: { caseId: caseId2 } }),
     ];
     const findSpy = jest
-      .spyOn(MongoCollectionAdapter.prototype, 'paginatedFind')
+      .spyOn(MongoCollectionAdapter.prototype, 'paginate')
       .mockResolvedValue({ data: expectedSyncedCaseArray });
     const result = await repo.searchCases(predicate);
     // TODO: can we find a way to not rely on the exact order here?
     const doc = using<SyncedCase>();
-    const expectedQuery = paginate<SyncedCase>(
-      predicate.offset,
-      predicate.limit,
-      [
-        and(
-          doc('documentType').equals('SYNCED_CASE'),
-          doc('caseId').contains(predicate.caseIds),
-          doc('chapter').contains(predicate.chapters),
-          doc('caseId').notContains(predicate.excludedCaseIds),
-        ),
+
+    const expectedQuery = {
+      stages: [
+        {
+          stage: 'MATCH',
+          q: and(
+            doc('documentType').equals('SYNCED_CASE'),
+            doc('caseId').contains(predicate.caseIds),
+            doc('chapter').contains(predicate.chapters),
+            doc('caseId').notContains(predicate.excludedCaseIds),
+          ),
+        },
+        {
+          stage: 'SORT',
+          fields: [
+            expect.objectContaining({ field: { name: 'dateFiled' }, direction: 'DESCENDING' }),
+            expect.objectContaining({ field: { name: 'caseNumber' }, direction: 'DESCENDING' }),
+          ],
+        },
+        {
+          stage: 'PAGE',
+          skip: predicate.offset,
+          limit: predicate.limit,
+        },
       ],
-      {
-        attributes: [
-          ['dateFiled', 'DESCENDING'],
-          ['caseNumber', 'DESCENDING'],
-        ],
-      },
-    );
+    };
+
     expect(findSpy).toHaveBeenCalledWith(expect.objectContaining(expectedQuery));
 
     expect(result).toEqual({ data: expectedSyncedCaseArray });
   });
 
-  test('should throw error when paginatedFind throws error', async () => {
+  test('should throw error when paginate throws error', async () => {
     const predicate: CasesSearchPredicate = {
       chapters: ['15'],
       excludeChildConsolidations: false,
@@ -429,14 +459,14 @@ describe('Cases repository', () => {
     };
 
     jest
-      .spyOn(MongoCollectionAdapter.prototype, 'paginatedFind')
+      .spyOn(MongoCollectionAdapter.prototype, 'paginate')
       .mockRejectedValue(new CamsError('CASES_MONGO_REPOSITORY'));
     await expect(async () => await repo.searchCases(predicate)).rejects.toThrow(
       'Unknown CAMS Error',
     );
   });
 
-  test('should throw error when paginatedFind has invalid limit and offset', async () => {
+  test('should throw error when paginate has invalid limit and offset', async () => {
     const predicate: CasesSearchPredicate = {
       chapters: ['15'],
       excludeChildConsolidations: false,
@@ -449,7 +479,7 @@ describe('Cases repository', () => {
       MockData.getSyncedCase({ override: { caseId: caseId2 } }),
     ];
     jest
-      .spyOn(MongoCollectionAdapter.prototype, 'paginatedFind')
+      .spyOn(MongoCollectionAdapter.prototype, 'paginate')
       .mockResolvedValue({ data: expectedSyncedCaseArray });
     await expect(async () => await repo.searchCases(predicate)).rejects.toThrow(
       'Case Search requires a pagination predicate with a valid limit and offset',

--- a/backend/lib/adapters/gateways/mongo/cases.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/cases.mongo.repository.ts
@@ -396,7 +396,7 @@ export class CasesMongoRepository extends BaseMongoRepository implements CasesRe
       sort(ascending(caseDocs.field('caseId'))),
     );
 
-    return await this.getAdapter<SyncedCase>()._aggregate(pipelineQuery);
+    return await this.getAdapter<SyncedCase>().aggregate(pipelineQuery);
   }
 
   async getSyncedCase(caseId: string): Promise<SyncedCase> {

--- a/backend/lib/adapters/gateways/mongo/cases.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/cases.mongo.repository.ts
@@ -323,14 +323,9 @@ export class CasesMongoRepository extends BaseMongoRepository implements CasesRe
 
   async searchCases(predicate: CasesSearchPredicate) {
     try {
-      const [documentType, dateFiled, caseNumber] = source<SyncedCase>().fields(
-        'documentType',
-        'dateFiled',
-        'caseNumber',
-      );
+      const [dateFiled, caseNumber] = source<SyncedCase>().fields('dateFiled', 'caseNumber');
 
       const conditions = this.addConditions(predicate);
-      conditions.push(documentType.equals('SYNCED_CASE'));
 
       if (!hasRequiredSearchFields(predicate)) {
         throw new CamsError(MODULE_NAME, {

--- a/backend/lib/adapters/gateways/mongo/office-assignee.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/office-assignee.mongo.repository.test.ts
@@ -24,9 +24,7 @@ describe('case assignment repo tests', () => {
 
   test('search should call Mongo find', async () => {
     //TODO: Create MockData function for officeAssignees
-    jest
-      .spyOn(MongoCollectionAdapter.prototype, 'find')
-      .mockResolvedValue(/*return expected OfficeAssignee[]  */);
+    jest.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]);
   });
   test('deleteMany should call mongo deleteMmany', () => {
     jest.spyOn(MongoCollectionAdapter.prototype, 'deleteMany').mockResolvedValue(3);

--- a/backend/lib/adapters/gateways/mongo/office-assignee.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/office-assignee.mongo.repository.test.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from 'crypto';
-// import MockData from '../../../../../common/src/cams/test-utilities/mock-data';
-// import { getCamsError } from '../../../common-errors/error-utilities';
 import { closeDeferred } from '../../../deferrable/defer-close';
 import { createMockApplicationContext } from '../../../testing/testing-utilities';
 import { ApplicationContext } from '../../types/basic';
 import { OfficeAssigneeMongoRepository } from './office-assignee.mongo.repository';
 import { MongoCollectionAdapter } from './utils/mongo-adapter';
+import MockData from '../../../../../common/src/cams/test-utilities/mock-data';
+import { OfficeAssignee } from '../../../use-cases/gateways.types';
 
 describe('case assignment repo tests', () => {
   let context: ApplicationContext;
@@ -22,15 +22,108 @@ describe('case assignment repo tests', () => {
     repo.release();
   });
 
-  test('search should call Mongo find', async () => {
-    //TODO: Create MockData function for officeAssignees
-    jest.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]);
+  test('should return a list of OfficeAssignee', async () => {
+    const assignees: OfficeAssignee[] = [
+      {
+        caseId: '',
+        officeCode: '',
+        userId: '',
+        name: '',
+      },
+    ];
+    const predicate = { caseId: '000-11-22222' };
+    const find = jest.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue(assignees);
+
+    const actual = await repo.search(predicate);
+
+    expect(find).toHaveBeenCalled();
+    expect(actual).toEqual(assignees);
   });
-  test('deleteMany should call mongo deleteMmany', () => {
-    jest.spyOn(MongoCollectionAdapter.prototype, 'deleteMany').mockResolvedValue(3);
+
+  test('should return a unique list of CamsUserReference by officeCode', async () => {
+    const assignees = MockData.buildArray(MockData.getCamsUserReference, 3);
+    const aggregate = jest.spyOn(MongoCollectionAdapter.prototype, 'aggregate').mockResolvedValue(
+      assignees.map((u) => {
+        return { ...u, _id: u.id };
+      }),
+    );
+
+    const officeCode = 'TEST-OFFICE';
+    const actual = await repo.getDistinctAssigneesByOffice(officeCode);
+
+    expect(aggregate).toHaveBeenCalled();
+    expect(actual).toEqual(assignees);
   });
-  test('create should call mongo insertOne', () => {
+
+  test('should delete OfficeAssignee records', async () => {
+    const deleteMany = jest
+      .spyOn(MongoCollectionAdapter.prototype, 'deleteMany')
+      .mockResolvedValue(3);
+    const predicate = { caseId: '000-11-22222' };
+
+    await repo.deleteMany(predicate);
+
+    expect(deleteMany).toHaveBeenCalled();
+  });
+
+  test('should insert an OfficeAssignee record', async () => {
     const mockId = randomUUID();
-    jest.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockResolvedValue(mockId);
+    const insertOne = jest
+      .spyOn(MongoCollectionAdapter.prototype, 'insertOne')
+      .mockResolvedValue(mockId);
+
+    const assignee: OfficeAssignee = {
+      caseId: '',
+      officeCode: '',
+      userId: '',
+      name: '',
+    };
+
+    await repo.create(assignee);
+
+    expect(insertOne).toHaveBeenCalled();
+  });
+
+  test('should translate a predicate into a query', () => {
+    const officeCodeQuery = repo.toQuery({ officeCode: 'TEST' });
+    expect(officeCodeQuery).toEqual({
+      condition: 'EQUALS',
+      leftOperand: {
+        name: 'officeCode',
+      },
+      rightOperand: 'TEST',
+    });
+
+    const caseAndUserIdsQuery = repo.toQuery({ caseId: '000-11-22222', userId: 'testUserId' });
+    expect(caseAndUserIdsQuery).toEqual({
+      conjunction: 'AND',
+      values: [
+        {
+          condition: 'EQUALS',
+          leftOperand: {
+            name: 'userId',
+          },
+          rightOperand: 'testUserId',
+        },
+        {
+          condition: 'EQUALS',
+          leftOperand: {
+            name: 'caseId',
+          },
+          rightOperand: '000-11-22222',
+        },
+      ],
+    });
+
+    const caseIdQuery = repo.toQuery({ caseId: '000-11-22222' });
+    expect(caseIdQuery).toEqual({
+      condition: 'EQUALS',
+      leftOperand: {
+        name: 'caseId',
+      },
+      rightOperand: '000-11-22222',
+    });
+
+    expect(() => repo.toQuery({})).toThrow();
   });
 });

--- a/backend/lib/adapters/gateways/mongo/orders.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/orders.mongo.repository.ts
@@ -90,14 +90,15 @@ export class OrdersMongoRepository extends BaseMongoRepository implements Orders
 
   async createMany(orders: Order[]): Promise<Order[]> {
     try {
-      if (!orders.length) return [];
+      if (!orders.length) {
+        return [];
+      }
       const adapter = this.getAdapter<Order>();
 
       const ids = await adapter.insertMany(orders);
-      const ordersWithIds = orders.map((order, idx) => {
+      return orders.map((order, idx) => {
         return { ...order, id: ids[idx] };
       });
-      return ordersWithIds;
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);
     }

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
@@ -1,7 +1,8 @@
 import { CamsError } from '../../../../common-errors/cams-error';
 import { NotFoundError } from '../../../../common-errors/not-found-error';
 import { CollectionHumble, DocumentClient } from '../../../../humble-objects/mongo-humble';
-import QueryBuilder, { ConditionOrConjunction, Pagination } from '../../../../query/query-builder';
+import QueryBuilder from '../../../../query/query-builder';
+import QueryPipeline from '../../../../query/query-pipeline';
 import { MongoCollectionAdapter, removeIds } from './mongo-adapter';
 
 const { and, orderBy } = QueryBuilder;
@@ -10,7 +11,7 @@ const MODULE_NAME = 'TEST-MODULE';
 
 const find = jest.fn();
 const findOne = jest.fn();
-const paginatedFind = jest.fn();
+const paginate = jest.fn();
 const replaceOne = jest.fn();
 const updateOne = jest.fn();
 const insertOne = jest.fn();
@@ -23,7 +24,7 @@ const aggregate = jest.fn();
 const spies = {
   find,
   findOne,
-  paginatedFind,
+  paginate,
   replaceOne,
   updateOne,
   insertOne,
@@ -115,7 +116,7 @@ describe('Mongo adapter', () => {
     expect(sort).toHaveBeenCalled();
   });
 
-  test('should return a sorted list of items from a paginatedFind', async () => {
+  test('should return a sorted list of items from paginate', async () => {
     const expectedValue = {
       metadata: { total: 3 },
       data: [{}, {}, {}],
@@ -127,31 +128,14 @@ describe('Mongo adapter', () => {
     ]);
     countDocuments.mockResolvedValue(3);
 
-    const item = await adapter.paginatedFind({
-      limit: 25,
-      skip: 0,
-      values: [testQuery as ConditionOrConjunction],
-      sort: orderBy(['foo', 'ASCENDING']),
-    });
-    expect(item).toEqual(expectedValue);
-  });
-
-  test('should throw error if calling paginatedFind without pagination query', async () => {
-    aggregate.mockResolvedValue([
-      {
-        metadata: [{ total: 3 }],
-        data: [{}, {}, {}],
-      },
-    ]);
-
-    await expect(
-      adapter.paginatedFind({
-        values: [testQuery as ConditionOrConjunction],
-        sort: orderBy(['foo', 'ASCENDING']),
-      } as Pagination<TestType>),
-    ).rejects.toThrow(
-      'Failed while querying with: {"values":[{"conjunction":"AND","values":[]}],"sort":{"attributes":[["foo","ASCENDING"]]}}',
+    const item = await adapter.paginate(
+      QueryPipeline.pipeline(
+        QueryPipeline.match(testQuery),
+        QueryPipeline.sort({ field: { name: 'foo' }, direction: 'ASCENDING' }),
+        QueryPipeline.paginate(0, 25),
+      ),
     );
+    expect(item).toEqual(expectedValue);
   });
 
   test('should return an empty list of items if find returns nothing', async () => {
@@ -411,9 +395,7 @@ describe('Mongo adapter', () => {
     await expect(adapter.deleteOne(testQuery)).rejects.toThrow(expectedError);
     await expect(adapter.deleteMany(testQuery)).rejects.toThrow(expectedError);
     await expect(adapter.find(testQuery)).rejects.toThrow(expectedError);
-    await expect(
-      adapter.paginatedFind({ limit: 25, skip: 0, values: [testQuery as ConditionOrConjunction] }),
-    ).rejects.toThrow(expectedError);
+    await expect(adapter.paginate(testQuery)).rejects.toThrow(expectedError);
     await expect(adapter.countDocuments(testQuery)).rejects.toThrow(expectedError);
     await expect(adapter.countAllDocuments()).rejects.toThrow(expectedError);
     await expect(adapter.findOne(testQuery)).rejects.toThrow(expectedError);

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
@@ -121,12 +121,14 @@ describe('Mongo adapter', () => {
       metadata: { total: 3 },
       data: [{}, {}, {}],
     };
-    aggregate.mockResolvedValue([
-      {
-        data: [{}, {}, {}],
+    aggregate.mockResolvedValue({
+      next: () => {
+        return Promise.resolve({
+          metadata: [{ total: 3 }],
+          data: [{}, {}, {}],
+        });
       },
-    ]);
-    countDocuments.mockResolvedValue(3);
+    });
 
     const item = await adapter.paginate(
       QueryPipeline.pipeline(

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
@@ -27,7 +27,7 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
     this.moduleName = moduleName + '_ADAPTER';
   }
 
-  async _aggregate<U = T>(pipeline: Pipeline): Promise<U[]> {
+  async aggregate<U = T>(pipeline: Pipeline): Promise<U[]> {
     const mongoQuery = toMongoAggregate(pipeline);
     try {
       const aggregationResult = await this.collectionHumble.aggregate(mongoQuery);

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-aggregate-renderer.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-aggregate-renderer.test.ts
@@ -54,6 +54,7 @@ describe('aggregation query renderer tests', () => {
       },
       {
         $facet: {
+          metadata: [{ $count: 'total' }],
           data: [
             {
               $skip: 0,

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-aggregate-renderer.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-aggregate-renderer.ts
@@ -20,11 +20,11 @@ import { CamsError } from '../../../../common-errors/cams-error';
 
 const MODULE_NAME = 'MONGO-AGGREGATE-RENDERER';
 
-export function toMongoSort(sort: Sort) {
+export function toMongoAggregateSort(sort: Sort) {
   return {
     $sort: sort.fields.reduce(
-      (acc, attribute) => {
-        acc[attribute.field.name] = attribute.direction === 'ASCENDING' ? 1 : -1;
+      (acc, sortSpec) => {
+        acc[sortSpec.field.name] = sortSpec.direction === 'ASCENDING' ? 1 : -1;
         return acc;
       },
       {} as Record<never, 1 | -1>,
@@ -146,7 +146,7 @@ const mapCondition: { [key: string]: string } = {
 export function toMongoAggregate(pipeline: Pipeline): AggregateQuery {
   return pipeline.stages.map((stage) => {
     if (stage.stage === 'SORT') {
-      return toMongoSort(stage);
+      return toMongoAggregateSort(stage);
     }
     if (stage.stage === 'PAGINATE') {
       return toMongoPaginatedFacet(stage);

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-aggregate-renderer.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-aggregate-renderer.ts
@@ -35,6 +35,7 @@ export function toMongoAggregateSort(sort: Sort) {
 function toMongoPaginatedFacet(paginate: Paginate) {
   return {
     $facet: {
+      metadata: [{ $count: 'total' }],
       data: [
         { $skip: paginate.skip },
         {

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-query-renderer.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-query-renderer.test.ts
@@ -1,5 +1,5 @@
-import QueryBuilder, { Field, Query, Sort } from '../../../../query/query-builder';
-import { toMongoQuery, toMongoSort } from './mongo-query-renderer';
+import QueryBuilder, { Field, Query } from '../../../../query/query-builder';
+import { toMongoQuery } from './mongo-query-renderer';
 
 type Foo = {
   uno: string;
@@ -8,7 +8,7 @@ type Foo = {
 };
 
 describe('Mongo Query Renderer', () => {
-  const { and, or, not, orderBy, paginate, using } = QueryBuilder;
+  const { and, or, not, using } = QueryBuilder;
   const doc = using<Foo>();
 
   test('should render a mongo query JSON', () => {
@@ -175,75 +175,6 @@ describe('Mongo Query Renderer', () => {
     };
 
     const actual = toMongoQuery(params.fn({ name: 'two' }));
-    expect(actual).toEqual(expected);
-  });
-
-  test('sort renders ascending and descending', () => {
-    expect(toMongoSort(orderBy(['foo', 'ASCENDING']))).toEqual({ foo: 1 });
-    expect(toMongoSort(orderBy(['foo', 'DESCENDING']))).toEqual({ foo: -1 });
-  });
-
-  test('sort renders multiple sort expressions', () => {
-    expect(toMongoSort(orderBy(['foo', 'ASCENDING'], ['bar', 'DESCENDING']))).toEqual({
-      foo: 1,
-      bar: -1,
-    });
-  });
-
-  test('should render a paginated aggregate mongo query JSON', () => {
-    const expected = [
-      {
-        $match: {
-          $or: [
-            { uno: { $eq: 'theValue' } },
-            {
-              $and: [
-                { two: { $eq: 45 } },
-                { three: { $eq: true } },
-                { $or: [{ uno: { $eq: 'hello' } }, { uno: { $eq: 'something' } }] },
-              ],
-            },
-          ],
-        },
-      },
-      {
-        $sort: {
-          uno: -1,
-          two: -1,
-        },
-      },
-      {
-        $facet: {
-          data: [
-            {
-              $skip: 0,
-            },
-            {
-              $limit: 25,
-            },
-          ],
-        },
-      },
-    ];
-
-    const baseQuery = or(
-      doc('uno').equals('theValue'),
-      and(
-        doc('two').equals(45),
-        doc('three').equals(true),
-        or(doc('uno').equals('hello'), doc('uno').equals('something')),
-      ),
-    );
-
-    const sort: Sort<Foo> = {
-      attributes: [
-        ['uno', 'DESCENDING'],
-        ['two', 'DESCENDING'],
-      ],
-    };
-
-    const actual = toMongoQuery(paginate(0, 25, [baseQuery], sort));
-
     expect(actual).toEqual(expected);
   });
 });

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-query-renderer.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-query-renderer.test.ts
@@ -1,5 +1,5 @@
 import QueryBuilder, { Field, Query } from '../../../../query/query-builder';
-import { toMongoQuery } from './mongo-query-renderer';
+import { toMongoQuery, toMongoSort } from './mongo-query-renderer';
 
 type Foo = {
   uno: string;
@@ -175,6 +175,20 @@ describe('Mongo Query Renderer', () => {
     };
 
     const actual = toMongoQuery(params.fn({ name: 'two' }));
+    expect(actual).toEqual(expected);
+  });
+
+  test('should render a sort expression', () => {
+    const expected = {
+      foo: 1,
+      bar: -1,
+    };
+    const actual = toMongoSort({
+      fields: [
+        { direction: 'ASCENDING', field: { name: 'foo' } },
+        { direction: 'DESCENDING', field: { name: 'bar' } },
+      ],
+    });
     expect(actual).toEqual(expected);
   });
 });

--- a/backend/lib/adapters/gateways/storage-queue/storage-queue-gateway.test.ts
+++ b/backend/lib/adapters/gateways/storage-queue/storage-queue-gateway.test.ts
@@ -1,0 +1,27 @@
+import { InvocationContextExtraOutputs } from '@azure/functions';
+import { createMockApplicationContext } from '../../../testing/testing-utilities';
+import StorageQueueGateway from './storage-queue-gateway';
+
+describe('storage queue gatwway', () => {
+  describe('using', () => {
+    const { using } = StorageQueueGateway;
+
+    test('should return an enqueue function to queue messages', async () => {
+      const extraOutputs: InvocationContextExtraOutputs = {
+        set: jest.fn(),
+        get: jest.fn(),
+      };
+
+      const context = await createMockApplicationContext();
+      context.extraOutputs = extraOutputs;
+      const actual = using(context, 'CASE_ASSIGNMENT_EVENT');
+
+      expect('enqueue' in actual).toBeTruthy();
+      expect(typeof actual.enqueue === 'function').toBeTruthy();
+
+      actual.enqueue({}, {});
+
+      expect(extraOutputs.set).toHaveBeenCalledWith(expect.anything(), [{}, {}]);
+    });
+  });
+});

--- a/backend/lib/humble-objects/mongo-humble.ts
+++ b/backend/lib/humble-objects/mongo-humble.ts
@@ -80,20 +80,14 @@ export class DocumentClient implements Closable {
 
 export type Filter = {
   [key: string]: unknown;
-  $where?: undefined;
-  $lookup?: undefined;
 };
 
-//TODO: Why is this boolean operation required to have this function?
-export type BooleanOperation = {
+export type DocumentQuery = {
+  [key: string]: Filter | Filter[];
   and?: Filter[];
   or?: Filter[];
   $where?: undefined;
   $lookup?: undefined;
-};
-
-export type DocumentQuery = BooleanOperation & {
-  [key: string]: Filter | Filter[] | BooleanOperation;
 };
 
 export type AggregateQuery = MongoDocument;

--- a/backend/lib/query/query-builder.test.ts
+++ b/backend/lib/query/query-builder.test.ts
@@ -3,11 +3,8 @@ import QueryBuilder, {
   Conjunction,
   isCondition,
   isConjunction,
-  isPagination,
-  isSort,
-  Pagination,
-  Sort,
-  SortedAttribute,
+  isSortSpec,
+  SortSpec,
 } from './query-builder';
 
 describe('Query Builder', () => {
@@ -17,7 +14,7 @@ describe('Query Builder', () => {
     three: boolean;
   };
 
-  const { not, and, or, orderBy, using } = QueryBuilder;
+  const { not, and, or, using } = QueryBuilder;
   const q = using<Foo>();
 
   test('should build correct query tree', () => {
@@ -185,15 +182,6 @@ describe('Query Builder', () => {
     expect(query).toEqual(conjunctionQuery.result);
   });
 
-  test('should proxy a list of SortDirection when orderBy is called', () => {
-    const attributeFoo: SortedAttribute<Foo> = ['uno', 'ASCENDING'];
-    const attributeBar: SortedAttribute<Foo> = ['uno', 'DESCENDING'];
-    expect(orderBy<Foo>(attributeFoo)).toEqual({ attributes: [attributeFoo] });
-    expect(orderBy<Foo>(attributeFoo, attributeBar)).toEqual({
-      attributes: [attributeFoo, attributeBar],
-    });
-  });
-
   test('isCondition', () => {
     const condition: Condition<Foo> = {
       condition: 'REGEX',
@@ -213,24 +201,11 @@ describe('Query Builder', () => {
     expect(isConjunction({})).toBeFalsy();
   });
 
-  test('isSort', () => {
-    const sort: Sort<Foo> = {
-      attributes: [['uno', 'ASCENDING']],
+  test('isSortSpec', () => {
+    const sort: SortSpec<Foo> = {
+      fields: [{ field: { name: 'uno' }, direction: 'ASCENDING' }],
     };
-    expect(isSort(sort)).toBeTruthy();
-    expect(isSort({})).toBeFalsy();
-  });
-
-  test('isPagination', () => {
-    const pagination: Pagination = {
-      limit: 100,
-      skip: 0,
-      values: [],
-    };
-    expect(isPagination(pagination)).toBeTruthy();
-    const notPagination = {
-      foo: 'bar',
-    };
-    expect(isPagination(notPagination)).toBeFalsy();
+    expect(isSortSpec(sort)).toBeTruthy();
+    expect(isSortSpec({})).toBeFalsy();
   });
 });

--- a/backend/lib/query/query-builder.ts
+++ b/backend/lib/query/query-builder.ts
@@ -1,4 +1,3 @@
-import { Sort as MongoSort } from 'mongodb';
 export type Condition<T = unknown> = {
   condition:
     | 'EQUALS'
@@ -196,16 +195,6 @@ export type SortSpec<T = never> = {
 
 export function isSortSpec(obj: unknown): obj is SortSpec {
   return typeof obj === 'object' && 'fields' in obj;
-}
-
-export function toMongoSort(sort: SortSpec): MongoSort {
-  return sort.fields.reduce(
-    (acc, sortSpec) => {
-      acc[sortSpec.field.name] = sortSpec.direction === 'ASCENDING' ? 1 : -1;
-      return acc;
-    },
-    {} as Record<keyof never, 1 | -1>,
-  );
 }
 
 function orderBy<T = never>(...specs: [keyof T, 'ASCENDING' | 'DESCENDING'][]): SortSpec {

--- a/backend/lib/query/query-pipeline.test.ts
+++ b/backend/lib/query/query-pipeline.test.ts
@@ -20,6 +20,8 @@ const {
   source,
   addFields,
   additionalField,
+  count,
+  first,
 } = QueryPipeline;
 
 describe('Query Pipeline', () => {
@@ -59,9 +61,6 @@ describe('Query Pipeline', () => {
       const collectionName = 'coll';
 
       const s = source<Foo>(collectionName);
-      // TODO: The fields function could return an array we deconstruct from rather than a record.
-      // That way we could more easily name the deconstructed variables. Think useState hook. Like:
-      //     const [ fooPrimaryKey, theOtherFooField ] = s.fields('uno', 'two');
       const [uno, _] = s.fields('uno', 'two');
 
       expect(uno.source).toEqual(collectionName);
@@ -281,5 +280,33 @@ describe('Query Pipeline', () => {
       foo: 'bar',
     };
     expect(isPaginate(notPagination)).toBeFalsy();
+  });
+
+  describe('accumulators', () => {
+    test('should create a count accumulator', () => {
+      const field = { name: 'total' };
+      const expected = {
+        accumulator: 'COUNT',
+        as: { name: 'total' },
+      };
+
+      const actual = count(field);
+
+      expect(actual).toEqual(expected);
+    });
+
+    test('should create a first accumulator', () => {
+      const field = { name: 'value' };
+      const as = { name: 'firstValue' };
+      const expected = {
+        accumulator: 'FIRST',
+        as: { name: 'firstValue' },
+        field: { name: 'value' },
+      };
+
+      const actual = first(field, as);
+
+      expect(actual).toEqual(expected);
+    });
   });
 });

--- a/backend/lib/query/query-pipeline.ts
+++ b/backend/lib/query/query-pipeline.ts
@@ -143,14 +143,14 @@ function sort(...fields: SortedField[]): Sort {
 
 function ascending(field: FieldReference<never>): SortedField {
   return {
-    field,
+    field: { name: field.name },
     direction: 'ASCENDING',
   };
 }
 
 function descending(field: FieldReference<never>): SortedField {
   return {
-    field,
+    field: { name: field.name },
     direction: 'DESCENDING',
   };
 }

--- a/backend/lib/query/query-pipeline.ts
+++ b/backend/lib/query/query-pipeline.ts
@@ -1,4 +1,11 @@
-import { ConditionFunctions, ConditionOrConjunction, Field, using } from './query-builder';
+import {
+  ConditionFunctions,
+  ConditionOrConjunction,
+  Field,
+  SortedField,
+  SortSpec,
+  using,
+} from './query-builder';
 
 function source<T = unknown>(source?: string) {
   return {
@@ -59,20 +66,6 @@ export function isPaginate(obj: unknown): obj is Paginate {
   return typeof obj === 'object' && 'limit' in obj && 'skip' in obj;
 }
 
-export type SortedField = {
-  field: FieldReference<never>;
-  direction: 'ASCENDING' | 'DESCENDING';
-};
-
-export type Sort = {
-  stage: 'SORT';
-  fields: SortedField[];
-};
-
-export function isSort(obj: unknown): obj is Sort {
-  return typeof obj === 'object' && 'stage' in obj && obj.stage === 'SORT';
-}
-
 export type Pipeline = {
   stages: Stage[];
 };
@@ -111,6 +104,14 @@ export type AdditionalField<T = never> = {
   querySource: FieldReference<never>;
   query: ConditionOrConjunction<T>;
 };
+
+export type Sort = SortSpec & {
+  stage: 'SORT';
+};
+
+export function isSort(obj: unknown): obj is Sort {
+  return typeof obj === 'object' && 'stage' in obj && obj.stage === 'SORT';
+}
 
 export type Stage<T = never> =
   | Paginate

--- a/backend/lib/use-cases/dataflows/case-closed-event.test.ts
+++ b/backend/lib/use-cases/dataflows/case-closed-event.test.ts
@@ -1,0 +1,24 @@
+import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import CaseClosedEventUseCase from './case-closed-event';
+
+describe('case closed event use case', () => {
+  describe('handleCaseClosedEvent', () => {
+    const event = { caseId: '000-11-22222' };
+    const deleteMany = jest.spyOn(MockMongoRepository.prototype, 'deleteMany');
+    const { handleCaseClosedEvent } = CaseClosedEventUseCase;
+
+    test('should proxy a message to pass caseId to deleteCaseAssignment', async () => {
+      deleteMany.mockResolvedValue();
+      const context = await createMockApplicationContext();
+      await handleCaseClosedEvent(context, event);
+      expect(deleteMany).toHaveBeenCalledWith(event);
+    });
+
+    test('should throw errors', async () => {
+      deleteMany.mockRejectedValue(new Error());
+      const context = await createMockApplicationContext();
+      await expect(handleCaseClosedEvent(context, event)).rejects.toThrow();
+    });
+  });
+});

--- a/backend/lib/use-cases/dataflows/migrate-office-assignees.ts
+++ b/backend/lib/use-cases/dataflows/migrate-office-assignees.ts
@@ -10,15 +10,9 @@ import { CamsError } from '../../common-errors/cams-error';
 import { mapDivisionCodeToUstpOffice } from '../../../../common/src/cams/offices';
 import { CaseAssignment } from '../../../../common/src/cams/assignments';
 import { isCaseOpen } from '../../../../common/src/cams/cases';
+import { OfficeAssignee } from '../gateways.types';
 
 const MODULE_NAME = 'MIGRATE-OFFICE-ASSIGNEES-USE-CASE';
-
-export type OfficeAssignee = {
-  caseId: string;
-  officeCode: string;
-  userId: string;
-  name: string;
-};
 
 async function migrateAssignments(context: ApplicationContext) {
   const assignmentsRepo = getAssignmentRepository(context);

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -28,9 +28,10 @@ import {
 import { UstpOfficeDetails } from '../../../common/src/cams/offices';
 import { CaseAssignment } from '../../../common/src/cams/assignments';
 import { CamsSession } from '../../../common/src/cams/session';
-import { ConditionOrConjunction, Pagination, Sort } from '../query/query-builder';
+import { ConditionOrConjunction, Query, SortSpec } from '../query/query-builder';
 import { AcmsConsolidation, AcmsPredicate } from './dataflows/migrate-consolidations';
 import { OfficeAssignee } from './dataflows/migrate-office-assignees';
+import { Pipeline } from '../query/query-pipeline';
 
 export type ReplaceResult = {
   id: string;
@@ -217,10 +218,10 @@ export type OfficeStaffSyncState = RuntimeState & {
 };
 
 export interface DocumentCollectionAdapter<T> {
-  find: (query: ConditionOrConjunction<T>, sort?: Sort) => Promise<T[]>;
-  paginatedFind: (query: Pagination<T>) => Promise<CamsPaginationResponse<T>>;
+  find: (query: ConditionOrConjunction<T>, sort?: SortSpec) => Promise<T[]>;
+  paginate: (pipelineOrQuery: Pipeline | Query) => Promise<CamsPaginationResponse<T>>;
   findOne: (query: ConditionOrConjunction<T>) => Promise<T>;
-  getAll: (sort?: Sort<T>) => Promise<T[]>;
+  getAll: (sort?: SortSpec) => Promise<T[]>;
   replaceOne: (
     query: ConditionOrConjunction<T>,
     item: unknown,

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -30,7 +30,6 @@ import { CaseAssignment } from '../../../common/src/cams/assignments';
 import { CamsSession } from '../../../common/src/cams/session';
 import { ConditionOrConjunction, Query, SortSpec } from '../query/query-builder';
 import { AcmsConsolidation, AcmsPredicate } from './dataflows/migrate-consolidations';
-import { OfficeAssignee } from './dataflows/migrate-office-assignees';
 import { Pipeline } from '../query/query-pipeline';
 
 export type ReplaceResult = {
@@ -239,6 +238,13 @@ export interface DocumentCollectionAdapter<T> {
 export type CamsPaginationResponse<T> = {
   metadata?: { total: number };
   data: T[];
+};
+
+export type OfficeAssignee = {
+  caseId: string;
+  officeCode: string;
+  userId: string;
+  name: string;
 };
 
 export type LogicalQueueNames = 'CASE_ASSIGNMENT_EVENT' | 'CASE_CLOSED_EVENT';

--- a/backend/lib/use-cases/offices/office-assignees.test.ts
+++ b/backend/lib/use-cases/offices/office-assignees.test.ts
@@ -1,0 +1,222 @@
+import { ApplicationContext } from '../../adapters/types/basic';
+import * as factory from '../../factory';
+import OfficeAssigneesUseCase from './office-assignees';
+import { CaseAssignment } from '../../../../common/src/cams/assignments';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { OfficeAssigneesRepository } from '../gateways.types';
+import { UstpOfficeDetails } from '../../../../common/src/cams/offices';
+
+describe('OfficeAssigneesUseCase', () => {
+  let mockContext: ApplicationContext;
+  let mockRepo: OfficeAssigneesRepository;
+  let mockGateway: {
+    getOffices: jest.Mock;
+    getOfficeName: jest.Mock;
+  };
+  let getOfficeAssigneesRepositorySpy: jest.SpyInstance;
+  let getOfficesGatewaySpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+
+    // Setup mock context
+    mockContext = await createMockApplicationContext();
+
+    // Setup mock repository
+    mockRepo = {
+      create: jest.fn(),
+      deleteMany: jest.fn(),
+      getDistinctAssigneesByOffice: jest.fn(),
+      search: jest.fn(),
+      release: jest.fn(),
+    };
+    getOfficeAssigneesRepositorySpy = jest
+      .spyOn(factory, 'getOfficeAssigneesRepository')
+      .mockReturnValue(mockRepo);
+
+    // Setup mock gateway
+    mockGateway = {
+      getOffices: jest.fn(),
+      getOfficeName: jest.fn(),
+    };
+    getOfficesGatewaySpy = jest.spyOn(factory, 'getOfficesGateway').mockReturnValue(mockGateway);
+  });
+
+  afterEach(() => {
+    // Restore all spies
+    getOfficeAssigneesRepositorySpy.mockRestore();
+    getOfficesGatewaySpy.mockRestore();
+  });
+
+  describe('handleCaseAssignmentEvent', () => {
+    it('should create a case assignment when unassignedOn is not provided', async () => {
+      // Setup
+      const mockOffices: UstpOfficeDetails[] = [
+        {
+          officeCode: 'TEST',
+          officeName: 'Test Office',
+          groups: [
+            {
+              groupDesignator: 'TEST',
+              divisions: [
+                {
+                  divisionCode: '000',
+                  court: { courtId: 'TEST' },
+                  courtOffice: { courtOfficeCode: 'TEST', courtOfficeName: 'Test Office' },
+                },
+              ],
+            },
+          ],
+          idpGroupName: 'Test Group',
+          regionId: 'TEST',
+          regionName: 'Test Region',
+        },
+      ];
+      mockGateway.getOffices.mockResolvedValue(mockOffices);
+
+      const event: CaseAssignment = {
+        documentType: 'ASSIGNMENT',
+        caseId: '000-11-22222',
+        userId: 'user1',
+        name: 'Test User',
+        role: 'ATTORNEY',
+        assignedOn: '2024-03-20T00:00:00Z',
+        updatedOn: '2024-03-20T00:00:00Z',
+        updatedBy: { id: 'system', name: 'System' },
+      };
+
+      // Execute
+      await OfficeAssigneesUseCase.handleCaseAssignmentEvent(mockContext, event);
+
+      // Verify
+      expect(mockRepo.create).toHaveBeenCalledWith({
+        officeCode: 'TEST',
+        caseId: '000-11-22222',
+        userId: 'user1',
+        name: 'Test User',
+      });
+      expect(mockRepo.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('should delete a case assignment when unassignedOn is provided', async () => {
+      // Setup
+      const mockOffices: UstpOfficeDetails[] = [
+        {
+          officeCode: 'TEST',
+          officeName: 'Test Office',
+          groups: [
+            {
+              groupDesignator: 'TEST',
+              divisions: [
+                {
+                  divisionCode: '000',
+                  court: { courtId: 'TEST' },
+                  courtOffice: { courtOfficeCode: 'TEST', courtOfficeName: 'Test Office' },
+                },
+              ],
+            },
+          ],
+          idpGroupName: 'Test Group',
+          regionId: 'TEST',
+          regionName: 'Test Region',
+        },
+      ];
+      mockGateway.getOffices.mockResolvedValue(mockOffices);
+
+      const event: CaseAssignment = {
+        documentType: 'ASSIGNMENT',
+        caseId: '000-11-22222',
+        userId: 'user1',
+        name: 'Test User',
+        role: 'ATTORNEY',
+        assignedOn: '2024-03-20T00:00:00Z',
+        unassignedOn: '2024-03-20T00:00:00Z',
+        updatedOn: '2024-03-20T00:00:00Z',
+        updatedBy: { id: 'system', name: 'System' },
+      };
+
+      // Execute
+      await OfficeAssigneesUseCase.handleCaseAssignmentEvent(mockContext, event);
+
+      // Verify
+      expect(mockRepo.deleteMany).toHaveBeenCalledWith({
+        caseId: '000-11-22222',
+        userId: 'user1',
+      });
+      expect(mockRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('should throw an error when office mapping fails', async () => {
+      // Setup
+      const mockOffices: UstpOfficeDetails[] = [
+        {
+          officeCode: 'TEST',
+          officeName: 'Test Office',
+          groups: [
+            {
+              groupDesignator: 'TEST',
+              divisions: [
+                {
+                  divisionCode: '999',
+                  court: { courtId: 'TEST' },
+                  courtOffice: { courtOfficeCode: 'TEST', courtOfficeName: 'Test Office' },
+                },
+              ],
+            },
+          ],
+          idpGroupName: 'Test Group',
+          regionId: 'TEST',
+          regionName: 'Test Region',
+        },
+      ];
+      mockGateway.getOffices.mockResolvedValue(mockOffices);
+
+      const event: CaseAssignment = {
+        documentType: 'ASSIGNMENT',
+        caseId: '000-11-22222',
+        userId: 'user1',
+        name: 'Test User',
+        role: 'ATTORNEY',
+        assignedOn: '2024-03-20T00:00:00Z',
+        updatedOn: '2024-03-20T00:00:00Z',
+        updatedBy: { id: 'system', name: 'System' },
+      };
+
+      // Execute and Verify
+      await expect(
+        OfficeAssigneesUseCase.handleCaseAssignmentEvent(mockContext, event),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('handleCaseClosedEvent', () => {
+    it('should delete all assignments for a closed case', async () => {
+      // Setup
+      const event = {
+        caseId: '000-11-22222',
+      };
+
+      // Execute
+      await OfficeAssigneesUseCase.handleCaseClosedEvent(mockContext, event);
+
+      // Verify
+      expect(mockRepo.deleteMany).toHaveBeenCalledWith({
+        caseId: '000-11-22222',
+      });
+    });
+
+    it('should throw an error when deletion fails', async () => {
+      // Setup
+      const event = {
+        caseId: '000-11-22222',
+      };
+      (mockRepo.deleteMany as jest.Mock).mockRejectedValue(new Error('Deletion failed'));
+
+      // Execute and Verify
+      await expect(
+        OfficeAssigneesUseCase.handleCaseClosedEvent(mockContext, event),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/backend/lib/use-cases/offices/office-assignees.ts
+++ b/backend/lib/use-cases/offices/office-assignees.ts
@@ -3,15 +3,9 @@ import { getOfficeAssigneesRepository, getOfficesGateway } from '../../factory';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
 import { CaseAssignment } from '../../../../common/src/cams/assignments';
 import { mapDivisionCodeToUstpOffice } from '../../../../common/src/cams/offices';
+import { OfficeAssignee } from '../gateways.types';
 
 const MODULE_NAME = 'OFFICE-ASSIGNEES-USE-CASE';
-
-export type OfficeAssignee = {
-  caseId: string;
-  officeCode: string;
-  userId: string;
-  name: string;
-};
 
 export type CaseClosedEvent = {
   caseId: string;


### PR DESCRIPTION
Jira ticket: CAMS-288

# Purpose

Remove pagination from query builder

# Major Changes

* Remove pagination from query builder
* Use query pipeline to apply pagination to a query

# Testing/Validation

* Fix broken unit tests

## Summary by Sourcery

Remove pagination from query builder and refactor query pipeline to use a more flexible approach for applying pagination and sorting

Enhancements:
- Refactored query builder and pipeline to separate pagination and sorting logic
- Improved type safety and flexibility of query construction

Tests:
- Updated multiple test suites to use new query pipeline methods
- Ensured compatibility with existing query patterns

Chores:
- Removed deprecated pagination methods
- Updated test cases to reflect new query pipeline approach