### PR TITLE
CAMS-548 Add case to consolidation order

### DIFF
--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -386,6 +386,7 @@ export class OrdersUseCase {
       response.push(updatedRemainingOrder as ConsolidationOrder);
     }
 
+    // TODO: delete this AFTER the successor has been confirmed to have been written to Cosmos.
     await consolidationsRepo.delete(provisionalOrder.id);
 
     const createdConsolidation = await consolidationsRepo.create(newConsolidation);

--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -386,10 +386,9 @@ export class OrdersUseCase {
       response.push(updatedRemainingOrder as ConsolidationOrder);
     }
 
-    // TODO: delete this AFTER the successor has been confirmed to have been written to Cosmos.
-    await consolidationsRepo.delete(provisionalOrder.id);
-
+    // Add the revised order to the repo and delete the original order.
     const createdConsolidation = await consolidationsRepo.create(newConsolidation);
+    await consolidationsRepo.delete(provisionalOrder.id);
     response.push(createdConsolidation as ConsolidationOrder);
 
     for (const childCase of newConsolidation.childCases) {

--- a/user-interface/src/case-detail/panels/CaseDetailOverview.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailOverview.test.tsx
@@ -171,7 +171,7 @@ describe('Case detail basic information panel', () => {
         expect(modal).toBeVisible();
       });
 
-      testingUtilities.selectCheckbox('0-checkbox');
+      await testingUtilities.selectCheckbox('0-checkbox');
 
       const submitButton = screen.getByTestId(`button-${assignmentModalId}-submit-button`);
       fireEvent.click(submitButton);

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -60,7 +60,9 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
   }
 
   function mapEditButtonRefs() {
-    if (!caseNotes) return;
+    if (!caseNotes) {
+      return;
+    }
 
     const newRefs = new Map<string, React.RefObject<OpenModalButtonRef>>();
 

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.scss
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.scss
@@ -1,0 +1,16 @@
+.add-case-modal {
+  .results-container {
+    margin: 2rem 0;
+    .search-results.grid-container {
+      margin-top: 2rem;
+      padding: 0;
+      .grid-row {
+        h4 {
+          font-size: 1.06rem;
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.test.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.test.tsx
@@ -92,7 +92,7 @@ describe('AddCaseModal', () => {
     expect(handleAddCaseReset).toHaveBeenCalled();
   });
 
-  test('k', () => {
+  test('should call verifyCaseCanBeAdded when provided caseToAddCaseNumber and caseToAddCourt', () => {
     const { viewModel } = renderWithProps();
     expect(viewModel.verifyCaseCanBeAdded).toHaveBeenCalled();
   });

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.test.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.test.tsx
@@ -1,0 +1,91 @@
+import { describe } from 'vitest';
+import {
+  AddCaseModal,
+  AddCaseModalImperative,
+} from '@/data-verification/consolidation/AddCaseModal';
+import { render, waitFor } from '@testing-library/react';
+import { AddCaseModel } from '@/data-verification/consolidation/consolidationViewModel';
+import MockData from '@common/cams/test-utilities/mock-data';
+import { BrowserRouter } from 'react-router-dom';
+import React from 'react';
+
+describe('AddCaseModal', () => {
+  const handleAddCaseCourtSelectChange = vi.fn().mockReturnValue(undefined);
+  const handleAddCaseNumberInputChange = vi.fn().mockReturnValue(undefined);
+  const handleAddCaseReset = vi.fn().mockReturnValue(undefined);
+  const handleAddCaseAction = vi.fn().mockResolvedValue(undefined);
+
+  function renderWithProps(override: Partial<AddCaseModel> = {}) {
+    const ref = React.createRef<AddCaseModalImperative>();
+
+    const defaultDivisionCode = '081';
+    const defaultViewModel: AddCaseModel = {
+      orderId: '1000',
+      defaultDivisionCode,
+      handleAddCaseCourtSelectChange,
+      handleAddCaseNumberInputChange,
+      handleAddCaseReset,
+      filteredOfficeRecords: [{ value: defaultDivisionCode, label: 'label' }],
+      additionalCaseDivisionRef: {
+        current: null,
+      },
+      additionalCaseNumberRef: {
+        current: null,
+      },
+      addCaseNumberError: null,
+      isLookingForCase: false,
+      caseToAdd: null,
+      handleAddCaseAction,
+    };
+    const viewModel: AddCaseModel = {
+      ...defaultViewModel,
+      ...override,
+    };
+
+    render(
+      <BrowserRouter>
+        <AddCaseModal id="test-id" addCaseModel={viewModel} ref={ref}></AddCaseModal>
+      </BrowserRouter>,
+    );
+    return { ref, viewModel };
+  }
+
+  test('should show error messages', async () => {
+    renderWithProps({ addCaseNumberError: 'Error message' });
+    expect(document.querySelector('.usa-alert__body')).toHaveTextContent('Error message');
+  });
+
+  test('should show case to add details', async () => {
+    const caseToAdd = MockData.getConsolidatedOrderCase();
+    renderWithProps({ caseToAdd });
+    const details = document.querySelector('.search-results');
+
+    expect(details).toHaveTextContent(caseToAdd.caseTitle);
+    expect(details).toHaveTextContent(caseToAdd.chapter);
+    expect(details).toHaveTextContent(caseToAdd.dateFiled);
+  });
+
+  test('should set the selected court division equal to the default division code', async () => {
+    const { ref, viewModel } = renderWithProps({ defaultDivisionCode: '081' });
+    ref.current!.show({});
+    await waitFor(() => {
+      expect(viewModel.additionalCaseDivisionRef.current!.getSelections()).toEqual([
+        { value: '081', label: 'label' },
+      ]);
+    });
+  });
+
+  test('should not set a court division if the default division code is bad', async () => {
+    const { ref, viewModel } = renderWithProps({ defaultDivisionCode: 'bad' });
+    ref.current!.show({});
+    await waitFor(() => {
+      expect(viewModel.additionalCaseDivisionRef.current!.getSelections()).toEqual([]);
+    });
+  });
+
+  test('should delegate reset to the view model', async () => {
+    const { ref } = renderWithProps();
+    ref.current!.hide(true);
+    expect(handleAddCaseReset).toHaveBeenCalled();
+  });
+});

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.test.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.test.tsx
@@ -36,6 +36,9 @@ describe('AddCaseModal', () => {
       isLookingForCase: false,
       caseToAdd: null,
       handleAddCaseAction,
+      caseToAddCourt: '710',
+      caseToAddCaseNumber: '11-11111',
+      verifyCaseCanBeAdded: vi.fn(),
     };
     const viewModel: AddCaseModel = {
       ...defaultViewModel,
@@ -87,5 +90,10 @@ describe('AddCaseModal', () => {
     const { ref } = renderWithProps();
     ref.current!.hide(true);
     expect(handleAddCaseReset).toHaveBeenCalled();
+  });
+
+  test('k', () => {
+    const { viewModel } = renderWithProps();
+    expect(viewModel.verifyCaseCanBeAdded).toHaveBeenCalled();
   });
 });

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
@@ -2,7 +2,7 @@ import './AddCaseModal.scss';
 import Modal from '@/lib/components/uswds/modal/Modal';
 import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 import { SubmitCancelBtnProps } from '@/lib/components/uswds/modal/SubmitCancelButtonGroup';
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import ComboBox from '@/lib/components/combobox/ComboBox';
 import CaseNumberInput from '@/lib/components/CaseNumberInput';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
@@ -20,6 +20,13 @@ export type AddCaseModalImperative = ModalRefType & {
 };
 
 function AddCaseForm(viewModel: AddCaseModel) {
+  useEffect(() => {
+    const { caseToAddCaseNumber, caseToAddCourt } = viewModel;
+    if (caseToAddCourt && caseToAddCaseNumber) {
+      viewModel.verifyCaseCanBeAdded();
+    }
+  }, [viewModel.caseToAddCaseNumber, viewModel.caseToAddCourt]);
+
   return (
     <section className={`add-case-form-container add-case-form-container-${viewModel.orderId}`}>
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
@@ -2,7 +2,7 @@ import './AddCaseModal.scss';
 import Modal from '@/lib/components/uswds/modal/Modal';
 import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 import { SubmitCancelBtnProps } from '@/lib/components/uswds/modal/SubmitCancelButtonGroup';
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import ComboBox from '@/lib/components/combobox/ComboBox';
 import CaseNumberInput from '@/lib/components/CaseNumberInput';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
@@ -19,21 +19,19 @@ export type AddCaseModalImperative = ModalRefType & {
   show: () => void;
 };
 
-// TODO: Refactor out the view model.
 function AddCaseForm(viewModel: AddCaseModel) {
   return (
     <section className={`add-case-form-container add-case-form-container-${viewModel.orderId}`}>
-      <h3>Enter lead case details:</h3>
-      <span id="add-case-form-instructions">
-        Choose a new court and enter a case number, and the lead case will be selected for this Case
-        Event automatically.
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <span id="add-case-form-instructions" tabIndex={0}>
+        Select the court and enter the case number of the case you would like to add.
       </span>
       <div className="add-case-court-container">
         <ComboBox
           id={'add-case-court'}
           className="add-case-court"
-          label="Select a court"
-          ariaDescription="foo bar"
+          label="Court"
+          ariaDescription=""
           aria-live="off"
           aria-describedby="add-case-form-instructions"
           onUpdateSelection={viewModel.handleAddCaseCourtSelectChange}
@@ -53,7 +51,7 @@ function AddCaseForm(viewModel: AddCaseModel) {
           allowPartialCaseNumber={false}
           required={true}
           disabled={viewModel.isLookingForCase}
-          label="Enter a case number"
+          label="Case number"
           ref={viewModel.additionalCaseNumberRef}
           aria-describedby="add-case-form-instructions"
         />
@@ -71,7 +69,7 @@ function AddCaseForm(viewModel: AddCaseModel) {
         ) : (
           <LoadingSpinner
             id={`add-case-number-loading-spinner-${viewModel.orderId}`}
-            caption="Verifying lead case number..."
+            caption="Searching for case..."
             height="40px"
             hidden={!viewModel.isLookingForCase}
           />
@@ -133,6 +131,10 @@ function _AddCaseModal(
 
   function show() {
     if (modalRef.current?.show) {
+      const divisionCode = props.addCaseModel.defaultDivisionCode;
+      const options = props.addCaseModel.filteredOfficeRecords;
+      const selected = options?.filter((option) => option.value === divisionCode) ?? [];
+      props.addCaseModel.additionalCaseDivisionRef.current?.setSelections(selected);
       modalRef.current?.show({});
     }
   }
@@ -145,13 +147,6 @@ function _AddCaseModal(
     show,
     hide: reset,
   }));
-
-  useEffect(() => {
-    const divisionCode = props.addCaseModel.defaultDivisionCode;
-    const options = props.addCaseModel.filteredOfficeRecords;
-    const selected = options?.filter((option) => option.value === divisionCode) ?? [];
-    props.addCaseModel.additionalCaseDivisionRef.current?.setSelections(selected);
-  }, []);
 
   return (
     <Modal

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
@@ -150,7 +150,7 @@ function _AddCaseModal(
   return (
     <Modal
       ref={modalRef}
-      modalId={orderId}
+      modalId={`add-case-modal-${orderId}`}
       className={`add-case-modal consolidation-order-modal`}
       heading="Add Case"
       data-testid={`add-case-modal-${orderId}`}

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
@@ -76,7 +76,6 @@ function AddCaseForm(viewModel: AddCaseModel) {
         )}
         {viewModel.caseToAdd && (
           <>
-            {/*<h4>Selected Case</h4>*/}
             <div className="search-results grid-container">
               <div className="grid-row">
                 <h4 className="grid-col-4">Case Title</h4>
@@ -133,7 +132,7 @@ function _AddCaseModal(
     if (modalRef.current?.show) {
       const divisionCode = props.addCaseModel.defaultDivisionCode;
       const options = props.addCaseModel.filteredOfficeRecords;
-      const selected = options?.filter((option) => option.value === divisionCode) ?? [];
+      const selected = options!.filter((option) => option.value === divisionCode);
       props.addCaseModel.additionalCaseDivisionRef.current?.setSelections(selected);
       modalRef.current?.show({});
     }

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
@@ -1,21 +1,18 @@
+import './AddCaseModal.scss';
 import Modal from '@/lib/components/uswds/modal/Modal';
 import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 import { SubmitCancelBtnProps } from '@/lib/components/uswds/modal/SubmitCancelButtonGroup';
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
-import './ConsolidationOrderModal.scss';
 import ComboBox from '@/lib/components/combobox/ComboBox';
 import CaseNumberInput from '@/lib/components/CaseNumberInput';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
-import { CaseTable } from '@/data-verification/transfer/CaseTable';
 import { AddCaseModel } from '@/data-verification/consolidation/consolidationViewModel';
+import { Link } from 'react-router-dom';
 
 export interface AddCaseModalProps {
   addCaseModel: AddCaseModel;
-  // id: string;
-  // onCancel: () => void;
-  // submitAddCase: () => void;
-  // courts?: CourtDivisionDetails[];
+  id: string;
 }
 
 export type AddCaseModalImperative = ModalRefType & {
@@ -25,44 +22,44 @@ export type AddCaseModalImperative = ModalRefType & {
 // TODO: Refactor out the view model.
 function AddCaseForm(addCaseModel: AddCaseModel) {
   return (
-    <section
-      className={`lead-case-form-container lead-case-form-container-${addCaseModel.orderId}`}
-    >
+    <section className={`add-case-form-container add-case-form-container-${addCaseModel.orderId}`}>
       <h3>Enter lead case details:</h3>
-      <span id="lead-case-form-instructions">
+      <span id="add-case-form-instructions">
         Choose a new court and enter a case number, and the lead case will be selected for this Case
         Event automatically.
       </span>
-      <div className="lead-case-court-container">
+      <div className="add-case-court-container">
         <ComboBox
-          id={'lead-case-court'}
-          className="lead-case-court"
+          id={'add-case-court'}
+          className="add-case-court"
           label="Select a court"
           ariaDescription="foo bar"
           aria-live="off"
-          aria-describedby="lead-case-form-instructions"
-          onUpdateSelection={addCaseModel.handleSelectLeadCaseCourt}
+          aria-describedby="add-case-form-instructions"
+          onUpdateSelection={addCaseModel.handleAddCaseCourtSelectChange}
           options={addCaseModel.filteredOfficeRecords!}
           required={true}
           multiSelect={false}
           ref={addCaseModel.additionalCaseDivisionRef}
         />
       </div>
-      <div className="lead-case-number-container">
+      <div className="add-case-number-container">
         <CaseNumberInput
-          id={`lead-case-input-${addCaseModel.orderId}`}
-          data-testid={`lead-case-input-${addCaseModel.orderId}`}
+          id={`add-case-input-${addCaseModel.orderId}`}
+          data-testid={`add-case-input-${addCaseModel.orderId}`}
           className="usa-input"
-          onChange={addCaseModel.handleLeadCaseInputChange}
+          onChange={addCaseModel.handleAddCaseNumberInputChange}
           allowPartialCaseNumber={false}
           required={true}
           label="Enter a case number"
           ref={addCaseModel.additionalCaseNumberRef}
-          aria-describedby="lead-case-form-instructions"
+          aria-describedby="add-case-form-instructions"
         />
+      </div>
+      <div className="results-container">
         {addCaseModel.addCaseNumberError ? (
           <Alert
-            id={`lead-case-number-alert-${addCaseModel.orderId}`}
+            id={`add-case-number-alert-${addCaseModel.orderId}`}
             message={addCaseModel.addCaseNumberError}
             type={UswdsAlertStyle.Error}
             show={true}
@@ -71,7 +68,7 @@ function AddCaseForm(addCaseModel: AddCaseModel) {
           ></Alert>
         ) : (
           <LoadingSpinner
-            id={`lead-case-number-loading-spinner-${addCaseModel.orderId}`}
+            id={`add-case-number-loading-spinner-${addCaseModel.orderId}`}
             caption="Verifying lead case number..."
             height="40px"
             hidden={!addCaseModel.isLookingForCase}
@@ -79,11 +76,30 @@ function AddCaseForm(addCaseModel: AddCaseModel) {
         )}
         {addCaseModel.caseToAdd && (
           <>
-            <h4>Selected Lead Case</h4>
-            <CaseTable
-              id={`valid-case-number-found-${addCaseModel.orderId}`}
-              cases={[addCaseModel.caseToAdd]}
-            ></CaseTable>
+            {/*<h4>Selected Case</h4>*/}
+            <div className="search-results grid-container">
+              <div className="grid-row">
+                <h4 className="grid-col-4">Case Title</h4>
+                <div className="grid-col-8">
+                  <Link
+                    className="usa-link"
+                    to={`/case-detail/${addCaseModel.caseToAdd.caseId}/`}
+                    title={`View case number ${addCaseModel.caseToAdd.caseId} details`}
+                    target="_blank"
+                  >
+                    {addCaseModel.caseToAdd.caseTitle}
+                  </Link>
+                </div>
+              </div>
+              <div className="grid-row">
+                <h4 className="grid-col-4">Chapter</h4>
+                <span className="grid-col-8">{addCaseModel.caseToAdd.chapter}</span>
+              </div>
+              <div className="grid-row">
+                <h4 className="grid-col-4">Filed Date</h4>
+                <span className="grid-col-8">{addCaseModel.caseToAdd.dateFiled}</span>
+              </div>
+            </div>
           </>
         )}
       </div>
@@ -105,14 +121,11 @@ function _AddCaseModal(
       label: 'Add Case',
       onClick: handleAddCaseAction,
       closeOnClick: true,
-      disabled: false,
+      disabled: !props.addCaseModel.caseToAdd,
     },
     cancelButton: {
       label: 'Go back',
-      onClick: () => {
-        reset();
-        // TODO: make sure we're clearing the store of any selected data.
-      },
+      onClick: props.addCaseModel.handleAddCaseReset,
     },
   };
 
@@ -122,7 +135,9 @@ function _AddCaseModal(
     }
   }
 
-  function reset() {}
+  function reset() {
+    props.addCaseModel.handleAddCaseReset();
+  }
 
   useImperativeHandle(AddCaseModalRef, () => ({
     show,

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
@@ -1,0 +1,148 @@
+import Modal from '@/lib/components/uswds/modal/Modal';
+import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
+import { SubmitCancelBtnProps } from '@/lib/components/uswds/modal/SubmitCancelButtonGroup';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import './ConsolidationOrderModal.scss';
+import ComboBox from '@/lib/components/combobox/ComboBox';
+import CaseNumberInput from '@/lib/components/CaseNumberInput';
+import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
+import { CaseTable } from '@/data-verification/transfer/CaseTable';
+import { AddCaseModel } from '@/data-verification/consolidation/consolidationViewModel';
+
+export interface AddCaseModalProps {
+  addCaseModel: AddCaseModel;
+  // id: string;
+  // onCancel: () => void;
+  // submitAddCase: () => void;
+  // courts?: CourtDivisionDetails[];
+}
+
+export type AddCaseModalImperative = ModalRefType & {
+  show: () => void;
+};
+
+// TODO: Refactor out the view model.
+function AddCaseForm(addCaseModel: AddCaseModel) {
+  return (
+    <section
+      className={`lead-case-form-container lead-case-form-container-${addCaseModel.orderId}`}
+    >
+      <h3>Enter lead case details:</h3>
+      <span id="lead-case-form-instructions">
+        Choose a new court and enter a case number, and the lead case will be selected for this Case
+        Event automatically.
+      </span>
+      <div className="lead-case-court-container">
+        <ComboBox
+          id={'lead-case-court'}
+          className="lead-case-court"
+          label="Select a court"
+          ariaDescription="foo bar"
+          aria-live="off"
+          aria-describedby="lead-case-form-instructions"
+          onUpdateSelection={addCaseModel.handleSelectLeadCaseCourt}
+          options={addCaseModel.filteredOfficeRecords!}
+          required={true}
+          multiSelect={false}
+          ref={addCaseModel.additionalCaseDivisionRef}
+        />
+      </div>
+      <div className="lead-case-number-container">
+        <CaseNumberInput
+          id={`lead-case-input-${addCaseModel.orderId}`}
+          data-testid={`lead-case-input-${addCaseModel.orderId}`}
+          className="usa-input"
+          onChange={addCaseModel.handleLeadCaseInputChange}
+          allowPartialCaseNumber={false}
+          required={true}
+          label="Enter a case number"
+          ref={addCaseModel.additionalCaseNumberRef}
+          aria-describedby="lead-case-form-instructions"
+        />
+        {addCaseModel.addCaseNumberError ? (
+          <Alert
+            id={`lead-case-number-alert-${addCaseModel.orderId}`}
+            message={addCaseModel.addCaseNumberError}
+            type={UswdsAlertStyle.Error}
+            show={true}
+            slim={true}
+            inline={true}
+          ></Alert>
+        ) : (
+          <LoadingSpinner
+            id={`lead-case-number-loading-spinner-${addCaseModel.orderId}`}
+            caption="Verifying lead case number..."
+            height="40px"
+            hidden={!addCaseModel.isLookingForCase}
+          />
+        )}
+        {addCaseModel.caseToAdd && (
+          <>
+            <h4>Selected Lead Case</h4>
+            <CaseTable
+              id={`valid-case-number-found-${addCaseModel.orderId}`}
+              cases={[addCaseModel.caseToAdd]}
+            ></CaseTable>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function _AddCaseModal(
+  props: AddCaseModalProps,
+  AddCaseModalRef: React.Ref<AddCaseModalImperative>,
+) {
+  const { handleAddCaseAction, orderId } = props.addCaseModel;
+  const modalRef = useRef<ModalRefType>(null);
+
+  const actionButtonGroup: SubmitCancelBtnProps = {
+    modalId: `add-case-modal-${orderId}`,
+    modalRef: modalRef,
+    submitButton: {
+      label: 'Add Case',
+      onClick: handleAddCaseAction,
+      closeOnClick: true,
+      disabled: false,
+    },
+    cancelButton: {
+      label: 'Go back',
+      onClick: () => {
+        reset();
+        // TODO: make sure we're clearing the store of any selected data.
+      },
+    },
+  };
+
+  function show() {
+    if (modalRef.current?.show) {
+      modalRef.current?.show({});
+    }
+  }
+
+  function reset() {}
+
+  useImperativeHandle(AddCaseModalRef, () => ({
+    show,
+    hide: reset,
+  }));
+
+  return (
+    <Modal
+      ref={modalRef}
+      modalId={orderId}
+      className={`add-case-modal consolidation-order-modal`}
+      heading="Add Case"
+      data-testid={`add-case-modal-${orderId}`}
+      onClose={() => {
+        /* TODO: do we need to do anything? */
+      }}
+      content={<AddCaseForm {...props.addCaseModel} />}
+      actionButtonGroup={actionButtonGroup}
+    ></Modal>
+  );
+}
+
+export const AddCaseModal = forwardRef(_AddCaseModal);

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
@@ -160,9 +160,7 @@ function _AddCaseModal(
       className={`add-case-modal consolidation-order-modal`}
       heading="Add Case"
       data-testid={`add-case-modal-${orderId}`}
-      onClose={() => {
-        /* TODO: do we need to do anything? */
-      }}
+      onClose={props.addCaseModel.handleAddCaseReset}
       content={<AddCaseForm {...props.addCaseModel} />}
       actionButtonGroup={actionButtonGroup}
     ></Modal>

--- a/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.tsx
@@ -270,7 +270,6 @@ function _ConsolidationCaseTable(
             })}
         </tbody>
       </table>
-      <Button>Add Case</Button>
     </>
   );
 }

--- a/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.tsx
@@ -270,6 +270,7 @@ function _ConsolidationCaseTable(
             })}
         </tbody>
       </table>
+      <Button>Add Case</Button>
     </>
   );
 }

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
@@ -96,21 +96,28 @@ describe('ConsolidationOrderAccordion tests', () => {
     );
   }
 
-  async function clickMarkLeadButton(index: number) {
+  async function setLeadCase(index: number) {
     const markAsLeadButton = screen.getByTestId(
       `button-assign-lead-case-list-${order.id}-${index}`,
     );
     expect(markAsLeadButton).not.toBeNull();
-    if (markAsLeadButton.classList.contains('usa-button--outline')) {
-      await user.click(markAsLeadButton);
-      expect(markAsLeadButton).not.toHaveClass('usa-button--outline');
-    } else {
-      await user.click(markAsLeadButton);
-      expect(markAsLeadButton).toHaveClass('usa-button--outline');
-    }
+    expect(markAsLeadButton.getAttribute('aria-checked')).not.toEqual('true');
+    await user.click(markAsLeadButton);
+    expect(markAsLeadButton.getAttribute('aria-checked')).toEqual('true');
+    return markAsLeadButton;
   }
 
-  async function selectTypeAndMarkLead() {
+  async function clearLeadCase(index: number) {
+    const markAsLeadButton = screen.getByTestId(
+      `button-assign-lead-case-list-${order.id}-${index}`,
+    );
+    expect(markAsLeadButton).not.toBeNull();
+    expect(markAsLeadButton.getAttribute('aria-checked')).toEqual('true');
+    await user.click(markAsLeadButton);
+    expect(markAsLeadButton.getAttribute('aria-checked')).not.toEqual('true');
+  }
+
+  async function selectConsolidationType() {
     const consolidationTypeRadio = document.querySelector('input[name="consolidation-type"]');
     const consolidationTypeRadioLabel = document.querySelector('.usa-radio__label');
     expect(consolidationTypeRadioLabel).not.toBeNull();
@@ -118,8 +125,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       await user.click(consolidationTypeRadioLabel);
     }
     expect(consolidationTypeRadio).toBeChecked();
-
-    await clickMarkLeadButton(0);
+    return consolidationTypeRadio;
   }
 
   async function clickCaseCheckbox(oid: string, idx: number) {
@@ -128,18 +134,40 @@ describe('ConsolidationOrderAccordion tests', () => {
     ) as Promise<HTMLInputElement | null>;
   }
 
-  function findCaseNumberInput(id: string) {
-    const caseIdInput = document.querySelector(`input#lead-case-input-${id}`);
-    expect(caseIdInput).toBeInTheDocument();
-    return caseIdInput;
-  }
+  async function fillInFormToEnableVerifyButton() {
+    await openAccordion(user, order.id!);
 
-  async function enterCaseNumber(caseIdInput: Element | null | undefined, value: string) {
-    if (!caseIdInput) {
-      throw Error();
-    }
+    const approveButton = findApproveButton(order.id!);
+    const rejectButton = findRejectButton(order.id!);
+    const clearButton = findClearButton(order.id!);
+    const consolidationTypeRadio = await selectConsolidationType();
+    const checkbox1 = await clickCaseCheckbox(order.id!, 0);
+    const checkbox2 = await clickCaseCheckbox(order.id!, 1);
 
-    await user.type(caseIdInput!, value);
+    expect(approveButton).not.toBeEnabled();
+    expect(rejectButton).not.toBeEnabled();
+
+    await waitFor(() => {
+      expect(rejectButton).toBeEnabled();
+    });
+    expect(approveButton).not.toBeEnabled();
+    const leadCaseButton = await setLeadCase(0);
+    expect(checkbox1).toBeChecked();
+    expect(consolidationTypeRadio).toBeChecked();
+    expect(leadCaseButton.getAttribute('aria-checked')).toEqual('true');
+    await waitFor(() => {
+      const approveButton = findApproveButton(order.id!);
+      expect(approveButton).toBeEnabled();
+    });
+
+    return {
+      approveButton,
+      rejectButton,
+      clearButton,
+      consolidationTypeRadio,
+      checkbox1,
+      checkbox2,
+    };
   }
 
   function findApproveButton(id: string) {
@@ -150,35 +178,8 @@ describe('ConsolidationOrderAccordion tests', () => {
     return document.querySelector(`#accordion-reject-button-${id}`);
   }
 
-  function findValidCaseNumberTable(id: string) {
-    return screen.queryByTestId(`valid-case-number-found-${id}`);
-  }
-
-  function findValidCaseNumberAlert(id: string) {
-    return screen.queryByTestId(`alert-container-lead-case-number-alert-${id}`);
-  }
-
-  async function toggleEnableCaseListForm(id: string) {
-    const caseNumberToggleCheckbox = screen.getByTestId(
-      `checkbox-lead-case-form-checkbox-toggle-${id}`,
-    );
-
-    const initialValue = (caseNumberToggleCheckbox as HTMLInputElement).checked;
-
-    const caseNumberToggleCheckboxButton = screen.getByTestId(
-      `button-checkbox-lead-case-form-checkbox-toggle-${id}-click-target`,
-    );
-    await user.click(caseNumberToggleCheckboxButton);
-
-    if (initialValue) {
-      await waitFor(() => {
-        expect(caseNumberToggleCheckbox).not.toBeChecked();
-      });
-    } else {
-      await waitFor(() => {
-        expect(caseNumberToggleCheckbox).toBeChecked();
-      });
-    }
+  function findClearButton(id: string) {
+    return document.querySelector(`#accordion-cancel-button-${id}`);
   }
 
   test('should render an order heading', async () => {
@@ -239,267 +240,6 @@ describe('ConsolidationOrderAccordion tests', () => {
     });
   });
 
-  test.skip('should correctly enable/disable buttons when selecting consolidated cases and lead case from order case list table', async () => {
-    renderWithProps();
-    await openAccordion(user, order.id!);
-    // setupApiGetMock({ bCase: order.childCases[0] });
-    // vi.spyOn(Api2, 'getCaseSummary').mockResolvedValue({ data: order.childCases[0] });
-
-    const includeAllCheckbox = document.querySelector(`.checkbox-toggle label button`);
-    const approveButton = findApproveButton(order.id!);
-    const rejectButton = findRejectButton(order.id!);
-
-    await selectTypeAndMarkLead();
-
-    expect(approveButton).not.toBeEnabled();
-    expect(rejectButton).not.toBeEnabled();
-
-    const firstCheckbox = await clickCaseCheckbox(order.id!, 0);
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    const secondCheckbox = await clickCaseCheckbox(order.id!, 1);
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    await clickMarkLeadButton(0);
-    await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    await clickMarkLeadButton(0);
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    await user.click(firstCheckbox!);
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    await user.click(secondCheckbox!);
-    await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).not.toBeEnabled();
-    });
-
-    await user.click(includeAllCheckbox!);
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    await user.click(includeAllCheckbox!);
-    await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).not.toBeEnabled();
-    });
-
-    await user.click(firstCheckbox!);
-    await user.click(secondCheckbox!);
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-  });
-
-  test.skip('should correctly enable/disable buttons based on selections in "case not listed" form', async () => {
-    renderWithProps();
-    await openAccordion(user, order.id!);
-    // setupApiGetMock({ bCase: order.childCases[0] });
-
-    const includeAllCheckbox = document.querySelector(`.checkbox-toggle label button`);
-    const approveButton = findApproveButton(order.id!);
-    const rejectButton = findRejectButton(order.id!);
-
-    await selectTypeAndMarkLead();
-    await user.click(includeAllCheckbox!);
-
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    const markAsLeadButton = screen.getByTestId(`button-assign-lead-case-list-${order.id}-0`);
-    expect(markAsLeadButton).not.toHaveClass('usa-button--outline');
-
-    await toggleEnableCaseListForm(order.id!);
-
-    await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-      expect(markAsLeadButton).toHaveClass('usa-button--outline');
-    });
-
-    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
-
-    const caseNumberInput = findCaseNumberInput(order.id!);
-
-    const validCaseNumber = getCaseNumber(order.childCases[0].caseId).replace('-', '');
-    await enterCaseNumber(caseNumberInput, validCaseNumber);
-
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    await enterCaseNumber(caseNumberInput, '11111111');
-
-    await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    await enterCaseNumber(caseNumberInput, '111111');
-
-    await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
-    await enterCaseNumber(caseNumberInput, validCaseNumber);
-
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
-
-    const leadCaseForm = document.querySelector(`.lead-case-form-container-${order.id}`);
-    expect(leadCaseForm).toBeInTheDocument();
-
-    await toggleEnableCaseListForm(order.id!);
-
-    await waitFor(() => {
-      expect(approveButton).not.toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-      expect(leadCaseForm).not.toBeInTheDocument();
-    });
-  });
-
-  test.skip('should show alert when no lead case can be found in search field, and case table when search finds a matching value', async () => {
-    renderWithProps();
-    await openAccordion(user, order.id!);
-    // setupApiGetMock({ bCase: order.childCases[0] });
-
-    await toggleEnableCaseListForm(order.id!);
-
-    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
-    const caseNumberInput = findCaseNumberInput(order.id!);
-
-    await enterCaseNumber(caseNumberInput, '11111111');
-
-    await waitFor(() => {
-      const alert = findValidCaseNumberAlert(order.id!);
-      expect(alert).toBeInTheDocument();
-      expect(alert).toHaveTextContent("We couldn't find a case with that number.");
-      expect(findValidCaseNumberTable(order.id!)).not.toBeInTheDocument();
-    });
-
-    await enterCaseNumber(caseNumberInput, '11111');
-
-    await waitFor(() => {
-      expect(findValidCaseNumberAlert(order.id!)).not.toBeInTheDocument();
-      expect(findValidCaseNumberTable(order.id!)).not.toBeInTheDocument();
-    });
-
-    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
-    await enterCaseNumber(
-      caseNumberInput,
-      getCaseNumber(order.childCases[0].caseId).replace('-', ''),
-    );
-
-    await waitFor(() => {
-      expect(findValidCaseNumberAlert(order.id!)).not.toBeInTheDocument();
-      expect(findValidCaseNumberTable(order.id!)).toBeInTheDocument();
-    });
-
-    await enterCaseNumber(caseNumberInput, '');
-
-    await waitFor(() => {
-      expect(findValidCaseNumberAlert(order.id!)).not.toBeInTheDocument();
-      expect(findValidCaseNumberTable(order.id!)).not.toBeInTheDocument();
-    });
-  });
-
-  test.skip('should show alert when no lead case can be found in search field, and error returned was not a 404', async () => {
-    renderWithProps();
-    await openAccordion(user, order.id!);
-
-    await toggleEnableCaseListForm(order.id!);
-
-    await testingUtilities.toggleComboBoxItemSelection(`lead-case-court`, 0);
-    const caseNumberInput = findCaseNumberInput(order.id!);
-
-    await enterCaseNumber(caseNumberInput, '00000000');
-
-    await waitFor(() => {
-      const alert = findValidCaseNumberAlert(order.id!);
-      expect(alert).toBeInTheDocument();
-      expect(alert).toHaveTextContent('Cannot verify lead case number.');
-      expect(findValidCaseNumberTable(order.id!)).not.toBeInTheDocument();
-    });
-  });
-
-  test.skip('should show alert when lookup of associated cases fails', async () => {
-    renderWithProps();
-    await openAccordion(user, order.id!);
-    const testCase = { ...order.childCases[0] };
-    testCase.caseId = '999-99-99999';
-
-    await toggleEnableCaseListForm(order.id!);
-
-    await testingUtilities.toggleComboBoxItemSelection('lead-case-court', 0);
-
-    const caseNumberInput = findCaseNumberInput(order.id!);
-
-    await enterCaseNumber(caseNumberInput, '9900001');
-
-    await waitFor(() => {
-      const alert = findValidCaseNumberAlert(order.id!);
-      expect(alert).toBeInTheDocument();
-      expect(alert).toHaveTextContent(
-        `Cannot verify lead case is not part of another consolidation. `,
-      );
-      expect(findValidCaseNumberTable(order.id!)).not.toBeInTheDocument();
-    });
-  });
-
-  test.skip('should open approval modal when approve button is clicked', async () => {
-    renderWithProps();
-    await openAccordion(user, order.id!);
-
-    const approveButton = document.querySelector(
-      `#accordion-approve-button-${order.id}`,
-    ) as HTMLButtonElement;
-    expect(approveButton).not.toBeEnabled();
-
-    await selectTypeAndMarkLead();
-
-    clickCaseCheckbox(order.id!, 0);
-    clickCaseCheckbox(order.id!, 1);
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-    });
-
-    await user.click(approveButton);
-
-    const modal = screen.getByTestId(`modal-confirmation-modal-${order.id}`);
-    await waitFor(() => {
-      expect(modal).toBeInTheDocument();
-      expect(modal).toHaveClass('is-visible');
-      // for some reason, toBeVisible() doesn't work.
-      expect(modal).toHaveStyle({ display: 'block' });
-    });
-  });
-
   test('should open rejection modal when reject button is clicked', async () => {
     renderWithProps();
     const rejectButton = document.querySelector(
@@ -507,7 +247,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     ) as HTMLButtonElement;
     expect(rejectButton).not.toBeEnabled();
 
-    await selectTypeAndMarkLead();
+    await selectConsolidationType();
 
     clickCaseCheckbox(order.id!, 0);
     await waitFor(() => {
@@ -545,7 +285,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     clickCaseCheckbox(order.id!, 0);
 
-    await selectTypeAndMarkLead();
+    await selectConsolidationType();
 
     await waitFor(() => {
       expect(rejectButton).toBeEnabled();
@@ -600,7 +340,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     clickCaseCheckbox(order.id!, 0);
 
-    await selectTypeAndMarkLead();
+    await selectConsolidationType();
 
     await waitFor(() => {
       expect(rejectButton).toBeEnabled();
@@ -636,6 +376,92 @@ describe('ConsolidationOrderAccordion tests', () => {
     });
   });
 
+  test.skip('should correctly enable/disable buttons when selecting consolidated cases and lead case from order case list table', async () => {
+    renderWithProps();
+    const { approveButton, rejectButton, checkbox1 } = await fillInFormToEnableVerifyButton();
+    const includeAllCheckbox = document.querySelector(
+      `#checkbox-case-list-${order.id}-checkbox-toggle`,
+    );
+
+    const secondCheckbox = await clickCaseCheckbox(order.id!, 1);
+    await waitFor(() => {
+      expect(approveButton).toBeEnabled();
+      expect(rejectButton).toBeEnabled();
+    });
+
+    await clearLeadCase(0);
+    await waitFor(() => {
+      expect(approveButton).not.toBeEnabled();
+      expect(rejectButton).toBeEnabled();
+    });
+
+    await setLeadCase(0);
+    await waitFor(() => {
+      expect(approveButton).toBeEnabled();
+      expect(rejectButton).toBeEnabled();
+    });
+
+    await user.click(checkbox1!);
+    await waitFor(() => {
+      expect(approveButton).toBeEnabled();
+      expect(rejectButton).toBeEnabled();
+    });
+
+    await user.click(secondCheckbox!);
+    await waitFor(() => {
+      expect(approveButton).not.toBeEnabled();
+      expect(rejectButton).not.toBeEnabled();
+    });
+
+    await user.click(includeAllCheckbox!);
+    await waitFor(() => {
+      expect(approveButton).toBeEnabled();
+      expect(rejectButton).toBeEnabled();
+    });
+
+    await user.click(includeAllCheckbox!);
+    await waitFor(() => {
+      expect(approveButton).not.toBeEnabled();
+      expect(rejectButton).not.toBeEnabled();
+    });
+
+    await user.click(checkbox1!);
+    await user.click(secondCheckbox!);
+    await waitFor(() => {
+      expect(approveButton).toBeEnabled();
+      expect(rejectButton).toBeEnabled();
+    });
+  });
+
+  test.skip('should open approval modal when approve button is clicked', async () => {
+    renderWithProps();
+    await openAccordion(user, order.id!);
+
+    const approveButton = document.querySelector(
+      `#accordion-approve-button-${order.id}`,
+    ) as HTMLButtonElement;
+    expect(approveButton).not.toBeEnabled();
+
+    await selectConsolidationType();
+    await setLeadCase(0);
+
+    clickCaseCheckbox(order.id!, 0);
+    clickCaseCheckbox(order.id!, 1);
+    await waitFor(() => {
+      expect(approveButton).toBeEnabled();
+    });
+
+    await user.click(approveButton);
+
+    const modal = screen.getByTestId(`modal-confirmation-modal-${order.id}`);
+    await waitFor(() => {
+      expect(modal).toBeInTheDocument();
+      expect(modal).toHaveClass('is-visible');
+      // for some reason, toBeVisible() doesn't work.
+      expect(modal).toHaveStyle({ display: 'block' });
+    });
+  });
+
   test.skip('should call orderUpdate for approval', async () => {
     const leadCase = order.childCases[0];
     const expectedOrderApproved: ConsolidationOrder = {
@@ -651,19 +477,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     });
 
     renderWithProps();
-    await openAccordion(user, order.id!);
-
-    const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
-    expect(approveButton).not.toBeEnabled();
-
-    clickCaseCheckbox(order.id!, 0);
-    clickCaseCheckbox(order.id!, 1);
-
-    await selectTypeAndMarkLead();
-
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-    });
+    const { approveButton } = await fillInFormToEnableVerifyButton();
     await user.click(approveButton as HTMLButtonElement);
 
     const modal = screen.getByTestId(`modal-confirmation-modal-${order.id}`);
@@ -701,26 +515,14 @@ describe('ConsolidationOrderAccordion tests', () => {
 
   test.skip('should handle api exception for approval', async () => {
     renderWithProps();
-    await openAccordion(user, order.id!);
-
-    // setupApiGetMock();
 
     const errorMessage = 'Some random error';
     const alertMessage =
       'An unknown error has occurred and has been logged.  Please try again later.';
     vi.spyOn(Api2, 'putConsolidationOrderApproval').mockRejectedValue(new Error(errorMessage));
 
-    const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
-    expect(approveButton).not.toBeEnabled();
+    const { approveButton } = await fillInFormToEnableVerifyButton();
 
-    clickCaseCheckbox(order.id!, 0);
-    clickCaseCheckbox(order.id!, 1);
-
-    await selectTypeAndMarkLead();
-
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-    });
     await user.click(approveButton as HTMLButtonElement);
 
     await waitFor(() => {
@@ -760,35 +562,19 @@ describe('ConsolidationOrderAccordion tests', () => {
   // TODO: The fact that this if failing makes no sense to me. Manually it works as expected.
   test.skip('should clear checkboxes and disable approve button when cancel is clicked', async () => {
     renderWithProps();
-    await openAccordion(user, order.id!);
+    const { approveButton, rejectButton, clearButton, checkbox1, checkbox2 } =
+      await fillInFormToEnableVerifyButton();
 
-    const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
-    const rejectButton = document.querySelector(`#accordion-reject-button-${order.id}`);
-    const cancelButton = document.querySelector(`#accordion-cancel-button-${order.id}`);
-    expect(approveButton).not.toBeEnabled();
-    expect(rejectButton).not.toBeEnabled();
-
-    const checkbox1: HTMLInputElement | null = await clickCaseCheckbox(order.id!, 0);
-    const checkbox2: HTMLInputElement | null = await clickCaseCheckbox(order.id!, 1);
-
-    expect(approveButton).not.toBeEnabled();
-
-    await selectTypeAndMarkLead();
-
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-      expect(rejectButton).toBeEnabled();
-    });
     await user.click(approveButton as HTMLButtonElement);
 
     await waitFor(() => {
       expect(checkbox1!.checked).toBeTruthy();
       expect(checkbox2!.checked).toBeTruthy();
-      expect(approveButton).toBeEnabled();
       expect(rejectButton).toBeEnabled();
+      expect(approveButton).toBeEnabled();
     });
 
-    await user.click(cancelButton as HTMLButtonElement);
+    await user.click(clearButton as HTMLButtonElement);
 
     await waitFor(() => {
       expect(checkbox1!.checked).toBeFalsy();
@@ -800,20 +586,10 @@ describe('ConsolidationOrderAccordion tests', () => {
 
   test.skip('should clear checkboxes and disable approve button when accordion is collapsed', async () => {
     renderWithProps();
-    await openAccordion(user, order.id!);
+    let { approveButton, checkbox1, checkbox2 } = await fillInFormToEnableVerifyButton();
 
-    const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
     const collapseButton = screen.getByTestId(`accordion-button-order-list-${order.id}`);
-    expect(approveButton).not.toBeEnabled();
 
-    let checkbox1: HTMLInputElement | null = await clickCaseCheckbox(order.id!, 0);
-    let checkbox2: HTMLInputElement | null = await clickCaseCheckbox(order.id!, 1);
-
-    await selectTypeAndMarkLead();
-
-    await waitFor(() => {
-      expect(approveButton).toBeEnabled();
-    });
     await user.click(approveButton as HTMLButtonElement);
 
     await waitFor(() => {
@@ -832,6 +608,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       `checkbox-case-selection-case-list-${order.id}-1`,
     ) as HTMLInputElement | null;
 
+    approveButton = findApproveButton(order.id!);
     await waitFor(() => {
       expect(checkbox1!.checked).toBeFalsy();
       expect(checkbox2!.checked).toBeFalsy();
@@ -841,19 +618,13 @@ describe('ConsolidationOrderAccordion tests', () => {
 
   test.skip('should select all checkboxes and enable approve button when Include All button is clicked and consolidation type and lead case are set', async () => {
     renderWithProps();
-    await openAccordion(user, order.id!);
-    // setupApiGetMock();
-
-    await selectTypeAndMarkLead();
-
-    const approveButton = document.querySelector(`#accordion-approve-button-${order.id}`);
-    expect(approveButton).not.toBeEnabled();
+    const { approveButton } = await fillInFormToEnableVerifyButton();
 
     const checkboxList: NodeListOf<HTMLInputElement> = document.querySelectorAll(
       'table input[type="checkbox"]',
     );
 
-    const includeAllButton = await testingUtilities.selectCheckbox(
+    const includeAllCheckbox = await testingUtilities.selectCheckbox(
       `case-list-${order.id}-checkbox-toggle`,
     );
 
@@ -872,7 +643,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       expect(checkboxList[0].checked).toBeFalsy();
     });
 
-    await user.click(includeAllButton!);
+    await user.click(includeAllCheckbox!);
     await waitFor(() => {
       for (const checkbox of checkboxList) {
         expect(checkbox.checked).toBeTruthy();
@@ -880,7 +651,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       expect(approveButton).toBeEnabled();
     });
 
-    await user.click(includeAllButton!);
+    await user.click(includeAllCheckbox!);
     await waitFor(() => {
       for (const checkbox of checkboxList) {
         expect(checkbox.checked).toBeFalsy();

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
@@ -881,24 +881,4 @@ describe('ConsolidationOrderAccordion tests', () => {
       expect(approveButton).toBeDisabled();
     });
   });
-
-  test('checking "lead case not listed" checkbox should clear markLeadCase button selection', async () => {
-    renderWithProps();
-    await openAccordion(user, order.id!);
-
-    const leadCaseNotListedCheckboxTestId = `button-checkbox-lead-case-form-checkbox-toggle-${order.id}-click-target`;
-    const leadCaseFormCheckbox = screen.getByTestId(leadCaseNotListedCheckboxTestId);
-    expect(leadCaseFormCheckbox).not.toBeChecked();
-
-    const markLeadButtonTestId = `button-assign-lead-case-list-${order.id}-0`;
-    const markLeadCaseButton = screen.getByTestId(markLeadButtonTestId);
-    expect(markLeadCaseButton).toHaveClass('usa-button--outline');
-
-    await user.click(markLeadCaseButton);
-    expect(markLeadCaseButton).not.toHaveClass('usa-button--outline');
-
-    await user.click(leadCaseFormCheckbox);
-    expect(leadCaseFormCheckbox).not.toBeChecked();
-    expect(screen.getByTestId(markLeadButtonTestId)).toHaveClass('usa-button--outline');
-  });
 });

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
@@ -100,6 +100,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     const markAsLeadButton = screen.getByTestId(
       `button-assign-lead-case-list-${order.id}-${index}`,
     );
+    expect(markAsLeadButton).not.toBeNull();
     if (markAsLeadButton.classList.contains('usa-button--outline')) {
       await user.click(markAsLeadButton);
       expect(markAsLeadButton).not.toHaveClass('usa-button--outline');
@@ -112,16 +113,19 @@ describe('ConsolidationOrderAccordion tests', () => {
   async function selectTypeAndMarkLead() {
     const consolidationTypeRadio = document.querySelector('input[name="consolidation-type"]');
     const consolidationTypeRadioLabel = document.querySelector('.usa-radio__label');
-    await user.click(consolidationTypeRadioLabel!);
+    expect(consolidationTypeRadioLabel).not.toBeNull();
+    if (consolidationTypeRadioLabel) {
+      await user.click(consolidationTypeRadioLabel);
+    }
     expect(consolidationTypeRadio).toBeChecked();
 
     await clickMarkLeadButton(0);
   }
 
-  function clickCaseCheckbox(oid: string, idx: number) {
+  async function clickCaseCheckbox(oid: string, idx: number) {
     return testingUtilities.selectCheckbox(
       `case-selection-case-list-${oid}-${idx}`,
-    ) as HTMLInputElement | null;
+    ) as Promise<HTMLInputElement | null>;
   }
 
   function findCaseNumberInput(id: string) {
@@ -131,7 +135,9 @@ describe('ConsolidationOrderAccordion tests', () => {
   }
 
   async function enterCaseNumber(caseIdInput: Element | null | undefined, value: string) {
-    if (!caseIdInput) throw Error();
+    if (!caseIdInput) {
+      throw Error();
+    }
 
     await user.type(caseIdInput!, value);
   }
@@ -248,13 +254,13 @@ describe('ConsolidationOrderAccordion tests', () => {
     expect(approveButton).not.toBeEnabled();
     expect(rejectButton).not.toBeEnabled();
 
-    const firstCheckbox = clickCaseCheckbox(order.id!, 0);
+    const firstCheckbox = await clickCaseCheckbox(order.id!, 0);
     await waitFor(() => {
       expect(approveButton).toBeEnabled();
       expect(rejectButton).toBeEnabled();
     });
 
-    const secondCheckbox = clickCaseCheckbox(order.id!, 1);
+    const secondCheckbox = await clickCaseCheckbox(order.id!, 1);
     await waitFor(() => {
       expect(approveButton).toBeEnabled();
       expect(rejectButton).toBeEnabled();
@@ -751,6 +757,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     });
   });
 
+  // TODO: The fact that this if failing makes no sense to me. Manually it works as expected.
   test.skip('should clear checkboxes and disable approve button when cancel is clicked', async () => {
     renderWithProps();
     await openAccordion(user, order.id!);
@@ -761,8 +768,8 @@ describe('ConsolidationOrderAccordion tests', () => {
     expect(approveButton).not.toBeEnabled();
     expect(rejectButton).not.toBeEnabled();
 
-    const checkbox1: HTMLInputElement | null = clickCaseCheckbox(order.id!, 0);
-    const checkbox2: HTMLInputElement | null = clickCaseCheckbox(order.id!, 1);
+    const checkbox1: HTMLInputElement | null = await clickCaseCheckbox(order.id!, 0);
+    const checkbox2: HTMLInputElement | null = await clickCaseCheckbox(order.id!, 1);
 
     expect(approveButton).not.toBeEnabled();
 
@@ -799,8 +806,8 @@ describe('ConsolidationOrderAccordion tests', () => {
     const collapseButton = screen.getByTestId(`accordion-button-order-list-${order.id}`);
     expect(approveButton).not.toBeEnabled();
 
-    let checkbox1: HTMLInputElement | null = clickCaseCheckbox(order.id!, 0);
-    let checkbox2: HTMLInputElement | null = clickCaseCheckbox(order.id!, 1);
+    let checkbox1: HTMLInputElement | null = await clickCaseCheckbox(order.id!, 0);
+    let checkbox2: HTMLInputElement | null = await clickCaseCheckbox(order.id!, 1);
 
     await selectTypeAndMarkLead();
 
@@ -846,7 +853,7 @@ describe('ConsolidationOrderAccordion tests', () => {
       'table input[type="checkbox"]',
     );
 
-    const includeAllButton = testingUtilities.selectCheckbox(
+    const includeAllButton = await testingUtilities.selectCheckbox(
       `case-list-${order.id}-checkbox-toggle`,
     );
 

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
@@ -55,6 +55,12 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     useCase.getValidLeadCase();
   }, [consolidationStore.leadCaseNumber, consolidationStore.leadCaseCourt]);
 
+  useEffect(() => {
+    if (consolidationStore.caseToAddCourt && consolidationStore.caseToAddCaseNumber) {
+      useCase.verifyCaseCanBeAdded();
+    }
+  }, [consolidationStore.caseToAddCourt, consolidationStore.caseToAddCaseNumber]);
+
   const viewModel: ConsolidationViewModel = {
     accordionFieldHeaders: fieldHeaders,
     approveButton: consolidationControls.approveButton,
@@ -99,6 +105,18 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     handleToggleLeadCaseForm: useCase.handleToggleLeadCaseForm,
     showConfirmationModal: consolidationControls.showConfirmationModal,
     updateAllSelections: useCase.updateAllSelections,
+
+    handleAddCaseReset: useCase.handleAddCaseReset,
+    handleAddCaseNumberInputChange: useCase.handleAddCaseNumberInputChange,
+    handleAddCaseCourtSelectChange: useCase.handleAddCaseCourtSelectChange,
+    showAddCaseModal: consolidationControls.showAddCaseModal,
+    addCaseModal: consolidationControls.addCaseModal,
+    handleAddCaseAction: useCase.handleAddCaseAction,
+    additionalCaseDivisionRef: consolidationControls.additionalCaseDivisionRef,
+    additionalCaseNumberRef: consolidationControls.additionalCaseNumberRef,
+    addCaseNumberError: consolidationStore.addCaseNumberError,
+    isLookingForCase: consolidationStore.isLookingForCase,
+    caseToAdd: consolidationStore.caseToAdd,
   };
 
   return <ConsolidationOrderAccordionView viewModel={viewModel}></ConsolidationOrderAccordionView>;

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
@@ -102,7 +102,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     handleAddCaseReset: useCase.handleAddCaseReset,
     handleAddCaseNumberInputChange: useCase.handleAddCaseNumberInputChange,
     handleAddCaseCourtSelectChange: useCase.handleAddCaseCourtSelectChange,
-    showAddCaseModal: consolidationControls.showAddCaseModal,
     addCaseModal: consolidationControls.addCaseModal,
     handleAddCaseAction: useCase.handleAddCaseAction,
     additionalCaseDivisionRef: consolidationControls.additionalCaseDivisionRef,

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
@@ -52,10 +52,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
   ]);
 
   useEffect(() => {
-    useCase.getValidLeadCase();
-  }, [consolidationStore.leadCaseNumber, consolidationStore.leadCaseCourt]);
-
-  useEffect(() => {
     if (consolidationStore.caseToAddCourt && consolidationStore.caseToAddCaseNumber) {
       useCase.verifyCaseCanBeAdded();
     }
@@ -80,9 +76,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     isValidatingLeadCaseNumber: consolidationStore.isValidatingLeadCaseNumber,
     jointAdministrationRadio: consolidationControls.jointAdministrationRadio,
     leadCase: consolidationStore.leadCase,
-    leadCaseDivisionRef: consolidationControls.leadCaseDivisionRef,
-    leadCaseNumberError: consolidationStore.leadCaseNumberError,
-    leadCaseNumberRef: consolidationControls.leadCaseNumberRef,
     order: consolidationStore.order,
     orderType: orderType, // TODO: why is orderType a Map<string, string>?
     rejectButton: consolidationControls.rejectButton,

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
@@ -95,7 +95,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     handleRejectButtonClick: useCase.handleRejectButtonClick,
     handleSelectConsolidationType: useCase.handleSelectConsolidationType,
     handleSelectLeadCaseCourt: useCase.handleSelectLeadCaseCourt,
-    handleToggleLeadCaseForm: useCase.handleToggleLeadCaseForm,
     showConfirmationModal: consolidationControls.showConfirmationModal,
     updateAllSelections: useCase.updateAllSelections,
 

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.tsx
@@ -51,13 +51,9 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     consolidationStore.consolidationType,
   ]);
 
-  useEffect(() => {
-    if (consolidationStore.caseToAddCourt && consolidationStore.caseToAddCaseNumber) {
-      useCase.verifyCaseCanBeAdded();
-    }
-  }, [consolidationStore.caseToAddCourt, consolidationStore.caseToAddCaseNumber]);
-
   const viewModel: ConsolidationViewModel = {
+    caseToAddCaseNumber: consolidationStore.caseToAddCaseNumber,
+    caseToAddCourt: consolidationStore.caseToAddCourt,
     accordionFieldHeaders: fieldHeaders,
     approveButton: consolidationControls.approveButton,
     caseTableActions: consolidationControls.caseTableActions,
@@ -89,7 +85,6 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     handleClearInputs: useCase.handleClearInputs,
     handleConfirmAction: useCase.handleConfirmAction,
     handleIncludeCase: useCase.handleIncludeCase,
-    handleLeadCaseInputChange: useCase.handleLeadCaseInputChange,
     handleMarkLeadCase: useCase.handleMarkLeadCase,
     handleOnExpand: useCase.handleOnExpand,
     handleRejectButtonClick: useCase.handleRejectButtonClick,
@@ -108,6 +103,7 @@ export function ConsolidationOrderAccordion(props: ConsolidationOrderAccordionPr
     addCaseNumberError: consolidationStore.addCaseNumberError,
     isLookingForCase: consolidationStore.isLookingForCase,
     caseToAdd: consolidationStore.caseToAdd,
+    verifyCaseCanBeAdded: useCase.verifyCaseCanBeAdded,
   };
 
   return <ConsolidationOrderAccordionView viewModel={viewModel}></ConsolidationOrderAccordionView>;

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -3,19 +3,13 @@ import { FormRequirementsNotice } from '@/lib/components/uswds/FormRequirementsN
 import { RadioGroup } from '@/lib/components/uswds/RadioGroup';
 import Radio from '@/lib/components/uswds/Radio';
 import { ConsolidationCaseTable } from '@/data-verification/consolidation/ConsolidationCasesTable';
-import Checkbox from '@/lib/components/uswds/Checkbox';
-import CaseNumberInput from '@/lib/components/CaseNumberInput';
-import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import { CaseTable } from '@/data-verification/transfer/CaseTable';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import { ConsolidationOrderModal } from '@/data-verification/consolidation/ConsolidationOrderModal';
 import { CaseNumber } from '@/lib/components/CaseNumber';
 import { ConsolidationViewModel } from '@/data-verification/consolidation/consolidationViewModel';
-import { getCaseNumber } from '@/lib/utils/caseNumber';
-import ComboBox from '@/lib/components/combobox/ComboBox';
 import { sanitizeText } from '@/lib/utils/sanitize-text';
-import { useEffect } from 'react';
 import { AddCaseModal } from '@/data-verification/consolidation/AddCaseModal';
 import { OpenModalButton } from '@/lib/components/uswds/modal/OpenModalButton';
 
@@ -31,18 +25,6 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
       viewModel.expandedAccordionId === `order-list-${viewModel.order.id}` ? 'Collapse' : 'Expand';
     return `Click to ${action}.`;
   }
-
-  useEffect(() => {
-    if (viewModel.showLeadCaseForm) {
-      const selectedOption = viewModel.filteredOfficeRecords?.find(
-        (office) => office.value === viewModel.divisionCode,
-      );
-
-      if (selectedOption && viewModel.leadCaseDivisionRef) {
-        viewModel.leadCaseDivisionRef.current?.setSelections([selectedOption]);
-      }
-    }
-  }, [viewModel.showLeadCaseForm]);
 
   return (
     <Accordion
@@ -159,90 +141,6 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
                 >
                   Add Case
                 </OpenModalButton>
-              </div>
-              <div className="grid-col-1"></div>
-            </div>
-            <div
-              className="lead-case-form grid-row grid-gap-lg"
-              data-testid={`lead-case-form-${viewModel.order.id}`}
-            >
-              <div className="grid-col-1"></div>
-              <div className="grid-col-10">
-                <Checkbox
-                  id={`lead-case-form-checkbox-toggle-${viewModel.order.id}`}
-                  className="lead-case-form-toggle"
-                  onChange={(ev) => viewModel.handleToggleLeadCaseForm(ev.target.checked)}
-                  value=""
-                  ref={viewModel.leadCaseFormToggle}
-                  label="Lead Case Not Listed"
-                  checked={viewModel.showLeadCaseForm}
-                ></Checkbox>
-                {viewModel.showLeadCaseForm && (
-                  <section
-                    className={`lead-case-form-container lead-case-form-container-${viewModel.order.id}`}
-                  >
-                    <h3>Enter lead case details:</h3>
-                    <span id="lead-case-form-instructions">
-                      Choose a new court and enter a case number, and the lead case will be selected
-                      for this Case Event automatically.
-                    </span>
-                    <div className="lead-case-court-container">
-                      <ComboBox
-                        id={'lead-case-court'}
-                        className="lead-case-court"
-                        label="Select a court"
-                        ariaDescription="foo bar"
-                        aria-live="off"
-                        aria-describedby="lead-case-form-instructions"
-                        onUpdateSelection={viewModel.handleSelectLeadCaseCourt}
-                        options={viewModel.filteredOfficeRecords!}
-                        required={true}
-                        multiSelect={false}
-                        ref={viewModel.leadCaseDivisionRef}
-                      />
-                    </div>
-                    <div className="lead-case-number-container">
-                      <CaseNumberInput
-                        id={`lead-case-input-${viewModel.order.id}`}
-                        data-testid={`lead-case-input-${viewModel.order.id}`}
-                        className="usa-input"
-                        value={getCaseNumber(viewModel.leadCase?.caseId)}
-                        onChange={viewModel.handleLeadCaseInputChange}
-                        allowPartialCaseNumber={false}
-                        required={true}
-                        label="Enter a case number"
-                        ref={viewModel.leadCaseNumberRef}
-                        aria-describedby="lead-case-form-instructions"
-                      />
-                      {viewModel.leadCaseNumberError ? (
-                        <Alert
-                          id={`lead-case-number-alert-${viewModel.order.id}`}
-                          message={viewModel.leadCaseNumberError}
-                          type={UswdsAlertStyle.Error}
-                          show={true}
-                          slim={true}
-                          inline={true}
-                        ></Alert>
-                      ) : (
-                        <LoadingSpinner
-                          id={`lead-case-number-loading-spinner-${viewModel.order.id}`}
-                          caption="Verifying lead case number..."
-                          height="40px"
-                          hidden={!viewModel.isValidatingLeadCaseNumber}
-                        />
-                      )}
-                      {viewModel.foundValidCaseNumber && viewModel.leadCase && (
-                        <>
-                          <h4>Selected Lead Case</h4>
-                          <CaseTable
-                            id={`valid-case-number-found-${viewModel.order.id}`}
-                            cases={[viewModel.leadCase]}
-                          ></CaseTable>
-                        </>
-                      )}
-                    </div>
-                  </section>
-                )}
               </div>
               <div className="grid-col-1"></div>
             </div>

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -16,6 +16,7 @@ import { getCaseNumber } from '@/lib/utils/caseNumber';
 import ComboBox from '@/lib/components/combobox/ComboBox';
 import { sanitizeText } from '@/lib/utils/sanitize-text';
 import { useEffect } from 'react';
+import { AddCaseModal } from '@/data-verification/consolidation/AddCaseModal';
 
 export type ConsolidationOrderAccordionViewProps = {
   viewModel: ConsolidationViewModel;
@@ -282,6 +283,11 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
               onCancel={() => {}}
               onConfirm={viewModel.handleConfirmAction}
             ></ConsolidationOrderModal>
+            {/* TODO: remove excess properties from below since AddCaseModel requires only some properties from ConsolidationViewModel */}
+            <AddCaseModal
+              ref={viewModel.addCaseModal}
+              addCaseModel={{ ...viewModel, orderId: viewModel.order.id! }}
+            ></AddCaseModal>
           </section>
         )}
         {viewModel.order.status === 'approved' && (

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -8,10 +8,44 @@ import { CaseTable } from '@/data-verification/transfer/CaseTable';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import { ConsolidationOrderModal } from '@/data-verification/consolidation/ConsolidationOrderModal';
 import { CaseNumber } from '@/lib/components/CaseNumber';
-import { ConsolidationViewModel } from '@/data-verification/consolidation/consolidationViewModel';
+import {
+  AddCaseModel,
+  ConsolidationViewModel,
+} from '@/data-verification/consolidation/consolidationViewModel';
 import { sanitizeText } from '@/lib/utils/sanitize-text';
 import { AddCaseModal } from '@/data-verification/consolidation/AddCaseModal';
 import { OpenModalButton } from '@/lib/components/uswds/modal/OpenModalButton';
+
+function toAddCaseModel(viewModel: ConsolidationViewModel): AddCaseModel {
+  const {
+    handleAddCaseCourtSelectChange,
+    handleAddCaseNumberInputChange,
+    handleAddCaseReset,
+    filteredOfficeRecords,
+    additionalCaseDivisionRef,
+    additionalCaseNumberRef,
+    addCaseNumberError,
+    isLookingForCase,
+    caseToAdd,
+    handleAddCaseAction,
+    order: { id: orderId, courtDivisionCode: defaultDivisionCode },
+  } = viewModel;
+
+  return {
+    handleAddCaseCourtSelectChange,
+    handleAddCaseNumberInputChange,
+    handleAddCaseReset,
+    filteredOfficeRecords,
+    additionalCaseDivisionRef,
+    additionalCaseNumberRef,
+    addCaseNumberError,
+    isLookingForCase,
+    caseToAdd,
+    handleAddCaseAction,
+    orderId: orderId ?? '',
+    defaultDivisionCode,
+  };
+}
 
 export type ConsolidationOrderAccordionViewProps = {
   viewModel: ConsolidationViewModel;
@@ -188,15 +222,10 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
               onCancel={() => {}}
               onConfirm={viewModel.handleConfirmAction}
             ></ConsolidationOrderModal>
-            {/* TODO: remove excess properties from below since AddCaseModel requires only some properties from ConsolidationViewModel */}
             <AddCaseModal
               id={`add-case-modal-${viewModel.order.id}`}
               ref={viewModel.addCaseModal}
-              addCaseModel={{
-                ...viewModel,
-                orderId: viewModel.order.id!,
-                defaultDivisionCode: viewModel.order.courtDivisionCode,
-              }}
+              addCaseModel={toAddCaseModel(viewModel)}
             ></AddCaseModal>
           </section>
         )}

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -17,6 +17,7 @@ import ComboBox from '@/lib/components/combobox/ComboBox';
 import { sanitizeText } from '@/lib/utils/sanitize-text';
 import { useEffect } from 'react';
 import { AddCaseModal } from '@/data-verification/consolidation/AddCaseModal';
+import { OpenModalButton } from '@/lib/components/uswds/modal/OpenModalButton';
 
 export type ConsolidationOrderAccordionViewProps = {
   viewModel: ConsolidationViewModel;
@@ -152,6 +153,12 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
                   ref={viewModel.caseTableActions}
                   onMarkLead={viewModel.handleMarkLeadCase}
                 ></ConsolidationCaseTable>
+                <OpenModalButton
+                  modalId={`add-case-modal-${viewModel.order.id}`}
+                  modalRef={viewModel.addCaseModal}
+                >
+                  Add Case
+                </OpenModalButton>
               </div>
               <div className="grid-col-1"></div>
             </div>
@@ -285,6 +292,7 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
             ></ConsolidationOrderModal>
             {/* TODO: remove excess properties from below since AddCaseModel requires only some properties from ConsolidationViewModel */}
             <AddCaseModal
+              id={`add-case-modal-${viewModel.order.id}`}
               ref={viewModel.addCaseModal}
               addCaseModel={{ ...viewModel, orderId: viewModel.order.id! }}
             ></AddCaseModal>

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -294,7 +294,11 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
             <AddCaseModal
               id={`add-case-modal-${viewModel.order.id}`}
               ref={viewModel.addCaseModal}
-              addCaseModel={{ ...viewModel, orderId: viewModel.order.id! }}
+              addCaseModel={{
+                ...viewModel,
+                orderId: viewModel.order.id!,
+                defaultDivisionCode: viewModel.order.courtDivisionCode,
+              }}
             ></AddCaseModal>
           </section>
         )}

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -208,7 +208,6 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
                   uswdsStyle={UswdsButtonStyle.Outline}
                   className="margin-right-2"
                   ref={viewModel.rejectButton}
-                  // disabled={true}
                 >
                   Reject
                 </Button>

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -18,6 +18,8 @@ import { OpenModalButton } from '@/lib/components/uswds/modal/OpenModalButton';
 
 function toAddCaseModel(viewModel: ConsolidationViewModel): AddCaseModel {
   const {
+    caseToAddCaseNumber,
+    caseToAddCourt,
     handleAddCaseCourtSelectChange,
     handleAddCaseNumberInputChange,
     handleAddCaseReset,
@@ -28,10 +30,13 @@ function toAddCaseModel(viewModel: ConsolidationViewModel): AddCaseModel {
     isLookingForCase,
     caseToAdd,
     handleAddCaseAction,
+    verifyCaseCanBeAdded,
     order: { id: orderId, courtDivisionCode: defaultDivisionCode },
   } = viewModel;
 
   return {
+    caseToAddCaseNumber,
+    caseToAddCourt,
     handleAddCaseCourtSelectChange,
     handleAddCaseNumberInputChange,
     handleAddCaseReset,
@@ -44,6 +49,7 @@ function toAddCaseModel(viewModel: ConsolidationViewModel): AddCaseModel {
     handleAddCaseAction,
     orderId: orderId ?? '',
     defaultDivisionCode,
+    verifyCaseCanBeAdded,
   };
 }
 
@@ -202,6 +208,7 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
                   uswdsStyle={UswdsButtonStyle.Outline}
                   className="margin-right-2"
                   ref={viewModel.rejectButton}
+                  // disabled={true}
                 >
                   Reject
                 </Button>

--- a/user-interface/src/data-verification/consolidation/consolidationControls.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControls.ts
@@ -4,6 +4,7 @@ import { ConfirmationModalImperative } from '@/data-verification/consolidation/C
 import { ComboBoxRef, InputRef, RadioRef } from '@/lib/type-declarations/input-fields';
 import { CheckboxRef } from '@/lib/components/uswds/Checkbox';
 import { ConsolidationOrderCase, ConsolidationType, OrderStatus } from '@common/cams/orders';
+import { AddCaseModalImperative } from '@/data-verification/consolidation/AddCaseModal';
 
 export type ShowConfirmationModal = (
   selectedCases: ConsolidationOrderCase[],
@@ -23,6 +24,7 @@ interface ConsolidationControls {
   caseTableActions: Ref<OrderTableImperative>;
   clearButton: Ref<ButtonRef>;
   confirmationModal: Ref<ConfirmationModalImperative>;
+  addCaseModal: Ref<AddCaseModalImperative>;
   jointAdministrationRadio: Ref<RadioRef>;
   leadCaseDivisionRef: Ref<ComboBoxRef>;
   leadCaseNumberRef: Ref<InputRef>;
@@ -33,11 +35,11 @@ interface ConsolidationControls {
   additionalCaseNumberRef: Ref<InputRef>;
 
   showConfirmationModal: ShowConfirmationModal;
+  showAddCaseModal: ShowAddCaseModal;
   disableLeadCaseForm: (disabled: boolean) => void;
   clearAllCheckBoxes: () => void;
   disableButton: (button: Ref<ButtonRef>, state: boolean) => void;
   unsetConsolidationType: () => void;
-  submitAddCase: () => void;
 }
 
 export type { ConsolidationControls };

--- a/user-interface/src/data-verification/consolidation/consolidationControls.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControls.ts
@@ -13,8 +13,6 @@ export type ShowConfirmationModal = (
   consolidationType?: ConsolidationType,
 ) => void;
 
-export type ShowAddCaseModal = (defaultOffice: string) => void;
-
 export type Ref<T> = {
   current: T | null;
 };
@@ -33,7 +31,6 @@ interface ConsolidationControls {
   additionalCaseNumberRef: Ref<InputRef>;
 
   showConfirmationModal: ShowConfirmationModal;
-  showAddCaseModal: ShowAddCaseModal;
   clearAllCheckBoxes: () => void;
   disableButton: (button: Ref<ButtonRef>, state: boolean) => void;
   unsetConsolidationType: () => void;

--- a/user-interface/src/data-verification/consolidation/consolidationControls.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControls.ts
@@ -26,8 +26,6 @@ interface ConsolidationControls {
   confirmationModal: Ref<ConfirmationModalImperative>;
   addCaseModal: Ref<AddCaseModalImperative>;
   jointAdministrationRadio: Ref<RadioRef>;
-  leadCaseDivisionRef: Ref<ComboBoxRef>;
-  leadCaseNumberRef: Ref<InputRef>;
   rejectButton: Ref<ButtonRef>;
   substantiveRadio: Ref<RadioRef>;
   leadCaseFormToggle: Ref<CheckboxRef>;
@@ -36,7 +34,6 @@ interface ConsolidationControls {
 
   showConfirmationModal: ShowConfirmationModal;
   showAddCaseModal: ShowAddCaseModal;
-  disableLeadCaseForm: (disabled: boolean) => void;
   clearAllCheckBoxes: () => void;
   disableButton: (button: Ref<ButtonRef>, state: boolean) => void;
   unsetConsolidationType: () => void;

--- a/user-interface/src/data-verification/consolidation/consolidationControls.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControls.ts
@@ -12,6 +12,8 @@ export type ShowConfirmationModal = (
   consolidationType?: ConsolidationType,
 ) => void;
 
+export type ShowAddCaseModal = (defaultOffice: string) => void;
+
 export type Ref<T> = {
   current: T | null;
 };
@@ -27,12 +29,15 @@ interface ConsolidationControls {
   rejectButton: Ref<ButtonRef>;
   substantiveRadio: Ref<RadioRef>;
   leadCaseFormToggle: Ref<CheckboxRef>;
+  additionalCaseDivisionRef: Ref<ComboBoxRef>;
+  additionalCaseNumberRef: Ref<InputRef>;
 
   showConfirmationModal: ShowConfirmationModal;
   disableLeadCaseForm: (disabled: boolean) => void;
   clearAllCheckBoxes: () => void;
   disableButton: (button: Ref<ButtonRef>, state: boolean) => void;
   unsetConsolidationType: () => void;
+  submitAddCase: () => void;
 }
 
 export type { ConsolidationControls };

--- a/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
@@ -101,7 +101,6 @@ export function useConsolidationControlsMock(): ConsolidationControls {
     status: OrderStatus,
     consolidationType?: ConsolidationType,
   ) => {};
-  const showAddCaseModal = (defaultOffice: string) => {};
 
   const clearAllCheckBoxes = () => {};
   const disableButton = (button: Ref<ButtonRef>, state: boolean) => {};
@@ -125,6 +124,5 @@ export function useConsolidationControlsMock(): ConsolidationControls {
     additionalCaseDivisionRef,
     additionalCaseNumberRef,
     addCaseModal: addCaseModalRef,
-    showAddCaseModal,
   };
 }

--- a/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
@@ -107,22 +107,20 @@ export function useConsolidationControlsMock(): ConsolidationControls {
   const unsetConsolidationType = () => {};
 
   return {
-    approveButton,
-    caseTableActions: caseTableRef,
-    clearButton,
-    confirmationModal: confirmationModalRef,
-    jointAdministrationRadio: jointAdministrationRef,
-    rejectButton,
-    substantiveRadio: substantiveRef,
-    leadCaseFormToggle: toggleLeadCaseFormRef,
-    showConfirmationModal,
-    clearAllCheckBoxes,
-    disableButton,
-    unsetConsolidationType,
-
-    // TODO: CAMS-548 properties
     additionalCaseDivisionRef,
     additionalCaseNumberRef,
     addCaseModal: addCaseModalRef,
+    approveButton,
+    caseTableActions: caseTableRef,
+    clearAllCheckBoxes,
+    clearButton,
+    confirmationModal: confirmationModalRef,
+    disableButton,
+    jointAdministrationRadio: jointAdministrationRef,
+    leadCaseFormToggle: toggleLeadCaseFormRef,
+    rejectButton,
+    showConfirmationModal,
+    substantiveRadio: substantiveRef,
+    unsetConsolidationType,
   };
 }

--- a/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
@@ -33,6 +33,12 @@ export function useConsolidationControlsMock(): ConsolidationControls {
       hide: () => {},
     },
   };
+  const addCaseModalRef = {
+    current: {
+      show: () => {},
+      hide: () => {},
+    },
+  };
   const jointAdministrationRef = {
     current: {
       disable: (value: boolean) => {},
@@ -58,6 +64,33 @@ export function useConsolidationControlsMock(): ConsolidationControls {
     },
   };
   const leadCaseNumberRef = {
+    current: {
+      setValue: (value: string) => {},
+      disable: (value: boolean) => {},
+      clearValue: () => {},
+      resetValue: () => {},
+      getValue: () => '',
+      focus: () => {},
+    },
+  };
+  const additionalCaseDivisionRef = {
+    current: {
+      setSelections: (options: ComboOption[]) => {},
+      getSelections: () => [
+        {
+          value: '',
+          label: '',
+          selected: false,
+          hidden: false,
+        },
+      ],
+      clearSelections: () => {},
+      disable: (value: boolean) => {},
+      focusInput: () => {},
+      focus: () => {},
+    },
+  };
+  const additionalCaseNumberRef = {
     current: {
       setValue: (value: string) => {},
       disable: (value: boolean) => {},
@@ -94,6 +127,8 @@ export function useConsolidationControlsMock(): ConsolidationControls {
     status: OrderStatus,
     consolidationType?: ConsolidationType,
   ) => {};
+  const showAddCaseModal = (defaultOffice: string) => {};
+
   const disableLeadCaseForm = (disabled: boolean) => {};
   const clearAllCheckBoxes = () => {};
   const disableButton = (button: Ref<ButtonRef>, state: boolean) => {};
@@ -115,5 +150,11 @@ export function useConsolidationControlsMock(): ConsolidationControls {
     clearAllCheckBoxes,
     disableButton,
     unsetConsolidationType,
+
+    // TODO: CAMS-548 properties
+    additionalCaseDivisionRef,
+    additionalCaseNumberRef,
+    addCaseModal: addCaseModalRef,
+    showAddCaseModal,
   };
 }

--- a/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
@@ -46,33 +46,7 @@ export function useConsolidationControlsMock(): ConsolidationControls {
       isChecked: () => true,
     },
   };
-  const leadCaseDivisionRef = {
-    current: {
-      setSelections: (options: ComboOption[]) => {},
-      getSelections: () => [
-        {
-          value: '',
-          label: '',
-          selected: false,
-          hidden: false,
-        },
-      ],
-      clearSelections: () => {},
-      disable: (value: boolean) => {},
-      focusInput: () => {},
-      focus: () => {},
-    },
-  };
-  const leadCaseNumberRef = {
-    current: {
-      setValue: (value: string) => {},
-      disable: (value: boolean) => {},
-      clearValue: () => {},
-      resetValue: () => {},
-      getValue: () => '',
-      focus: () => {},
-    },
-  };
+
   const additionalCaseDivisionRef = {
     current: {
       setSelections: (options: ComboOption[]) => {},
@@ -129,7 +103,6 @@ export function useConsolidationControlsMock(): ConsolidationControls {
   ) => {};
   const showAddCaseModal = (defaultOffice: string) => {};
 
-  const disableLeadCaseForm = (disabled: boolean) => {};
   const clearAllCheckBoxes = () => {};
   const disableButton = (button: Ref<ButtonRef>, state: boolean) => {};
   const unsetConsolidationType = () => {};
@@ -140,13 +113,10 @@ export function useConsolidationControlsMock(): ConsolidationControls {
     clearButton,
     confirmationModal: confirmationModalRef,
     jointAdministrationRadio: jointAdministrationRef,
-    leadCaseDivisionRef,
-    leadCaseNumberRef,
     rejectButton,
     substantiveRadio: substantiveRef,
     leadCaseFormToggle: toggleLeadCaseFormRef,
     showConfirmationModal,
-    disableLeadCaseForm,
     clearAllCheckBoxes,
     disableButton,
     unsetConsolidationType,

--- a/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
@@ -6,19 +6,19 @@ import { ConfirmationModalImperative } from '@/data-verification/consolidation/C
 import { ComboBoxRef, InputRef, RadioRef } from '@/lib/type-declarations/input-fields';
 import { CheckboxRef } from '@/lib/components/uswds/Checkbox';
 import { ConsolidationOrderCase, ConsolidationType, OrderStatus } from '@common/cams/orders';
-import {
-  AddCaseModalImperative
-} from "@/data-verification/consolidation/AddCaseModal";
+import { AddCaseModalImperative } from '@/data-verification/consolidation/AddCaseModal';
 
 export function useConsolidationControlsReact(): ConsolidationControls {
   const approveButton = useRef<ButtonRef>(null);
   const caseTableActions = useRef<OrderTableImperative>(null);
   const clearButton = useRef<ButtonRef>(null);
   const confirmationModal = useRef<ConfirmationModalImperative>(null);
-  const addCaseModal = useRef<AddCaseModalImperative>(null)
+  const addCaseModal = useRef<AddCaseModalImperative>(null);
   const jointAdministrationRadio = useRef<RadioRef>(null);
   const leadCaseDivisionRef = useRef<ComboBoxRef>(null);
   const leadCaseNumberRef = useRef<InputRef>(null);
+  const additionalCaseDivisionRef = useRef<ComboBoxRef>(null);
+  const additionalCaseNumberRef = useRef<InputRef>(null);
   const rejectButton = useRef<ButtonRef>(null);
   const substantiveRadio = useRef<RadioRef>(null);
   const leadCaseFormToggle = useRef<CheckboxRef>(null);
@@ -37,10 +37,10 @@ export function useConsolidationControlsReact(): ConsolidationControls {
     });
   };
 
-  // TODO: We need a showAddCaseModal
-  const showAddCaseModal = () => {
+  const showAddCaseModal = (_defaultOffice: string) => {
+    // TODO: implement
     // addCaseModal.show
-  }
+  };
 
   const disableLeadCaseForm = (disabled: boolean) => {
     leadCaseDivisionRef.current?.disable(disabled);
@@ -65,8 +65,8 @@ export function useConsolidationControlsReact(): ConsolidationControls {
     clearButton,
     confirmationModal,
     jointAdministrationRadio,
-    leadCaseDivisionRef: leadCaseDivisionRef,
-    leadCaseNumberRef: leadCaseNumberRef,
+    leadCaseDivisionRef,
+    leadCaseNumberRef,
     rejectButton,
     substantiveRadio,
     leadCaseFormToggle,
@@ -75,5 +75,11 @@ export function useConsolidationControlsReact(): ConsolidationControls {
     clearAllCheckBoxes,
     disableButton,
     unsetConsolidationType,
+
+    // TODO: CAMS-548 properties
+    additionalCaseDivisionRef,
+    additionalCaseNumberRef,
+    addCaseModal,
+    showAddCaseModal,
   };
 }

--- a/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
@@ -6,12 +6,16 @@ import { ConfirmationModalImperative } from '@/data-verification/consolidation/C
 import { ComboBoxRef, InputRef, RadioRef } from '@/lib/type-declarations/input-fields';
 import { CheckboxRef } from '@/lib/components/uswds/Checkbox';
 import { ConsolidationOrderCase, ConsolidationType, OrderStatus } from '@common/cams/orders';
+import {
+  AddCaseModalImperative
+} from "@/data-verification/consolidation/AddCaseModal";
 
 export function useConsolidationControlsReact(): ConsolidationControls {
   const approveButton = useRef<ButtonRef>(null);
   const caseTableActions = useRef<OrderTableImperative>(null);
   const clearButton = useRef<ButtonRef>(null);
   const confirmationModal = useRef<ConfirmationModalImperative>(null);
+  const addCaseModal = useRef<AddCaseModalImperative>(null)
   const jointAdministrationRadio = useRef<RadioRef>(null);
   const leadCaseDivisionRef = useRef<ComboBoxRef>(null);
   const leadCaseNumberRef = useRef<InputRef>(null);
@@ -32,6 +36,11 @@ export function useConsolidationControlsReact(): ConsolidationControls {
       consolidationType,
     });
   };
+
+  // TODO: We need a showAddCaseModal
+  const showAddCaseModal = () => {
+    // addCaseModal.show
+  }
 
   const disableLeadCaseForm = (disabled: boolean) => {
     leadCaseDivisionRef.current?.disable(disabled);

--- a/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
@@ -35,11 +35,6 @@ export function useConsolidationControlsReact(): ConsolidationControls {
     });
   };
 
-  const showAddCaseModal = (_defaultOffice: string) => {
-    // TODO: implement
-    // addCaseModal.show
-  };
-
   const unsetConsolidationType = () => {
     jointAdministrationRadio.current?.check(false);
     substantiveRadio.current?.check(false);
@@ -71,6 +66,5 @@ export function useConsolidationControlsReact(): ConsolidationControls {
     additionalCaseDivisionRef,
     additionalCaseNumberRef,
     addCaseModal,
-    showAddCaseModal,
   };
 }

--- a/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
@@ -15,8 +15,6 @@ export function useConsolidationControlsReact(): ConsolidationControls {
   const confirmationModal = useRef<ConfirmationModalImperative>(null);
   const addCaseModal = useRef<AddCaseModalImperative>(null);
   const jointAdministrationRadio = useRef<RadioRef>(null);
-  const leadCaseDivisionRef = useRef<ComboBoxRef>(null);
-  const leadCaseNumberRef = useRef<InputRef>(null);
   const additionalCaseDivisionRef = useRef<ComboBoxRef>(null);
   const additionalCaseNumberRef = useRef<InputRef>(null);
   const rejectButton = useRef<ButtonRef>(null);
@@ -42,10 +40,6 @@ export function useConsolidationControlsReact(): ConsolidationControls {
     // addCaseModal.show
   };
 
-  const disableLeadCaseForm = (disabled: boolean) => {
-    leadCaseDivisionRef.current?.disable(disabled);
-    leadCaseNumberRef.current?.disable(disabled);
-  };
   const unsetConsolidationType = () => {
     jointAdministrationRadio.current?.check(false);
     substantiveRadio.current?.check(false);
@@ -65,13 +59,10 @@ export function useConsolidationControlsReact(): ConsolidationControls {
     clearButton,
     confirmationModal,
     jointAdministrationRadio,
-    leadCaseDivisionRef,
-    leadCaseNumberRef,
     rejectButton,
     substantiveRadio,
     leadCaseFormToggle,
     showConfirmationModal,
-    disableLeadCaseForm,
     clearAllCheckBoxes,
     disableButton,
     unsetConsolidationType,

--- a/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsReact.ts
@@ -49,22 +49,20 @@ export function useConsolidationControlsReact(): ConsolidationControls {
   };
 
   return {
-    approveButton,
-    caseTableActions,
-    clearButton,
-    confirmationModal,
-    jointAdministrationRadio,
-    rejectButton,
-    substantiveRadio,
-    leadCaseFormToggle,
-    showConfirmationModal,
-    clearAllCheckBoxes,
-    disableButton,
-    unsetConsolidationType,
-
-    // TODO: CAMS-548 properties
     additionalCaseDivisionRef,
     additionalCaseNumberRef,
     addCaseModal,
+    approveButton,
+    caseTableActions,
+    clearAllCheckBoxes,
+    clearButton,
+    confirmationModal,
+    disableButton,
+    jointAdministrationRadio,
+    leadCaseFormToggle,
+    rejectButton,
+    showConfirmationModal,
+    substantiveRadio,
+    unsetConsolidationType,
   };
 }

--- a/user-interface/src/data-verification/consolidation/consolidationOrderAccordionUtils.test.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationOrderAccordionUtils.test.ts
@@ -1,6 +1,6 @@
 import {
   fetchLeadCaseAttorneys,
-  getCurrentLeadCaseId,
+  getCaseId,
 } from '@/data-verification/consolidation/consolidationOrderAccordionUtils';
 import { CaseAssignment } from '@common/cams/assignments';
 import { MockData } from '@common/cams/test-utilities/mock-data';
@@ -20,25 +20,22 @@ describe('consolidationOrderAccordion presenter tests', () => {
     vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
   });
 
-  test('should get lead case id', () => {
-    const leadCaseCourt = '081';
-    const leadCaseNumber = '24-12345';
-    expect(getCurrentLeadCaseId({ leadCaseCourt, leadCaseNumber })).toEqual('081-24-12345');
+  test('should get case id', () => {
+    const court = '081';
+    const caseNumber = '24-12345';
+    expect(getCaseId({ court, caseNumber })).toEqual('081-24-12345');
   });
 
-  const leadCaseIdInputCases = [
-    { leadCaseCourt: '081' },
-    { leadCaseNumber: '24-12345' },
-    { leadCaseCourt: '2', leadCaseNumber: '12-42255' },
-    { leadCaseCourt: '225', leadCaseNumber: '12-422' },
+  const caseIdInputCases = [
+    { court: '081' },
+    { court: '24-12345' },
+    { court: '2', caseNumber: '12-42255' },
+    { court: '225', caseNumber: '12-422' },
   ];
 
-  test.each(leadCaseIdInputCases)(
-    'should get empty string for lead case id',
-    (params: { leadCaseCourt?: string; leadCaseNumber?: string }) => {
-      expect(getCurrentLeadCaseId(params)).toEqual('');
-    },
-  );
+  test.each(caseIdInputCases)('should get empty string for lead case id', (params) => {
+    expect(getCaseId(params)).toEqual('');
+  });
 
   test('should return empty array when no attorneys are found', async () => {
     const order: ConsolidationOrder = MockData.getConsolidationOrder();

--- a/user-interface/src/data-verification/consolidation/consolidationOrderAccordionUtils.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationOrderAccordionUtils.ts
@@ -2,14 +2,14 @@ import { CaseAssignment } from '@common/cams/assignments';
 import { useApi2 } from '@/lib/hooks/UseApi2';
 import { CaseSummary } from '@common/cams/cases';
 
-export function getCurrentLeadCaseId(params: { leadCaseCourt?: string; leadCaseNumber?: string }) {
+export function getCaseId(params: { court?: string; caseNumber?: string }) {
   if (
-    params.leadCaseCourt &&
-    params.leadCaseCourt.length === 3 &&
-    params.leadCaseNumber &&
-    params.leadCaseNumber.length === 8
+    params.court &&
+    params.court.length === 3 &&
+    params.caseNumber &&
+    params.caseNumber.length === 8
   ) {
-    return `${params.leadCaseCourt}-${params.leadCaseNumber}`;
+    return `${params.court}-${params.caseNumber}`;
   }
   return '';
 }

--- a/user-interface/src/data-verification/consolidation/consolidationStore.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationStore.ts
@@ -2,6 +2,18 @@ import { ConsolidationOrder, ConsolidationOrderCase, ConsolidationType } from '@
 import { CourtDivisionDetails } from '@common/cams/courts';
 
 interface ConsolidationStore {
+  addCaseNumberError: string | null;
+  setAddCaseNumberError(val: string | null): void;
+
+  caseToAdd: ConsolidationOrderCase | null;
+  setCaseToAdd(val: ConsolidationOrderCase | null): void;
+
+  caseToAddCourt: string;
+  setCaseToAddCourt(val: string): void;
+
+  caseToAddCaseNumber: string;
+  setCaseToAddCaseNumber(val: string): void;
+
   consolidationType: ConsolidationType | null;
   setConsolidationType(val: ConsolidationType | null): void;
 
@@ -16,6 +28,9 @@ interface ConsolidationStore {
 
   isDataEnhanced: boolean;
   setIsDataEnhanced(val: boolean): void;
+
+  isLookingForCase: boolean;
+  setIsLookingForCase(val: boolean): void;
 
   isValidatingLeadCaseNumber: boolean;
   setIsValidatingLeadCaseNumber(val: boolean): void;

--- a/user-interface/src/data-verification/consolidation/consolidationStoreMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationStoreMock.ts
@@ -4,11 +4,14 @@ import { ConsolidationStore } from '@/data-verification/consolidation/consolidat
 import { ConsolidationOrder, ConsolidationOrderCase, ConsolidationType } from '@common/cams/orders';
 
 export class ConsolidationStoreMock implements ConsolidationStore {
+  addCaseNumberError: string | null = null;
+  caseToAdd: ConsolidationOrderCase | null = null;
   consolidationType: ConsolidationType | null = null;
   filteredOfficesList: CourtDivisionDetails[] | null;
   foundValidCaseNumber: boolean = false;
   isProcessing: boolean = false;
   isDataEnhanced: boolean = false;
+  isLookingForCase: boolean = false;
   isValidatingLeadCaseNumber: boolean = false;
   leadCase: ConsolidationOrderCase | null = null;
   leadCaseCourt: string = '';
@@ -18,10 +21,28 @@ export class ConsolidationStoreMock implements ConsolidationStore {
   order: ConsolidationOrder;
   selectedCases: ConsolidationOrderCase[] = [];
   showLeadCaseForm: boolean = false;
+  caseToAddCourt: string = '';
+  caseToAddCaseNumber: string = '';
 
   constructor(props: ConsolidationOrderAccordionProps, officesList: CourtDivisionDetails[]) {
     this.filteredOfficesList = filterCourtByDivision(props.order.courtDivisionCode, officesList);
     this.order = props.order;
+  }
+
+  setCaseToAddCourt(val: string): void {
+    this.caseToAddCourt = val;
+  }
+
+  setCaseToAddCaseNumber(val: string): void {
+    this.caseToAddCaseNumber = val;
+  }
+
+  setAddCaseNumberError(val: string | null): void {
+    this.addCaseNumberError = val;
+  }
+
+  setCaseToAdd(val: ConsolidationOrderCase | null): void {
+    this.caseToAdd = val;
   }
 
   setConsolidationType = (newType: ConsolidationType): void => {
@@ -43,6 +64,10 @@ export class ConsolidationStoreMock implements ConsolidationStore {
   setIsDataEnhanced = (val: boolean): void => {
     this.isDataEnhanced = val;
   };
+
+  setIsLookingForCase(val: boolean): void {
+    this.isLookingForCase = val;
+  }
 
   setIsValidatingLeadCaseNumber = (val: boolean): void => {
     this.isValidatingLeadCaseNumber = val;

--- a/user-interface/src/data-verification/consolidation/consolidationStoreMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationStoreMock.ts
@@ -29,21 +29,21 @@ export class ConsolidationStoreMock implements ConsolidationStore {
     this.order = props.order;
   }
 
-  setCaseToAddCourt(val: string): void {
+  setCaseToAddCourt = (val: string): void => {
     this.caseToAddCourt = val;
-  }
+  };
 
-  setCaseToAddCaseNumber(val: string): void {
+  setCaseToAddCaseNumber = (val: string): void => {
     this.caseToAddCaseNumber = val;
-  }
+  };
 
-  setAddCaseNumberError(val: string | null): void {
+  setAddCaseNumberError = (val: string | null): void => {
     this.addCaseNumberError = val;
-  }
+  };
 
-  setCaseToAdd(val: ConsolidationOrderCase | null): void {
+  setCaseToAdd = (val: ConsolidationOrderCase | null): void => {
     this.caseToAdd = val;
-  }
+  };
 
   setConsolidationType = (newType: ConsolidationType): void => {
     this.consolidationType = newType;
@@ -65,9 +65,9 @@ export class ConsolidationStoreMock implements ConsolidationStore {
     this.isDataEnhanced = val;
   };
 
-  setIsLookingForCase(val: boolean): void {
+  setIsLookingForCase = (val: boolean): void => {
     this.isLookingForCase = val;
-  }
+  };
 
   setIsValidatingLeadCaseNumber = (val: boolean): void => {
     this.isValidatingLeadCaseNumber = val;

--- a/user-interface/src/data-verification/consolidation/consolidationStoreReact.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationStoreReact.ts
@@ -24,8 +24,21 @@ export function useConsolidationStoreReact(
   const [order, setOrder] = useState<ConsolidationOrder>(props.order);
   const [selectedCases, setSelectedCases] = useState<Array<ConsolidationOrderCase>>([]);
   const [showLeadCaseForm, setShowLeadCaseForm] = useState<boolean>(false);
+  const [addCaseNumberError, setAddCaseNumberError] = useState<string | null>(null);
+  const [caseToAdd, setCaseToAdd] = useState<ConsolidationOrderCase | null>(null);
+  const [isLookingForCase, setIsLookingForCase] = useState<boolean>(false);
+  const [caseToAddCourt, setCaseToAddCourt] = useState<string>('');
+  const [caseToAddCaseNumber, setCaseToAddCaseNumber] = useState<string>('');
 
   return {
+    caseToAddCourt,
+    setCaseToAddCourt,
+    caseToAddCaseNumber,
+    setCaseToAddCaseNumber,
+    addCaseNumberError,
+    setAddCaseNumberError,
+    caseToAdd,
+    setCaseToAdd,
     consolidationType,
     setConsolidationType,
     filteredOfficesList,
@@ -36,6 +49,8 @@ export function useConsolidationStoreReact(
     setIsProcessing: setIsConsolidationProcessing,
     isDataEnhanced,
     setIsDataEnhanced,
+    isLookingForCase,
+    setIsLookingForCase,
     isValidatingLeadCaseNumber,
     setIsValidatingLeadCaseNumber,
     leadCase,

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -88,6 +88,7 @@ interface AddCaseModel
     | 'handleAddCaseAction'
   > {
   orderId: string;
+  defaultDivisionCode: string;
 }
 
 export type { ConsolidationViewModel, AddCaseModel };

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -20,6 +20,8 @@ interface ConsolidationViewModel {
   accordionFieldHeaders: string[];
   addCaseModal: React.RefObject<AddCaseModalImperative>;
   addCaseNumberError: string | null;
+  caseToAddCaseNumber: string | null;
+  caseToAddCourt: string | null;
   additionalCaseDivisionRef: Ref<ComboBoxRef>;
   additionalCaseNumberRef: Ref<InputRef>;
   approveButton: React.Ref<ButtonRef>;
@@ -57,7 +59,6 @@ interface ConsolidationViewModel {
   handleClearInputs: () => void;
   handleConfirmAction: (action: ConfirmActionResults) => void;
   handleIncludeCase: (bCase: ConsolidationOrderCase) => void;
-  handleLeadCaseInputChange: (caseNumber?: string) => void;
   handleMarkLeadCase: (bCase: ConsolidationOrderCase) => void;
   handleOnExpand: () => void;
   handleRejectButtonClick: () => void;
@@ -65,11 +66,14 @@ interface ConsolidationViewModel {
   handleSelectLeadCaseCourt: (option: ComboOptionList) => void;
   showConfirmationModal: ShowConfirmationModal;
   updateAllSelections: (caseList: ConsolidationOrderCase[]) => void;
+  verifyCaseCanBeAdded: () => void;
 }
 
 interface AddCaseModel
   extends Pick<
     ConsolidationViewModel,
+    | 'caseToAddCaseNumber'
+    | 'caseToAddCourt'
     | 'handleAddCaseCourtSelectChange'
     | 'handleAddCaseNumberInputChange'
     | 'handleAddCaseReset'
@@ -80,6 +84,7 @@ interface AddCaseModel
     | 'isLookingForCase'
     | 'caseToAdd'
     | 'handleAddCaseAction'
+    | 'verifyCaseCanBeAdded'
   > {
   orderId: string;
   defaultDivisionCode: string;

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -33,9 +33,6 @@ interface ConsolidationViewModel {
   isValidatingLeadCaseNumber: boolean;
   jointAdministrationRadio: React.Ref<RadioRef>;
   leadCase: ConsolidationOrderCase | null;
-  leadCaseDivisionRef: React.RefObject<ComboBoxRef>;
-  leadCaseNumberError: string;
-  leadCaseNumberRef: React.Ref<InputRef>;
   order: ConsolidationOrder;
   orderType: Map<string, string>;
   rejectButton: React.Ref<ButtonRef>;

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -16,9 +16,15 @@ import { ComboOption, ComboOptionList } from '@/lib/components/combobox/ComboBox
 import { AddCaseModalImperative } from '@/data-verification/consolidation/AddCaseModal';
 
 interface ConsolidationViewModel {
+  // Non-function properties
   accordionFieldHeaders: string[];
+  addCaseModal: React.RefObject<AddCaseModalImperative>;
+  addCaseNumberError: string | null;
+  additionalCaseDivisionRef: Ref<ComboBoxRef>;
+  additionalCaseNumberRef: Ref<InputRef>;
   approveButton: React.Ref<ButtonRef>;
   caseTableActions: React.Ref<OrderTableImperative>;
+  caseToAdd: ConsolidationOrderCase | null;
   clearButton: React.Ref<ButtonRef>;
   confirmationModal: React.Ref<ConfirmationModalImperative>;
   divisionCode: string | undefined;
@@ -28,10 +34,12 @@ interface ConsolidationViewModel {
   foundValidCaseNumber: boolean;
   hidden: boolean;
   isDataEnhanced: boolean;
+  isLookingForCase: boolean;
   isProcessing: boolean;
   isValidatingLeadCaseNumber: boolean;
   jointAdministrationRadio: React.Ref<RadioRef>;
   leadCase: ConsolidationOrderCase | null;
+  leadCaseFormToggle: React.Ref<CheckboxRef>;
   order: ConsolidationOrder;
   orderType: Map<string, string>;
   rejectButton: React.Ref<ButtonRef>;
@@ -39,8 +47,12 @@ interface ConsolidationViewModel {
   showLeadCaseForm: boolean;
   statusType: Map<string, string>;
   substantiveRadio: React.Ref<RadioRef>;
-  leadCaseFormToggle: React.Ref<CheckboxRef>;
 
+  // Function properties
+  handleAddCaseAction: () => void;
+  handleAddCaseCourtSelectChange: (option: ComboOptionList) => void;
+  handleAddCaseNumberInputChange: (caseNumber?: string) => void;
+  handleAddCaseReset: () => void;
   handleApproveButtonClick: () => void;
   handleClearInputs: () => void;
   handleConfirmAction: (action: ConfirmActionResults) => void;
@@ -54,18 +66,6 @@ interface ConsolidationViewModel {
   handleToggleLeadCaseForm: (checked: boolean) => void;
   showConfirmationModal: ShowConfirmationModal;
   updateAllSelections: (caseList: ConsolidationOrderCase[]) => void;
-
-  // TODO: Reorg this when we are nearing done.
-  addCaseModal: React.RefObject<AddCaseModalImperative>;
-  handleAddCaseAction: () => void;
-  handleAddCaseReset: () => void;
-  additionalCaseDivisionRef: Ref<ComboBoxRef>;
-  additionalCaseNumberRef: Ref<InputRef>;
-  addCaseNumberError: string | null;
-  isLookingForCase: boolean;
-  caseToAdd: ConsolidationOrderCase | null;
-  handleAddCaseNumberInputChange: (caseNumber?: string) => void;
-  handleAddCaseCourtSelectChange: (option: ComboOptionList) => void;
 }
 
 interface AddCaseModel

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -8,8 +8,14 @@ import {
   ConfirmationModalImperative,
 } from '@/data-verification/consolidation/ConsolidationOrderModal';
 import React from 'react';
-import { ShowConfirmationModal } from '@/data-verification/consolidation/consolidationControls';
+import {
+  Ref,
+  ShowAddCaseModal,
+  ShowConfirmationModal,
+} from '@/data-verification/consolidation/consolidationControls';
 import { ComboOption, ComboOptionList } from '@/lib/components/combobox/ComboBox';
+import { AddCaseModalImperative } from '@/data-verification/consolidation/AddCaseModal';
+import { CaseSummary } from '@common/cams/cases';
 
 interface ConsolidationViewModel {
   accordionFieldHeaders: string[];
@@ -52,7 +58,33 @@ interface ConsolidationViewModel {
   handleSelectLeadCaseCourt: (option: ComboOptionList) => void;
   handleToggleLeadCaseForm: (checked: boolean) => void;
   showConfirmationModal: ShowConfirmationModal;
+  showAddCaseModal: ShowAddCaseModal;
   updateAllSelections: (caseList: ConsolidationOrderCase[]) => void;
+
+  // TODO: Reorg this when we are nearing done.
+  addCaseModal: React.Ref<AddCaseModalImperative>;
+  handleAddCaseAction: () => void;
+  additionalCaseDivisionRef: Ref<ComboBoxRef>;
+  additionalCaseNumberRef: Ref<InputRef>;
+  addCaseNumberError: string;
+  isLookingForCase: boolean;
+  caseToAdd: CaseSummary;
 }
 
-export type { ConsolidationViewModel };
+interface AddCaseModel
+  extends Pick<
+    ConsolidationViewModel,
+    | 'handleSelectLeadCaseCourt'
+    | 'handleLeadCaseInputChange'
+    | 'filteredOfficeRecords'
+    | 'additionalCaseDivisionRef'
+    | 'additionalCaseNumberRef'
+    | 'addCaseNumberError'
+    | 'isLookingForCase'
+    | 'caseToAdd'
+    | 'handleAddCaseAction'
+  > {
+  orderId: string;
+}
+
+export type { ConsolidationViewModel, AddCaseModel };

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -63,7 +63,6 @@ interface ConsolidationViewModel {
   handleRejectButtonClick: () => void;
   handleSelectConsolidationType: (value: string) => void;
   handleSelectLeadCaseCourt: (option: ComboOptionList) => void;
-  handleToggleLeadCaseForm: (checked: boolean) => void;
   showConfirmationModal: ShowConfirmationModal;
   updateAllSelections: (caseList: ConsolidationOrderCase[]) => void;
 }

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -10,7 +10,6 @@ import {
 import React from 'react';
 import {
   Ref,
-  ShowAddCaseModal,
   ShowConfirmationModal,
 } from '@/data-verification/consolidation/consolidationControls';
 import { ComboOption, ComboOptionList } from '@/lib/components/combobox/ComboBox';
@@ -54,7 +53,6 @@ interface ConsolidationViewModel {
   handleSelectLeadCaseCourt: (option: ComboOptionList) => void;
   handleToggleLeadCaseForm: (checked: boolean) => void;
   showConfirmationModal: ShowConfirmationModal;
-  showAddCaseModal: ShowAddCaseModal;
   updateAllSelections: (caseList: ConsolidationOrderCase[]) => void;
 
   // TODO: Reorg this when we are nearing done.

--- a/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationViewModel.ts
@@ -15,7 +15,6 @@ import {
 } from '@/data-verification/consolidation/consolidationControls';
 import { ComboOption, ComboOptionList } from '@/lib/components/combobox/ComboBox';
 import { AddCaseModalImperative } from '@/data-verification/consolidation/AddCaseModal';
-import { CaseSummary } from '@common/cams/cases';
 
 interface ConsolidationViewModel {
   accordionFieldHeaders: string[];
@@ -62,20 +61,24 @@ interface ConsolidationViewModel {
   updateAllSelections: (caseList: ConsolidationOrderCase[]) => void;
 
   // TODO: Reorg this when we are nearing done.
-  addCaseModal: React.Ref<AddCaseModalImperative>;
+  addCaseModal: React.RefObject<AddCaseModalImperative>;
   handleAddCaseAction: () => void;
+  handleAddCaseReset: () => void;
   additionalCaseDivisionRef: Ref<ComboBoxRef>;
   additionalCaseNumberRef: Ref<InputRef>;
-  addCaseNumberError: string;
+  addCaseNumberError: string | null;
   isLookingForCase: boolean;
-  caseToAdd: CaseSummary;
+  caseToAdd: ConsolidationOrderCase | null;
+  handleAddCaseNumberInputChange: (caseNumber?: string) => void;
+  handleAddCaseCourtSelectChange: (option: ComboOptionList) => void;
 }
 
 interface AddCaseModel
   extends Pick<
     ConsolidationViewModel,
-    | 'handleSelectLeadCaseCourt'
-    | 'handleLeadCaseInputChange'
+    | 'handleAddCaseCourtSelectChange'
+    | 'handleAddCaseNumberInputChange'
+    | 'handleAddCaseReset'
     | 'filteredOfficeRecords'
     | 'additionalCaseDivisionRef'
     | 'additionalCaseNumberRef'

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
@@ -83,7 +83,6 @@ describe('Consolidation UseCase tests', () => {
   test('should properly handle handleClearInputs', () => {
     const clearAllCheckBoxesSpy = vi.spyOn(controls, 'clearAllCheckBoxes');
     const unsetConsolidationTypeSpy = vi.spyOn(controls, 'unsetConsolidationType');
-    const showLeadCaseFormSpy = vi.spyOn(store, 'setShowLeadCaseForm');
 
     setupAddCase();
 
@@ -94,7 +93,6 @@ describe('Consolidation UseCase tests', () => {
     expectClearLeadCase();
     expect(clearAllCheckBoxesSpy).toHaveBeenCalled();
     expect(unsetConsolidationTypeSpy).toHaveBeenCalled();
-    expect(showLeadCaseFormSpy).toHaveBeenCalledWith(false);
   });
 
   test('should call approveConsolidation when approve button is clicked', () => {
@@ -165,7 +163,6 @@ describe('Consolidation UseCase tests', () => {
     expect(store.leadCaseId).toEqual(newLeadCase.caseId);
     expect(store.leadCaseNumber).toEqual('');
     expect(store.leadCaseCourt).toEqual('');
-    expect(store.showLeadCaseForm).toBe(false);
     expect(setLeadCaseSpy).toHaveBeenCalledWith(newLeadCase);
     expect(setLeadCaseIdSpy).toHaveBeenCalledWith(newLeadCase.caseId);
 
@@ -242,13 +239,6 @@ describe('Consolidation UseCase tests', () => {
     const newLeadCaseCourt = { label: 'test', value: 'test value' };
     useCase.handleSelectLeadCaseCourt(newLeadCaseCourt);
     expect(setLeadCaseCourtSpy).toHaveBeenCalled();
-  });
-
-  test('should clear lead case and set show lead case form when lead case form toggle is selected', () => {
-    setupAddCase();
-    useCase.handleToggleLeadCaseForm(true);
-    expect(store.showLeadCaseForm).toBe(true);
-    expectClearLeadCase();
   });
 
   test('should return a valid case if case is not already consolidated and is not the child of another consolidation', async () => {

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
@@ -27,30 +27,30 @@ describe('Consolidation UseCase tests', () => {
   const onOrderUpdateSpy = vi.fn();
   const { waitFor } = TestingUtilities;
 
-  function setupAddCase() {
+  const setupAddCase = () => {
     store.setCaseToAdd(mockAddCase);
     store.setCaseToAddCaseNumber(getCaseNumber(mockAddCase.caseId));
     store.setCaseToAddCourt(mockAddCase.courtDivisionCode);
     store.setAddCaseNumberError('error message');
-  }
+  };
 
-  function includeCases(mockCases: ConsolidationOrderCase[]) {
+  const includeCases = (mockCases: ConsolidationOrderCase[]) => {
     store.setSelectedCases(mockCases);
     store.setLeadCase(mockCases[1]);
     store.setConsolidationType('administrative');
-  }
+  };
 
-  function expectClearLeadCase() {
+  const expectClearLeadCase = () => {
     expect(store.leadCase).toBeNull();
     expect(store.leadCaseId).toEqual('');
     expect(store.leadCaseNumber).toEqual('');
     expect(store.leadCaseNumberError).toEqual('');
     expect(store.foundValidCaseNumber).toBe(false);
-  }
+  };
 
   const accordionFieldHeaders = ['Court District', 'Order Filed', 'Event Type', 'Event Status'];
 
-  function initUseCase() {
+  const initUseCase = () => {
     const props = {
       order: mockOrder,
       statusType: orderStatusType,
@@ -66,7 +66,7 @@ describe('Consolidation UseCase tests', () => {
     controls = useConsolidationControlsMock();
 
     useCase = consolidationUseCase(store, controls, props.onOrderUpdate, props.onExpand);
-  }
+  };
 
   beforeEach(async () => {
     vi.stubEnv('CAMS_USE_FAKE_API', 'true');

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
@@ -173,34 +173,6 @@ describe('Consolidation UseCase tests', () => {
     expect(setLeadCaseIdSpy).toHaveBeenCalledWith('');
   });
 
-  test('should handle clearing the lead case number input', () => {
-    setupAddCase();
-    store.setFoundValidCaseNumber(true);
-    store.setShowLeadCaseForm(true);
-    const controlSpy = vi.spyOn(controls, 'disableButton');
-
-    useCase.handleLeadCaseInputChange();
-
-    expect(store.leadCaseNumber).toEqual('');
-    expect(store.foundValidCaseNumber).toEqual(false);
-    expect(store.leadCase).toBeNull();
-    expect(store.leadCaseNumberError).toEqual('');
-    expect(controlSpy).toHaveBeenCalledWith(controls.approveButton, true);
-  });
-
-  test('should handle setting the lead case number input', () => {
-    setupAddCase();
-    store.setFoundValidCaseNumber(true);
-    store.setShowLeadCaseForm(true);
-    const disableButtonSpy = vi.spyOn(controls, 'disableButton');
-
-    const caseNumber = '24-12345';
-    useCase.handleLeadCaseInputChange(caseNumber);
-
-    expect(store.leadCaseNumber).toEqual(caseNumber);
-    expect(disableButtonSpy).not.toHaveBeenCalled();
-  });
-
   test('should get caseAssignments and caseAssociations when accordion is expanded', async () => {
     const setIsDataEnhancedSpy = vi.spyOn(store, 'setIsDataEnhanced');
     const assignmentsSpy = vi.spyOn(Api2, 'getCaseAssignments');

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
@@ -354,6 +354,78 @@ describe('Consolidation UseCase tests', () => {
     expect(disableButtonSpy).not.toHaveBeenCalledWith(controls.approveButton, false);
   });
 
+  test('areAnySelectedCasesConsolidated should return false if none of the selected case is consolidated', async () => {
+    const disableButtonSpy = vi.spyOn(controls, 'disableButton');
+    const selections = MockData.buildArray(MockData.getConsolidatedOrderCase, 3);
+    store.setIsDataEnhanced(true);
+    store.setLeadCaseId('12-34567');
+    store.setConsolidationType('administrative');
+    useCase.updateAllSelections(selections);
+    useCase.updateSubmitButtonsState();
+    expect(disableButtonSpy).toHaveBeenCalledWith(controls.approveButton, false);
+  });
+
+  test('should set case number to add if handleAddCaseNumberInputChange is supplied a case number', async () => {
+    const disableButtonSpy = vi.spyOn(controls, 'disableButton');
+    store.setCaseToAddCaseNumber('');
+    expect(store.caseToAddCaseNumber).toEqual('');
+    const bCase = MockData.getConsolidatedOrderCase();
+    const newCaseNumber = '11-11111';
+    store.setCaseToAdd(bCase);
+    expect(store.caseToAdd).toEqual(bCase);
+    useCase.handleAddCaseNumberInputChange(newCaseNumber);
+
+    expect(store.caseToAdd).toEqual(bCase);
+    expect(store.caseToAddCaseNumber).toEqual(newCaseNumber);
+    expect(disableButtonSpy).not.toHaveBeenCalled();
+  });
+
+  test('should clear case number and case to add, and disable button if handleAddCaseNumberInputChange not supplied a case number', async () => {
+    const disableButtonSpy = vi.spyOn(controls, 'disableButton');
+    const oldCaseNumber = '11-11111';
+    store.setCaseToAddCaseNumber(oldCaseNumber);
+    expect(store.caseToAddCaseNumber).toEqual(oldCaseNumber);
+    const bCase = MockData.getConsolidatedOrderCase();
+    store.setCaseToAdd(bCase);
+    expect(store.caseToAdd).toEqual(bCase);
+    useCase.handleAddCaseNumberInputChange();
+
+    expect(store.caseToAdd).toBeNull();
+    expect(store.caseToAddCaseNumber).toEqual('');
+    expect(disableButtonSpy).toHaveBeenCalledWith(controls.approveButton, true);
+  });
+
+  test('handleAddCaseCourtSelectChange should update store.setCaseToAddCourt when a value is supplied', async () => {
+    const disableButtonSpy = vi.spyOn(controls, 'disableButton');
+    const originalCourt = 'old court';
+    const newCourt = 'new court';
+    store.setCaseToAddCourt(originalCourt);
+    expect(store.caseToAddCourt).toEqual(originalCourt);
+    const bCase = MockData.getConsolidatedOrderCase();
+    store.setCaseToAdd(bCase);
+    expect(store.caseToAdd).toEqual(bCase);
+
+    useCase.handleAddCaseCourtSelectChange([{ label: 'foo', value: newCourt }]);
+    expect(store.caseToAddCourt).toEqual(newCourt);
+    expect(store.caseToAdd).toEqual(bCase);
+    expect(disableButtonSpy).not.toHaveBeenCalled();
+  });
+
+  test('handleAddCaseCourtSelectChange should clear store.caseToAddCourt, store.caseToAdd, and disable approveButton when a value is not supplied', async () => {
+    const disableButtonSpy = vi.spyOn(controls, 'disableButton');
+    const originalCourt = 'old court';
+    store.setCaseToAddCourt(originalCourt);
+    expect(store.caseToAddCourt).toEqual(originalCourt);
+    const bCase = MockData.getConsolidatedOrderCase();
+    store.setCaseToAdd(bCase);
+    expect(store.caseToAdd).toEqual(bCase);
+
+    useCase.handleAddCaseCourtSelectChange([]);
+    expect(store.caseToAddCourt).toEqual('');
+    expect(store.caseToAdd).toBeNull();
+    expect(disableButtonSpy).toHaveBeenCalledWith(controls.approveButton, true);
+  });
+
   test('should throw if lead case is a child in any other consolidation', () => {
     const caseId = '120-23-12345';
     const documentType = 'CONSOLIDATION_TO';

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
@@ -46,7 +46,6 @@ export interface ConsolidationsUseCase {
   handleClearInputs(): void;
   handleConfirmAction(action: ConfirmActionResults): void;
   handleIncludeCase(bCase: ConsolidationOrderCase): void;
-  handleLeadCaseInputChange(caseNumber?: string): void;
   handleMarkLeadCase(bCase: ConsolidationOrderCase): void;
   handleOnExpand(): Promise<void>;
   handleRejectButtonClick(): void;
@@ -390,15 +389,6 @@ const consolidationUseCase = (
     updateSubmitButtonsState();
   };
 
-  const handleLeadCaseInputChange = async (caseNumber?: string) => {
-    if (caseNumber) {
-      store.setLeadCaseNumber(caseNumber);
-    } else {
-      clearLeadCase();
-      controls.disableButton(controls.approveButton, true);
-    }
-  };
-
   const handleAddCaseNumberInputChange = async (caseNumber?: string) => {
     if (caseNumber) {
       store.setCaseToAddCaseNumber(caseNumber);
@@ -482,7 +472,6 @@ const consolidationUseCase = (
     handleClearInputs,
     handleConfirmAction,
     handleIncludeCase,
-    handleLeadCaseInputChange,
     handleMarkLeadCase,
     handleOnExpand,
     handleRejectButtonClick,

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
@@ -63,32 +63,31 @@ const consolidationUseCase = (
   onOrderUpdate: OnOrderUpdate,
   onExpand?: OnExpand,
 ): ConsolidationsUseCase => {
-  function clearLeadCase(): void {
+  const clearLeadCase = (): void => {
     store.setLeadCase(null);
     store.setLeadCaseId('');
     store.setLeadCaseNumber('');
     store.setLeadCaseNumberError('');
     store.setFoundValidCaseNumber(false);
-  }
+  };
 
-  function clearSelectedCases(): void {
+  const clearSelectedCases = (): void => {
     store.setSelectedCases([]);
     controls.clearAllCheckBoxes();
-  }
+  };
 
-  function handleAddCaseAction() {
+  const handleAddCaseAction = () => {
     if (store.caseToAdd) {
       store.order.childCases.push(store.caseToAdd);
     }
     handleAddCaseReset();
-  }
+  };
 
-  function handleCaseAssociationResponse(
+  const handleCaseAssociationResponse = (
     response: ResponseBody<Consolidation[]>,
     currentLeadCaseId: string,
-  ) {
+  ) => {
     const associations = response.data;
-    // if lead is a child of another case
     const childCaseFactsList = associations
       .filter((reference) => reference.caseId === currentLeadCaseId)
       .filter((reference) => reference.documentType === 'CONSOLIDATION_TO')
@@ -136,9 +135,9 @@ const consolidationUseCase = (
     } else {
       return response.data as Consolidation[];
     }
-  }
+  };
 
-  function verifyCaseCanBeAdded() {
+  const verifyCaseCanBeAdded = () => {
     const api2 = useApi2();
     const caseIdToVerify = getCaseId({
       court: store.caseToAddCourt,
@@ -168,7 +167,6 @@ const consolidationUseCase = (
             return response.data as CaseSummary;
           })
           .catch((error) => {
-            // Brittle way to determine if we have encountered a 404...
             const isNotFound = (error.message as string).startsWith('404');
             const message = isNotFound
               ? "We couldn't find a case with that number."
@@ -223,9 +221,9 @@ const consolidationUseCase = (
           }, 100);
         });
     }
-  }
+  };
 
-  function approveConsolidation(action: ConfirmActionResults) {
+  const approveConsolidation = (action: ConfirmActionResults) => {
     const api = useApi2();
     const genericErrorMessage =
       'An unknown error has occurred and has been logged.  Please try again later.';
@@ -269,9 +267,9 @@ const consolidationUseCase = (
           });
         });
     }
-  }
+  };
 
-  function rejectConsolidation(action: ConfirmActionResults) {
+  const rejectConsolidation = (action: ConfirmActionResults) => {
     const api = useApi2();
     const genericErrorMessage =
       'An unknown error has occurred and has been logged.  Please try again later.';
@@ -309,9 +307,9 @@ const consolidationUseCase = (
           });
         });
     }
-  }
+  };
 
-  function updateSubmitButtonsState() {
+  const updateSubmitButtonsState = () => {
     if (store.selectedCases.length) {
       const disableApprove =
         !store.isDataEnhanced ||
@@ -326,54 +324,53 @@ const consolidationUseCase = (
       controls.disableButton(controls.approveButton, true);
     }
     controls.disableButton(controls.clearButton, store.isProcessing);
-  }
+  };
 
-  function areAnySelectedCasesConsolidated() {
+  const areAnySelectedCasesConsolidated = () => {
     const consolidatedSelections = store.selectedCases.filter(
       (bCase) => bCase.associations!.length > 0,
     );
     return consolidatedSelections.length !== 0;
-  }
+  };
 
-  function setOrderWithDataEnhancement(order: ConsolidationOrder) {
+  const setOrderWithDataEnhancement = (order: ConsolidationOrder) => {
     store.setOrder({ ...order });
-  }
+  };
 
-  function updateAllSelections(caseList: ConsolidationOrderCase[]) {
+  const updateAllSelections = (caseList: ConsolidationOrderCase[]) => {
     store.setSelectedCases(caseList);
-  }
+  };
 
-  //========== HANDLERS ==========
-  function handleApproveButtonClick() {
+  const handleApproveButtonClick = () => {
     controls.showConfirmationModal(
       store.selectedCases!,
       store.leadCase!,
       'approved',
       store.consolidationType!,
     );
-  }
+  };
 
-  function handleRejectButtonClick() {
+  const handleRejectButtonClick = () => {
     controls.showConfirmationModal(store.selectedCases, store.leadCase!, 'rejected');
-  }
+  };
 
-  function handleClearInputs(): void {
+  const handleClearInputs = (): void => {
     clearLeadCase();
     clearSelectedCases();
     handleToggleLeadCaseForm(false);
     controls.unsetConsolidationType();
-  }
+  };
 
-  function handleAddCaseReset(): void {
+  const handleAddCaseReset = (): void => {
     store.setCaseToAddCaseNumber('');
     store.setCaseToAddCourt('');
     controls.additionalCaseDivisionRef.current?.clearSelections();
     controls.additionalCaseNumberRef.current?.clearValue();
     store.setAddCaseNumberError(null);
     store.setCaseToAdd(null);
-  }
+  };
 
-  function handleConfirmAction(action: ConfirmActionResults): void {
+  const handleConfirmAction = (action: ConfirmActionResults): void => {
     switch (action.status) {
       case 'approved':
         approveConsolidation(action);
@@ -382,9 +379,9 @@ const consolidationUseCase = (
         rejectConsolidation(action);
         break;
     }
-  }
+  };
 
-  function handleIncludeCase(bCase: ConsolidationOrderCase) {
+  const handleIncludeCase = (bCase: ConsolidationOrderCase) => {
     let tempSelectedCases: ConsolidationOrderCase[];
     if (store.selectedCases.includes(bCase)) {
       tempSelectedCases = store.selectedCases.filter((aCase) => bCase !== aCase);
@@ -393,18 +390,18 @@ const consolidationUseCase = (
     }
     store.setSelectedCases(tempSelectedCases);
     updateSubmitButtonsState();
-  }
+  };
 
-  async function handleLeadCaseInputChange(caseNumber?: string) {
+  const handleLeadCaseInputChange = async (caseNumber?: string) => {
     if (caseNumber) {
       store.setLeadCaseNumber(caseNumber);
     } else {
       clearLeadCase();
       controls.disableButton(controls.approveButton, true);
     }
-  }
+  };
 
-  async function handleAddCaseNumberInputChange(caseNumber?: string) {
+  const handleAddCaseNumberInputChange = async (caseNumber?: string) => {
     if (caseNumber) {
       store.setCaseToAddCaseNumber(caseNumber);
     } else {
@@ -412,9 +409,9 @@ const consolidationUseCase = (
       store.setCaseToAdd(null);
       controls.disableButton(controls.approveButton, true);
     }
-  }
+  };
 
-  function handleAddCaseCourtSelectChange(option: ComboOption[]): void {
+  const handleAddCaseCourtSelectChange = (option: ComboOption[]): void => {
     const court = option[0]?.value ?? '';
     if (court) {
       store.setCaseToAddCourt(court);
@@ -423,9 +420,9 @@ const consolidationUseCase = (
       store.setCaseToAdd(null);
       controls.disableButton(controls.approveButton, true);
     }
-  }
+  };
 
-  function handleMarkLeadCase(bCase: ConsolidationOrderCase) {
+  const handleMarkLeadCase = (bCase: ConsolidationOrderCase) => {
     store.setShowLeadCaseForm(false);
     store.setLeadCaseNumber('');
     store.setLeadCaseCourt('');
@@ -437,9 +434,9 @@ const consolidationUseCase = (
       store.setLeadCaseId(bCase.caseId);
       store.setLeadCase(bCase);
     }
-  }
+  };
 
-  async function handleOnExpand() {
+  const handleOnExpand = async () => {
     const api2 = useApi2();
     if (onExpand) {
       onExpand(`order-list-${store.order.id}`);
@@ -465,21 +462,21 @@ const consolidationUseCase = (
       setOrderWithDataEnhancement(store.order);
       store.setIsDataEnhanced(isDataEnhanced);
     }
-  }
+  };
 
-  function handleSelectConsolidationType(value: string): void {
+  const handleSelectConsolidationType = (value: string): void => {
     store.setConsolidationType(value as ConsolidationType);
-  }
+  };
 
-  function handleSelectLeadCaseCourt(option: ComboOption[]): void {
+  const handleSelectLeadCaseCourt = (option: ComboOption[]): void => {
     const court = option[0]?.value ?? '';
     store.setLeadCaseCourt(court);
-  }
+  };
 
-  function handleToggleLeadCaseForm(checked: boolean): void {
+  const handleToggleLeadCaseForm = (checked: boolean): void => {
     clearLeadCase();
     store.setShowLeadCaseForm(checked);
-  }
+  };
 
   return {
     verifyCaseCanBeAdded,

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
@@ -270,8 +270,8 @@ const consolidationUseCase = (
       Promise.all(calls)
         .then((responses) => {
           const caseSummary = responses[0] as CaseSummary;
-          const attorneyAssignments = responses[1] as CaseAssignment[];
-          const associations = responses[2] as Consolidation[];
+          const associations = responses[1] as Consolidation[];
+          const attorneyAssignments = responses[2] as CaseAssignment[];
           store.setCaseToAdd({
             ...caseSummary,
             docketEntries: [],

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
@@ -52,7 +52,6 @@ export interface ConsolidationsUseCase {
   handleRejectButtonClick(): void;
   handleSelectConsolidationType(value: string): void;
   handleSelectLeadCaseCourt(option: ComboOptionList): void;
-  handleToggleLeadCaseForm(checked: boolean): void;
   handleAddCaseNumberInputChange(caseNumber?: string): void;
   handleAddCaseCourtSelectChange(option: ComboOptionList): void;
 }
@@ -357,7 +356,6 @@ const consolidationUseCase = (
   const handleClearInputs = (): void => {
     clearLeadCase();
     clearSelectedCases();
-    handleToggleLeadCaseForm(false);
     controls.unsetConsolidationType();
   };
 
@@ -473,11 +471,6 @@ const consolidationUseCase = (
     store.setLeadCaseCourt(court);
   };
 
-  const handleToggleLeadCaseForm = (checked: boolean): void => {
-    clearLeadCase();
-    store.setShowLeadCaseForm(checked);
-  };
-
   return {
     verifyCaseCanBeAdded,
     updateSubmitButtonsState,
@@ -495,7 +488,6 @@ const consolidationUseCase = (
     handleRejectButtonClick,
     handleSelectConsolidationType,
     handleSelectLeadCaseCourt,
-    handleToggleLeadCaseForm,
     handleAddCaseCourtSelectChange,
     handleAddCaseNumberInputChange,
   };

--- a/user-interface/src/lib/components/CaseNumberInput.tsx
+++ b/user-interface/src/lib/components/CaseNumberInput.tsx
@@ -86,7 +86,9 @@ function CaseNumberInputComponent(props: CaseNumberInputProps, ref: React.Ref<In
   }
 
   function handleOnFocus(ev: React.FocusEvent<HTMLElement>) {
-    if (onFocus) onFocus(ev);
+    if (onFocus) {
+      onFocus(ev);
+    }
   }
 
   function focus() {

--- a/user-interface/src/lib/components/LoadingSpinner.scss
+++ b/user-interface/src/lib/components/LoadingSpinner.scss
@@ -2,13 +2,11 @@
 .loading-spinner {
   display: flex;
   align-content: center;
-  align-items: flex-start;
-  flex-direction: row;
+  align-items: center;
 
   .loading-spinner-caption {
     padding-left: 0;
     line-height: 2.5rem;
-    align-self: center;
   }
 
   .animate-spin {

--- a/user-interface/src/lib/components/LoadingSpinner.scss
+++ b/user-interface/src/lib/components/LoadingSpinner.scss
@@ -2,10 +2,13 @@
 .loading-spinner {
   display: flex;
   align-content: center;
+  align-items: flex-start;
+  flex-direction: row;
 
   .loading-spinner-caption {
     padding-left: 0;
     line-height: 2.5rem;
+    align-self: center;
   }
 
   .animate-spin {

--- a/user-interface/src/lib/components/LoadingSpinner.tsx
+++ b/user-interface/src/lib/components/LoadingSpinner.tsx
@@ -19,7 +19,7 @@ export function LoadingSpinner(props: LoadingSpinnerProps) {
       className={`loading-spinner ${className ?? ''}`}
       data-testid={id}
       style={{
-        display: hidden === true ? 'none' : 'block',
+        display: hidden === true ? 'none' : 'flex',
         height: height ? height : undefined,
       }}
     >

--- a/user-interface/src/lib/components/LoadingSpinner.tsx
+++ b/user-interface/src/lib/components/LoadingSpinner.tsx
@@ -19,7 +19,7 @@ export function LoadingSpinner(props: LoadingSpinnerProps) {
       className={`loading-spinner ${className ?? ''}`}
       data-testid={id}
       style={{
-        visibility: hidden === true ? 'hidden' : 'visible',
+        display: hidden === true ? 'none' : 'block',
         height: height ? height : undefined,
       }}
     >

--- a/user-interface/src/lib/components/combobox/ComboBox.scss
+++ b/user-interface/src/lib/components/combobox/ComboBox.scss
@@ -10,9 +10,17 @@ $listItemHoverBackground: #b0b0b0;
 
 .combo-box-form-group {
   max-width: 100%;
+  position: relative;
+
   .combo-box-label {
     display: flex;
     justify-content: space-between;
+  }
+
+  .clear-all-button {
+    position: absolute;
+    top: 0;
+    right: 0;
   }
 
   .usa-combo-box {

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -416,18 +416,6 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
         >
           {label} {props.required && <span className="required-form-field">*</span>}
         </label>
-        {selectedMap.size > 0 && (
-          <Button
-            className="clear-all-button"
-            uswdsStyle={UswdsButtonStyle.Unstyled}
-            onClick={handleClearAllClick}
-            onKeyDown={handleClearAllKeyDown}
-            id={`${comboBoxId}-clear-all`}
-            aria-label={`Clear all ${label ?? ''} items selected.`}
-          >
-            clear
-          </Button>
-        )}
       </div>
       <div className="usa-combo-box">
         <div
@@ -543,6 +531,18 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
           </div>
         )}
       </div>
+      {selectedMap.size > 0 && (
+        <Button
+          className="clear-all-button"
+          uswdsStyle={UswdsButtonStyle.Unstyled}
+          onClick={handleClearAllClick}
+          onKeyDown={handleClearAllKeyDown}
+          id={`${comboBoxId}-clear-all`}
+          aria-label={`Clear all ${label ?? ''} items selected.`}
+        >
+          clear
+        </Button>
+      )}
     </div>
   );
 }

--- a/user-interface/src/lib/components/uswds/Alert.scss
+++ b/user-interface/src/lib/components/uswds/Alert.scss
@@ -58,10 +58,6 @@
   background-size: 1.5rem;
 }
 
-.usa-alert.usa-alert--slim .usa-alert__body {
-  padding-left: 3rem;
-}
-
 .usa-alert__unset {
   visibility: hidden;
 }

--- a/user-interface/src/lib/components/uswds/Button.tsx
+++ b/user-interface/src/lib/components/uswds/Button.tsx
@@ -49,6 +49,7 @@ const ButtonComponent = (props: ButtonProps, ref: React.Ref<ButtonRef>) => {
   const tabIndex = props.tabIndex ?? 0;
 
   function disableButton(state: boolean) {
+    console.log(`disabled state request = ${state}`);
     setIsDisabled(state);
   }
 

--- a/user-interface/src/lib/components/uswds/Button.tsx
+++ b/user-interface/src/lib/components/uswds/Button.tsx
@@ -49,7 +49,6 @@ const ButtonComponent = (props: ButtonProps, ref: React.Ref<ButtonRef>) => {
   const tabIndex = props.tabIndex ?? 0;
 
   function disableButton(state: boolean) {
-    console.log(`disabled state request = ${state}`);
     setIsDisabled(state);
   }
 

--- a/user-interface/src/lib/components/uswds/Checkbox.test.tsx
+++ b/user-interface/src/lib/components/uswds/Checkbox.test.tsx
@@ -28,7 +28,7 @@ describe('Test Checkbox component', async () => {
     const checkboxOnClick = vi.fn();
     renderWithProps({ onChange: checkboxOnClick });
 
-    testingUtilities.selectCheckbox('checkbox123');
+    await testingUtilities.selectCheckbox('checkbox123');
     expect(checkboxOnClick).toHaveBeenCalled();
   });
 

--- a/user-interface/src/lib/components/uswds/Input.tsx
+++ b/user-interface/src/lib/components/uswds/Input.tsx
@@ -43,7 +43,9 @@ function InputComponent(props: InputProps, ref: React.Ref<InputRef>) {
   function clearValue() {
     setInputValue('');
     emitChange('');
-    if (inputRef.current) (inputRef.current as HTMLInputElement).focus();
+    if (inputRef.current) {
+      (inputRef.current as HTMLInputElement).focus();
+    }
   }
 
   function setValue(value: string) {

--- a/user-interface/src/lib/components/uswds/forms.scss
+++ b/user-interface/src/lib/components/uswds/forms.scss
@@ -9,7 +9,7 @@ button.unstyled-button {
 }
 
 .usa-form-group {
-  label:has(+ .usa-input-group input[required])::after {
+  label:has(~ .usa-input-group input[required])::after {
     content: ' *';
     color: $secondary-dark;
   }

--- a/user-interface/src/lib/components/uswds/modal/Modal.tsx
+++ b/user-interface/src/lib/components/uswds/modal/Modal.tsx
@@ -1,8 +1,19 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, {
+  forwardRef,
+  RefObject,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import { SubmitCancelButtonGroup, SubmitCancelBtnProps } from './SubmitCancelButtonGroup';
 import { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import useComponent from '@/lib/hooks/UseComponent';
 import { ModalRefType, SubmitCancelButtonGroupRef, OpenModalButtonRef } from './modal-refs';
+
+export type ModalShowOptions = {
+  openModalButtonRef?: RefObject<OpenModalButtonRef>;
+};
 
 export interface ModalProps {
   modalId: string;
@@ -35,10 +46,8 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
   }
 
   const handleKeyDown = (ev: React.KeyboardEvent<HTMLElement> | KeyboardEvent) => {
-    if (!props.forceAction) {
-      if (ev.key === 'Escape') {
-        close(ev);
-      }
+    if (!props.forceAction && ev.key === 'Escape') {
+      close(ev);
     }
   };
 
@@ -46,7 +55,9 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
     ev: React.KeyboardEvent<HTMLElement> | KeyboardEvent,
     firstEl: HTMLElement | null,
   ) => {
-    if (!firstEl) return;
+    if (!firstEl) {
+      return;
+    }
 
     if (
       ev.key == 'Tab' &&
@@ -76,8 +87,12 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
   function submitBtnClick(e: React.MouseEvent<HTMLButtonElement>) {
     if (props.actionButtonGroup.submitButton?.onClick) {
       const { onClick, closeOnClick } = props.actionButtonGroup.submitButton;
-      if (onClick) onClick(e);
-      if (closeOnClick !== false) close(e);
+      if (onClick) {
+        onClick(e);
+      }
+      if (closeOnClick !== false) {
+        close(e);
+      }
     }
   }
 
@@ -97,11 +112,11 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
     }
   }
 
-  function showModal(options: object) {
+  function showModal(options: ModalShowOptions) {
     if (props.onOpen) {
       props.onOpen();
     }
-    if (options && 'openModalButtonRef' in options) {
+    if ('openModalButtonRef' in options) {
       const openRef = options.openModalButtonRef as React.RefObject<OpenModalButtonRef>;
       setOpenModalButtonRef(openRef);
     }
@@ -144,13 +159,17 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
             const inputLabel = firstEl.parentElement?.querySelector('label');
             if (inputLabel) {
               const labelButton = inputLabel.querySelector('button.usa-radio__label');
-              if (labelButton) firstEl = labelButton as HTMLElement;
+              if (labelButton) {
+                firstEl = labelButton as HTMLElement;
+              }
             }
           } else if (firstEl.classList.contains('usa-checkbox__input')) {
             const inputLabel = firstEl.parentElement?.querySelector('label');
             if (inputLabel) {
               const labelButton = inputLabel.querySelector('button.usa-checkbox__label');
-              if (labelButton) firstEl = labelButton as HTMLElement;
+              if (labelButton) {
+                firstEl = labelButton as HTMLElement;
+              }
             }
           }
         }
@@ -169,10 +188,12 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
 
       if (firstEl) {
         setFirstElement(firstEl);
-        (firstEl as HTMLElement).focus();
       } else {
         setFirstElement(modalShellRef.current as HTMLElement);
-        modalShellRef.current.focus();
+      }
+
+      if (firstEl) {
+        (firstEl as HTMLElement).focus();
       }
 
       const keyDownEventHandler = (ev: KeyboardEvent) => {
@@ -192,12 +213,9 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
 
   return (
     <div
-      className={`usa-modal-wrapper ${isVisible ? 'is-visible' : 'is-hidden'}`}
-      role="dialog"
       id={props.modalId + '-wrapper'}
+      className={`usa-modal-wrapper ${isVisible ? 'is-visible' : 'is-hidden'}`}
       data-testid={`modal-${props.modalId}`}
-      aria-labelledby={props.modalId + '-heading'}
-      aria-describedby={props.modalId + '-description'}
     >
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
@@ -217,6 +235,8 @@ function ModalComponent(props: ModalProps, ref: React.Ref<ModalRefType>) {
           data-testid={`modal-content-${props.modalId}`}
           role="dialog"
           aria-modal="true"
+          aria-labelledby={props.modalId + '-heading'}
+          aria-describedby={props.modalId + '-description'}
         >
           <div className="usa-modal__content">
             <div className="usa-modal__main">

--- a/user-interface/src/lib/testing/testing-utilities.ts
+++ b/user-interface/src/lib/testing/testing-utilities.ts
@@ -89,12 +89,12 @@ function spyOnUseState() {
   return vi.spyOn(UseStateModule, 'useState').mockImplementation(useStateMock);
 }
 
-function selectCheckbox(id: string) {
+async function selectCheckbox(id: string) {
   const checkbox = document.querySelector(`#checkbox-${id}`);
   if (checkbox) {
     const checkboxLabelButton = document.querySelector(`#checkbox-${id}-click-target`);
     if (checkboxLabelButton) {
-      fireEvent.click(checkboxLabelButton);
+      await userEvent.click(checkboxLabelButton);
     }
   }
   return checkbox;

--- a/user-interface/src/login/providers/mock/MockLogin.test.tsx
+++ b/user-interface/src/login/providers/mock/MockLogin.test.tsx
@@ -39,7 +39,7 @@ describe('MockLogin', () => {
     );
 
     await waitFor(() => {
-      const modal = screen.getByTestId('modal-login-modal');
+      const modal = screen.getByTestId('modal-content-login-modal');
       expect(modal).toBeInTheDocument();
       expect(modal).toHaveAttribute('aria-labelledby', 'login-modal-heading');
     });

--- a/user-interface/src/login/providers/mock/MockLogin.tsx
+++ b/user-interface/src/login/providers/mock/MockLogin.tsx
@@ -95,7 +95,9 @@ export function MockLogin(props: MockLoginProps) {
   const modalId = 'login-modal';
 
   useEffect(() => {
-    modalRef.current?.show(!!state.session);
+    if (state.session) {
+      modalRef.current?.show({});
+    }
   }, []);
 
   if (state.session)

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModal.test.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { AssignAttorneyModalProps, AssignAttorneyModalRef } from './assignAttorneyModal.types';
 import React from 'react';
@@ -11,6 +11,7 @@ import testingUtilities from '@/lib/testing/testing-utilities';
 import Api2 from '@/lib/models/api2';
 import { REGION_02_GROUP_NY } from '@common/cams/test-utilities/mock-user';
 import AssignAttorneyModal from './AssignAttorneyModal';
+import userEvent from '@testing-library/user-event';
 
 const offices = [REGION_02_GROUP_NY!];
 const susan = MockData.getAttorneyUser({ name: 'Susan Arbeit', offices });
@@ -94,35 +95,35 @@ describe('Test Assign Attorney Modal Component', () => {
     const modal = screen.getByTestId(`modal-${modalId}`);
     const submitButton = screen.getByTestId(`button-${modalId}-submit-button`);
 
-    fireEvent.click(button);
+    await userEvent.click(button);
 
     await waitFor(() => {
       expect(modal).toHaveClass('is-visible');
       expect(submitButton).toBeDisabled();
     });
 
-    const checkbox1 = testingUtilities.selectCheckbox('1-checkbox');
+    const checkbox1 = await testingUtilities.selectCheckbox('1-checkbox');
 
     await waitFor(() => {
       expect(checkbox1).toBeChecked();
       expect(submitButton).toBeEnabled();
     });
 
-    const checkbox2 = testingUtilities.selectCheckbox('2-checkbox');
+    const checkbox2 = await testingUtilities.selectCheckbox('2-checkbox');
 
     await waitFor(() => {
       expect(checkbox2).toBeChecked();
       expect(submitButton).toBeEnabled();
     });
 
-    testingUtilities.selectCheckbox('1-checkbox');
+    await testingUtilities.selectCheckbox('1-checkbox');
 
     await waitFor(() => {
       expect(checkbox1).not.toBeChecked();
       expect(submitButton).toBeEnabled();
     });
 
-    testingUtilities.selectCheckbox('2-checkbox');
+    await testingUtilities.selectCheckbox('2-checkbox');
 
     await waitFor(() => {
       expect(checkbox2).not.toBeChecked();
@@ -154,16 +155,16 @@ describe('Test Assign Attorney Modal Component', () => {
     const modal = screen.getByTestId(`modal-${modalId}`);
 
     const submitButton = screen.getByTestId(`button-${modalId}-submit-button`);
-    fireEvent.click(button);
+    await userEvent.click(button);
 
     await waitFor(() => {
       expect(modal).toHaveClass('is-visible');
     });
 
-    testingUtilities.selectCheckbox('1-checkbox');
-    testingUtilities.selectCheckbox('2-checkbox');
-    testingUtilities.selectCheckbox('3-checkbox');
-    fireEvent.click(submitButton);
+    await testingUtilities.selectCheckbox('1-checkbox');
+    await testingUtilities.selectCheckbox('2-checkbox');
+    await testingUtilities.selectCheckbox('3-checkbox');
+    await userEvent.click(submitButton);
 
     const expectedAttorneys = attorneyList
       .sort((a, b) => {
@@ -258,10 +259,10 @@ describe('Test Assign Attorney Modal Component', () => {
       expect(modal).toHaveClass('is-visible');
     });
 
-    testingUtilities.selectCheckbox('1-checkbox');
-    testingUtilities.selectCheckbox('2-checkbox');
-    testingUtilities.selectCheckbox('3-checkbox');
-    fireEvent.click(submitButton);
+    await testingUtilities.selectCheckbox('1-checkbox');
+    await testingUtilities.selectCheckbox('2-checkbox');
+    await testingUtilities.selectCheckbox('3-checkbox');
+    await userEvent.click(submitButton);
 
     await waitFor(() => {
       expect(callback).toHaveBeenCalledWith(

--- a/user-interface/vitest.config.mts
+++ b/user-interface/vitest.config.mts
@@ -33,6 +33,8 @@ export default defineConfig({
         '**/**humble.ts',
         '*.config.*js',
         ...coverageConfigDefaults.exclude,
+        './src/initialize.ts',
+        './envToConfig.js',
       ],
       thresholds: {
         branches: 90,


### PR DESCRIPTION
# Purpose

Allow users to add a case to a consolidation order.

# Major Changes

* Add a modal that allows a user to add a case to a consolidation order.
* The modal checks to see if the case already exists on the order.
* The modal confirms the case is a valid case.
* The modal confirms the case is not a child of another consolidation order.
* Existing "add lead case" functionality removed from the consolidation accordion.

# Testing/Validation

* Manual testing
* Unit tests written

# Definition of Done:

- [x] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed: More important code doesn’t directly depend on less important code
- [x] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [x] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add a modal-based workflow to allow users to add cases to consolidation orders, replacing the legacy "lead case not listed" form and updating business logic, state management, controls, and tests to support the new flow.

New Features:
- Introduce an Add Case modal that validates and adds a case to a consolidation order, ensuring the case exists, isn’t already included, and isn’t part of another consolidation.

Enhancements:
- Remove the old lead-case form and related handlers from the consolidation accordion.
- Refactor the consolidation use case, store, and controls to support the add-case flow (including state for caseToAdd, addCaseNumberError, and isLookingForCase).
- Improve the generic Modal component by typing show options, enhancing focus management, and integrating with an OpenModalButtonRef.
- Reposition the ComboBox clear-all button to avoid layout issues and adjust LoadingSpinner and input focus behaviors for consistency.

Tests:
- Update unit tests for consolidationsUseCase to cover the new add-case handlers and validation scenarios.
- Adjust accordion and utility tests to remove legacy lead-case assertions and verify the new AddCaseModal integration.

Chores:
- Clean up unused imports and TODO comments in backend and React control mocks.