### PR TITLE
CAMS-389: Fix staging deploy

### DIFF
--- a/.github/workflows/reusable-database-deploy.yml
+++ b/.github/workflows/reusable-database-deploy.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           azcliversion: 2.62.0
           inlineScript: |
+            export AZURE_CORE_USE_MSAL_HTTP_CACHE=false
             cmd="az cosmosdb mongodb database exists --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} -n ${{ steps.generateE2eName.outputs.e2eDatabaseName }} -g ${{ secrets.AZURE_RG }} -o tsv"
             echo $cmd
             e2eCosmosDbExists=$($cmd)

--- a/.github/workflows/reusable-database-deploy.yml
+++ b/.github/workflows/reusable-database-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           azcliversion: 2.62.0
           inlineScript: |
-            export AZURE_CORE_USE_MSAL_HTTP_CACHE=false
+            export AZURE_CORE_USE_MSAL_HTTP_CACHE=${{ vars.AZURE_CORE_USE_MSAL_HTTP_CACHE }}
             cmd="az cosmosdb mongodb database exists --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} -n ${{ steps.generateE2eName.outputs.e2eDatabaseName }} -g ${{ secrets.AZURE_RG }} -o tsv"
             echo $cmd
             e2eCosmosDbExists=$($cmd)

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -58,18 +58,14 @@ function on_exit() {
 trap on_exit EXIT
 
 # verify gitSha
-ls -la
 mkdir sha-verify
-pushd sha-verify
-fullPath=$(echo "../${artifact_path}" | sed 's#/\{2,\}#/#g')
-unzip -q "${fullPath}"
-shaFound=$(grep "${gitSha}" index.html)
+unzip -q "${artifact_path}" -d sha-verify
+shaFound=$(grep "${gitSha}" sha-verify/index.html)
 if [[ ${shaFound} == "" ]]; then
   exit 3
 else
   echo "Found ${gitSha} in index.html."
 fi
-popd
 
 # allow build agent access to execute deployment
 agent_ip=$(curl -s --retry 3 --retry-delay 30 --retry-all-errors https://api.ipify.org)

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -60,7 +60,7 @@ trap on_exit EXIT
 # verify gitSha
 mkdir sha-verify
 pushd sha-verify
-echo ls -la
+ls -la
 fullPath=$(echo "../${artifact_path}" | sed 's#/\+#/#g')
 unzip -q "${fullPath}"
 shaFound=$(grep "${gitSha}" index.html)

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -58,9 +58,9 @@ function on_exit() {
 trap on_exit EXIT
 
 # verify gitSha
+ls -la
 mkdir sha-verify
 pushd sha-verify
-ls -la
 fullPath=$(echo "../${artifact_path}" | sed 's#/\{2,\}#/#g')
 unzip -q "${fullPath}"
 shaFound=$(grep "${gitSha}" index.html)

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -60,7 +60,7 @@ trap on_exit EXIT
 # verify gitSha
 mkdir sha-verify
 pushd sha-verify
-unzip -q ../"${artifact_path}"
+unzip -q "${artifact_path}"
 shaFound=$(grep "${gitSha}" index.html)
 if [[ ${shaFound} == "" ]]; then
   exit 3

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -61,7 +61,7 @@ trap on_exit EXIT
 mkdir sha-verify
 pushd sha-verify
 ls -la
-fullPath=$(echo "../${artifact_path}" | sed 's#/\+#/#g')
+fullPath=$(echo "../${artifact_path}" | sed 's#/\{2,\}#/#g')
 unzip -q "${fullPath}"
 shaFound=$(grep "${gitSha}" index.html)
 if [[ ${shaFound} == "" ]]; then

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -60,7 +60,9 @@ trap on_exit EXIT
 # verify gitSha
 mkdir sha-verify
 pushd sha-verify
-unzip -q "${artifact_path}"
+echo ls -la
+fullPath=$(echo "../${artifact_path}" | sed 's#/\+#/#g')
+unzip -q "${fullPath}"
 shaFound=$(grep "${gitSha}" index.html)
 if [[ ${shaFound} == "" ]]; then
   exit 3


### PR DESCRIPTION
# Purpose

The path where the zip file is located in the USTP runner is not handled the same way as it is in GitHub Actions.

# Major Changes

Instead of `pushd`ing into the directory where we then unzip the file and check for the git sha, we now do everything from the runner's default directory.

# Testing/Validation

Ran a successful deployment in staging.

# Notes

This also includes a workaround for a problem with the Azure CLI version now in use by the GitHub Actions runners. https://github.com/Azure/azure-cli/issues/31419#issuecomment-2858720156

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
