### PR TITLE
CAMS-525 Enable filtering of closed cases

### DIFF
--- a/user-interface/src/search-results/SearchResults.tsx
+++ b/user-interface/src/search-results/SearchResults.tsx
@@ -18,7 +18,7 @@ export function isValidSearchPredicate(searchPredicate: CasesSearchPredicate): b
     return false;
   }
   return Object.keys(searchPredicate).reduce((isIt, key) => {
-    if (['limit', 'offset'].includes(key)) {
+    if (['limit', 'offset', 'excludeClosedCases'].includes(key)) {
       return isIt;
     }
     return isIt || !!searchPredicate[key as keyof CasesSearchPredicate];

--- a/user-interface/src/search-results/SearchResults.tsx
+++ b/user-interface/src/search-results/SearchResults.tsx
@@ -18,7 +18,7 @@ export function isValidSearchPredicate(searchPredicate: CasesSearchPredicate): b
     return false;
   }
   return Object.keys(searchPredicate).reduce((isIt, key) => {
-    if (['limit', 'offset', 'excludeClosedCases'].includes(key)) {
+    if (['limit', 'offset'].includes(key)) {
       return isIt;
     }
     return isIt || !!searchPredicate[key as keyof CasesSearchPredicate];

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -451,4 +451,67 @@ describe('search screen', () => {
       expect(screen.getByTestId('alert-default-state-alert')).toBeInTheDocument();
     });
   });
+
+  test.skip('should update search predicate when Include Closed Cases checkbox is toggled', async () => {
+    renderWithoutProps();
+
+    // Clear the default search on initial render
+    searchCasesSpy.mockClear();
+
+    // Get the checkbox, checkbox label, and search button
+    const includeClosedCheckbox = screen.getByTestId('checkbox-include-closed');
+    const includeClosedCheckboxLabel = screen.getByLabelText('Include Closed Cases');
+    const searchButton = screen.getByTestId('button-search-submit');
+
+    // Verify initial state (checkbox is unchecked by default, excludeClosedCases is true)
+    expect(includeClosedCheckbox).not.toBeChecked();
+
+    // Click the checkbox label to include closed cases
+    await userEvent.click(includeClosedCheckboxLabel);
+
+    // Click search button to perform search
+    await userEvent.click(searchButton);
+
+    // Wait for search to complete
+    await waitFor(() => {
+      expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
+    });
+
+    // Now check if the checkbox is checked
+    const updatedCheckbox = screen.getByTestId('checkbox-include-closed');
+    await waitFor(() => {
+      expect(updatedCheckbox).toBeChecked();
+    });
+
+    // Verify that search was called with excludeClosedCases set to false
+    expect(searchCasesSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        excludeClosedCases: false,
+      }),
+      includeAssignments,
+    );
+
+    // Click the checkbox label again to exclude closed cases
+    await userEvent.click(includeClosedCheckboxLabel);
+
+    // Click search button to perform search
+    await userEvent.click(searchButton);
+
+    // Wait for search to complete
+    await waitFor(() => {
+      expect(document.querySelector('.loading-spinner')).not.toBeInTheDocument();
+    });
+
+    // Now check if the checkbox is unchecked
+    const updatedCheckbox2 = screen.getByTestId('checkbox-include-closed');
+    expect(updatedCheckbox2).not.toBeChecked();
+
+    // Verify that search was called with excludeClosedCases set to true
+    expect(searchCasesSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        excludeClosedCases: true,
+      }),
+      includeAssignments,
+    );
+  });
 });

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -163,6 +163,7 @@ describe('search screen', () => {
     renderWithoutProps();
 
     const searchButton = screen.getByTestId('button-search-submit');
+    await userEvent.click(searchButton);
 
     await waitFor(() => {
       expect(document.querySelector('.search-results table')).toBeInTheDocument();
@@ -336,6 +337,9 @@ describe('search screen', () => {
     let table = document.querySelector('.search-results table');
     expect(table).not.toBeInTheDocument();
 
+    let searchButton = screen.getByTestId('button-search-submit');
+    await userEvent.click(searchButton);
+
     let noResultsAlert = document.querySelector('#no-results-alert');
 
     await waitFor(() => {
@@ -352,7 +356,7 @@ describe('search screen', () => {
     await waitFor(() => {
       expect(caseNumberInput['value']).toEqual('00-11111');
     });
-    const searchButton = screen.getByTestId('button-search-submit');
+    searchButton = screen.getByTestId('button-search-submit');
     await userEvent.click(searchButton);
 
     await waitFor(() => {
@@ -459,15 +463,16 @@ describe('search screen', () => {
     searchCasesSpy.mockClear();
 
     // Get the checkbox, checkbox label, and search button
-    const includeClosedCheckbox = screen.getByTestId('checkbox-include-closed');
-    const includeClosedCheckboxLabel = screen.getByLabelText('Include Closed Cases');
+    const checkbox = screen.getByTestId('checkbox-include-closed');
+    const checkboxLabel = screen.getByLabelText('Include Closed Cases');
     const searchButton = screen.getByTestId('button-search-submit');
 
     // Verify initial state (checkbox is unchecked by default, excludeClosedCases is true)
-    expect(includeClosedCheckbox).not.toBeChecked();
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
 
     // Click the checkbox label to include closed cases
-    await userEvent.click(includeClosedCheckboxLabel);
+    await userEvent.click(checkboxLabel);
 
     // Click search button to perform search
     await userEvent.click(searchButton);
@@ -479,6 +484,7 @@ describe('search screen', () => {
 
     // Now check if the checkbox is checked
     const updatedCheckbox = screen.getByTestId('checkbox-include-closed');
+    expect(updatedCheckbox).toBeInTheDocument();
     await waitFor(() => {
       expect(updatedCheckbox).toBeChecked();
     });
@@ -492,7 +498,7 @@ describe('search screen', () => {
     );
 
     // Click the checkbox label again to exclude closed cases
-    await userEvent.click(includeClosedCheckboxLabel);
+    await userEvent.click(checkboxLabel);
 
     // Click search button to perform search
     await userEvent.click(searchButton);

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -451,10 +451,6 @@ describe('search screen', () => {
     renderWithoutProps();
 
     await waitFor(() => {
-      expect(document.querySelector('.pills-and-clear-all')).toBeNull();
-    });
-
-    await waitFor(() => {
       expect(screen.getByTestId('alert-default-state-alert')).toBeInTheDocument();
     });
   });

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -260,6 +260,7 @@ describe('search screen', () => {
       divisionCodes: expect.anything(),
       offset: 0,
       excludeChildConsolidations: false,
+      excludeClosedCases: true,
     };
 
     renderWithoutProps();
@@ -434,10 +435,6 @@ describe('search screen', () => {
     );
 
     renderWithoutProps();
-
-    await waitFor(() => {
-      expect(document.querySelector('.pills-and-clear-all')).toBeNull();
-    });
 
     const searchButton = screen.getByTestId('button-search-submit');
     expect(searchButton).toBeDisabled();

--- a/user-interface/src/search/SearchScreen.test.tsx
+++ b/user-interface/src/search/SearchScreen.test.tsx
@@ -456,25 +456,19 @@ describe('search screen', () => {
     });
   });
 
-  test.skip('should update search predicate when Include Closed Cases checkbox is toggled', async () => {
+  test('should update search predicate when Include Closed Cases checkbox is toggled', async () => {
     renderWithoutProps();
+    const caseNumberInput = screen.getByTestId('basic-search-field');
+    await userEvent.type(caseNumberInput, '1100000');
 
-    // Clear the default search on initial render
-    searchCasesSpy.mockClear();
-
-    // Get the checkbox, checkbox label, and search button
-    const checkbox = screen.getByTestId('checkbox-include-closed');
-    const checkboxLabel = screen.getByLabelText('Include Closed Cases');
-    const searchButton = screen.getByTestId('button-search-submit');
-
-    // Verify initial state (checkbox is unchecked by default, excludeClosedCases is true)
-    expect(checkbox).toBeInTheDocument();
-    expect(checkbox).not.toBeChecked();
+    const initialCheckbox = screen.getByTestId('checkbox-include-closed');
+    expect(initialCheckbox).not.toBeChecked();
 
     // Click the checkbox label to include closed cases
-    await userEvent.click(checkboxLabel);
+    await userEvent.click(document.querySelector('#checkbox-include-closed-click-target')!);
 
     // Click search button to perform search
+    const searchButton = screen.getByTestId('button-search-submit');
     await userEvent.click(searchButton);
 
     // Wait for search to complete
@@ -483,11 +477,8 @@ describe('search screen', () => {
     });
 
     // Now check if the checkbox is checked
-    const updatedCheckbox = screen.getByTestId('checkbox-include-closed');
-    expect(updatedCheckbox).toBeInTheDocument();
-    await waitFor(() => {
-      expect(updatedCheckbox).toBeChecked();
-    });
+    const checkedCheckbox = screen.getByTestId('checkbox-include-closed');
+    expect(checkedCheckbox).toBeChecked();
 
     // Verify that search was called with excludeClosedCases set to false
     expect(searchCasesSpy).toHaveBeenLastCalledWith(
@@ -498,7 +489,7 @@ describe('search screen', () => {
     );
 
     // Click the checkbox label again to exclude closed cases
-    await userEvent.click(checkboxLabel);
+    await userEvent.click(document.querySelector('#checkbox-include-closed-click-target')!);
 
     // Click search button to perform search
     await userEvent.click(searchButton);
@@ -509,8 +500,8 @@ describe('search screen', () => {
     });
 
     // Now check if the checkbox is unchecked
-    const updatedCheckbox2 = screen.getByTestId('checkbox-include-closed');
-    expect(updatedCheckbox2).not.toBeChecked();
+    const uncheckedCheckbox = screen.getByTestId('checkbox-include-closed');
+    expect(uncheckedCheckbox).not.toBeChecked();
 
     // Verify that search was called with excludeClosedCases set to true
     expect(searchCasesSpy).toHaveBeenLastCalledWith(

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -1,5 +1,5 @@
 import './SearchScreen.scss';
-import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import {
   CasesSearchPredicate,
   DEFAULT_SEARCH_LIMIT,
@@ -49,8 +49,7 @@ export default function SearchScreen() {
   };
   const [temporarySearchPredicate, setTemporarySearchPredicate] =
     useState<CasesSearchPredicate>(defaultSearchPredicate);
-  const [searchPredicate, setSearchPredicate] =
-    useState<CasesSearchPredicate>(defaultSearchPredicate);
+  const [searchPredicate, setSearchPredicate] = useState<CasesSearchPredicate>({});
 
   const infoModalRef = useRef(null);
   const infoModalId = 'info-modal';
@@ -77,7 +76,7 @@ export default function SearchScreen() {
     setChapterList(chapterArray);
   }
 
-  async function getCourts() {
+  function getCourts() {
     api
       .getCourts()
       .then((response) => {
@@ -159,9 +158,11 @@ export default function SearchScreen() {
   }
 
   function handleIncludeClosedCheckbox(ev: ChangeEvent<HTMLInputElement>) {
-    setTemporarySearchPredicate({
-      ...temporarySearchPredicate,
-      excludeClosedCases: !ev.target.checked,
+    setTemporarySearchPredicate((previous) => {
+      return {
+        ...previous,
+        excludeClosedCases: !ev.target.checked,
+      };
     });
   }
 
@@ -264,7 +265,7 @@ export default function SearchScreen() {
                   id="include-closed"
                   name="includeClosedCases"
                   value="true"
-                  checked={!searchPredicate.excludeClosedCases}
+                  checked={!temporarySearchPredicate.excludeClosedCases}
                   label="Include Closed Cases"
                   onChange={handleIncludeClosedCheckbox}
                 />

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -258,11 +258,12 @@ export default function SearchScreen() {
                 />
               </div>
             </div>
-            <div className="case-include-closed form-field" data-testid="case-include-closed">
+            <div className="case-include-closed form-field">
               <div className="usa-search usa-search--small">
                 <Checkbox
-                  id="include-closed-checkbox"
-                  value="includeClosedCases"
+                  id="include-closed"
+                  name="includeClosedCases"
+                  value="true"
                   checked={!searchPredicate.excludeClosedCases}
                   label="Include Closed Cases"
                   onChange={handleIncludeClosedCheckbox}

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -1,5 +1,5 @@
 import './SearchScreen.scss';
-import { useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import {
   CasesSearchPredicate,
   DEFAULT_SEARCH_LIMIT,
@@ -23,6 +23,7 @@ import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 import { getCourtDivisionCodes } from '@common/cams/users';
 import LocalStorage from '@/lib/utils/local-storage';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import Checkbox from '@/lib/components/uswds/Checkbox';
 
 export default function SearchScreen() {
   const session = LocalStorage.getSession();
@@ -38,6 +39,7 @@ export default function SearchScreen() {
     limit: DEFAULT_SEARCH_LIMIT,
     offset: DEFAULT_SEARCH_OFFSET,
     excludeChildConsolidations: false,
+    excludeClosedCases: true,
     divisionCodes: defaultDivisionCodes,
   });
 
@@ -147,6 +149,13 @@ export default function SearchScreen() {
     setTemporarySearchPredicate(newPredicate);
   }
 
+  function handleExcludeClosedCheckbox(ev: ChangeEvent<HTMLInputElement>) {
+    setTemporarySearchPredicate({
+      ...temporarySearchPredicate,
+      excludeClosedCases: ev.target.checked,
+    });
+  }
+
   function performSearch() {
     setSearchPredicate(temporarySearchPredicate);
   }
@@ -237,6 +246,17 @@ export default function SearchScreen() {
                   ref={chapterSelectionRef}
                   singularLabel="chapter"
                   pluralLabel="chapters"
+                />
+              </div>
+            </div>
+            <div className="case-exclude-closed form-field" data-testid="case-exclude-closed">
+              <div className="usa-search usa-search--small">
+                <Checkbox
+                  id="exclude-closed-checkbox"
+                  value="excludeClosedCases"
+                  checked={true}
+                  label="Exclude Closed Cases"
+                  onChange={handleExcludeClosedCheckbox}
                 />
               </div>
             </div>


### PR DESCRIPTION
# Purpose

Enable the user to filter closed cases from case search.

# Major Changes

* Added checkbox to search filters to include / exclude closed cases.
* Removed automatic initial search behavior

# Testing/Validation

* Manual testing
* Unit test coverage 100%

## Summary by Sourcery

Add functionality to filter closed cases in case search with a new checkbox option

New Features:
- Added checkbox to include or exclude closed cases in case search

Enhancements:
- Removed automatic initial search behavior
- Updated search validation logic to support new filtering option

Tests:
- Added comprehensive test coverage for new include closed cases functionality