### PR TITLE
GitHub actions failure notification

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -33,12 +33,6 @@ on:
           - 'true'
 
 jobs:
-  force-failure:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Force failure
-        run: exit 1
-
   setup:
     name: Setup
     uses: ./.github/workflows/reusable-build-info.yml

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -33,6 +33,12 @@ on:
           - 'true'
 
 jobs:
+  force-failure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Force failure
+        run: exit 1
+
   setup:
     name: Setup
     uses: ./.github/workflows/reusable-build-info.yml

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -165,23 +165,3 @@ jobs:
       e2eCosmosDbExists: ${{ needs.deploy.outputs.e2eCosmosDbExists }}
       initialDeployment: ${{ needs.setup.outputs.initialDeployment }}
     secrets: inherit # pragma: allowlist secret
-
-  notify-on-failure:
-    name: Send Slack Notification on Failure
-    needs:
-      [
-        setup,
-        accessibility-test,
-        unit-test-frontend,
-        unit-test-backend,
-        unit-test-common,
-        security-scan,
-        build,
-        deploy,
-        deploy-code-slot,
-      ]
-    if: always() && failure()
-    uses: ./.github/workflows/slack-notification.yml
-    with:
-      message: '🚨 Continuous Deployment workflow failed.'
-    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -161,8 +161,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
 
   notify-on-failure:
-    name: Send Slack Notification on Failure
-    if: failure()
+    name: Send Slack Notification
     uses: ./.github/workflows/slack-notification.yml
     with:
-      message: '🚨 Continuous Deployment workflow failed.'
+      message: 'Continuous Deployment workflow finished.'

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -159,3 +159,10 @@ jobs:
       e2eCosmosDbExists: ${{ needs.deploy.outputs.e2eCosmosDbExists }}
       initialDeployment: ${{ needs.setup.outputs.initialDeployment }}
     secrets: inherit # pragma: allowlist secret
+
+  notify-on-failure:
+    name: Send Slack Notification on Failure
+    if: failure()
+    uses: ./.github/workflows/slack-notification.yml
+    with:
+      message: '🚨 Continuous Deployment workflow failed.'

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -168,19 +168,7 @@ jobs:
 
   notify-on-failure:
     name: Send Slack Notification on Failure
-    needs:
-      [
-        setup,
-        accessibility-test,
-        unit-test-frontend,
-        unit-test-backend,
-        unit-test-common,
-        security-scan,
-        build,
-        deploy,
-        deploy-code-slot,
-      ]
-    if: failure()
+    if: always() && failure()
     uses: ./.github/workflows/slack-notification.yml
     with:
       message: '🚨 Continuous Deployment workflow failed.'

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -165,3 +165,4 @@ jobs:
     uses: ./.github/workflows/slack-notification.yml
     with:
       message: 'Continuous Deployment workflow finished.'
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -168,6 +168,18 @@ jobs:
 
   notify-on-failure:
     name: Send Slack Notification on Failure
+    needs:
+      [
+        setup,
+        accessibility-test,
+        unit-test-frontend,
+        unit-test-backend,
+        unit-test-common,
+        security-scan,
+        build,
+        deploy,
+        deploy-code-slot,
+      ]
     if: always() && failure()
     uses: ./.github/workflows/slack-notification.yml
     with:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -164,5 +164,5 @@ jobs:
     name: Send Slack Notification
     uses: ./.github/workflows/slack-notification.yml
     with:
-      message: 'Continuous Deployment workflow finished.'
+      message: '🚨 Continuous Deployment workflow failed.'
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -161,7 +161,8 @@ jobs:
     secrets: inherit # pragma: allowlist secret
 
   notify-on-failure:
-    name: Send Slack Notification
+    name: Send Slack Notification on Failure
+    if: failure()
     uses: ./.github/workflows/slack-notification.yml
     with:
       message: '🚨 Continuous Deployment workflow failed.'

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -168,6 +168,18 @@ jobs:
 
   notify-on-failure:
     name: Send Slack Notification on Failure
+    needs:
+      [
+        setup,
+        accessibility-test,
+        unit-test-frontend,
+        unit-test-backend,
+        unit-test-common,
+        security-scan,
+        build,
+        deploy,
+        deploy-code-slot,
+      ]
     if: failure()
     uses: ./.github/workflows/slack-notification.yml
     with:

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,0 +1,27 @@
+on:
+  workflow_call:
+    inputs:
+      message:
+        required: true
+        type: string
+
+jobs:
+  notify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          short_hash="${GITHUB_SHA::7}"
+          full_message=$(cat <<EOF
+              ${{ inputs.message }}
+              • *Branch:* ${{ github.ref_name }}
+              • *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|$short_hash>
+              • *Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>
+              EOF
+            )
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg text "$full_message" '{text: $text}')" \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -14,13 +14,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           short_hash="${GITHUB_SHA::7}"
-          full_message=$(cat <<EOF
-              ${{ inputs.message }}
-              • *Branch:* ${{ github.ref_name }}
-              • *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|$short_hash>
-              • *Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>
-              EOF
-            )
+          full_message=$(printf "%s\n• *Branch:* %s\n• *Commit:* <%s|%s>\n• *Run:* <%s|View Workflow>" \
+            "${{ inputs.message }}" \
+            "${{ github.ref_name }}" \
+            "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" \
+            "$short_hash" \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          )
+
           curl -X POST -H 'Content-type: application/json' \
             --data "$(jq -n --arg text "$full_message" '{text: $text}')" \
             "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   notify:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,25 +1,28 @@
 on:
-  workflow_call:
-    inputs:
-      message:
-        required: true
-        type: string
+  workflow_run:
+    workflows:
+      - Continuous Deployment
+    types:
+      - completed
 
 jobs:
   notify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          short_hash="${GITHUB_SHA::7}"
+          head_sha="${{ github.event.workflow_run.head_sha }}"
+          short_hash=$(echo "$head_sha" | cut -c1-7)
+          message="🚨 *Continuous Deployment* workflow failed."
           full_message=$(printf "%s\n• *Branch:* %s\n• *Commit:* <%s|%s>\n• *Run:* <%s|View Workflow>" \
-            "${{ inputs.message }}" \
-            "${{ github.ref_name }}" \
-            "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" \
+            "$message" \
+            "${{ github.event.workflow_run.head_branch }}" \
+            "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}" \
             "$short_hash" \
-            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
           )
 
           curl -X POST -H 'Content-type: application/json' \

--- a/.github/workflows/sub-deploy.yml
+++ b/.github/workflows/sub-deploy.yml
@@ -80,7 +80,7 @@ jobs:
       isDeployment: true
 
   deploy-db:
-    name: ComosDb
+    name: CosmosDb
     uses: ./.github/workflows/reusable-database-deploy.yml
     needs: [deploy-infra]
     if: ((github.ref == 'refs/heads/main') || (inputs.deployBranch == 'true'))


### PR DESCRIPTION
# Purpose

We want visibility into workflow failures.

# Major Changes

Add a new workflow that triggers on the completion of `Continuous Deployment` and if that workflow failed, sends a message to Slack.

# Testing/Validation

Validated a different trigger type worked, but this type must exist on the main branch to be executed so further testing is required.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [x] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add a Slack notification workflow to alert the team about Continuous Deployment workflow failures

CI:
- Created a new GitHub Actions workflow to send Slack notifications for Continuous Deployment workflow failures

Chores:
- Fixed a typo in CosmosDb job name in the deployment workflow