### PR TITLE
CAMS-525: Remove e2e tests again

### DIFF
--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -160,25 +160,10 @@ jobs:
       slotName: ${{ inputs.slotName }}
     secrets: inherit # pragma: allowlist secret
 
-  execute-e2e-test:
-    needs:
-      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
-    uses: ./.github/workflows/reusable-e2e.yml
-    with:
-      apiFunctionName: ${{ inputs.apiFunctionName }}
-      slotName: ${{ inputs.slotName }}
-      webappName: ${{ inputs.webappName }}
-      stackName: ${{ inputs.stackName }}
-      azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
-      ghaEnvironment: ${{ inputs.ghaEnvironment }}
-      branchHashId: ${{ inputs.environmentHash }}
-      e2eCosmosDbExists: ${{ inputs.e2eCosmosDbExists }}
-    secrets: inherit # pragma: allowlist secret
-
   swap-webapp-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       webappName: ${{ inputs.webappName }}
@@ -202,7 +187,7 @@ jobs:
   swap-nodeapi-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       apiFunctionName: ${{ inputs.apiFunctionName }}
@@ -226,7 +211,7 @@ jobs:
   swap-dataflows-app-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       slotName: ${{ inputs.slotName }}


### PR DESCRIPTION
# Purpose

The e2e tests are not working well with Okta integration.

# Major Changes

Remove e2e tests for now.

# Notes

We will be working on remediating the problems with Okta integration tomorrow which should fix the e2e tests.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove e2e tests from the deployment workflow due to issues with Okta integration

CI:
- Removed 'execute-e2e-test' job from deployment workflow
- Updated job dependencies to remove e2e test execution requirements

Chores:
- Removed e2e test execution step from deployment workflow