### PR TITLE
Add a definition of done item about regression

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Looking to create a bug?
 
-Please go the the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**
+Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**
 
 * [Bug](?expand=1&template=bug.md)
 
@@ -22,6 +22,7 @@ Optional - capture notes for nuances or future work that could be done.
 
 # Definition of Done:
 
-- [ ] Code refactored for clarity - Developers can understand the work simply by reviewing the code
-- [ ] Dependency rule followed - More important code doesn’t directly depend on less important code
-- [ ] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain
+- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
+- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
+- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
+- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -13,3 +13,10 @@ Enumerate on steps to validate that this is fixed.
 # Other Changes
 
 Optional - capture notes for nuances or future work that could be done.
+
+# Definition of Done:
+
+- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
+- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
+- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
+- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application


### PR DESCRIPTION
# Purpose

We want to track a PR dod item related to regressions to remind developers to check the application for regression of behaviors that are not covered by tests (typically UI changes).

# Major Changes

Add a new dod item to the main pr template and copy all dod items to the bug pr template.

## Summary by Sourcery

Add a new definition of done item to track potential regressions in pull request templates

New Features:
- Added a new 'No regressions' checklist item to the definition of done in both main and bug PR templates

Enhancements:
- Improved formatting of existing definition of done items with clearer formatting