### PR TITLE
CAMS-286: Add a darker separator for the unassigned option

### DIFF
--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
@@ -78,7 +78,7 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
 
   getPage<T>(result: MongoDocument): CamsPaginationResponse<T> {
     return {
-      metadata: result['metadata'] ? result['metadata'][0] : { total: 0 },
+      metadata: result['metadata'] && result['metadata'][0] ? result['metadata'][0] : { total: 0 },
       data: result['data'] ?? [],
     };
   }

--- a/user-interface/src/lib/components/combobox/ComboBox.scss
+++ b/user-interface/src/lib/components/combobox/ComboBox.scss
@@ -1,4 +1,5 @@
 $separatorColor: #c6cace;
+$sectionSeparatorColor: #565c65;
 $listItemHoverBorderColor: #333;
 $listItemSelectedBorderColor: #949494;
 $listItemTextColor: #1b1b1b;
@@ -133,6 +134,10 @@ $listItemHoverBackground: #b0b0b0;
         }
         li.hidden {
           display: none;
+        }
+        li.divider {
+          border-bottom-color: $sectionSeparatorColor;
+          border-bottom: 1px solid;
         }
       }
     }

--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -1007,4 +1007,22 @@ describe('test cams combobox', () => {
     await userEvent.type(inputField!, 'test');
     expect(updateFilterMock).toHaveBeenCalledWith('test');
   });
+
+  test('should add divider style when divider prop is set to true', async () => {
+    const options: ComboOption[] = [
+      { label: 'option 0', value: 'o0', divider: true },
+      { label: 'option 1', value: 'o1', divider: false },
+      { label: 'option 2', value: 'o2', divider: true },
+      { label: 'option 3', value: 'o3' },
+    ];
+
+    renderWithProps({ options });
+
+    const listItems = document.querySelectorAll('li');
+
+    expect(listItems[0]).toHaveClass('divider');
+    expect(listItems[1]).not.toHaveClass('divider');
+    expect(listItems[2]).toHaveClass('divider');
+    expect(listItems[3]).not.toHaveClass('divider');
+  });
 });

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -20,6 +20,7 @@ export type ComboOption = {
   label: string;
   selected?: boolean;
   hidden?: boolean;
+  divider?: boolean;
 };
 
 export type ComboOptionList = ComboOption | Array<ComboOption>;
@@ -227,6 +228,9 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
       classNames.push('hidden');
     } else if (isSelected(option)) {
       classNames.push('selected');
+    }
+    if (option.divider) {
+      classNames.push('divider');
     }
     return classNames.join(' ');
   }

--- a/user-interface/src/search-results/SearchResults.tsx
+++ b/user-interface/src/search-results/SearchResults.tsx
@@ -3,7 +3,7 @@ import { useTrackEvent } from '@microsoft/applicationinsights-react-js';
 import { CaseBasics, SyncedCase } from '@common/cams/cases';
 import { Table, TableBody, TableRowProps } from '@/lib/components/uswds/Table';
 import { CasesSearchPredicate } from '@common/api/search';
-import Alert, { AlertDetails, UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import Alert, { AlertDetails, AlertProps, UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { useAppInsights } from '@/lib/hooks/UseApplicationInsights';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import { Pagination } from '@/lib/components/uswds/Pagination';
@@ -44,6 +44,7 @@ export type SearchResultsProps = JSX.IntrinsicElements['table'] & {
   onStartSearching?: () => void;
   onEndSearching?: () => void;
   noResultsMessage?: string;
+  noResultsAlertProps?: AlertProps;
   header: (props: SearchResultsHeaderProps) => JSX.Element;
   row: (props: SearchResultsRowProps) => JSX.Element;
 };
@@ -55,6 +56,7 @@ export function SearchResults(props: SearchResultsProps) {
     onStartSearching,
     onEndSearching,
     noResultsMessage: noResultsMessageProp,
+    noResultsAlertProps,
     header: Header,
     row: Row,
     ...otherProps
@@ -155,7 +157,7 @@ export function SearchResults(props: SearchResultsProps) {
           ></Alert>
         </div>
       )}
-      {!isSearching && emptyResponse && !alertInfo && (
+      {!isSearching && emptyResponse && !alertInfo && !noResultsAlertProps && (
         <div className="search-alert">
           <Alert
             id="no-results-alert"
@@ -168,6 +170,11 @@ export function SearchResults(props: SearchResultsProps) {
             inline={true}
             role="alert"
           ></Alert>
+        </div>
+      )}
+      {!isSearching && emptyResponse && noResultsAlertProps && (
+        <div className="search-alert">
+          <Alert {...noResultsAlertProps} id="no-results-alert" className="measure-6"></Alert>
         </div>
       )}
       {isSearching && (

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilter.types.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilter.types.ts
@@ -7,6 +7,7 @@ import { CamsUserReference } from '@common/cams/users';
 export const UNASSIGNED_OPTION = {
   value: 'UNASSIGNED',
   label: '(unassigned)',
+  divider: true,
 };
 
 interface StaffAssignmentFilterStore {

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
@@ -75,6 +75,7 @@ describe('staff assignment filter use case tests', () => {
       {
         label: '(unassigned)',
         value: 'UNASSIGNED',
+        divider: true,
       },
     ];
     assignees.forEach((assignee) => {

--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreenView.tsx
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreenView.tsx
@@ -9,10 +9,28 @@ import { StaffAssignmentHeader } from '../header/StaffAssignmentHeader';
 import AssignAttorneyModal from '../modal/AssignAttorneyModal';
 import StaffAssignmentFilter from '../filters/StaffAssignmentFilter';
 import { StaffAssignmentScreenViewProps } from './StaffAssignment.types';
+import { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 
 export function StaffAssignmentScreenView(props: StaffAssignmentScreenViewProps) {
   const { viewModel } = props;
   const showAssignments = viewModel.hasValidPermission && viewModel.hasAssignedOffices;
+
+  const searchPredicate = viewModel.getPredicateByUserContextWithFilter(
+    viewModel.session!.user,
+    viewModel.staffAssignmentFilter,
+  );
+
+  const noResultsAlertProps = searchPredicate.includeOnlyUnassigned
+    ? {
+        message: 'There are no more cases to be assigned.',
+        title: 'All Cases Assigned',
+        type: UswdsAlertStyle.Info,
+      }
+    : {
+        message: 'There are no cases currently assigned.',
+        title: 'No Cases Assigned',
+        type: UswdsAlertStyle.Warning,
+      };
 
   return (
     <MainContent className="staff-assignment case-list">
@@ -52,11 +70,8 @@ export function StaffAssignmentScreenView(props: StaffAssignmentScreenViewProps)
           {showAssignments && (
             <SearchResults
               id="search-results"
-              searchPredicate={viewModel.getPredicateByUserContextWithFilter(
-                viewModel.session!.user,
-                viewModel.staffAssignmentFilter,
-              )}
-              noResultsMessage="No cases currently assigned."
+              searchPredicate={searchPredicate}
+              noResultsAlertProps={noResultsAlertProps}
               header={StaffAssignmentHeader}
               row={viewModel.StaffAssignmentRowClosure}
             ></SearchResults>

--- a/user-interface/src/staff-assignment/screen/staffAssignmentUseCase.ts
+++ b/user-interface/src/staff-assignment/screen/staffAssignmentUseCase.ts
@@ -72,11 +72,15 @@ const useStaffAssignmentUseCase = (
       offset: DEFAULT_SEARCH_OFFSET,
       divisionCodes: getCourtDivisionCodes(user),
       chapters: getChapters(),
-      assignments: filter?.assignee ? [filter.assignee] : undefined,
       excludeChildConsolidations: true,
       excludeClosedCases: true,
-      includeOnlyUnassigned: filter?.includeOnlyUnassigned ?? undefined,
     };
+
+    if (filter?.includeOnlyUnassigned) {
+      predicate.includeOnlyUnassigned = true;
+    } else if (filter?.assignee) {
+      predicate.assignments = [filter.assignee];
+    }
 
     return predicate;
   };


### PR DESCRIPTION
# Purpose

We want to have a visual separation between the `(unassigned)` option and the office assignees.

# Major Changes

- Add a divider to the ComboBox.
- Make the `(unassigned)` option have a divider.

# Testing/Validation

Added and updated automated tests.

# Definition of Done:

- [ ] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed - More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

Add a visual separator between unassigned option and office assignees in the ComboBox component

New Features:
- Introduced a divider option for ComboBox list items to create visual separation between sections

Enhancements:
- Updated ComboBox component to support adding dividers between list items
- Added a darker separator color for improved visual distinction

Tests:
- Added a new test to verify the divider styling for ComboBox list items