### PR TITLE
CAMS-389: dual configuration

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -103,7 +103,6 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     with:
       nodeVersion: ${{ vars.NODE_VERSION }}
-      camsServerHostname: ${{ needs.setup.outputs.apiFunctionName }}.azurewebsites.us
       camsServerPort: ${{ vars.CAMS_SERVER_PORT }}
       camsServerProtocol: ${{ vars.CAMS_SERVER_PROTOCOL }}
       camsBasePath: ${{ vars.CAMS_BASE_PATH }}

--- a/.github/workflows/reusable-build-frontend.yml
+++ b/.github/workflows/reusable-build-frontend.yml
@@ -88,8 +88,6 @@ jobs:
 
       - name: Generate Staging Slot Configuration
         run: |
-          npm ci
-          echo "TODO: modify these values and remove the ones we don't need?"
           export CAMS_SERVER_HOSTNAME=${{ inputs.camsStagingHostname }}
           export CAMS_SERVER_PORT=${{ inputs.camsServerPort }}
           export CAMS_SERVER_PROTOCOL=${{ inputs.camsServerProtocol }}

--- a/.github/workflows/reusable-build-frontend.yml
+++ b/.github/workflows/reusable-build-frontend.yml
@@ -12,6 +12,9 @@ on:
       camsServerHostname:
         required: true
         type: string
+      camsStagingHostname:
+        required: true
+        type: string
       camsServerPort:
         required: true
         type: string
@@ -82,6 +85,22 @@ jobs:
           export CAMS_LOGIN_PROVIDER_CONFIG='${{ vars.CAMS_LOGIN_PROVIDER_CONFIG }}'
           export CAMS_INFO_SHA=${{ github.sha }}
           npm run build --if-present
+
+      - name: Generate Staging Slot Configuration
+        run: |
+          npm ci
+          echo "TODO: modify these values and remove the ones we don't need?"
+          export CAMS_SERVER_HOSTNAME=${{ inputs.camsStagingHostname }}
+          export CAMS_SERVER_PORT=${{ inputs.camsServerPort }}
+          export CAMS_SERVER_PROTOCOL=${{ inputs.camsServerProtocol }}
+          export CAMS_BASE_PATH=${{ inputs.camsBasePath }}
+          export CAMS_APPLICATIONINSIGHTS_CONNECTION_STRING="${appiString}"
+          export CAMS_FEATURE_FLAG_CLIENT_ID="${{ secrets.LD_DEVELOPMENT_CLIENT_ID }}"
+          export CAMS_LAUNCH_DARKLY_ENV="${{ inputs.launchDarklyEnvironment }}"
+          export CAMS_LOGIN_PROVIDER=${{ vars.CAMS_LOGIN_PROVIDER }}
+          export CAMS_LOGIN_PROVIDER_CONFIG='${{ vars.CAMS_LOGIN_PROVIDER_CONFIG }}'
+          export CAMS_INFO_SHA=${{ github.sha }}
+          npm run stagingConfig
 
       - name: Package
         if: inputs.isDeployment

--- a/.github/workflows/reusable-build-frontend.yml
+++ b/.github/workflows/reusable-build-frontend.yml
@@ -101,6 +101,7 @@ jobs:
           export CAMS_LOGIN_PROVIDER_CONFIG='${{ vars.CAMS_LOGIN_PROVIDER_CONFIG }}'
           export CAMS_INFO_SHA=${{ github.sha }}
           npm run stagingConfig
+          mv ./public/configuration-staging.json ./build/
 
       - name: Package
         if: inputs.isDeployment

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           echo "Running Playwright Tests..."
           mkdir -p playwright/.auth
-          OKTA_USER_NAME=${{secrets.OKTA_USER_NAME_USTP}} OKTA_PASSWORD=${{secrets.OKTA_PASSWORD_USTP}} TARGET_HOST=https://${{ inputs.webappName }}.azurewebsites.us CAMS_LOGIN_PROVIDER=${{ vars.CAMS_LOGIN_PROVIDER }} npx playwright test --reporter=list,html
+          OKTA_USER_NAME=${{secrets.OKTA_USER_NAME_USTP}} OKTA_PASSWORD=${{secrets.OKTA_PASSWORD_USTP}} TARGET_HOST=https://${{ inputs.webappName }}-${{ inputs.slotName }}.azurewebsites.us CAMS_LOGIN_PROVIDER=${{ vars.CAMS_LOGIN_PROVIDER }} npx playwright test --reporter=list,html
 
       - name: Upload report
         uses: actions/upload-artifact@v4.4.0

--- a/.github/workflows/sub-build.yml
+++ b/.github/workflows/sub-build.yml
@@ -41,7 +41,7 @@ jobs:
     with:
       nodeVersion: ${{ vars.NODE_VERSION }}
       camsServerHostname: ${{ inputs.apiFunctionName }}.azurewebsites.us
-      camsStagingHostname: ${{ inputs.apiFunctionName }}-staging.azurewebsites.us
+      camsStagingHostname: ${{ inputs.apiFunctionName }}-${{ vars.SLOT_NAME }}.azurewebsites.us
       camsServerPort: ${{ vars.CAMS_SERVER_PORT }}
       camsServerProtocol: ${{ vars.CAMS_SERVER_PROTOCOL }}
       camsBasePath: ${{ vars.CAMS_BASE_PATH }}

--- a/.github/workflows/sub-build.yml
+++ b/.github/workflows/sub-build.yml
@@ -12,9 +12,6 @@ on:
       dataflowsFunctionName:
         required: true
         type: string
-      camsServerHostname:
-        required: true
-        type: string
       camsServerPort:
         required: true
         type: string
@@ -44,6 +41,7 @@ jobs:
     with:
       nodeVersion: ${{ vars.NODE_VERSION }}
       camsServerHostname: ${{ inputs.apiFunctionName }}.azurewebsites.us
+      camsStagingHostname: ${{ inputs.apiFunctionName }}-staging.azurewebsites.us
       camsServerPort: ${{ vars.CAMS_SERVER_PORT }}
       camsServerProtocol: ${{ vars.CAMS_SERVER_PROTOCOL }}
       camsBasePath: ${{ vars.CAMS_BASE_PATH }}

--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -160,10 +160,25 @@ jobs:
       slotName: ${{ inputs.slotName }}
     secrets: inherit # pragma: allowlist secret
 
+  execute-e2e-test:
+    needs:
+      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
+    uses: ./.github/workflows/reusable-e2e.yml
+    with:
+      apiFunctionName: ${{ inputs.apiFunctionName }}
+      slotName: ${{ inputs.slotName }}
+      webappName: ${{ inputs.webappName }}
+      stackName: ${{ inputs.stackName }}
+      azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
+      ghaEnvironment: ${{ inputs.ghaEnvironment }}
+      branchHashId: ${{ inputs.environmentHash }}
+      e2eCosmosDbExists: ${{ inputs.e2eCosmosDbExists }}
+    secrets: inherit # pragma: allowlist secret
+
   swap-webapp-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       webappName: ${{ inputs.webappName }}
@@ -187,7 +202,7 @@ jobs:
   swap-nodeapi-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       apiFunctionName: ${{ inputs.apiFunctionName }}
@@ -211,7 +226,7 @@ jobs:
   swap-dataflows-app-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       slotName: ${{ inputs.slotName }}

--- a/.github/workflows/sub-deploy.yml
+++ b/.github/workflows/sub-deploy.yml
@@ -70,7 +70,7 @@ jobs:
     with:
       nodeVersion: ${{ vars.NODE_VERSION }}
       camsServerHostname: ${{ inputs.apiFunctionName }}.azurewebsites.us
-      camsStagingHostname: ${{ inputs.apiFunctionName }}-staging.azurewebsites.us
+      camsStagingHostname: ${{ inputs.apiFunctionName }}-${{ vars.SLOT_NAME }}.azurewebsites.us
       camsServerPort: ${{ vars.CAMS_SERVER_PORT }}
       camsServerProtocol: ${{ vars.CAMS_SERVER_PROTOCOL }}
       camsBasePath: ${{ vars.CAMS_BASE_PATH }}

--- a/.github/workflows/sub-deploy.yml
+++ b/.github/workflows/sub-deploy.yml
@@ -70,6 +70,7 @@ jobs:
     with:
       nodeVersion: ${{ vars.NODE_VERSION }}
       camsServerHostname: ${{ inputs.apiFunctionName }}.azurewebsites.us
+      camsStagingHostname: ${{ inputs.apiFunctionName }}-staging.azurewebsites.us
       camsServerPort: ${{ vars.CAMS_SERVER_PORT }}
       camsServerProtocol: ${{ vars.CAMS_SERVER_PROTOCOL }}
       camsBasePath: ${{ vars.CAMS_BASE_PATH }}

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 3 : 0,
+  /* Stop after 2 failures in CI. */
+  maxFailures: process.env.CI ? 2 : undefined,
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters. We define the output folder in case the default ever changes. */

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   expect: {
     timeout: 10000,
   },
-  timeout: 30000, //Set Test timeout to 1 minute
+  timeout: 30000,
   testDir: './playwright',
   /* Run tests in files in parallel */
   fullyParallel: false,

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -12,9 +12,9 @@ require('dotenv').config();
  */
 export default defineConfig({
   expect: {
-    timeout: 60000,
+    timeout: 10000,
   },
-  timeout: 60000, //Set Test timeout to 1 minute
+  timeout: 30000, //Set Test timeout to 1 minute
   testDir: './playwright',
   /* Run tests in files in parallel */
   fullyParallel: false,

--- a/user-interface/.gitignore
+++ b/user-interface/.gitignore
@@ -18,6 +18,7 @@
 .env.test.local
 .env.production.local
 public/configuration.json
+public/configuration-staging.json
 
 npm-debug.log*
 yarn-debug.log*

--- a/user-interface/envToConfig.js
+++ b/user-interface/envToConfig.js
@@ -1,8 +1,19 @@
 const fs = require('fs');
 const dotenv = require('dotenv');
+const { parseArgs } = require('util');
 dotenv.config();
 
-const localConfigurationJsonPath = './public/configuration.json';
+const { configFileName } = parseArgs({
+  options: {
+    configFileName: {
+      type: 'string',
+      short: 'f',
+      default: 'configuration.json',
+    },
+  },
+}).values;
+
+const localConfigurationJsonPath = `./public/${configFileName}`;
 
 try {
   const configObject = {};

--- a/user-interface/package.json
+++ b/user-interface/package.json
@@ -89,6 +89,7 @@
     "pa11y-ci": "pa11y-ci",
     "dependency-cruiser-graphical": "current_time=$(date +'%Y-%m-%d_%H%M') && npx depcruise --output-type dot --do-not-follow '^node_modules($|/)' public src | dot -T svg > ../docs/architecture/dependency-cruiser/user-interface/dependency-graph_${current_time}.svg",
     "dependency-cruiser:ci": "npx depcruise --output-type err-long public src",
-    "envToConfig": "node ./envToConfig.js"
+    "envToConfig": "node ./envToConfig.js",
+    "stagingConfig": "node ./envToConfig.js -f configuration-staging.json"
   }
 }

--- a/user-interface/src/initialize.ts
+++ b/user-interface/src/initialize.ts
@@ -1,6 +1,10 @@
 async function loadConfiguration() {
   console.log('Fetching configuration.json.');
-  const response = await fetch('/configuration.json');
+  const stagingSuffix = '-staging.azurewebsites.us';
+  const configurationUrl = window.location.hostname.endsWith(stagingSuffix)
+    ? '/configuration-staging.json'
+    : '/configuration.json';
+  const response = await fetch(configurationUrl);
 
   if (!response.ok) {
     throw new Error(`Failed to fetch configuration.json.`);

--- a/user-interface/src/initialize.ts
+++ b/user-interface/src/initialize.ts
@@ -1,5 +1,4 @@
 async function loadConfiguration() {
-  console.log('Fetching configuration.json.');
   const stagingSuffix = '-staging.azurewebsites.us';
   const configurationUrl = window.location.hostname.endsWith(stagingSuffix)
     ? '/configuration-staging.json'


### PR DESCRIPTION
# Purpose

We want to include configuration for both deployment slots in the build.

# Major Changes

- Add a configuration file for the staging slot.
- Add e2e tests back in.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Implement dual configuration support for production and staging slots by generating a separate staging config during frontend builds, updating the UI loader to pick up configuration-staging.json based on hostname, and enhancing GitHub Actions to include staging hostnames and run end-to-end tests against the staging slot before swapping deployments.

New Features:
- Support separate staging slot configuration by generating and loading configuration-staging.json
- Run end-to-end tests against the staging slot in CI workflows before swapping slots

Enhancements:
- Enhance envToConfig script to accept a custom filename for configuration files
- Detect staging hostnames in the UI loader to fetch the appropriate config file

Build:
- Add a "Generate Staging Slot Configuration" step to the reusable frontend build workflow

CI:
- Inject camsStagingHostname input and add an execute-e2e-test job in sub-deploy workflows
- Update reusable-e2e workflow to target slot-specific subdomains

Tests:
- Reduce Playwright timeouts and introduce a maxFailures limit for CI runs