### PR TITLE
CAMS-286 Add unassigned filter option to case assignment

### DIFF
--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -31,6 +31,7 @@ import { CamsSession } from '../../../common/src/cams/session';
 import { ConditionOrConjunction, Query, SortSpec } from '../query/query-builder';
 import { AcmsConsolidation, AcmsPredicate } from './dataflows/migrate-consolidations';
 import { Pipeline } from '../query/query-pipeline';
+import { ResourceActions } from '../../../common/src/cams/actions';
 
 export type ReplaceResult = {
   id: string;
@@ -158,7 +159,9 @@ export interface CasesRepository extends Releasable {
   getCaseHistory(caseId: string): Promise<CaseHistory[]>;
   createCaseHistory(history: CaseHistory): Promise<void>;
   syncDxtrCase(bCase: SyncedCase): Promise<void>;
-  searchCases(predicate: CasesSearchPredicate): Promise<CamsPaginationResponse<SyncedCase>>;
+  searchCases(
+    predicate: CasesSearchPredicate,
+  ): Promise<CamsPaginationResponse<ResourceActions<SyncedCase>>>;
   getConsolidationChildCaseIds(predicate: CasesSearchPredicate): Promise<string[]>;
   deleteSyncedCases(): Promise<void>;
   getSyncedCase(caseId: string): Promise<SyncedCase>;

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
@@ -32,14 +32,12 @@ const notesSubmissionErrorMessage = 'There was a problem submitting the case not
 
 const modalOpenButtonRef = React.createRef<OpenModalButtonRef>();
 let session: CamsSession;
-let renderCount = 0;
 
 function renderWithProps(
   modalRef: React.RefObject<CaseNoteFormModalRef>,
   modalProps?: Partial<CaseNoteFormModalProps>,
   openProps?: Partial<CaseNoteFormModalOpenProps>,
 ) {
-  renderCount++;
   const defaultModalProps = {
     modalId,
     ref: modalOpenButtonRef,
@@ -69,7 +67,6 @@ function renderWithProps(
       </BrowserRouter>
     </React.StrictMode>,
   );
-  console.log(`Rendered the stuff ${renderCount} times!!!!!!!!!!!!!!!!`);
 }
 
 async function openWithExpectedContent(data: CaseNoteInput) {

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilter.types.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilter.types.ts
@@ -4,6 +4,11 @@ import { ResponseBody } from '@common/api/response';
 import { UstpOfficeDetails } from '@common/cams/offices';
 import { CamsUserReference } from '@common/cams/users';
 
+export const UNASSIGNED_OPTION = {
+  value: 'UNASSIGNED',
+  label: '(unassigned)',
+};
+
 interface StaffAssignmentFilterStore {
   filterAssigneeCallback: ((assignees: ComboOption[]) => void) | null;
   setFilterAssigneeCallback(val: ((assignees: ComboOption[]) => void) | null): void;
@@ -38,7 +43,8 @@ interface StaffAssignmentFilterRef {
 }
 
 type StaffAssignmentScreenFilter = {
-  assignee: CamsUserReference;
+  assignee?: CamsUserReference;
+  includeOnlyUnassigned?: boolean;
 };
 
 type StaffAssignmentFilterProps = {

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
@@ -70,8 +70,13 @@ describe('staff assignment filter use case tests', () => {
     vi.restoreAllMocks();
   });
 
-  test('assigneesToComboOptions should return valid comboOptions for supplied assignees', async () => {
-    const expectedComboOptions: ComboOption[] = [];
+  test('assigneesToComboOptions should return valid comboOptions for supplied assignees and unassigned option', async () => {
+    const expectedComboOptions: ComboOption[] = [
+      {
+        label: '(unassigned)',
+        value: 'UNASSIGNED',
+      },
+    ];
     assignees.forEach((assignee) => {
       expectedComboOptions.push({
         label: assignee.name,

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.ts
@@ -2,6 +2,7 @@ import {
   StaffAssignmentFilterControls,
   StaffAssignmentFilterUseCase,
   StaffAssignmentFilterStore,
+  UNASSIGNED_OPTION,
 } from './staffAssignmentFilter.types';
 import { ResponseBody } from '@common/api/response';
 import { CamsUserReference } from '@common/cams/users';
@@ -22,6 +23,7 @@ const staffAssignmentFilterUseCase = (
         label: assignee.name,
       });
     });
+    comboOptions.unshift(UNASSIGNED_OPTION);
     return comboOptions;
   };
 

--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.test.tsx
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.test.tsx
@@ -99,7 +99,7 @@ describe('StaffAssignmentScreen', () => {
 
     let assigneeItem;
     await waitFor(() => {
-      assigneeItem = screen.getByTestId('staff-assignees-option-item-0');
+      assigneeItem = screen.getByTestId('staff-assignees-option-item-1');
       expect(assigneeItem).toBeInTheDocument();
     });
 

--- a/user-interface/src/staff-assignment/screen/staffAssignmentUseCase.test.ts
+++ b/user-interface/src/staff-assignment/screen/staffAssignmentUseCase.test.ts
@@ -110,6 +110,19 @@ describe('staff assignment use case tests', () => {
     expect(setStaffAssignmentFilterSpy).toHaveBeenCalledWith(expectedFilter);
   });
 
+  test('handleFilterAssignee should set valid staffAssignmentFilter when array of assignees supplied', async () => {
+    const comboOptions = [
+      {
+        label: '(unassigned)',
+        value: 'UNASSIGNED',
+      },
+    ];
+    const expectedFilter = { includeOnlyUnassigned: true };
+
+    useCase.handleFilterAssignee(comboOptions);
+    expect(setStaffAssignmentFilterSpy).toHaveBeenCalledWith(expectedFilter);
+  });
+
   test('handleFilterAssignee should set staffAssignmentFilter to undefined when array of assignees is empty', async () => {
     const comboOptions: ComboOption[] = [];
 
@@ -117,7 +130,7 @@ describe('staff assignment use case tests', () => {
     expect(setStaffAssignmentFilterSpy).toHaveBeenCalledWith(undefined);
   });
 
-  test('getPredicateByUserContextWithFilter should return a valid predicate when a valid filter is passed', async () => {
+  test('getPredicateByUserContextWithFilter should return a valid predicate when a valid filter is passed that is not UNASSIGNED', async () => {
     const expectedDivisionCodes = ['081', '087'];
     const filter = { assignee: assignees[0] };
     const expectedPredicate: CasesSearchPredicate = {
@@ -126,6 +139,23 @@ describe('staff assignment use case tests', () => {
       divisionCodes: expectedDivisionCodes,
       chapters: ['15', '11', '12'],
       assignments: [assignees[0]],
+      excludeChildConsolidations: true,
+      excludeClosedCases: true,
+    };
+    vi.spyOn(commonUsers, 'getCourtDivisionCodes').mockReturnValue(expectedDivisionCodes);
+    const newPredicate = useCase.getPredicateByUserContextWithFilter(session.user, filter);
+    expect(newPredicate).toEqual(expectedPredicate);
+  });
+
+  test('getPredicateByUserContextWithFilter should return a valid predicate when UNASSIGNED is passed as the filter', async () => {
+    const expectedDivisionCodes = ['081', '087'];
+    const filter = { includeOnlyUnassigned: true };
+    const expectedPredicate: CasesSearchPredicate = {
+      limit: DEFAULT_SEARCH_LIMIT,
+      offset: DEFAULT_SEARCH_OFFSET,
+      divisionCodes: expectedDivisionCodes,
+      chapters: ['15', '11', '12'],
+      includeOnlyUnassigned: true,
       excludeChildConsolidations: true,
       excludeClosedCases: true,
     };

--- a/user-interface/src/staff-assignment/screen/staffAssignmentUseCase.ts
+++ b/user-interface/src/staff-assignment/screen/staffAssignmentUseCase.ts
@@ -21,13 +21,17 @@ const useStaffAssignmentUseCase = (
   controls: StaffAssignmentControls,
 ): StaffAssignmentUseCase => {
   const handleFilterAssignee = (assignees: ComboOption[]) => {
-    if (assignees[0]) {
+    if (assignees[0] && assignees[0].value === 'UNASSIGNED') {
+      const newFilter = {
+        includeOnlyUnassigned: true,
+      };
+      store.setStaffAssignmentFilter(newFilter);
+    } else if (assignees[0]) {
       const assignee: CamsUserReference = {
         id: assignees[0].value,
         name: assignees[0].label,
       };
       const newFilter = {
-        ...store.staffAssignmentFilter,
         assignee,
       };
       store.setStaffAssignmentFilter(newFilter);
@@ -71,6 +75,7 @@ const useStaffAssignmentUseCase = (
       assignments: filter?.assignee ? [filter.assignee] : undefined,
       excludeChildConsolidations: true,
       excludeClosedCases: true,
+      includeOnlyUnassigned: filter?.includeOnlyUnassigned ?? undefined,
     };
 
     return predicate;

--- a/user-interface/vitest.config.mts
+++ b/user-interface/vitest.config.mts
@@ -29,6 +29,7 @@ export default defineConfig({
         '**/staff-assignment/screen/StaffAssignmentScreenView.tsx',
         '**/staff-assignment/filters/StaffAssignmentFilterView.tsx',
         '**/*.d.ts',
+        '**/*.types.ts',
         '**/**humble.ts',
         '*.config.*js',
         ...coverageConfigDefaults.exclude,


### PR DESCRIPTION
# Purpose

Filter assigned cases from the Case Assignment screen.

# Major Changes

- Add the "(unassigned}" option to the filter drop down
- Flag `includeOnlyUnassigned` to true on the CaseSearchPredicate if the unassigned option is selected.

# Testing/Validation

- TDD
- Manual testing

# Definition of Done:

- [X] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [X] Dependency rule followed - More important code doesn’t directly depend on less important code
- [X] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

Add an unassigned filter option to the case assignment screen, allowing users to filter and view unassigned cases

New Features:
- Introduce an '(unassigned)' filter option in the case assignment dropdown to show only unassigned cases

Enhancements:
- Update case search predicate to support filtering for unassigned cases
- Modify staff assignment filter use case to include unassigned option in combo options

Tests:
- Add new test cases to validate the unassigned filter functionality
- Update existing test cases to accommodate the new unassigned filter option