### PR TITLE
CAMS-389 Fix healthcheck

### DIFF
--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -75,11 +75,13 @@ jobs:
       - name: Deploy to Azure WebApp Slot
         id: deploy-webapp-slot-step
         run: |
+          echo $(ls -la)
           ./ops/scripts/pipeline/slots/az-app-slot-deploy.sh \
           --src ./${{ inputs.webappName }}.zip \
           -g ${{ steps.rgApp.outputs.out }} \
           -n ${{ inputs.webappName }} \
-          --slotName ${{ inputs.slotName }}
+          --slotName ${{ inputs.slotName }} \
+          --gitSha ${{ github.sha }}
 
   deploy-api-slot:
     runs-on: ubuntu-latest

--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -75,7 +75,6 @@ jobs:
       - name: Deploy to Azure WebApp Slot
         id: deploy-webapp-slot-step
         run: |
-          echo $(ls -la)
           ./ops/scripts/pipeline/slots/az-app-slot-deploy.sh \
           --src ./${{ inputs.webappName }}.zip \
           -g ${{ steps.rgApp.outputs.out }} \

--- a/ops/scripts/pipeline/endpoint-test.sh
+++ b/ops/scripts/pipeline/endpoint-test.sh
@@ -62,8 +62,6 @@ targetWebAppURL="https://${webapp_name}.azurewebsites.us"
 if [[ ${slot_name} == "staging" ]]; then
   targetApiURL="https://${api_name}-${slot_name}.azurewebsites.us/api/healthcheck"
   targetWebAppURL="https://${webapp_name}-${slot_name}.azurewebsites.us"
-  #  targetApiURL="${targetApiURL}?x-ms-routing-name=${slot_name}"
-  #  targetWebAppURL="${targetWebAppURL}?x-ms-routing-name=${slot_name}"
 else
   echo "No Slot Provided"
   targetApiURL="https://${api_name}.azurewebsites.us/api/healthcheck"

--- a/ops/scripts/pipeline/endpoint-test.sh
+++ b/ops/scripts/pipeline/endpoint-test.sh
@@ -59,9 +59,9 @@ apiStatusCode=""
 targetApiURL="https://${api_name}.azurewebsites.us/api/healthcheck"
 targetWebAppURL="https://${webapp_name}.azurewebsites.us"
 
-if [[ ${slot_name} != "" ]]; then
-  targetApiURL="https://${api_name}.${slot_name}.azurewebsites.us/api/healthcheck"
-  targetWebAppURL="https://${webapp_name}.${slot_name}.azurewebsites.us"
+if [[ ${slot_name} == "staging" ]]; then
+  targetApiURL="https://${api_name}-${slot_name}.azurewebsites.us/api/healthcheck"
+  targetWebAppURL="https://${webapp_name}-${slot_name}.azurewebsites.us"
   #  targetApiURL="${targetApiURL}?x-ms-routing-name=${slot_name}"
   #  targetWebAppURL="${targetWebAppURL}?x-ms-routing-name=${slot_name}"
 else

--- a/ops/scripts/pipeline/endpoint-test.sh
+++ b/ops/scripts/pipeline/endpoint-test.sh
@@ -59,11 +59,15 @@ apiStatusCode=""
 targetApiURL="https://${api_name}.azurewebsites.us/api/healthcheck"
 targetWebAppURL="https://${webapp_name}.azurewebsites.us"
 
-if [[ ${slot_name} == "staging" ]]; then
-  targetApiURL="${targetApiURL}?x-ms-routing-name=${slot_name}"
-  targetWebAppURL="${targetWebAppURL}?x-ms-routing-name=${slot_name}"
+if [[ ${slot_name} != "" ]]; then
+  targetApiURL="https://${api_name}.${slot_name}.azurewebsites.us/api/healthcheck"
+  targetWebAppURL="https://${webapp_name}.${slot_name}.azurewebsites.us"
+  #  targetApiURL="${targetApiURL}?x-ms-routing-name=${slot_name}"
+  #  targetWebAppURL="${targetWebAppURL}?x-ms-routing-name=${slot_name}"
 else
   echo "No Slot Provided"
+  targetApiURL="https://${api_name}.azurewebsites.us/api/healthcheck"
+  targetWebAppURL="https://${webapp_name}.azurewebsites.us"
 fi
 
 if [[ ${slot_name} == "initial" ]]; then
@@ -90,7 +94,7 @@ if [[ "${expected_git_sha}" != '' ]]; then
   currentGitSha=""
   while [ "${expected_git_sha}" != "${currentGitSha}" ] && [ ${retry} -le 2 ]; do
     retry=$((retry+1))
-    curl "${targetApiURL}" | tee api_response.json
+    curl "${targetApiURL}" -s | tee api_response.json
     currentGitSha=$(python3 -c "import sys, json; print(json.load(open('api_response.json'))['data']['info']['sha'])")
     echo "Current sha ${currentGitSha}"
     if [[ "${expected_git_sha}" == "${currentGitSha}" ]]; then
@@ -103,9 +107,10 @@ if [[ "${expected_git_sha}" != '' ]]; then
     # Check front end SHA meta tag
     shaCheck="OK"
     if [[ $("${webCmd[@]}") == "200" && "$expected_git_sha" != "" ]]; then
-      shaFound=$(curl "$targetWebAppURL" | grep "$expected_git_sha")
+      shaFound=$(curl "$targetWebAppURL" -s | grep "$expected_git_sha")
       if [[ $shaFound == "" ]]; then
         shaCheck="FAILED"
+        curl "$targetWebAppURL" -s | grep -i meta
       fi
     fi
 

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -59,12 +59,15 @@ trap on_exit EXIT
 
 # verify gitSha
 mkdir sha-verify
-cd sha-verify
-unzip ../"${artifact_path}"
+pushd sha-verify
+unzip -q ../"${artifact_path}"
 shaFound=$(grep "${gitSha}" index.html)
 if [[ ${shaFound} == "" ]]; then
   exit 3
+else
+  echo "Found ${gitSha} in index.html."
 fi
+popd
 
 # allow build agent access to execute deployment
 agent_ip=$(curl -s --retry 3 --retry-delay 30 --retry-all-errors https://api.ipify.org)

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -77,7 +77,7 @@ az webapp config access-restriction add -g "${app_rg}" -n "${app_name}" --slot "
 
 # Gives some extra time for prior management operation to complete before starting deployment
 sleep 10
-az webapp deploy --resource-group "${app_rg}" --src-path "${artifact_path}" --name "${app_name}" --slot "${slot_name}" --type zip --async true --track-status false
+az webapp deploy --resource-group "${app_rg}" --src-path "${artifact_path}" --name "${app_name}" --slot "${slot_name}" --type zip --async true --track-status false --clean true
 
 # shellcheck disable=SC2086
 az webapp traffic-routing set --distribution ${slot_name}=0 --name "${app_name}" --resource-group "${app_rg}"


### PR DESCRIPTION
# Purpose

Fix failing health check in CI workflow

# Major Changes

Corrected URLs to test in endpoint test.

# Testing/Validation

Manual run of the CI pipeline

## Summary by Sourcery

Fix health check failures in CI by correcting endpoint URLs for staging slots and refining curl usage in the endpoint test script

Bug Fixes:
- Use hyphenated hostnames instead of query parameters for staging API and webapp URLs
- Restore proper default URLs when no slot is provided
- Add -s flag to curl commands to suppress unnecessary output
- Output the meta tag from the webapp response when SHA verification fails