### PR TITLE
CAMS-286: Sort unassigned cases the same way as other searches

### DIFF
--- a/backend/lib/adapters/gateways/mongo/cases.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/cases.mongo.repository.test.ts
@@ -478,7 +478,13 @@ describe('Cases repository', () => {
         expect.objectContaining({ stage: 'ADD_FIELDS' }),
         expect.objectContaining({ condition: 'EQUALS', stage: 'MATCH' }),
         expect.objectContaining({ stage: 'EXCLUDE' }),
-        expect.objectContaining({ stage: 'SORT' }),
+        expect.objectContaining({
+          stage: 'SORT',
+          fields: [
+            { field: { name: 'dateFiled' }, direction: 'DESCENDING' },
+            { field: { name: 'caseNumber' }, direction: 'DESCENDING' },
+          ],
+        }),
         expect.objectContaining({
           stage: 'PAGINATE',
           skip: predicate.offset,

--- a/backend/lib/adapters/gateways/mongo/cases.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/cases.mongo.repository.ts
@@ -24,7 +24,6 @@ const { and, or, using } = QueryBuilder;
 const {
   addFields,
   additionalField,
-  ascending,
   descending,
   exclude,
   join,
@@ -390,6 +389,8 @@ export class CasesMongoRepository extends BaseMongoRepository implements CasesRe
       assignmentUnassignedOn.notExists(),
     );
 
+    const [dateFiled, caseNumber] = source<SyncedCase>().fields('dateFiled', 'caseNumber');
+
     const pipelineQuery = pipeline(
       match(initialMatch),
       join<CaseAssignment>(assignmentDocs.field('caseId'))
@@ -398,7 +399,7 @@ export class CasesMongoRepository extends BaseMongoRepository implements CasesRe
       addFields(matchingAssignments, assignments),
       match(assignmentsField.equals([])),
       exclude(allAssignmentsTempField, matchingAssignmentsTempField),
-      sort(ascending(caseDocs.field('caseId'))),
+      sort(descending(dateFiled), descending(caseNumber)),
       paginate(predicate.offset, predicate.limit),
     );
 


### PR DESCRIPTION
# Purpose

Unassigned cases should be sorted the same as other searches.

# Major Changes

Update the unassigned case search to use the same sort as the other searches.

# Testing/Validation

Update automated tests.

# Definition of Done:

- [ ] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed - More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

Update the sorting mechanism for unassigned cases to use the same sorting criteria as other case searches

Enhancements:
- Modify the unassigned case search pipeline to sort by dateFiled and caseNumber in descending order

Tests:
- Update test cases to verify the new sorting logic for unassigned cases