### PR TITLE
No longer identify config files as source

### DIFF
--- a/ops/git-setup/pre-commit-hook-content
+++ b/ops/git-setup/pre-commit-hook-content
@@ -36,7 +36,7 @@ test_files_changed=false
 
 for file in $staged_files; do
     # Check if file is a source code file (ts, tsx, js, jsx)
-    if [[ $file =~ \.(ts|tsx|js|jsx)$ && ! $file =~ \.test\.(ts|tsx|js|jsx)$ && ! $file =~ \.d\.ts$ ]]; then
+    if [[ $file =~ \.(ts|tsx|js|jsx)$ && ! $file =~ \.test\.(ts|tsx|js|jsx)$ && ! $file =~ \.d\.ts$ && ! $file =~ \.config\.ts$ ]]; then
         source_files_changed=true
     # Check if file is a test file
     elif [[ $file =~ \.test\.(ts|tsx|js|jsx)$ ]]; then


### PR DESCRIPTION
# Purpose

Config files with a `.ts` file type are being identified as source for the purposes of checking whether tests should be changing.

# Major Changes

Add config file naming convention to the ignore list for identifying source files.

# Testing/Validation

Tested locally that changes to only `playwright.config.ts` do not trigger the prompt about untested changes.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhancements:
- Improve source file identification logic to ignore configuration files