### PR TITLE
CAMS-553 - Use new CAMS column to filter offices

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
@@ -10,22 +10,6 @@ import { buildOfficeCode, getOfficeName } from '../../../use-cases/offices/offic
 
 const MODULE_NAME = 'OFFICES-GATEWAY';
 
-// Remove invalid divisions at the gateway rather than forcing the
-// more important use case code to include logic to remove them.
-const INVALID_DIVISION_CODES = [
-  '070',
-  '314',
-  '990',
-  '991',
-  '992',
-  '993',
-  '994',
-  '995',
-  '996',
-  '999',
-];
-const INVALID_DIVISION_CODES_SQL = INVALID_DIVISION_CODES.map((code) => "'" + code + "'").join(',');
-
 type DxtrFlatOfficeDetails = {
   officeName: string;
   officeCode: string;
@@ -110,7 +94,7 @@ export default class OfficesDxtrGateway implements OfficesGateway {
     JOIN [dbo].[AO_COURT] c on a.COURT_ID = c.COURT_ID
     JOIN [dbo].[AO_GRP_DES] d on a.GRP_DES = d.GRP_DES
     JOIN [dbo].[AO_REGION] r on d.REGION_ID = r.REGION_ID
-    WHERE a.[CS_DIV_ACMS] not in (${INVALID_DIVISION_CODES_SQL})
+    WHERE b.CAMS = 'Y'
     ORDER BY a.STATE, c.COURT_NAME, b.OFFICE_NAME_DISPLAY`;
 
     const queryResult: QueryResults = await executeQuery(


### PR DESCRIPTION
# Purpose

Show only the active court divisions in CAMS.

# Major Changes

* Delegate active court divisions to use in CAMS to DXTR.
* Modified query to only return court divisions where AO_OFFICES.CAMS = 'Y'.
* Removed prior court division code suppression logic.

# Testing/Validation

* Manual testing

## Summary by Sourcery

Use the new CAMS column to only fetch active court divisions and clean up obsolete exclusion logic

Enhancements:
- Modify office retrieval to filter court divisions by the AO_OFFICES.CAMS flag
- Remove legacy hardcoded invalid division codes and related suppression logic from the DXTR gateway