### PR TITLE
CAMS-389 - Change build artifact name on deploy slot

### DIFF
--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -76,7 +76,7 @@ jobs:
         id: deploy-webapp-slot-step
         run: |
           ./ops/scripts/pipeline/slots/az-app-slot-deploy.sh \
-          --src ./${{ inputs.webappName }}.zip \
+          --src ./${{ inputs.webappName }}-build.zip \
           -g ${{ steps.rgApp.outputs.out }} \
           -n ${{ inputs.webappName }} \
           --slotName ${{ inputs.slotName }}


### PR DESCRIPTION
Jira ticket: CAMS-389

 Co-authored-by: Fritz Madden <96319835+fmaddenflx@users.noreply.github.com>
 Co-authored-by: Brian Posey <15091170+btposey@users.noreply.github.com>

# Purpose

Attempt to troubleshoot build artifact not deploying properly to staging slot

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

CI:
- Update sub-deploy-code-slot.yml to reference `${{ inputs.webappName }}-build.zip` instead of `${{ inputs.webappName }}.zip`