### PR TITLE
CAMS-525 run e2e

### DIFF
--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -187,7 +187,7 @@ jobs:
   swap-nodeapi-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       apiFunctionName: ${{ inputs.apiFunctionName }}
@@ -211,7 +211,7 @@ jobs:
   swap-dataflows-app-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       slotName: ${{ inputs.slotName }}

--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -160,10 +160,25 @@ jobs:
       slotName: ${{ inputs.slotName }}
     secrets: inherit # pragma: allowlist secret
 
+  execute-e2e-test:
+    needs:
+      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
+    uses: ./.github/workflows/reusable-e2e.yml
+    with:
+      apiFunctionName: ${{ inputs.apiFunctionName }}
+      slotName: ${{ inputs.slotName }}
+      webappName: ${{ inputs.webappName }}
+      stackName: ${{ inputs.stackName }}
+      azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
+      ghaEnvironment: ${{ inputs.ghaEnvironment }}
+      branchHashId: ${{ inputs.environmentHash }}
+      e2eCosmosDbExists: ${{ inputs.e2eCosmosDbExists }}
+    secrets: inherit # pragma: allowlist secret
+
   swap-webapp-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       webappName: ${{ inputs.webappName }}


### PR DESCRIPTION
# Purpose

We want to run e2e tests.

# Major Changes

Reenable e2e tests.

# Testing/Validation

We will need to ensure the tests pass after merge to main.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Modify deployment workflow to include end-to-end (e2e) testing as part of the deployment process

CI:
- Add a new job to execute e2e tests in the deployment workflow
- Update deployment slot swap jobs to depend on e2e test execution