### PR TITLE
CAMS-389: Add workaround to cleanup steps for azure cli issue

### DIFF
--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           azcliversion: 2.62.0
           inlineScript: |
-            export AZURE_CORE_USE_MSAL_HTTP_CACHE=${{ vars.AZURE_CORE_USE_MSAL_HTTP_CACHE }}
+export AZURE_CORE_USE_MSAL_HTTP_CACHE="${{ vars.AZURE_CORE_USE_MSAL_HTTP_CACHE }}"
             ./ops/scripts/utility/az-delete-branch-resources.sh \
             --app-resource-group=${{ secrets.AZ_APP_RG }} \
             --db-account=${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \

--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           azcliversion: 2.62.0
           inlineScript: |
+            export AZURE_CORE_USE_MSAL_HTTP_CACHE=${{ vars.AZURE_CORE_USE_MSAL_HTTP_CACHE }}
             ./ops/scripts/utility/az-delete-branch-resources.sh \
             --app-resource-group=${{ secrets.AZ_APP_RG }} \
             --db-account=${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \

--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           azcliversion: 2.62.0
           inlineScript: |
-export AZURE_CORE_USE_MSAL_HTTP_CACHE="${{ vars.AZURE_CORE_USE_MSAL_HTTP_CACHE }}"
+            export AZURE_CORE_USE_MSAL_HTTP_CACHE="${{ vars.AZURE_CORE_USE_MSAL_HTTP_CACHE }}"
             ./ops/scripts/utility/az-delete-branch-resources.sh \
             --app-resource-group=${{ secrets.AZ_APP_RG }} \
             --db-account=${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \


### PR DESCRIPTION
# Purpose

[This PR](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/pull/1351) added a workaround for a failing step in the Continuous Deployment workflow due to issues with the az cli, but we forgot to add it to the other place we pin the az cli version.

This PR adds that workaround to that place, the `cleanup` step of `azure-remove-branch`

# Major Changes

Describe what has changed.

# Testing/Validation

Successful cleanup of resources that failed to cleanup: https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/15124053621

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

CI:
- Add export of AZURE_CORE_USE_MSAL_HTTP_CACHE in the cleanup step of the azure-remove-branch GitHub Actions workflow to address Azure CLI authentication issues.