### PR TITLE
CAMS-525: Implement Default Divisions on Search Screen

### DIFF
--- a/common/src/cams/test-utilities/mock-user.ts
+++ b/common/src/cams/test-utilities/mock-user.ts
@@ -4,16 +4,16 @@ import { CamsUser } from '../users';
 
 export const REGION_02_GROUP_NY = MOCKED_USTP_OFFICE_DATA_MAP.get(
   'USTP_CAMS_Region_2_Office_Manhattan',
-);
+)!;
 export const REGION_02_GROUP_BU = MOCKED_USTP_OFFICE_DATA_MAP.get(
   'USTP_CAMS_Region_2_Office_Buffalo',
-);
+)!;
 export const REGION_02_GROUP_SE = MOCKED_USTP_OFFICE_DATA_MAP.get(
   'USTP_CAMS_Region_18_Office_Seattle',
-);
+)!;
 export const REGION_03_GROUP_WL = MOCKED_USTP_OFFICE_DATA_MAP.get(
   'USTP_CAMS_Region_3_Office_Wilmington',
-);
+)!;
 
 export type MockUser = {
   sub: string;

--- a/user-interface/.pa11yci
+++ b/user-interface/.pa11yci
@@ -26,6 +26,7 @@
         "set field #basic-search-field to joint",
         "set field #document-number-search-field to 10000",
         "clear field #document-number-search-field",
+        "click element #facet-multi-select-expand",
         "click element #facet-multi-select-combo-box-input",
         "click element #docket-date-range-date-start"
       ],
@@ -72,15 +73,7 @@
         "wait for element #no-results-alert to be visible",
         "set field [data-testid='basic-search-field'] to 99-99999",
         "click element #search-submit",
-        "wait for element #search-error-alert to be visible",
-        "click element #clear-basic-search-field",
-        "click element #search-submit",
-        "wait for element [data-testid='alert-default-state-alert'] to be visible",
-        "click element [data-testid='button-court-selections-search-expand']",
-        "click element [data-testid='court-selections-search-option-item-2']",
-        "click element [data-testid='button-court-selections-search-expand']",
-        "click element #search-submit",
-        "wait for element #search-results > table to be visible"
+        "wait for element #search-error-alert to be visible"
       ]
     },
     {

--- a/user-interface/src/App.test.tsx
+++ b/user-interface/src/App.test.tsx
@@ -12,20 +12,21 @@ describe('App', () => {
     });
   }
 
+  function renderWithoutProps() {
+    render(
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>,
+    );
+    scrollTo(0);
+  }
+
   beforeEach(() => {
     window.scrollTo = vi.fn(({ top }) => {
       if (typeof top === 'number') {
         scrollTo(top);
       }
     });
-
-    render(
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>,
-    );
-
-    scrollTo(0);
   });
 
   afterEach(() => {
@@ -37,17 +38,14 @@ describe('App', () => {
       throw Error('mock error');
     });
 
-    render(
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>,
-    );
+    renderWithoutProps();
 
     const alert = await screen.findByTestId('error-boundary-message');
     expect(alert).toBeInTheDocument();
   });
 
   test('should add className of header-scrolled-out to App when screen is scrolled down beyond 100px', async () => {
+    renderWithoutProps();
     const app = document.querySelector('.App');
     expect(app).not.toHaveClass('header-scrolled-out');
 
@@ -63,6 +61,7 @@ describe('App', () => {
   });
 
   test('should display scroll button when screen is scrolled beyond 100px', async () => {
+    renderWithoutProps();
     const scrollToTopBtn = document.querySelector('.scroll-to-top-button');
 
     expect(scrollToTopBtn).not.toHaveClass('show');
@@ -79,6 +78,7 @@ describe('App', () => {
   });
 
   test('should scroll to top when scroll-to-top button is clicked', async () => {
+    renderWithoutProps();
     const scrollToTopBtn = document.querySelector('.scroll-to-top-button');
 
     await waitFor(() => {

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.test.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.test.tsx
@@ -142,7 +142,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     const userItem = screen.getByTestId('user-list-option-item-4');
@@ -165,7 +165,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     const userItem = screen.getByTestId('user-list-option-item-4');
@@ -188,7 +188,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     const userItem = screen.getByTestId('user-list-option-item-4');
@@ -219,8 +219,8 @@ describe('Privileged Identity screen tests', () => {
     await expectItemToBeDisabled(`#save-button`);
 
     const dateInput = document.querySelector(`#${dateInputId}`);
-    // NOTE For some reason (known issue) a date input element can not be changed by typing a date
-    // in the format that the UI expects. The date may only be changed using a change event and
+    // NOTE For some reason (known issue) a date input element cannot be changed by typing a date
+    // in the format that the UI expects. The date may only be changed using a change event, and
     // the format must be in YYYY-DD-MM format.
     await user.type(dateInput!, mockDate1);
 
@@ -235,7 +235,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     await expectItemToBeDisabled(`#cancel-button`);
@@ -271,7 +271,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     await expectFormToBeDisabled();
@@ -298,7 +298,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     const userItem = screen.getByTestId('user-list-option-item-0');
@@ -326,7 +326,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     const userItem = screen.getByTestId('user-list-option-item-0');
@@ -354,7 +354,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     const userItem = screen.getByTestId('user-list-option-item-0');
@@ -376,7 +376,7 @@ describe('Privileged Identity screen tests', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('loading-spinner-caption')).not.toBeInTheDocument();
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
     const userItem = screen.getByTestId('user-list-option-item-0');

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.test.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.test.tsx
@@ -27,21 +27,29 @@ async function expectItemToBeEnabled(selector: string) {
 }
 
 describe('Privileged Identity screen tests', () => {
-  const env = process.env;
+  const { env } = process;
   let mockUserList: CamsUserReference[];
   let mockGroups: RoleAndOfficeGroupNames;
   let officeListItemId: string;
   let roleListItemId: string;
   let mockUserRecord: PrivilegedIdentityUser;
 
-  const officeListComboBoxInput = `office-list-combo-box-input`;
-  const roleListComboBoxInput = `role-list-combo-box-input`;
+  const officeListComboBoxContainer = `#office-list .input-container`;
+  const roleListComboBoxContainer = `#role-list .input-container`;
   const dateInputId = 'privileged-expiration-date';
   const mockDate1 = `${new Date().getFullYear() + 1}-01-01`;
 
+  async function expectComboBoxToBeDisabled(selector: string) {
+    expect(document.querySelector(selector)).toHaveClass('disabled');
+  }
+
+  async function expectComboBoxToBeEnabled(selector: string) {
+    expect(document.querySelector(selector)).not.toHaveClass('disabled');
+  }
+
   async function expectFormToBeDisabled() {
-    await expectItemToBeDisabled(`#${officeListComboBoxInput}`);
-    await expectItemToBeDisabled(`#${roleListComboBoxInput}`);
+    expectComboBoxToBeDisabled(`${officeListComboBoxContainer}`);
+    expectComboBoxToBeDisabled(`${roleListComboBoxContainer}`);
     await expectItemToBeDisabled(`#${dateInputId}`);
     await expectItemToBeDisabled(`#delete-button`);
     await expectItemToBeDisabled(`#save-button`);
@@ -49,8 +57,8 @@ describe('Privileged Identity screen tests', () => {
   }
 
   async function expectFormToBeEnabled() {
-    await expectItemToBeEnabled(`#${officeListComboBoxInput}`);
-    await expectItemToBeEnabled(`#${roleListComboBoxInput}`);
+    expectComboBoxToBeEnabled(`${officeListComboBoxContainer}`);
+    expectComboBoxToBeEnabled(`${roleListComboBoxContainer}`);
     await expectItemToBeEnabled(`#${dateInputId}`);
     await expectItemToBeEnabled(`#cancel-button`);
   }
@@ -145,13 +153,13 @@ describe('Privileged Identity screen tests', () => {
       expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
-    const userItem = screen.getByTestId('user-list-option-item-4');
-    expect(userItem).toBeInTheDocument();
-
     await expectFormToBeDisabled();
 
     expect(screen.queryByTestId(officeListItemId)).not.toBeInTheDocument();
     expect(screen.queryByTestId(roleListItemId)).not.toBeInTheDocument();
+
+    const userItem = screen.getByTestId('user-list-option-item-4');
+    expect(userItem).toBeInTheDocument();
 
     await user.click(userItem);
 
@@ -168,14 +176,16 @@ describe('Privileged Identity screen tests', () => {
       expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
+    expectComboBoxToBeDisabled(`${officeListComboBoxContainer}`);
+
     const userItem = screen.getByTestId('user-list-option-item-4');
     expect(userItem).toBeInTheDocument();
 
-    await expectItemToBeDisabled(`#${officeListComboBoxInput}`);
-
     await user.click(userItem);
 
-    await expectItemToBeEnabled(`#${officeListComboBoxInput}`);
+    await waitFor(() => {
+      expectComboBoxToBeEnabled(`${officeListComboBoxContainer}`);
+    });
 
     expect(screen.getByTestId(officeListItemId)).toBeInTheDocument();
 
@@ -275,19 +285,19 @@ describe('Privileged Identity screen tests', () => {
     });
 
     await expectFormToBeDisabled();
-    expect(document.querySelector('#pill-user-list')).not.toBeInTheDocument();
 
     const userItem = screen.getByTestId('user-list-option-item-0');
+    expect(userItem).not.toHaveClass('selected');
     await user.click(userItem);
+    expect(userItem).toHaveClass('selected');
 
     await expectFormToBeEnabled();
-    expect(document.querySelector('#pill-user-list')).toBeInTheDocument();
 
     const cancelButton = document.querySelector('#cancel-button');
     await user.click(cancelButton!);
 
     await expectFormToBeDisabled();
-    expect(document.querySelector('#pill-user-list')).not.toBeInTheDocument();
+    expect(userItem).not.toHaveClass('selected');
   });
 
   test('should save record when clicking save.', async () => {
@@ -304,7 +314,7 @@ describe('Privileged Identity screen tests', () => {
     const userItem = screen.getByTestId('user-list-option-item-0');
     await user.click(userItem);
 
-    await expectItemToBeEnabled(`#${roleListComboBoxInput}`);
+    expectComboBoxToBeEnabled(`${roleListComboBoxContainer}`);
 
     const roleListItem = screen.getByTestId(roleListItemId);
     await user.click(roleListItem);
@@ -332,7 +342,7 @@ describe('Privileged Identity screen tests', () => {
     const userItem = screen.getByTestId('user-list-option-item-0');
     await user.click(userItem);
 
-    await expectItemToBeEnabled(`#${roleListComboBoxInput}`);
+    expectComboBoxToBeEnabled(`${roleListComboBoxContainer}`);
 
     const roleListItem = screen.getByTestId(roleListItemId);
     await user.click(roleListItem);

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
@@ -15,7 +15,7 @@ import {
 import { CamsUserReference } from '@common/cams/users';
 import { symmetricDifference } from '@common/cams/utilities';
 import { getIsoDate, getTodaysIsoDate } from '@common/date-helper';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 export function toComboOption(groupName: string) {
   return {
@@ -40,7 +40,7 @@ export function PrivilegedIdentity() {
     offices: [],
   });
   const [userList, setUserList] = useState<CamsUserReference[]>([]);
-  const [selectedUser, setSelectedUser] = useState<CamsUserReference | null>(null);
+  // const [selectedUser, setSelectedUser] = useState<CamsUserReference | null>(null);
   const [existingGroupNameSet, setExistingGroupNameSet] = useState<Set<string>>(new Set());
   const [existingExpiration, setExistingExpiration] = useState<string | null>(null);
   const [updatedGroupNameSet, setUpdatedGroupNameSet] = useState<Set<string>>(new Set());
@@ -113,9 +113,9 @@ export function PrivilegedIdentity() {
   }
 
   function handleSelectUser(options: ComboOption[]) {
-    if (options?.length === 1) {
+    if (options.length === 1) {
       const userId = options[0].value;
-      setSelectedUser(userList.find((user) => user.id === options[0].value)!);
+      // setSelectedUser(userList.find((user) => user.id === options[0].value)!);
       api
         .getPrivilegedIdentityUser(userId)
         .then((response) => {
@@ -150,7 +150,7 @@ export function PrivilegedIdentity() {
           deleteButtonRef.current?.disableButton(true);
         });
     } else {
-      disableForm();
+      clearForm();
     }
   }
 
@@ -193,8 +193,12 @@ export function PrivilegedIdentity() {
       });
   }
 
-  function clearForm() {
+  function discard() {
+    clearForm();
     userListRef.current?.clearValue();
+  }
+
+  function clearForm() {
     officeListRef.current?.clearValue();
     roleListRef.current?.clearValue();
     datePickerRef.current?.clearValue();
@@ -261,7 +265,6 @@ export function PrivilegedIdentity() {
                 })}
                 onUpdateSelection={handleSelectUser}
                 multiSelect={false}
-                value={selectedUser?.id}
                 ref={userListRef}
               ></ComboBox>
             </div>
@@ -341,7 +344,7 @@ export function PrivilegedIdentity() {
                     id="cancel-button"
                     uswdsStyle={UswdsButtonStyle.Unstyled}
                     disabled={true}
-                    onClick={clearForm}
+                    onClick={discard}
                     ref={cancelButtonRef}
                   >
                     Discard

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
@@ -278,6 +278,7 @@ export function PrivilegedIdentity() {
                 })}
                 disabled={true}
                 multiSelect={true}
+                singularLabel="office"
                 pluralLabel="offices"
                 onUpdateSelection={handleGroupNameUpdate}
                 ref={officeListRef}
@@ -294,6 +295,7 @@ export function PrivilegedIdentity() {
                 })}
                 disabled={true}
                 multiSelect={true}
+                singularLabel="role"
                 pluralLabel="roles"
                 onUpdateSelection={handleGroupNameUpdate}
                 ref={roleListRef}

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
@@ -40,7 +40,6 @@ export function PrivilegedIdentity() {
     offices: [],
   });
   const [userList, setUserList] = useState<CamsUserReference[]>([]);
-  // const [selectedUser, setSelectedUser] = useState<CamsUserReference | null>(null);
   const [existingGroupNameSet, setExistingGroupNameSet] = useState<Set<string>>(new Set());
   const [existingExpiration, setExistingExpiration] = useState<string | null>(null);
   const [updatedGroupNameSet, setUpdatedGroupNameSet] = useState<Set<string>>(new Set());
@@ -143,8 +142,8 @@ export function PrivilegedIdentity() {
           setExistingGroupNameSet(new Set<string>(new Set<string>()));
           setExistingExpiration(null);
 
-          officeListRef.current?.clearValue();
-          roleListRef.current?.clearValue();
+          officeListRef.current?.clearSelections();
+          roleListRef.current?.clearSelections();
           datePickerRef.current?.clearValue();
           enableForm();
           deleteButtonRef.current?.disableButton(true);
@@ -195,12 +194,12 @@ export function PrivilegedIdentity() {
 
   function discard() {
     clearForm();
-    userListRef.current?.clearValue();
+    userListRef.current?.clearSelections();
   }
 
   function clearForm() {
-    officeListRef.current?.clearValue();
-    roleListRef.current?.clearValue();
+    officeListRef.current?.clearSelections();
+    roleListRef.current?.clearSelections();
     datePickerRef.current?.clearValue();
     disableForm();
   }
@@ -279,6 +278,7 @@ export function PrivilegedIdentity() {
                 })}
                 disabled={true}
                 multiSelect={true}
+                pluralLabel="offices"
                 onUpdateSelection={handleGroupNameUpdate}
                 ref={officeListRef}
               ></ComboBox>
@@ -294,6 +294,7 @@ export function PrivilegedIdentity() {
                 })}
                 disabled={true}
                 multiSelect={true}
+                pluralLabel="roles"
                 onUpdateSelection={handleGroupNameUpdate}
                 ref={roleListRef}
               ></ComboBox>

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
@@ -102,8 +102,8 @@ export function PrivilegedIdentity() {
 
   function handleGroupNameUpdate() {
     const formGroupNameSet = new Set<string>([
-      ...(officeListRef.current?.getValue() ?? []).map((option) => option.value),
-      ...(roleListRef.current?.getValue() ?? []).map((option) => option.value),
+      ...(officeListRef.current?.getSelections() ?? []).map((option) => option.value),
+      ...(roleListRef.current?.getSelections() ?? []).map((option) => option.value),
     ]);
     setUpdatedGroupNameSet(formGroupNameSet);
   }
@@ -126,12 +126,12 @@ export function PrivilegedIdentity() {
           setExistingExpiration(expires);
           setNewExpiration(expires);
 
-          officeListRef.current?.setValue(
+          officeListRef.current?.setSelections(
             groupNames.offices
               .filter((groupName) => groups.includes(groupName))
               .map((groupName) => toComboOption(groupName)),
           );
-          roleListRef.current?.setValue(
+          roleListRef.current?.setSelections(
             groupNames.roles
               .filter((groupName) => groups.includes(groupName))
               .map((groupName) => toComboOption(groupName)),
@@ -155,11 +155,11 @@ export function PrivilegedIdentity() {
   }
 
   async function handleSave() {
-    const userId = userListRef.current?.getValue()[0].value;
+    const userId = userListRef.current?.getSelections()[0].value;
     const permissions: ElevatePrivilegedUserAction = {
       groups: [
-        ...(roleListRef.current?.getValue().map((option) => option.value) || []),
-        ...(officeListRef.current?.getValue().map((option) => option.value) || []),
+        ...(roleListRef.current?.getSelections().map((option) => option.value) || []),
+        ...(officeListRef.current?.getSelections().map((option) => option.value) || []),
       ],
       expires: datePickerRef.current?.getValue() ?? getTodaysIsoDate(),
     };
@@ -178,7 +178,7 @@ export function PrivilegedIdentity() {
   }
 
   async function handleDelete() {
-    const userId = userListRef.current?.getValue()[0].value;
+    const userId = userListRef.current?.getSelections()[0].value;
     api
       .deletePrivilegedIdentityUser(userId)
       .then(() => {

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
@@ -114,7 +114,6 @@ export function PrivilegedIdentity() {
   function handleSelectUser(options: ComboOption[]) {
     if (options.length === 1) {
       const userId = options[0].value;
-      // setSelectedUser(userList.find((user) => user.id === options[0].value)!);
       api
         .getPrivilegedIdentityUser(userId)
         .then((response) => {

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -592,12 +592,12 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
                         id="facet-multi-select"
                         options={getSummaryFacetList(caseDocketSummaryFacets)}
                         onClose={handleSelectedFacet}
-                        onPillSelection={handleSelectedFacet}
                         onUpdateSelection={handleFacetClear}
                         label="Filter by Summary"
                         ariaDescription="Select multiple options. Results will update when the dropdown is closed."
                         aria-live="off"
                         multiSelect={true}
+                        singularLabel="summary"
                         pluralLabel="summaries"
                         ref={facetPickerRef}
                       />

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -377,7 +377,7 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
     setSelectedDateRange({ ...selectedDateRange, start: undefined, end: undefined });
     dateRangeRef.current?.clearValue();
     setSelectedFacets([]);
-    facetPickerRef.current?.clearValue();
+    facetPickerRef.current?.clearSelections();
     return;
   }
 
@@ -598,6 +598,7 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
                         ariaDescription="Select multiple options. Results will update when the dropdown is closed."
                         aria-live="off"
                         multiSelect={true}
+                        pluralLabel="summaries"
                         ref={facetPickerRef}
                       />
                     </div>

--- a/user-interface/src/case-detail/CaseDetailScreenSortAndFilter.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreenSortAndFilter.test.tsx
@@ -685,8 +685,6 @@ describe('Case Detail sort, search, and filter tests', () => {
 
       const docketFacetContainer = screen.getByTestId('facet-multi-select-container-test-id');
       expect(docketFacetContainer).toBeInTheDocument();
-      let docketFacetInput = screen.getByTestId('combo-box-input');
-      expect(docketFacetInput).toBeInTheDocument();
 
       const clearFiltersButton = screen.getByTestId('clear-filters');
       expect(clearFiltersButton).toBeInTheDocument();
@@ -698,9 +696,9 @@ describe('Case Detail sort, search, and filter tests', () => {
       fireEvent.change(startDateText, { target: { value: '2023-07-01' } });
       fireEvent.change(endDateText, { target: { value: '2023-011-01' } });
       fireEvent.change(docNumberSearchInput, { target: { value: '1' } });
-      fireEvent.change(docketFacetInput, {
-        target: { value: testCaseDocketEntries[0].summaryText },
-      });
+      await userEvent.click(docketFacetContainer);
+      const item0 = docketFacetContainer.querySelector('li');
+      await userEvent.click(item0!);
 
       const docketListAfterInput = screen.getByTestId('searchable-docket');
       expect(docketListAfterInput.children.length).toEqual(1);
@@ -713,8 +711,10 @@ describe('Case Detail sort, search, and filter tests', () => {
       searchInput = screen.getByTestId('document-number-search-field');
       expect(searchInput.textContent).toBe('');
 
-      docketFacetInput = screen.getByTestId('combo-box-input');
-      expect(docketFacetInput.textContent).toBe('');
+      const selectedFacets = document.querySelector(
+        '#facet-multi-select-item-list-container li.selected',
+      );
+      expect(selectedFacets).not.toBeInTheDocument();
 
       startDateText = screen.getByTestId('docket-date-range-date-start');
       expect(startDateText.textContent).toBe('');

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
@@ -292,7 +292,6 @@ describe('case note tests', () => {
 
     const titleInput = screen.getByTestId(titleInputId);
 
-    screen.debug(modal);
     await waitFor(() => {
       expect(titleInput).toHaveValue('');
     });

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -172,8 +172,15 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
     setFocusId(noteId);
   }
 
+  function focus() {
+    if (caseNotes && caseNotes[0].id) {
+      setFocusId(caseNotes[0].id);
+    }
+  }
+
   useImperativeHandle(ref, () => {
     return {
+      focus,
       focusEditButton,
     };
   });

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
@@ -332,7 +332,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       expect(markAsLeadButton).toHaveClass('usa-button--outline');
     });
 
-    await testingUtilities.selectComboBoxItem(`lead-case-court`, 0);
+    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
 
     const caseNumberInput = findCaseNumberInput(order.id!);
 
@@ -358,7 +358,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       expect(rejectButton).toBeEnabled();
     });
 
-    await testingUtilities.selectComboBoxItem(`lead-case-court`, 0);
+    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
     await enterCaseNumber(caseNumberInput, validCaseNumber);
 
     await waitFor(() => {
@@ -385,7 +385,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await toggleEnableCaseListForm(order.id!);
 
-    await testingUtilities.selectComboBoxItem(`lead-case-court`, 0);
+    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
     const caseNumberInput = findCaseNumberInput(order.id!);
 
     await enterCaseNumber(caseNumberInput, '11111111');
@@ -404,7 +404,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       expect(findValidCaseNumberTable(order.id!)).not.toBeInTheDocument();
     });
 
-    await testingUtilities.selectComboBoxItem(`lead-case-court`, 0);
+    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
     await enterCaseNumber(
       caseNumberInput,
       getCaseNumber(order.childCases[0].caseId).replace('-', ''),
@@ -429,7 +429,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await toggleEnableCaseListForm(order.id!);
 
-    await testingUtilities.selectComboBoxItem(`lead-case-court`, 0);
+    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
     const caseNumberInput = findCaseNumberInput(order.id!);
 
     await enterCaseNumber(caseNumberInput, '00000000');
@@ -450,7 +450,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await toggleEnableCaseListForm(order.id!);
 
-    await testingUtilities.selectComboBoxItem('lead-case-court', 0);
+    await testingUtilities.toggleComboBoxItemSelection('lead-case-court', 0);
 
     const caseNumberInput = findCaseNumberInput(order.id!);
 

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { ConsolidationOrder } from '@common/cams/orders';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import './ConsolidationOrderAccordion.scss';
-import { getOfficeList } from '@/data-verification/dataVerificationHelper';
+import { getDivisionComboOptions } from '@/data-verification/dataVerificationHelper';
 import { getUniqueDivisionCodeOrUndefined } from '@/data-verification/consolidation/consolidationOrderAccordionUtils';
 import type { ConsolidationStore } from '@/data-verification/consolidation/consolidationStore';
 import { useConsolidationStoreReact } from '@/data-verification/consolidation/consolidationStoreReact';
@@ -63,7 +63,9 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     confirmationModal: consolidationControls.confirmationModal,
     divisionCode: getUniqueDivisionCodeOrUndefined(consolidationStore.order.childCases),
     expandedAccordionId: expandedId!,
-    filteredOfficeRecords: getOfficeList(consolidationStore.filteredOfficesList ?? props.courts),
+    filteredOfficeRecords: getDivisionComboOptions(
+      consolidationStore.filteredOfficesList ?? props.courts,
+    ),
     formattedOrderFiledDate: formatDate(consolidationStore.order.orderDate),
     foundValidCaseNumber: consolidationStore.foundValidCaseNumber,
     hidden: hidden ?? false,

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -15,6 +15,7 @@ import { ConsolidationViewModel } from '@/data-verification/consolidation/consol
 import { getCaseNumber } from '@/lib/utils/caseNumber';
 import ComboBox from '@/lib/components/combobox/ComboBox';
 import { sanitizeText } from '@/lib/utils/sanitize-text';
+import { useEffect } from 'react';
 
 export type ConsolidationOrderAccordionViewProps = {
   viewModel: ConsolidationViewModel;
@@ -28,6 +29,18 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
       viewModel.expandedAccordionId === `order-list-${viewModel.order.id}` ? 'Collapse' : 'Expand';
     return `Click to ${action}.`;
   }
+
+  useEffect(() => {
+    if (viewModel.showLeadCaseForm) {
+      const selectedOption = viewModel.filteredOfficeRecords?.find(
+        (office) => office.value === viewModel.divisionCode,
+      );
+
+      if (selectedOption && viewModel.leadCaseDivisionInput) {
+        viewModel.leadCaseDivisionInput.current?.setSelections([selectedOption]);
+      }
+    }
+  }, [viewModel.showLeadCaseForm]);
 
   return (
     <Accordion
@@ -175,7 +188,6 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
                         aria-describedby="lead-case-form-instructions"
                         onUpdateSelection={viewModel.handleSelectLeadCaseCourt}
                         options={viewModel.filteredOfficeRecords!}
-                        value={viewModel.divisionCode}
                         required={true}
                         multiSelect={false}
                         ref={viewModel.leadCaseDivisionInput}

--- a/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
@@ -42,8 +42,8 @@ export function useConsolidationControlsMock(): ConsolidationControls {
   };
   const leadCaseDivisionRef = {
     current: {
-      setValue: (options: ComboOption[]) => {},
-      getValue: () => [
+      setSelections: (options: ComboOption[]) => {},
+      getSelections: () => [
         {
           value: '',
           label: '',
@@ -51,7 +51,7 @@ export function useConsolidationControlsMock(): ConsolidationControls {
           hidden: false,
         },
       ],
-      clearValue: () => {},
+      clearSelections: () => {},
       disable: (value: boolean) => {},
       focusInput: () => {},
       focusSingleSelectionPill: () => {},
@@ -64,6 +64,7 @@ export function useConsolidationControlsMock(): ConsolidationControls {
       clearValue: () => {},
       resetValue: () => {},
       getValue: () => '',
+      focus: () => {},
     },
   };
   const rejectButton = {

--- a/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
@@ -54,7 +54,6 @@ export function useConsolidationControlsMock(): ConsolidationControls {
       clearSelections: () => {},
       disable: (value: boolean) => {},
       focusInput: () => {},
-      focusSingleSelectionPill: () => {},
     },
   };
   const leadCaseNumberRef = {

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -28,7 +28,7 @@ interface ConsolidationViewModel {
   isValidatingLeadCaseNumber: boolean;
   jointAdministrationRadio: React.Ref<RadioRef>;
   leadCase: ConsolidationOrderCase | null;
-  leadCaseDivisionInput: React.Ref<ComboBoxRef>;
+  leadCaseDivisionInput: React.RefObject<ComboBoxRef>;
   leadCaseNumberError: string;
   leadCaseNumberInput: React.Ref<InputRef>;
   order: ConsolidationOrder;

--- a/user-interface/src/data-verification/dataVerificationHelper.test.ts
+++ b/user-interface/src/data-verification/dataVerificationHelper.test.ts
@@ -15,6 +15,7 @@ describe('data verification helper tests', () => {
         groupDesignator: '',
         regionId: '',
         regionName: '',
+        state: 'NY',
       },
       {
         officeName: '',
@@ -26,16 +27,19 @@ describe('data verification helper tests', () => {
         groupDesignator: '',
         regionId: '',
         regionName: '',
+        state: 'CA',
       },
     ];
     const expected = [
       {
         value: '111',
         label: 'Test Court 1 (Manhattan)',
+        selectedLabel: 'Manhattan, NY',
       },
       {
         value: '222',
         label: 'Test Court 2 (Los Angeles)',
+        selectedLabel: 'Los Angeles, CA',
       },
     ];
     const actual = getOfficeList(offices);
@@ -83,9 +87,9 @@ describe('data verification helper tests', () => {
     ];
 
     const expectedOptions: Array<Record<string, string>> = [
-      { value: '001', label: 'A (New York 1)' },
-      { value: '002', label: 'B (New York 1)' },
-      { value: '003', label: 'C (New York 1)' },
+      { value: '001', label: 'A (New York 1)', selectedLabel: 'New York 1, NY' },
+      { value: '002', label: 'B (New York 1)', selectedLabel: 'New York 1, NY' },
+      { value: '003', label: 'C (New York 1)', selectedLabel: 'New York 1, NY' },
     ];
 
     const sortedTestOffices = [...testOffices].sort((a, b) =>
@@ -114,7 +118,7 @@ describe('data verification helper tests', () => {
     ];
 
     const expectedOptions: Array<Record<string, string>> = [
-      { value: '002', label: 'B (New York 1) Legacy' },
+      { value: '002', label: 'B (New York 1) Legacy', selectedLabel: 'New York 1, NY' },
     ];
 
     const actualOptions = getOfficeList(testOffices);

--- a/user-interface/src/data-verification/dataVerificationHelper.test.ts
+++ b/user-interface/src/data-verification/dataVerificationHelper.test.ts
@@ -1,6 +1,6 @@
 import { describe } from 'vitest';
 import { CourtDivisionDetails } from '@common/cams/courts';
-import { courtSorter, getOfficeList } from './dataVerificationHelper';
+import { courtSorter, getDivisionComboOptions } from './dataVerificationHelper';
 
 describe('data verification helper tests', () => {
   test('should properly map court information for selection', () => {
@@ -42,7 +42,7 @@ describe('data verification helper tests', () => {
         selectedLabel: 'Los Angeles, CA',
       },
     ];
-    const actual = getOfficeList(offices);
+    const actual = getDivisionComboOptions(offices);
     expect(actual).toEqual(expected);
   });
 
@@ -96,7 +96,7 @@ describe('data verification helper tests', () => {
       a.courtDivisionCode < b.courtDivisionCode ? -1 : 1,
     );
 
-    const actualOptions = getOfficeList(sortedTestOffices);
+    const actualOptions = getDivisionComboOptions(sortedTestOffices);
     expect(actualOptions).toStrictEqual(expectedOptions);
   });
 
@@ -121,7 +121,7 @@ describe('data verification helper tests', () => {
       { value: '002', label: 'B (New York 1) Legacy', selectedLabel: 'New York 1, NY' },
     ];
 
-    const actualOptions = getOfficeList(testOffices);
+    const actualOptions = getDivisionComboOptions(testOffices);
     expect(actualOptions).toStrictEqual(expectedOptions);
   });
 

--- a/user-interface/src/data-verification/dataVerificationHelper.ts
+++ b/user-interface/src/data-verification/dataVerificationHelper.ts
@@ -1,6 +1,7 @@
+import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { CourtDivisionDetails } from '@common/cams/courts';
 
-export function getOfficeList(officesList: CourtDivisionDetails[]) {
+export function getOfficeList(officesList: CourtDivisionDetails[]): ComboOption[] {
   return officesList.map((court) => {
     let label = `${court.courtName} (${court.courtDivisionName})`;
     if (court.isLegacy) {

--- a/user-interface/src/data-verification/dataVerificationHelper.ts
+++ b/user-interface/src/data-verification/dataVerificationHelper.ts
@@ -1,7 +1,7 @@
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { CourtDivisionDetails } from '@common/cams/courts';
 
-export function getOfficeList(officesList: CourtDivisionDetails[]): ComboOption[] {
+export function getDivisionComboOptions(officesList: CourtDivisionDetails[]): ComboOption[] {
   return officesList.map((court) => {
     let label = `${court.courtName} (${court.courtDivisionName})`;
     if (court.isLegacy) {

--- a/user-interface/src/data-verification/dataVerificationHelper.ts
+++ b/user-interface/src/data-verification/dataVerificationHelper.ts
@@ -10,6 +10,7 @@ export function getOfficeList(officesList: CourtDivisionDetails[]): ComboOption[
     return {
       value: court.courtDivisionCode,
       label,
+      selectedLabel: `${court.courtDivisionName}, ${court.state}`,
     };
   });
 }

--- a/user-interface/src/data-verification/transfer/CaseTable.test.tsx
+++ b/user-interface/src/data-verification/transfer/CaseTable.test.tsx
@@ -81,15 +81,16 @@ describe('CaseTable component', () => {
   describe('with onSelect', () => {
     const onSelect = vi.fn();
 
-    beforeEach(() => {
+    const renderWithoutProps = () => {
       render(
         <BrowserRouter>
           <CaseTable id="test-case-table" cases={cases} onSelect={onSelect}></CaseTable>
         </BrowserRouter>,
       );
-    });
+    };
 
     test('should render radio buttons to select cases when onSelect is provided', () => {
+      renderWithoutProps();
       const table = screen.getByTestId('test-case-table');
       expect(table).toBeInTheDocument();
 
@@ -101,6 +102,7 @@ describe('CaseTable component', () => {
     });
 
     test('should call onSelect when a case is selected', () => {
+      renderWithoutProps();
       const radio0 = screen.queryByTestId('button-radio-test-case-table-checkbox-0-click-target');
       expect(radio0).toBeInTheDocument();
 

--- a/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
+++ b/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
@@ -5,7 +5,7 @@ import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 're
 import { CaseTable, CaseTableImperative } from './CaseTable';
 import Alert, { AlertDetails, UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { FormRequirementsNotice } from '@/lib/components/uswds/FormRequirementsNotice';
-import { getOfficeList } from '../dataVerificationHelper';
+import { getDivisionComboOptions } from '../dataVerificationHelper';
 import CaseNumberInput from '@/lib/components/CaseNumberInput';
 import { TransferOrder } from '@common/cams/orders';
 import { ComboBoxRef, InputRef } from '@/lib/type-declarations/input-fields';
@@ -254,7 +254,7 @@ function _SuggestedTransferCases(
                         wrapPills={true}
                         ref={courtSelectionRef}
                         onUpdateSelection={handleCourtSelection}
-                        options={getOfficeList(officesList)}
+                        options={getDivisionComboOptions(officesList)}
                         ariaLabelPrefix="Select a Court and Division"
                         required={true}
                       />

--- a/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
+++ b/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
@@ -156,7 +156,7 @@ function _SuggestedTransferCases(
     // TODO: Make sure the following only happens when we click the 'Clear' button, not the 'go back' button on the modal
     setNewCaseNumber(order.docketSuggestedCaseNumber || null);
     setNewCaseDivision(null);
-    courtSelectionRef.current?.clearValue();
+    courtSelectionRef.current?.clearSelections();
     caseNumberRef.current?.resetValue();
   }
 

--- a/user-interface/src/lib/components/CaseNumberInput.tsx
+++ b/user-interface/src/lib/components/CaseNumberInput.tsx
@@ -89,7 +89,11 @@ function CaseNumberInputComponent(props: CaseNumberInputProps, ref: React.Ref<In
     if (onFocus) onFocus(ev);
   }
 
-  useImperativeHandle(ref, () => ({ clearValue, resetValue, setValue, getValue, disable }));
+  function focus() {
+    forwardedRef?.current?.focus();
+  }
+
+  useImperativeHandle(ref, () => ({ clearValue, resetValue, setValue, getValue, disable, focus }));
 
   useEffect(() => {
     if (isDisabled && onDisable) {

--- a/user-interface/src/lib/components/cams/DropdownMenu/DropdownMenu.test.tsx
+++ b/user-interface/src/lib/components/cams/DropdownMenu/DropdownMenu.test.tsx
@@ -48,10 +48,6 @@ describe('DropdownMenu component tests', () => {
         <button id="test-button-1">Test Button 1</button>
       </BrowserRouter>,
     );
-  }
-
-  beforeEach(() => {
-    renderMenu();
     menu = document.querySelector(`#${menuId}`) as HTMLElement;
     item1 = document.querySelector(`#menu-link-${menuId}-0`) as HTMLElement;
     item2 = document.querySelector(`#menu-link-${menuId}-1`) as HTMLElement;
@@ -59,13 +55,14 @@ describe('DropdownMenu component tests', () => {
     item4 = document.querySelector(`#menu-link-${menuId}-3`) as HTMLElement;
     button0 = document.querySelector(`#test-button-0`) as HTMLElement;
     button1 = document.querySelector(`#test-button-1`) as HTMLElement;
-  });
+  }
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
   test('Menu should expand when clicking menu button, and focused item should be first menu item in list', async () => {
+    renderMenu();
     menu.focus();
     expect(menu.getAttribute('aria-expanded')).toBe('false');
 
@@ -76,6 +73,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('Menu should expand when pressing Enter key, and focused item should be first menu item in list', async () => {
+    renderMenu();
     menu.focus();
     expect(menu.getAttribute('aria-expanded')).toBe('false');
 
@@ -86,6 +84,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('Menu should expand when pressing Space key, and focused item should be first menu item in list', async () => {
+    renderMenu();
     menu.focus();
     expect(menu.getAttribute('aria-expanded')).toBe('false');
 
@@ -96,6 +95,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('Menu should have aria-controls="test-menu-item-list", aria-label, and aria-haspopup="menu" and UL should have role="menu", and LI should have role="menuitem"', () => {
+    renderMenu();
     expect(menu).toHaveAttribute('aria-controls', `${menuId}-item-list`);
     expect(menu).toHaveAttribute('aria-label', 'Test Aria Label');
     expect(menu).toHaveAttribute('aria-haspopup', 'menu');
@@ -111,6 +111,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('Menu should close when clicking outside of menu', async () => {
+    renderMenu();
     await userEvent.click(menu);
     expect(menu.getAttribute('aria-expanded')).toBe('true');
 
@@ -119,6 +120,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('If expanded, then pressing Tab should focus on next item outside of menu and close menu.', async () => {
+    renderMenu();
     const user = userEvent.setup();
     expect(menu.getAttribute('aria-expanded')).toBe('false');
 
@@ -132,6 +134,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('If expanded, then pressing Shift-Tab should close menu and focus on menu.', async () => {
+    renderMenu();
     expect(menu.getAttribute('aria-expanded')).toBe('false');
 
     await userEvent.click(menu);
@@ -143,6 +146,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('If expanded, then pressing Down Arrow should focus on each menu item in turn. If the last item was already focused, then the first menu item should receive focus.', async () => {
+    renderMenu();
     const user = userEvent.setup();
 
     expect(menu.getAttribute('aria-expanded')).toBe('false');
@@ -166,6 +170,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('If expanded, and last item is focused, then pressing Up Arrow should focus on each item above in sequence until reaching the top.  Pressing up arrow again should focus on the last menu item in the list.', async () => {
+    renderMenu();
     const user = userEvent.setup();
 
     await user.click(menu);
@@ -186,6 +191,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('If expanded, End key should jump to last item in list and Home key should jump to first item in list.', async () => {
+    renderMenu();
     const user = userEvent.setup();
 
     menu.focus();
@@ -200,6 +206,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('If expanded, pressing a letter or number should jump to the first menu item that starts with that letter', async () => {
+    renderMenu();
     const user = userEvent.setup();
 
     menu.focus();
@@ -220,6 +227,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('If expanded, and menu item is focused, then pressing Escape should close menu and closed menu, being the parent of items, should receive focus.', async () => {
+    renderMenu();
     expect(menu!.getAttribute('aria-expanded')).toBe('false');
 
     menu.focus();
@@ -233,6 +241,7 @@ describe('DropdownMenu component tests', () => {
   });
 
   test('Should call click function onClick', async () => {
+    renderMenu();
     await userEvent.click(menu);
     expect(clickFn).toHaveBeenCalled();
   });
@@ -250,6 +259,7 @@ describe('DropdownMenu component tests', () => {
     });
 
     test('Should follow link when Enter key is pressed', async () => {
+      renderMenu();
       await userEvent.click(menu);
       expect(item1).toHaveFocus();
       await userEvent.keyboard('{Enter}');
@@ -258,6 +268,7 @@ describe('DropdownMenu component tests', () => {
     });
 
     test('Should follow link when Space key is pressed', async () => {
+      renderMenu();
       await userEvent.click(menu);
       expect(item1).toHaveFocus();
       await userEvent.keyboard(' ');

--- a/user-interface/src/lib/components/cams/linkUtils.test.tsx
+++ b/user-interface/src/lib/components/cams/linkUtils.test.tsx
@@ -4,13 +4,13 @@ import { render } from '@testing-library/react';
 describe('Test link utilities', () => {
   test('executeLinkClick should execute onClick on the given link', async () => {
     const testFunction = vi.fn();
-    const { container } = render(
+    render(
       <a href="/" onClick={testFunction}>
         {' '}
       </a>,
     );
 
-    const link = container.querySelector('a') as HTMLAnchorElement;
+    const link = document.querySelector('a') as HTMLAnchorElement;
     if (link) {
       LinkUtils.executeLinkClick(link);
       expect(testFunction).toHaveBeenCalledTimes(1);

--- a/user-interface/src/lib/components/combobox/ComboBox.scss
+++ b/user-interface/src/lib/components/combobox/ComboBox.scss
@@ -10,20 +10,9 @@ $listItemHoverBackground: #b0b0b0;
 
 .combo-box-form-group {
   max-width: 100%;
-  .combo-box-label.multi-select {
+  .combo-box-label {
     display: flex;
     justify-content: space-between;
-  }
-
-  .pills-and-clear-all {
-    display: flex;
-    justify-content: space-between;
-    .pill-box {
-      max-width: calc(100% - 3rem);
-    }
-    .pill-clear-button {
-      height: 1.5rem;
-    }
   }
 
   .usa-combo-box {
@@ -54,11 +43,25 @@ $listItemHoverBackground: #b0b0b0;
         position: relative;
         width: 100%;
 
+        .selection-label {
+          min-height: 1.3rem;
+        }
+
+        .selection-label.ellipsis {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        svg {
+          margin-top: 0.2rem;
+        }
+
         .combo-box-input {
           border: none;
           background: none;
-          width: 100%;
-          margin: 0 5px;
+          width: calc(100% - 25px);
+          margin: 0;
         }
         .combo-box-input:disabled, .combo-box-input[aria-disabled=true] {
           color: colors.$disabledInputText;

--- a/user-interface/src/lib/components/combobox/ComboBox.scss
+++ b/user-interface/src/lib/components/combobox/ComboBox.scss
@@ -80,6 +80,7 @@ $listItemHoverBackground: #b0b0b0;
     }
     .input-container.disabled {
       background-color: colors.$disabledInputBackground;
+      cursor: not-allowed;
     }
     .input-container:has(.combo-box-input:focus) {
       outline-width: 4px;

--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -109,20 +109,6 @@ describe('test cams combobox', () => {
     vi.restoreAllMocks();
   });
 
-  test('Should properly render selections when value prop is set', async () => {
-    const ref = React.createRef<ComboBoxRef>();
-    const expectedSelections = [
-      {
-        label: 'option 2',
-        value: 'o2',
-      },
-    ];
-    renderWithProps({ value: 'o2' }, ref);
-
-    const selections = ref.current?.getValue();
-    expect(selections).toEqual(expectedSelections);
-  });
-
   test('Clicking on the toggle button should open or close the dropdown list and put the focus on the input field.  When closed it should call onClose()', async () => {
     const onClose = vi.fn();
 
@@ -331,7 +317,7 @@ describe('test cams combobox', () => {
 
     await userEvent.type(comboboxInputField, 'this is gibberish');
     comboboxInputField.focus();
-    const result = ref.current?.getValue();
+    const result = ref.current?.getSelections();
     expect(result).toEqual([]);
 
     await userEvent.tab();
@@ -666,7 +652,7 @@ describe('test cams combobox', () => {
     await userEvent.click(listButtons![2]);
 
     await waitFor(() => {
-      const selections = ref.current?.getValue();
+      const selections = ref.current?.getSelections();
       expect(selections!.length).toEqual(1);
 
       const listItems = document.querySelectorAll('li');
@@ -689,7 +675,7 @@ describe('test cams combobox', () => {
       expect(listItems[1]!).not.toHaveClass('selected');
       expect(listItems[2]!).not.toHaveClass('selected');
 
-      const selections = ref.current?.getValue();
+      const selections = ref.current?.getSelections();
       expect(selections!.length).toEqual(0);
     });
   });
@@ -814,13 +800,13 @@ describe('test cams combobox', () => {
     await userEvent.click(listButtons![0]);
     await userEvent.click(listButtons![2]);
 
-    const setResult = ref.current?.getValue();
+    const setResult = ref.current?.getSelections();
     expect(setResult).toEqual(expectedValues);
 
     ref.current?.clearValue();
 
     await waitFor(() => {
-      const emptyResult = ref.current?.getValue();
+      const emptyResult = ref.current?.getSelections();
       expect(emptyResult).toEqual([]);
     });
   });
@@ -840,13 +826,13 @@ describe('test cams combobox', () => {
 
     renderWithProps({ options }, ref);
 
-    let selections = ref.current?.getValue();
+    let selections = ref.current?.getSelections();
     expect(selections).toEqual([]);
 
-    ref.current?.setValue(options);
+    ref.current?.setSelections(options);
 
     await waitFor(() => {
-      selections = ref.current?.getValue();
+      selections = ref.current?.getSelections();
       expect(selections).toEqual(options.map((option) => ({ ...option })));
     });
   });

--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -432,7 +432,6 @@ describe('test cams combobox', () => {
 
   test('should not open when combobox is disabled', async () => {
     renderWithProps({ disabled: true });
-    // await toggleDropdown();
 
     const inputContainer = document.querySelector('.input-container');
     await userEvent.click(inputContainer!);
@@ -804,7 +803,6 @@ describe('test cams combobox', () => {
 
     ref.current?.disable(true);
 
-    // const expandButton = document.querySelector('.expand-button');
     await waitFor(() => {
       const disabledExpandButton = document.querySelector('.expand-button');
       expect(disabledExpandButton).not.toBeEnabled();

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -131,7 +131,7 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
     setSelectedMap(new Map(values.map((value) => [value.value, value])));
   }
 
-  function clearValue() {
+  function clearSelections() {
     setSelectedMap(new Map());
   }
 
@@ -187,11 +187,7 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
   }
 
   function getInputClassName(): string {
-    let className = 'usa-tooltip combo-box-input';
-    if (multiSelect !== true && selectedMap.size === 1) {
-      className += ' hide-input';
-    }
-    return className;
+    return 'usa-tooltip combo-box-input';
   }
 
   function setListItemClass(_index: number, option: ComboOption) {
@@ -238,7 +234,7 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
   // ========== HANDLERS ==========
 
   function handleClearAllClick() {
-    clearValue();
+    clearSelections();
     clearFilter();
     filterRef.current?.focus();
 
@@ -344,12 +340,16 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
   }
 
   function handleToggleKeyDown(ev: React.KeyboardEvent) {
-    if (ev.key === 'ArrowDown') {
+    if (!comboboxDisabled && ev.key === 'ArrowDown') {
       handleToggleDropdown();
     }
   }
 
   function handleToggleDropdown() {
+    if (comboboxDisabled) {
+      return;
+    }
+
     const inputContainer = document.querySelector(`#${comboBoxId} .input-container`);
     const topYPos = inputContainer?.getBoundingClientRect().top;
     const bottomYPos = inputContainer?.getBoundingClientRect().bottom;
@@ -398,7 +398,7 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
   useImperativeHandle(ref, () => ({
     setSelections,
     getSelections,
-    clearValue,
+    clearSelections,
     disable,
     focusInput,
     focusSingleSelectionPill,

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -425,6 +425,7 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
             uswdsStyle={UswdsButtonStyle.Unstyled}
             onClick={handleClearAllClick}
             onKeyDown={handleClearAllKeyDown}
+            id={`${comboBoxId}-clear-all`}
           >
             clear
           </Button>

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -13,7 +13,6 @@ import Button, { UswdsButtonStyle } from '../uswds/Button';
 import PillBox from '../PillBox';
 import useOutsideClick from '@/lib/hooks/UseOutsideClick';
 import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
-import { Pill } from '../Pill';
 
 export type ComboOption = {
   value: string;
@@ -42,6 +41,7 @@ export interface ComboBoxProps extends Omit<InputProps, 'onChange' | 'onFocus' |
   onFocus?: (ev: React.FocusEvent<HTMLElement>) => void;
   multiSelect?: boolean;
   wrapPills?: boolean;
+  selectedLabel: string;
 }
 
 function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
@@ -58,6 +58,7 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
     ariaLabelPrefix,
     ariaDescription,
     options: _options,
+    selectedLabel,
     ...otherProps
   } = props;
 
@@ -326,14 +327,6 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
     filterRef.current?.focus();
   }
 
-  function handleSingleSelectPillClick() {
-    handleClearAllClick();
-    if (onPillSelection) {
-      onPillSelection([]);
-    }
-    filterRef.current?.focus();
-  }
-
   function handleToggleDropdown(_ev: React.MouseEvent<HTMLButtonElement>) {
     const inputContainer = document.querySelector(`#${comboBoxId} .input-container`);
     const topYPos = inputContainer?.getBoundingClientRect().top;
@@ -388,6 +381,10 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
 
   // ========== JSX ==========
 
+  function getSelectedLabel() {
+    return `${selectedMap.size} ${selectedMap.size === 1 ? `${selectedLabel}` : `${selectedLabel}s`} selected`;
+  }
+
   return (
     <div id={comboBoxId} className="usa-form-group combo-box-form-group" ref={comboBoxRef}>
       <div className={`combo-box-label ${multiSelect === true ? 'multi-select' : 'single-select'}`}>
@@ -439,36 +436,21 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
           aria-labelledby={comboBoxId + '-label'}
         >
           <div className="combo-box-input-container" role="presentation">
-            {multiSelect === false && selectedMap.size === 1 && (
-              <Pill
-                id={`pill-${comboBoxId}`}
-                label={[...selectedMap.values()][0].label}
-                ariaLabelPrefix={ariaLabelPrefix ?? undefined}
-                value={[...selectedMap.values()][0].value}
-                wrapText={wrapPills}
-                onKeyDown={(ev) => handleKeyDown(ev, 0)}
-                onClick={handleSingleSelectPillClick}
-                disabled={comboboxDisabled}
-                ref={singleSelectionPillRef}
-              ></Pill>
-            )}
-            <input
-              {...otherProps}
-              id={`${comboBoxId}-combo-box-input`}
-              data-testid="combo-box-input"
-              className={getInputClassName()}
-              onChange={handleInputFilter}
-              onKeyDown={(ev) => handleKeyDown(ev, 0)}
-              onClick={openDropdown}
-              onFocus={handleOnInputFocus}
-              disabled={comboboxDisabled}
-              aria-label={`${ariaLabelPrefix ? ariaLabelPrefix + ': ' : ''}Enter text to filter options. Use up and down arrows to open dropdown list.`}
-              aria-describedby={`${comboBoxId}-aria-description`}
-              aria-live={props['aria-live'] ?? undefined}
-              aria-autocomplete="list"
-              aria-activedescendant={currentListItem ?? ''}
-              ref={filterRef}
-            />
+            {/*{multiSelect === false && selectedMap.size === 1 && (*/}
+            {/*  <Pill*/}
+            {/*    id={`pill-${comboBoxId}`}*/}
+            {/*    label={[...selectedMap.values()][0].label}*/}
+            {/*    ariaLabelPrefix={ariaLabelPrefix ?? undefined}*/}
+            {/*    value={[...selectedMap.values()][0].value}*/}
+            {/*    wrapText={wrapPills}*/}
+            {/*    onKeyDown={(ev) => handleKeyDown(ev, 0)}*/}
+            {/*    onClick={handleSingleSelectPillClick}*/}
+            {/*    disabled={comboboxDisabled}*/}
+            {/*    ref={singleSelectionPillRef}*/}
+            {/*  ></Pill>*/}
+            {/*)}*/}
+            {/* label */}
+            <span>{getSelectedLabel()}</span>
           </div>
           <Button
             id={`${comboBoxId}-expand`}
@@ -498,6 +480,29 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
               aria-multiselectable={multiSelect === true ? 'true' : 'false'}
               ref={comboBoxListRef}
             >
+              <li
+                id={'combo-box-input-container'}
+                className={'something?'}
+                data-testid={'combo-box-input-container'}
+              >
+                <input
+                  {...otherProps}
+                  id={`${comboBoxId}-combo-box-input`}
+                  data-testid="combo-box-input"
+                  className={getInputClassName()}
+                  onChange={handleInputFilter}
+                  onKeyDown={(ev) => handleKeyDown(ev, 0)}
+                  onClick={openDropdown}
+                  onFocus={handleOnInputFocus}
+                  disabled={comboboxDisabled}
+                  aria-label={`${ariaLabelPrefix ? ariaLabelPrefix + ': ' : ''}Enter text to filter options. Use up and down arrows to open dropdown list.`}
+                  aria-describedby={`${comboBoxId}-aria-description`}
+                  aria-live={props['aria-live'] ?? undefined}
+                  aria-autocomplete="list"
+                  aria-activedescendant={currentListItem ?? ''}
+                  ref={filterRef}
+                />
+              </li>
               {props.options
                 .filter(
                   (option) => !filter || option.label.toLowerCase().includes(filter.toLowerCase()),

--- a/user-interface/src/lib/components/uswds/DatePicker.tsx
+++ b/user-interface/src/lib/components/uswds/DatePicker.tsx
@@ -1,7 +1,7 @@
 import './forms.scss';
 import './DatePicker.scss';
 import { InputRef } from '@/lib/type-declarations/input-fields';
-import { forwardRef, useImperativeHandle, useState } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { getIsoDate, isInvalidDate } from '@common/date-helper';
 
 export type DatePickerProps = JSX.IntrinsicElements['input'] & {
@@ -19,6 +19,8 @@ export type DatePickerProps = JSX.IntrinsicElements['input'] & {
 function DatePickerComponent(props: DatePickerProps, ref: React.Ref<InputRef>) {
   const { id, label, minDate, maxDate } = props;
   const defaultErrorMessage = 'Date is not within allowed range. Enter a valid date.';
+
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [isDisabled, setIsDisabled] = useState<boolean>(!!props.disabled);
@@ -116,6 +118,10 @@ function DatePickerComponent(props: DatePickerProps, ref: React.Ref<InputRef>) {
     }
   }
 
+  function focus() {
+    inputRef?.current?.focus();
+  }
+
   useImperativeHandle(ref, () => {
     return {
       clearValue,
@@ -123,6 +129,7 @@ function DatePickerComponent(props: DatePickerProps, ref: React.Ref<InputRef>) {
       getValue,
       setValue,
       disable,
+      focus,
     };
   });
 
@@ -147,6 +154,7 @@ function DatePickerComponent(props: DatePickerProps, ref: React.Ref<InputRef>) {
           value={dateValue ?? undefined}
           disabled={isDisabled}
           required={props.required}
+          ref={inputRef}
         />
       </div>
       <div className="date-error">{errorMessage}</div>

--- a/user-interface/src/lib/components/uswds/DateRangePicker.tsx
+++ b/user-interface/src/lib/components/uswds/DateRangePicker.tsx
@@ -93,6 +93,10 @@ function DateRangePickerComponent(props: DateRangePickerProps, ref: React.Ref<Da
     endDateRef.current?.disable(value);
   }
 
+  function focus() {
+    startDateRef?.current?.focus();
+  }
+
   useImperativeHandle(ref, () => {
     return {
       clearValue,
@@ -100,6 +104,7 @@ function DateRangePickerComponent(props: DateRangePickerProps, ref: React.Ref<Da
       setValue,
       disable,
       getValue,
+      focus,
     };
   });
 

--- a/user-interface/src/lib/components/uswds/Input.test.tsx
+++ b/user-interface/src/lib/components/uswds/Input.test.tsx
@@ -8,15 +8,16 @@ describe('Tests for USWDS Input component.', () => {
   const ref = React.createRef<InputRef>();
   const youChangedMe = vi.fn();
 
-  beforeEach(() => {
+  const renderWithoutProps = () => {
     render(
       <div>
         <Input ref={ref} id="input-1" inputMode="numeric" value="1" onChange={youChangedMe}></Input>
       </div>,
     );
-  });
+  };
 
   test('Should change value when ref.setValue() is called and set value back to original when ref.resetValue() is called.', async () => {
+    renderWithoutProps();
     const inputEl = screen.getByTestId('input-1');
     expect(inputEl).toHaveValue('1');
 
@@ -32,6 +33,7 @@ describe('Tests for USWDS Input component.', () => {
   });
 
   test('Should clear value when ref.clearValue is called.', async () => {
+    renderWithoutProps();
     const inputEl = screen.getByTestId('input-1');
     ref.current?.setValue('2');
 
@@ -46,6 +48,7 @@ describe('Tests for USWDS Input component.', () => {
   });
 
   test('Should call props.onChange when a change is made to input by keypress or by ref.', async () => {
+    renderWithoutProps();
     const inputEl = screen.getByTestId('input-1');
 
     ref.current?.setValue('2');

--- a/user-interface/src/lib/components/uswds/Input.tsx
+++ b/user-interface/src/lib/components/uswds/Input.tsx
@@ -23,7 +23,7 @@ function InputComponent(props: InputProps, ref: React.Ref<InputRef>) {
 
   const { includeClearButton, ariaDescription, errorMessage, ...otherProps } = props;
 
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   function emitChange(value: string) {
     if (props.onChange) {
@@ -72,11 +72,15 @@ function InputComponent(props: InputProps, ref: React.Ref<InputRef>) {
     }
   }
 
+  function focus() {
+    inputRef?.current?.focus();
+  }
+
   useEffect(() => {
     setInputValue(props.value || '');
   }, [props.value]);
 
-  useImperativeHandle(ref, () => ({ clearValue, resetValue, setValue, getValue, disable }));
+  useImperativeHandle(ref, () => ({ clearValue, resetValue, setValue, getValue, disable, focus }));
 
   return (
     <>

--- a/user-interface/src/lib/components/uswds/Radio.test.tsx
+++ b/user-interface/src/lib/components/uswds/Radio.test.tsx
@@ -18,11 +18,12 @@ describe('Tests for USWDS Input component.', () => {
 
   const radioTestId = `radio-${defaultProps.id}`;
 
-  beforeEach(() => {
+  const renderWithoutProps = () => {
     render(<Radio {...defaultProps} ref={ref}></Radio>);
-  });
+  };
 
   test('should call onChange callback when checked or unchecked', async () => {
+    renderWithoutProps();
     const radioButton = testingUtilities.selectRadio('1');
     await waitFor(() => {
       expect(onChangeHandlerSpy).toHaveBeenCalled();
@@ -32,11 +33,13 @@ describe('Tests for USWDS Input component.', () => {
   });
 
   test('should render the radio button label', () => {
+    renderWithoutProps();
     const radioButtonLabel = document.querySelector('.usa-radio__label');
     expect(radioButtonLabel).toHaveTextContent(defaultProps.label);
   });
 
   test('should be able to check/uncheck programmatically', async () => {
+    renderWithoutProps();
     const radioButton = screen.getByTestId(radioTestId);
     expect(radioButton).not.toBeChecked();
 
@@ -55,6 +58,7 @@ describe('Tests for USWDS Input component.', () => {
   });
 
   test('should be able to disable/enable programmatically', async () => {
+    renderWithoutProps();
     const radioButton = screen.getByTestId(radioTestId);
     expect(radioButton).not.toBeDisabled();
 

--- a/user-interface/src/lib/components/uswds/TextArea.test.tsx
+++ b/user-interface/src/lib/components/uswds/TextArea.test.tsx
@@ -15,7 +15,7 @@ describe('Tests for USWDS TextArea component', () => {
   const newValue = 'new value';
   const testClassName = 'test-class-name';
 
-  beforeEach(() => {
+  const renderWithoutProps = () => {
     render(
       <div>
         <TextArea
@@ -28,9 +28,10 @@ describe('Tests for USWDS TextArea component', () => {
         />
       </div>,
     );
-  });
+  };
 
   test('Should include label if provided', async () => {
+    renderWithoutProps();
     const labelEl = screen.getByTestId(labelId);
     expect(labelEl).toBeInTheDocument();
     expect(labelEl).toHaveClass('usa-label ' + testClassName + '-label');
@@ -39,6 +40,7 @@ describe('Tests for USWDS TextArea component', () => {
   });
 
   test('TextArea should include correct class and id', async () => {
+    renderWithoutProps();
     const textAreaEl = screen.getByTestId(textAreaId);
     expect(textAreaEl).toBeInTheDocument();
     expect(textAreaEl).toHaveClass('usa-textarea ' + testClassName);
@@ -46,11 +48,13 @@ describe('Tests for USWDS TextArea component', () => {
   });
 
   test('Should not include aria description if none is supplied', async () => {
+    renderWithoutProps();
     const usaHintEl = document.querySelector('.usa-hint');
     expect(usaHintEl).not.toBeInTheDocument();
   });
 
   test('Should change value when ref.setValue() is called and set value back to original when ref.resetValue() is called.', async () => {
+    renderWithoutProps();
     const inputEl = screen.getByTestId(textAreaId);
     expect(inputEl).toHaveValue(value);
 
@@ -66,6 +70,7 @@ describe('Tests for USWDS TextArea component', () => {
   });
 
   test('Should clear value when ref.clearValue is called.', async () => {
+    renderWithoutProps();
     const inputEl = screen.getByTestId(textAreaId);
     ref.current?.setValue(newValue);
 
@@ -80,6 +85,7 @@ describe('Tests for USWDS TextArea component', () => {
   });
 
   test('clearValue should skip focus if inputRef is null', async () => {
+    renderWithoutProps();
     const mockInnerRef = { current: { focus: vi.fn(), value: '' } };
     const useRefMock = vi.spyOn(React, 'useRef').mockReturnValueOnce(mockInnerRef);
 
@@ -94,6 +100,7 @@ describe('Tests for USWDS TextArea component', () => {
   });
 
   test('Should return value when ref.getValue is called.', async () => {
+    renderWithoutProps();
     const inputEl = screen.getByTestId(textAreaId);
     ref.current?.setValue(newValue);
 
@@ -105,6 +112,7 @@ describe('Tests for USWDS TextArea component', () => {
   });
 
   test('Should call props.onChange when a change is made to textarea by keypress or by ref.', async () => {
+    renderWithoutProps();
     const inputEl = screen.getByTestId(textAreaId);
 
     ref.current?.setValue(newValue);
@@ -152,7 +160,7 @@ describe('Test in odd cases', () => {
   const newValue = 'new value';
   const testClassName = 'test-class-name';
 
-  beforeEach(() => {
+  const renderWithoutProp = () => {
     render(
       <div>
         <TextArea
@@ -164,9 +172,10 @@ describe('Test in odd cases', () => {
         />
       </div>,
     );
-  });
+  };
 
   test('test null on reset if no value provided to props', async () => {
+    renderWithoutProp();
     const inputEl = screen.getByTestId(textAreaId);
 
     ref.current?.setValue(newValue);

--- a/user-interface/src/lib/components/uswds/TextArea.tsx
+++ b/user-interface/src/lib/components/uswds/TextArea.tsx
@@ -1,7 +1,7 @@
 import './TextArea.scss';
 import './forms.scss';
 import { TextAreaRef } from '@/lib/type-declarations/input-fields';
-import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 export type TextAreaProps = JSX.IntrinsicElements['textarea'] & {
   id: string;
@@ -14,6 +14,8 @@ function TextAreaComponent(props: TextAreaProps, ref: React.Ref<TextAreaRef>) {
   const { id, label, ariaDescription, ...otherProps } = props;
   const labelId = `textarea-label-${id}`;
   const textAreaId = `textarea-${id}`;
+
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const [inputValue, setInputValue] = useState<string>(props.value || '');
   const [inputDisabled, setInputDisabled] = useState<boolean>(props.disabled ?? false);
@@ -61,7 +63,11 @@ function TextAreaComponent(props: TextAreaProps, ref: React.Ref<TextAreaRef>) {
     setInputValue(props.value || '');
   }, [props.value]);
 
-  useImperativeHandle(ref, () => ({ clearValue, resetValue, setValue, getValue, disable }));
+  function focus() {
+    inputRef?.current?.focus();
+  }
+
+  useImperativeHandle(ref, () => ({ clearValue, resetValue, setValue, getValue, disable, focus }));
 
   return (
     <div className="usa-form-group textarea-container">
@@ -89,6 +95,7 @@ function TextAreaComponent(props: TextAreaProps, ref: React.Ref<TextAreaRef>) {
           disabled={inputDisabled}
           value={inputValue}
           aria-describedby={ariaDescription ? ariaDescribedBy() : undefined}
+          ref={inputRef}
         ></textarea>
       </div>
     </div>

--- a/user-interface/src/lib/components/uswds/modal/OpenModalButton.test.tsx
+++ b/user-interface/src/lib/components/uswds/modal/OpenModalButton.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { OpenModalButton } from './OpenModalButton';
 import React from 'react';
 import { OpenModalButtonRef } from './modal-refs';
+import userEvent from '@testing-library/user-event';
 
 describe('Toggle Modal Button tests', () => {
   const modalId = 'test-modal';
@@ -20,7 +21,7 @@ describe('Toggle Modal Button tests', () => {
   };
   let openButtonRef: React.RefObject<OpenModalButtonRef>;
 
-  beforeEach(() => {
+  const renderWithoutProps = () => {
     openButtonRef = React.createRef<OpenModalButtonRef>();
     render(
       <OpenModalButton
@@ -34,9 +35,10 @@ describe('Toggle Modal Button tests', () => {
       </OpenModalButton>,
     );
     button = document.querySelector('.usa-button');
-  });
+  };
 
   test('calling ref.disable should disable button', async () => {
+    renderWithoutProps();
     expect(button).not.toHaveAttribute('disabled');
 
     openButtonRef?.current?.disableButton(true);
@@ -47,6 +49,7 @@ describe('Toggle Modal Button tests', () => {
   });
 
   test('should focus on button when ref.focus is called', async () => {
+    renderWithoutProps();
     expect(document.activeElement).toBe(document.body);
 
     openButtonRef?.current?.focus();
@@ -57,7 +60,8 @@ describe('Toggle Modal Button tests', () => {
   });
 
   test('should call onClick callback when button is clicked', async () => {
-    fireEvent.click(button!);
+    renderWithoutProps();
+    await userEvent.click(button!);
 
     await waitFor(() => expect(buttonClick).toHaveBeenCalled());
   });

--- a/user-interface/src/lib/testing/testing-utilities.ts
+++ b/user-interface/src/lib/testing/testing-utilities.ts
@@ -111,7 +111,6 @@ function selectRadio(id: string) {
   return radio;
 }
 
-// TODO: either turn this into a toggle or create an unselect function
 async function toggleComboBoxItemSelection(id: string, itemIndex: number = 0, selected = true) {
   const selectedClass = selected ? 'selected' : 'unselected';
   const itemListContainer = document.querySelector(`#${id}-item-list-container`);

--- a/user-interface/src/lib/testing/testing-utilities.ts
+++ b/user-interface/src/lib/testing/testing-utilities.ts
@@ -111,7 +111,9 @@ function selectRadio(id: string) {
   return radio;
 }
 
-async function selectComboBoxItem(id: string, itemIndex: number = 0) {
+// TODO: either turn this into a toggle or create an unselect function
+async function toggleComboBoxItemSelection(id: string, itemIndex: number = 0, selected = true) {
+  const selectedClass = selected ? 'selected' : 'unselected';
   const itemListContainer = document.querySelector(`#${id}-item-list-container`);
   if (!itemListContainer!.classList.contains('expanded')) {
     const expandButton = document.querySelector(`#${id}-expand`);
@@ -128,7 +130,7 @@ async function selectComboBoxItem(id: string, itemIndex: number = 0) {
 
   await userEvent.click(listItem);
   await vi.waitFor(() => {
-    expect(listItem).toHaveClass('selected');
+    expect(listItem).toHaveClass(selectedClass);
   });
 }
 
@@ -141,7 +143,7 @@ export const TestingUtilities = {
   spyOnUseState,
   selectCheckbox,
   selectRadio,
-  selectComboBoxItem,
+  toggleComboBoxItemSelection,
 };
 
 export default TestingUtilities;

--- a/user-interface/src/lib/type-declarations/input-fields.d.ts
+++ b/user-interface/src/lib/type-declarations/input-fields.d.ts
@@ -6,6 +6,7 @@ export interface InputRef {
   clearValue: () => void;
   resetValue: () => void;
   getValue: () => string;
+  focus: () => void;
 }
 
 export interface TextAreaRef {

--- a/user-interface/src/lib/type-declarations/input-fields.d.ts
+++ b/user-interface/src/lib/type-declarations/input-fields.d.ts
@@ -17,7 +17,6 @@ export interface ComboBoxRef {
   clearSelections: () => void;
   disable: (value: boolean) => void;
   focusInput: () => void;
-  focusSingleSelectionPill: () => void;
 }
 
 export interface RadioRef {

--- a/user-interface/src/lib/type-declarations/input-fields.d.ts
+++ b/user-interface/src/lib/type-declarations/input-fields.d.ts
@@ -9,18 +9,12 @@ export interface InputRef {
   focus: () => void;
 }
 
-export interface TextAreaRef {
-  setValue: (value: string) => void;
-  disable: (value: boolean) => void;
-  clearValue: () => void;
-  resetValue: () => void;
-  getValue: () => string;
-}
+export type TextAreaRef = InputRef;
 
 export interface ComboBoxRef {
   setSelections: (options: ComboOption[]) => void;
   getSelections: () => ComboOption[];
-  clearValue: () => void;
+  clearSelections: () => void;
   disable: (value: boolean) => void;
   focusInput: () => void;
   focusSingleSelectionPill: () => void;

--- a/user-interface/src/lib/type-declarations/input-fields.d.ts
+++ b/user-interface/src/lib/type-declarations/input-fields.d.ts
@@ -17,8 +17,8 @@ export interface TextAreaRef {
 }
 
 export interface ComboBoxRef {
-  setValue: (options: ComboOption[]) => void;
-  getValue: () => ComboOption[];
+  setSelections: (options: ComboOption[]) => void;
+  getSelections: () => ComboOption[];
   clearValue: () => void;
   disable: (value: boolean) => void;
   focusInput: () => void;

--- a/user-interface/src/router.test.tsx
+++ b/user-interface/src/router.test.tsx
@@ -19,14 +19,16 @@ describe('App Router Tests', () => {
     );
   });
 
-  test('should route /staff-assignment to CaseAssignment', async () => {
+  test('should route /search to SearchScreen', async () => {
     render(<App />, { wrapper: BrowserRouter });
 
-    await expect(screen.getByTestId('header-search-link')).toBeVisible();
+    expect(screen.getByTestId('header-search-link')).toBeVisible();
 
     await userEvent.click(screen.getByTestId('header-search-link'));
 
-    expect(screen.getByTestId('alert-container-default-state-alert')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.querySelector('main.search-screen')).toBeInTheDocument();
+    });
   });
 
   test('should render My Cases page when an invalid URL is supplied', async () => {

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -1,6 +1,6 @@
 import { MockData } from '@common/cams/test-utilities/mock-data';
 import { SyncedCase } from '@common/cams/cases';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import SearchScreen from '@/search/SearchScreen';
 import { CasesSearchPredicate, DEFAULT_SEARCH_LIMIT } from '@common/api/search';
@@ -9,6 +9,7 @@ import { MockInstance } from 'vitest';
 import { ResponseBody } from '@common/api/response';
 import Api2 from '@/lib/models/api2';
 import userEvent from '@testing-library/user-event';
+import LocalStorage from '@/lib/utils/local-storage';
 
 describe('search screen', () => {
   const caseList = MockData.buildArray(MockData.getSyncedCase, 2);
@@ -36,6 +37,7 @@ describe('search screen', () => {
   beforeEach(async () => {
     vi.stubEnv('CAMS_PA11Y', 'true');
     searchCasesSpy = vi.spyOn(Api2, 'searchCases').mockResolvedValue(searchResponseBody);
+    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession());
   });
 
   afterEach(() => {
@@ -60,12 +62,10 @@ describe('search screen', () => {
     renderWithoutProps();
 
     const searchButton = screen.getByTestId('button-search-submit');
-    let defaultStateAlert = document.querySelector('#default-state-alert');
-    expect(defaultStateAlert).toBeInTheDocument();
-    expect(defaultStateAlert).toBeVisible();
 
-    let table = document.querySelector('.search-results table');
-    expect(table).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.querySelector('.search-results table')).not.toBeInTheDocument();
+    });
     const expandButton = screen.getByTestId('button-case-chapter-search-expand');
 
     // Make first search request...
@@ -75,14 +75,11 @@ describe('search screen', () => {
 
     await waitFor(() => {
       // wait for the default state alert to be removed
-      defaultStateAlert = document.querySelector('#default-state-alert');
-      expect(defaultStateAlert).not.toBeInTheDocument();
+      expect(document.querySelector('#default-state-alert')).not.toBeInTheDocument();
     });
 
     await waitFor(() => {
-      // wait for results to load
-      table = document.querySelector('.search-results table');
-      expect(table).toBeVisible();
+      expect(document.querySelector('.search-results table')).toBeInTheDocument();
     });
 
     const rows = document.querySelectorAll('#search-results-table-body > tr');
@@ -98,11 +95,10 @@ describe('search screen', () => {
     await userEvent.click(searchButton);
 
     await waitFor(() => {
-      // wait for loading to disappear
       expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
-      table = document.querySelector('.search-results table');
-      expect(table).toBeVisible();
     });
+    const table = document.querySelector('.search-results table');
+    expect(table).toBeVisible();
 
     expect(searchCasesSpy).toHaveBeenLastCalledWith(
       expect.objectContaining(divisionSearchPredicate),
@@ -140,14 +136,9 @@ describe('search screen', () => {
     renderWithoutProps();
 
     const searchButton = screen.getByTestId('button-search-submit');
-    const defaultStateAlert = document.querySelector('#default-state-alert');
-    expect(defaultStateAlert).toBeInTheDocument();
-    expect(defaultStateAlert).toBeVisible();
 
-    let table;
     await waitFor(() => {
-      table = document.querySelector('.search-results table');
-      expect(table).not.toBeInTheDocument();
+      expect(document.querySelector('.search-results table')).toBeInTheDocument();
     });
 
     const expandButton = screen.getByTestId('button-court-selections-search-expand');
@@ -172,15 +163,9 @@ describe('search screen', () => {
     await userEvent.click(searchButton);
 
     await waitFor(() => {
-      // wait for loading to appear and default state alert to be removed
-      expect(defaultStateAlert).not.toBeVisible();
-    });
-
-    await waitFor(() => {
       // wait for loading to disappear
       expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
-      table = document.querySelector('.search-results table');
-      expect(table).toBeVisible();
+      expect(document.querySelector('.search-results table')).toBeVisible();
     });
 
     const rows = document.querySelectorAll('#search-results-table-body > tr');
@@ -208,8 +193,7 @@ describe('search screen', () => {
     await waitFor(() => {
       // wait for loading to disappear
       expect(loadingSpinner).not.toBeInTheDocument();
-      table = document.querySelector('.search-results table');
-      expect(table).toBeVisible();
+      expect(document.querySelector('.search-results table')).toBeVisible();
     });
 
     expect(searchCasesSpy).toHaveBeenLastCalledWith(
@@ -236,6 +220,7 @@ describe('search screen', () => {
     const caseNumber = '00-11111';
     const casesSearchPredicate: CasesSearchPredicate = {
       caseNumber,
+      divisionCodes: expect.anything(),
       limit: 25,
       offset: 0,
       excludeChildConsolidations: false,
@@ -243,119 +228,80 @@ describe('search screen', () => {
 
     renderWithoutProps();
 
-    let defaultStateAlert = document.querySelector('#default-state-alert');
-    expect(defaultStateAlert).toBeInTheDocument();
-    expect(defaultStateAlert).toBeVisible();
+    // Clear the default search on initial render.
+    searchCasesSpy.mockClear();
 
     const caseNumberInput = screen.getByTestId('basic-search-field');
     expect(caseNumberInput).toBeInTheDocument();
-    expect(caseNumberInput).toBeEnabled();
-
-    let table = document.querySelector('.search-results table');
-    expect(table).not.toBeInTheDocument();
-
-    fireEvent.change(caseNumberInput, { target: { value: '00-00000' } });
-    const searchButton = screen.getByTestId('button-search-submit');
-    fireEvent.click(searchButton);
 
     await waitFor(() => {
-      // wait for loading to appear and default state alert to be removed
-      defaultStateAlert = document.querySelector('#default-state-alert');
-      expect(defaultStateAlert).not.toBeInTheDocument();
-      expect(document.querySelector('.loading-spinner')).toBeInTheDocument();
+      expect(caseNumberInput).toBeEnabled();
     });
+
+    await userEvent.type(caseNumberInput, caseNumber);
+    const searchButton = screen.getByTestId('button-search-submit');
+    await userEvent.click(searchButton);
 
     await waitFor(() => {
       // wait for loading to disappear
-      expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
-      table = document.querySelector('.search-results table');
-      expect(table).toBeVisible();
+      expect(document.querySelector('.search-results table')).toBeVisible();
     });
 
     const rows = document.querySelectorAll('#search-results-table-body > tr');
     expect(rows).toHaveLength(caseList.length);
 
-    fireEvent.change(caseNumberInput, { target: { value: caseNumber } });
-    fireEvent.click(searchButton);
+    await userEvent.type(caseNumberInput, caseNumber);
+    await userEvent.click(searchButton);
 
     await waitFor(() => {
-      expect(document.querySelector('.loading-spinner')).toBeInTheDocument();
-      table = document.querySelector('.search-results table');
-      expect(table).not.toBeInTheDocument();
+      expect(document.querySelector('.search-results table')).toBeInTheDocument();
     });
 
     expect(searchCasesSpy).toHaveBeenCalledWith(casesSearchPredicate, includeAssignments);
   });
 
   test('should only search for full case number', async () => {
-    const caseNumber = '';
+    const incompleteCaseNumber = '12123';
     renderWithoutProps();
 
-    let defaultStateAlert = document.querySelector('#default-state-alert');
-    expect(defaultStateAlert).toBeInTheDocument();
-    expect(defaultStateAlert).toBeVisible();
+    // Clear the default search on initial render.
+    searchCasesSpy.mockClear();
 
     const caseNumberInput = screen.getByTestId('basic-search-field');
     expect(caseNumberInput).toBeInTheDocument();
-    expect(caseNumberInput).toBeEnabled();
-
-    let table = document.querySelector('.search-results table');
-    expect(table).not.toBeInTheDocument();
-
-    fireEvent.change(caseNumberInput, { target: { value: '00-00000' } });
-    const searchButton = screen.getByTestId('button-search-submit');
-    fireEvent.click(searchButton);
 
     await waitFor(() => {
-      // wait for loading to appear and default state alert to be removed
-      defaultStateAlert = document.querySelector('#default-state-alert');
-      expect(defaultStateAlert).not.toBeInTheDocument();
-      expect(document.querySelector('.loading-spinner')).toBeInTheDocument();
+      expect(caseNumberInput).toBeEnabled();
     });
 
+    await userEvent.type(caseNumberInput, '00-00000');
+    const searchButton = screen.getByTestId('button-search-submit');
+    await userEvent.click(searchButton);
+
     await waitFor(() => {
-      // wait for loading to disappear
-      expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
-      table = document.querySelector('.search-results table');
-      expect(table).toBeVisible();
+      expect(document.querySelector('.search-results table')).toBeVisible();
     });
 
     const rows = document.querySelectorAll('#search-results-table-body > tr');
     expect(rows).toHaveLength(caseList.length);
 
-    fireEvent.change(caseNumberInput, { target: { value: caseNumber } });
-    fireEvent.click(searchButton);
+    await userEvent.type(caseNumberInput, incompleteCaseNumber);
+    const numberOfCallsBefore = searchCasesSpy.mock.calls.length;
+    await userEvent.click(searchButton);
 
-    await waitFor(() => {
-      expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
-      table = document.querySelector('.search-results table');
-      expect(table).not.toBeInTheDocument();
-      expect(screen.getByTestId('alert-message-default-state-alert')).toBeInTheDocument();
-    });
-
-    expect(searchCasesSpy.mock.calls).toHaveLength(1);
+    expect(searchCasesSpy.mock.calls).toHaveLength(numberOfCallsBefore);
   });
 
   test('should show the no results alert when no results are available', async () => {
-    renderWithoutProps();
-
     vi.spyOn(Api2, 'searchCases').mockResolvedValueOnce(emptySearchResponseBody);
-
-    const caseNumberInput = screen.getByTestId('basic-search-field');
+    renderWithoutProps();
 
     let table = document.querySelector('.search-results table');
     expect(table).not.toBeInTheDocument();
 
     let noResultsAlert = document.querySelector('#no-results-alert');
-    expect(noResultsAlert).not.toBeInTheDocument();
-
-    fireEvent.change(caseNumberInput, { target: { value: '00-00000' } });
-    const searchButton = screen.getByTestId('button-search-submit');
-    fireEvent.click(searchButton);
 
     await waitFor(() => {
-      expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
-
       table = document.querySelector('.search-results table');
       expect(table).not.toBeInTheDocument();
 
@@ -364,36 +310,51 @@ describe('search screen', () => {
       expect(noResultsAlert).toBeVisible();
     });
 
-    fireEvent.change(caseNumberInput, { target: { value: '00-11111' } });
-    fireEvent.click(searchButton);
+    const caseNumberInput: HTMLInputElement = screen.getByTestId('basic-search-field');
+    await userEvent.type(caseNumberInput, '00-11111');
+    await waitFor(() => {
+      expect(caseNumberInput['value']).toEqual('00-11111');
+    });
+    const searchButton = screen.getByTestId('button-search-submit');
+    await userEvent.click(searchButton);
 
     await waitFor(() => {
-      expect(document.querySelector('.loading-spinner')).toBeInTheDocument();
-
       noResultsAlert = document.querySelector('#no-results-alert');
       expect(noResultsAlert).not.toBeInTheDocument();
     });
   });
 
   test('should show the error alert when an error is encountered', async () => {
+    const caseNumber = '00-00000';
+    vi.spyOn(Api2, 'searchCases').mockImplementation(
+      (predicate: CasesSearchPredicate, _options?: unknown) => {
+        if (predicate.caseNumber === caseNumber) {
+          return Promise.reject({
+            message: 'some error',
+          });
+        }
+        return Promise.resolve(searchResponseBody);
+      },
+    );
+
     renderWithoutProps();
 
-    vi.spyOn(Api2, 'searchCases')
-      .mockRejectedValueOnce({
-        message: 'some error',
-      })
-      .mockResolvedValue(searchResponseBody);
-
-    const caseNumberInput = screen.getByTestId('basic-search-field');
+    const caseNumberInput: HTMLInputElement = screen.getByTestId('basic-search-field');
     const searchButton = screen.getByTestId('button-search-submit');
     expect(document.querySelector('#search-error-alert')).not.toBeInTheDocument();
 
-    fireEvent.change(caseNumberInput, { target: { value: '00-00000' } });
+    await waitFor(() => {
+      expect(caseNumberInput).toBeEnabled();
+    });
 
-    fireEvent.click(searchButton);
+    await userEvent.type(caseNumberInput, caseNumber);
+    await waitFor(() => {
+      expect(caseNumberInput['value']).toEqual(caseNumber);
+    });
+
+    await userEvent.click(searchButton);
 
     await waitFor(() => {
-      expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
       expect(document.querySelector('.search-results table')).not.toBeInTheDocument();
 
       const searchErrorAlert = document.querySelector('#search-error-alert');
@@ -402,15 +363,18 @@ describe('search screen', () => {
     });
 
     // TODO: We need to make sure the SearchResults.tsx can use the mock api to look this up.
-    fireEvent.change(caseNumberInput, { target: { value: '00-11111' } });
-    fireEvent.click(searchButton);
     await waitFor(() => {
-      expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
+      expect(caseNumberInput).toBeEnabled();
+    });
 
+    await userEvent.clear(caseNumberInput);
+    await userEvent.type(caseNumberInput, '00-11111');
+    await userEvent.click(searchButton);
+    await waitFor(() => {
       const searchErrorAlert = document.querySelector('#search-error-alert');
       expect(searchErrorAlert).not.toBeInTheDocument();
-      expect(document.querySelector('.search-results table')).toBeInTheDocument();
     });
+    expect(document.querySelector('.search-results table')).toBeInTheDocument();
   });
 
   test('should show an error alert if offices cannot be retrieved from API', async () => {
@@ -425,6 +389,37 @@ describe('search screen', () => {
 
     await waitFor(() => {
       expect(globalAlertSpy.error).toHaveBeenCalledWith('Cannot load office list');
+    });
+  });
+
+  test('search button should be disabled until search criteria is entered', async () => {
+    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(
+      MockData.getCamsSession({ user: MockData.getCamsUser({ offices: [] }) }),
+    );
+
+    renderWithoutProps();
+
+    await waitFor(() => {
+      expect(document.querySelector('.pills-and-clear-all')).toBeNull();
+    });
+
+    const searchButton = screen.getByTestId('button-search-submit');
+    expect(searchButton).toBeDisabled();
+  });
+
+  test('should show an alert if the user does not have an assigned office', async () => {
+    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(
+      MockData.getCamsSession({ user: MockData.getCamsUser({ offices: [] }) }),
+    );
+
+    renderWithoutProps();
+
+    await waitFor(() => {
+      expect(document.querySelector('.pills-and-clear-all')).toBeNull();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alert-default-state-alert')).toBeInTheDocument();
     });
   });
 });

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -94,6 +94,8 @@ describe('search screen', () => {
 
     await testingUtilities.selectComboBoxItem('case-chapter-search', 3);
     await userEvent.click(expandButton!);
+
+    expect(document.querySelectorAll('#case-chapter-search-item-list li.selected')).toHaveLength(2);
     await userEvent.click(searchButton);
 
     await waitFor(() => {
@@ -107,17 +109,15 @@ describe('search screen', () => {
       includeAssignments,
     );
 
-    const clearPillButton = document.querySelector('#case-chapter-search .pill-clear-button');
-    expect(clearPillButton).toBeInTheDocument();
+    const clearButton = document.querySelector('#case-chapter-search .clear-all-button');
+    expect(clearButton).toBeInTheDocument();
 
-    const pillBox = document.querySelector('#case-chapter-search-pill-box');
-    expect(pillBox).toBeInTheDocument();
-    expect(pillBox?.children.length).toBeGreaterThan(0);
-
-    await userEvent.click(clearPillButton!);
+    await userEvent.click(clearButton!);
 
     await waitFor(() => {
-      expect(pillBox).not.toBeInTheDocument();
+      expect(
+        document.querySelector('#case-chapter-search-item-list li.selected'),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -230,17 +230,15 @@ describe('search screen', () => {
     );
 
     // clear division selection
-    const clearPillButton = document.querySelector('#court-selections-search .pill-clear-button');
-    expect(clearPillButton).toBeInTheDocument();
+    const clearButton = document.querySelector('#court-selections-search .clear-all-button');
+    expect(clearButton).toBeInTheDocument();
 
-    const pillBox = document.querySelector('#court-selections-search-pill-box');
-    expect(pillBox).toBeInTheDocument();
-    expect(pillBox?.children.length).toBeGreaterThan(0);
-
-    await userEvent.click(clearPillButton!);
+    await userEvent.click(clearButton!);
 
     await waitFor(() => {
-      expect(pillBox).not.toBeInTheDocument();
+      expect(
+        document.querySelector('#case-chapter-search-item-list li.selected'),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -248,8 +246,8 @@ describe('search screen', () => {
     const caseNumber = '00-11111';
     const casesSearchPredicate: CasesSearchPredicate = {
       caseNumber,
-      divisionCodes: expect.anything(),
       limit: 25,
+      divisionCodes: expect.anything(),
       offset: 0,
       excludeChildConsolidations: false,
     };

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -76,7 +76,7 @@ describe('search screen', () => {
     const expandButton = screen.getByTestId('button-case-chapter-search-expand');
 
     // Make first search request...
-    await testingUtilities.selectComboBoxItem('case-chapter-search', 2);
+    await testingUtilities.toggleComboBoxItemSelection('case-chapter-search', 2);
     await userEvent.click(expandButton!);
     await userEvent.click(searchButton);
 
@@ -97,7 +97,7 @@ describe('search screen', () => {
       includeAssignments,
     );
 
-    await testingUtilities.selectComboBoxItem('case-chapter-search', 3);
+    await testingUtilities.toggleComboBoxItemSelection('case-chapter-search', 3);
     await userEvent.click(expandButton!);
 
     expect(document.querySelectorAll('#case-chapter-search-item-list li.selected')).toHaveLength(2);
@@ -177,7 +177,7 @@ describe('search screen', () => {
 
     // Make first search request....
     let itemToSelect = userDivisions.length + 1;
-    await testingUtilities.selectComboBoxItem('court-selections-search', itemToSelect);
+    await testingUtilities.toggleComboBoxItemSelection('court-selections-search', itemToSelect);
 
     await userEvent.click(expandButton);
 
@@ -213,7 +213,7 @@ describe('search screen', () => {
 
     // Make second search request...
     await userEvent.click(expandButton);
-    await testingUtilities.selectComboBoxItem('court-selections-search', ++itemToSelect);
+    await testingUtilities.toggleComboBoxItemSelection('court-selections-search', ++itemToSelect);
 
     await userEvent.click(expandButton);
 

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -8,7 +8,7 @@ import {
 import CaseNumberInput from '@/lib/components/CaseNumberInput';
 import { useApi2 } from '@/lib/hooks/UseApi2';
 import { ComboBoxRef, InputRef } from '@/lib/type-declarations/input-fields';
-import { courtSorter, getOfficeList } from '@/data-verification/dataVerificationHelper';
+import { courtSorter, getDivisionComboOptions } from '@/data-verification/dataVerificationHelper';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import SearchResults, { isValidSearchPredicate } from '@/search-results/SearchResults';
 import { SearchResultsHeader } from './SearchResultsHeader';
@@ -71,8 +71,8 @@ export default function SearchScreen() {
       .getCourts()
       .then((response) => {
         const newOfficesList = response.data.sort(courtSorter);
-        const officeComboOptions = getOfficeList(newOfficesList);
-        const filteredDivisionCodes = getOfficeList(
+        const officeComboOptions = getDivisionComboOptions(newOfficesList);
+        const filteredDivisionCodes = getDivisionComboOptions(
           newOfficesList.filter((office) =>
             defaultDivisionCodes?.includes(office.courtDivisionCode),
           ),
@@ -235,7 +235,8 @@ export default function SearchScreen() {
                   required={false}
                   multiSelect={true}
                   ref={chapterSelectionRef}
-                  pluralLabel={'chapters'}
+                  singularLabel="chapter"
+                  pluralLabel="chapters"
                 />
               </div>
             </div>

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -79,6 +79,9 @@ export default function SearchScreen() {
         );
         if (filteredDivisionCodes.length) {
           filteredDivisionCodes[filteredDivisionCodes.length - 1].divider = true;
+          filteredDivisionCodes.forEach((option: ComboOption) => {
+            option.isAriaDefault = true;
+          });
         }
         const filteredOfficeComboOptions = officeComboOptions.filter((officeComboOption) => {
           return !defaultDivisionCodes?.includes(officeComboOption.value);
@@ -144,6 +147,7 @@ export default function SearchScreen() {
   function handleChapterSelection(selections: ComboOption[]) {
     let performSearch = false;
 
+    // TODO:   Why in none of the tests is temporarySearchPredicate.chapters ever set?
     if (
       temporarySearchPredicate.chapters &&
       temporarySearchPredicate.chapters.length == selections.length
@@ -235,7 +239,6 @@ export default function SearchScreen() {
                   ariaDescription="multi-select"
                   aria-live="off"
                   onClose={handleCourtSelection}
-                  onPillSelection={handleCourtSelection}
                   onUpdateSelection={handleCourtSelection}
                   onFocus={handleFilterFormElementFocus}
                   options={officesList}
@@ -243,7 +246,8 @@ export default function SearchScreen() {
                   multiSelect={true}
                   wrapPills={true}
                   ref={courtSelectionRef}
-                  pluralLabel={'divisions'}
+                  singularLabel="division"
+                  pluralLabel="divisions"
                   overflowStrategy="ellipsis"
                 />
               </div>
@@ -258,7 +262,6 @@ export default function SearchScreen() {
                   ariaDescription="multi-select"
                   aria-live="off"
                   onClose={handleChapterSelection}
-                  onPillSelection={handleChapterSelection}
                   onUpdateSelection={handleChapterClear}
                   onFocus={handleFilterFormElementFocus}
                   options={chapterList}

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -77,10 +77,12 @@ export default function SearchScreen() {
             defaultDivisionCodes?.includes(office.courtDivisionCode),
           ),
         );
-        filteredDivisionCodes[filteredDivisionCodes.length - 1].divider = true;
-        const filteredOfficeComboOptions = officeComboOptions.filter(
-          (officeComboOption) => !filteredDivisionCodes.includes(officeComboOption),
-        );
+        if (filteredDivisionCodes.length) {
+          filteredDivisionCodes[filteredDivisionCodes.length - 1].divider = true;
+        }
+        const filteredOfficeComboOptions = officeComboOptions.filter((officeComboOption) => {
+          return !defaultDivisionCodes?.includes(officeComboOption.value);
+        });
         const finalOfficeComboOptions = [...filteredDivisionCodes, ...filteredOfficeComboOptions];
         setOfficesList(finalOfficeComboOptions);
         courtSelectionRef.current?.setSelections(filteredDivisionCodes);
@@ -241,7 +243,8 @@ export default function SearchScreen() {
                   multiSelect={true}
                   wrapPills={true}
                   ref={courtSelectionRef}
-                  selectedLabel={'division'}
+                  pluralLabel={'divisions'}
+                  overflowStrategy="ellipsis"
                 />
               </div>
             </div>
@@ -262,7 +265,7 @@ export default function SearchScreen() {
                   required={false}
                   multiSelect={true}
                   ref={chapterSelectionRef}
-                  selectedLabel={'chapter'}
+                  pluralLabel={'chapters'}
                 />
               </div>
             </div>

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -136,46 +136,15 @@ export default function SearchScreen() {
     setTemporarySearchPredicate(newPredicate);
   }
 
-  function handleChapterClear(options: ComboOption[]) {
-    if (options.length === 0 && temporarySearchPredicate.chapters) {
-      const newPredicate = { ...temporarySearchPredicate };
-      delete newPredicate.chapters;
-      setTemporarySearchPredicate(newPredicate);
-    }
-  }
-
   function handleChapterSelection(selections: ComboOption[]) {
-    let performSearch = false;
-
-    // TODO:   Why in none of the tests is temporarySearchPredicate.chapters ever set?
-    if (
-      temporarySearchPredicate.chapters &&
-      temporarySearchPredicate.chapters.length == selections.length
-    ) {
-      selections.forEach((chapter) => {
-        if (
-          temporarySearchPredicate.chapters &&
-          !temporarySearchPredicate.chapters.includes(chapter.value)
-        ) {
-          performSearch = true;
-        }
-      });
-    } else {
-      performSearch = true;
+    const newPredicate = {
+      ...temporarySearchPredicate,
+    };
+    delete newPredicate.chapters;
+    if (selections.length) {
+      newPredicate.chapters = selections.map((option: ComboOption) => option.value);
     }
-
-    if (performSearch) {
-      const newPredicate = {
-        ...temporarySearchPredicate,
-      };
-      delete newPredicate.chapters;
-
-      if (selections.length) {
-        newPredicate.chapters = selections.map((option: ComboOption) => option.value);
-      }
-
-      setTemporarySearchPredicate(newPredicate);
-    }
+    setTemporarySearchPredicate(newPredicate);
   }
 
   function performSearch() {
@@ -238,7 +207,6 @@ export default function SearchScreen() {
                   ariaLabelPrefix="District (Division)"
                   ariaDescription="multi-select"
                   aria-live="off"
-                  onClose={handleCourtSelection}
                   onUpdateSelection={handleCourtSelection}
                   onFocus={handleFilterFormElementFocus}
                   options={officesList}
@@ -261,8 +229,7 @@ export default function SearchScreen() {
                   ariaLabelPrefix="Chapter"
                   ariaDescription="multi-select"
                   aria-live="off"
-                  onClose={handleChapterSelection}
-                  onUpdateSelection={handleChapterClear}
+                  onUpdateSelection={handleChapterSelection}
                   onFocus={handleFilterFormElementFocus}
                   options={chapterList}
                   required={false}

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
@@ -32,8 +32,8 @@ describe('staff assignment filter use case tests', () => {
   };
   const comboBoxRef = {
     current: {
-      setValue: (_options: ComboOption[]) => {},
-      getValue: () => [
+      setSelections: (_options: ComboOption[]) => {},
+      getSelections: () => [
         {
           value: '',
           label: '',
@@ -41,7 +41,7 @@ describe('staff assignment filter use case tests', () => {
           hidden: false,
         },
       ],
-      clearValue: () => {},
+      clearSelections: () => {},
       disable: (_value: boolean) => {},
       focusInput: () => {},
       focusSingleSelectionPill: () => {},

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
@@ -44,7 +44,6 @@ describe('staff assignment filter use case tests', () => {
       clearSelections: () => {},
       disable: (_value: boolean) => {},
       focusInput: () => {},
-      focusSingleSelectionPill: () => {},
     },
   };
   const mockControls: StaffAssignmentFilterControls = {

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.ts
@@ -43,7 +43,7 @@ const staffAssignmentFilterUseCase = (
   };
 
   const focusOnAssigneesFilter = () => {
-    controls.assigneesFilterRef.current?.focusSingleSelectionPill();
+    controls.assigneesFilterRef.current?.focusInput();
   };
 
   const getOfficeAssignees = async (


### PR DESCRIPTION
# Purpose

Implement simple changes to ComboBox rather than reimplementing the entire thing.  Complete 525 such that the users default divisions show up at the top of the combo box list by default and user can then change their selections if need be.

# Major Changes

Major changes to ComboBox (though not as drastic as our first attempts).

# Testing/Validation

Tests have all been updated.

# Notes

A lot of updates were made to combo box.  look 'em over.

# Definition of Done:

- [ ] Code refactored for clarity - Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed - More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated - UX and code aligns to the team’s latest understanding of the domain

## Summary by Sourcery

Refactor the ComboBox component to simplify its implementation and improve user experience, focusing on default division selection and accessibility

New Features:
- Implement default division selection at the top of the ComboBox list
- Add more descriptive aria labels for ComboBox items
- Improve selection and filtering behavior

Enhancements:
- Simplified ComboBox state management
- Improved keyboard navigation
- Enhanced selection and clear functionality
- More consistent focus management

Tests:
- Updated test cases to reflect new ComboBox behavior
- Added comprehensive aria label test cases
- Improved test coverage for keyboard interactions