### PR TITLE
CAMS-548 - Refactor consolidation E2E tests for new add case modal

### DIFF
--- a/test/e2e/playwright/consolidation-orders.spec.ts
+++ b/test/e2e/playwright/consolidation-orders.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from './fixture/urlQueryString';
 import { Order, ConsolidationOrder } from '../../../common/src/cams/orders';
 import { logout } from './login/login-helpers';
-import { KNOWN_GOOD_TRANSFER_FROM_CASE_ID } from '../scripts/data-generation-utils';
+import { KNOWN_GOOD_TRANSFER_FROM_CASE_NUMBER } from '../scripts/data-generation-utils';
 
 const timeoutOption = { timeout: 30000 };
 
@@ -69,7 +69,7 @@ test.describe('Consolidation Orders', () => {
         .locator(
           `button[data-testid="button-checkbox-case-selection-case-list-${pendingConsolidationOrder.id}-${i}-click-target"]`,
         )
-        .dispatchEvent('click');
+        .click();
     }
 
     // mark first child case as lead case
@@ -77,7 +77,7 @@ test.describe('Consolidation Orders', () => {
       `button-assign-lead-case-list-${pendingConsolidationOrder.id}-0`,
     );
 
-    await markAsLeadButton1.dispatchEvent('click');
+    await markAsLeadButton1.click();
 
     await expect(
       page.getByTestId(`button-accordion-approve-button-${pendingConsolidationOrder.id}`),
@@ -132,27 +132,27 @@ test.describe('Consolidation Orders', () => {
       .getByTestId(
         `button-checkbox-case-selection-case-list-${pendingConsolidationOrder.id}-0-click-target`,
       )
-      .dispatchEvent('click');
+      .click();
 
     await page
       .getByTestId(`button-assign-lead-case-list-${pendingConsolidationOrder.id}-0`)
-      .dispatchEvent('click');
+      .click();
 
     await page
       .getByTestId(
         `button-checkbox-case-selection-case-list-${pendingConsolidationOrder.id}-1-click-target`,
       )
-      .dispatchEvent('click');
+      .click();
 
     // Open add case modal and check a case
     await page
       .getByTestId(`accordion-content-${pendingConsolidationOrder.id}`)
       .getByTestId('open-modal-button')
-      .dispatchEvent('click');
+      .click();
 
     await page
       .getByTestId(`add-case-input-${pendingConsolidationOrder.id}`)
-      .fill(KNOWN_GOOD_TRANSFER_FROM_CASE_ID.slice(4));
+      .fill(KNOWN_GOOD_TRANSFER_FROM_CASE_NUMBER);
 
     await expect(
       page.getByTestId(`button-add-case-modal-${pendingConsolidationOrder.id}-submit-button`),
@@ -160,7 +160,7 @@ test.describe('Consolidation Orders', () => {
 
     await page
       .getByTestId(`button-add-case-modal-${pendingConsolidationOrder.id}-submit-button`)
-      .dispatchEvent('click');
+      .click();
 
     // Action click validate (approve button)
     await expect(
@@ -169,7 +169,7 @@ test.describe('Consolidation Orders', () => {
 
     await page
       .getByTestId(`button-accordion-approve-button-${pendingConsolidationOrder.id}`)
-      .dispatchEvent('click');
+      .click();
 
     // Assert modal opened and is actionable
     await expect(

--- a/test/e2e/playwright/consolidation-orders.spec.ts
+++ b/test/e2e/playwright/consolidation-orders.spec.ts
@@ -76,7 +76,7 @@ test.describe('Consolidation Orders', () => {
     }
 
     // mark first child case as lead case
-    const markAsLeadButton1 = await page.getByTestId(
+    const markAsLeadButton1 = page.getByTestId(
       `button-assign-lead-case-list-${pendingConsolidationOrder.id}-0`,
     );
 
@@ -114,11 +114,13 @@ test.describe('Consolidation Orders', () => {
     await page.getByTestId('order-status-filter-transfer').click();
 
     // Assert state of all filters
-    expect(page.getByTestId('order-status-filter-pending').locator('svg')).toBeVisible();
-    expect(page.getByTestId('order-status-filter-approved').locator('svg')).not.toBeVisible();
-    expect(page.getByTestId('order-status-filter-rejected').locator('svg')).not.toBeVisible();
-    expect(page.getByTestId('order-status-filter-transfer').locator('svg')).not.toBeVisible();
-    expect(page.getByTestId('order-status-filter-consolidation').locator('svg')).toBeVisible();
+    await expect(page.getByTestId('order-status-filter-pending').locator('svg')).toBeVisible();
+    await expect(page.getByTestId('order-status-filter-approved').locator('svg')).not.toBeVisible();
+    await expect(page.getByTestId('order-status-filter-rejected').locator('svg')).not.toBeVisible();
+    await expect(page.getByTestId('order-status-filter-transfer').locator('svg')).not.toBeVisible();
+    await expect(
+      page.getByTestId('order-status-filter-consolidation').locator('svg'),
+    ).toBeVisible();
 
     // Action open accordian
     await page.getByTestId(`accordion-button-order-list-${pendingConsolidationOrder.id}`).click();
@@ -130,7 +132,7 @@ test.describe('Consolidation Orders', () => {
 
     await consolidationTypeSubstantive.click();
 
-    let firstChildCaseId;
+    let firstChildCaseId: string;
     if (isConsolidationOrder(pendingConsolidationOrder)) {
       firstChildCaseId = pendingConsolidationOrder.childCases[0].caseId.slice(4);
     }
@@ -141,27 +143,29 @@ test.describe('Consolidation Orders', () => {
       )
       .dispatchEvent('click');
 
+    // Open add case modal and check a case
     await page
-      .locator(
-        `#checkbox-lead-case-form-checkbox-toggle-${pendingConsolidationOrder.id}-click-target`,
-      )
+      .getByTestId(`accordion-content-${pendingConsolidationOrder.id}`)
+      .getByTestId('open-modal-button')
       .dispatchEvent('click');
 
-    // Action fill form for selecting a lead case not listed in child cases
+    // TODO: Need to fill in a child case Id that isn't already in the child cases list on the order.
+    // TODO: Get the child case Id from the seeded database.
+    await page.getByTestId(`add-case-input-${pendingConsolidationOrder.id}`).fill(firstChildCaseId);
+
+    await expect(
+      page.getByTestId(`button-add-case-modal-${pendingConsolidationOrder.id}-submit-button`),
+    ).toBeEnabled();
 
     await page
-      .getByTestId(`lead-case-input-${pendingConsolidationOrder.id}`)
-      .fill(firstChildCaseId);
+      .getByTestId(`button-add-case-modal-${pendingConsolidationOrder.id}-submit-button`)
+      .dispatchEvent('click');
 
-    // wait for loading assigned attorneys to complete
-    await page.waitForSelector(
-      `#lead-case-number-loading-spinner-${pendingConsolidationOrder.id}`,
-      timeoutOption,
-    );
-    await page.waitForSelector(
-      `#valid-case-number-found-${pendingConsolidationOrder.id}`,
-      timeoutOption,
-    );
+    await page
+      .getByTestId(
+        'button-checkbox-case-selection-case-list-67d4b30c-e90f-4d9d-9e52-f7c8ccb86f51-1-click-target',
+      )
+      .dispatchEvent('click');
 
     // Action click validate (approve button)
     await expect(
@@ -170,13 +174,14 @@ test.describe('Consolidation Orders', () => {
 
     await page
       .getByTestId(`button-accordion-approve-button-${pendingConsolidationOrder.id}`)
-      .click();
+      .dispatchEvent('click');
 
     // Assert modal opened and is actionable
-    expect(
+    await expect(
       page.getByTestId(`modal-overlay-confirmation-modal-${pendingConsolidationOrder.id}`),
     ).toBeVisible();
-    expect(
+
+    await expect(
       page.getByTestId(`button-confirmation-modal-${pendingConsolidationOrder.id}-submit-button`),
     ).toBeEnabled();
   });

--- a/test/e2e/scripts/data-generation-utils.ts
+++ b/test/e2e/scripts/data-generation-utils.ts
@@ -9,7 +9,9 @@ import { ConsolidationOrder, TransferOrder } from '../../../common/src/cams/orde
 import { extractAndPrepareSqlData } from './dxtr-utils';
 import { insertConsolidationOrders, insertTransferOrders, syncCases } from './cosmos-utils';
 
-export const KNOWN_GOOD_TRANSFER_FROM_CASE_ID = '081-65-67641';
+export const KNOWN_GOOD_TRANSFER_FROM_CASE_NUMBER = '65-67641';
+export const KNOWN_GOOD_TRANSFER_FROM_CASE_ID = '081-' + KNOWN_GOOD_TRANSFER_FROM_CASE_NUMBER;
+
 export const KNOWN_GOOD_TRANSFER_TO_CASE_ID = '091-69-12345';
 
 dotenv.config();


### PR DESCRIPTION
# Purpose

Adjust the E2E tests to accommodate the new add case modal for consolidation orders.

# Major Changes

Consolidation tests interactions were modified to include the new modal interaction to add cases.

# Testing/Validation

E2E tests are passing

## Summary by Sourcery

Refactor consolidation orders E2E tests to support the new add-case modal and streamline element interactions and assertions

Enhancements:
- Simplify pending consolidation order retrieval by casting to ConsolidationOrder and removing type guards
- Replace direct clicks with dispatchEvent('click') for hidden USWDS checkbox inputs
- Update locators and assertions to use Playwright's expect with toBeVisible and toBeEnabled
- Incorporate new add-case modal flow: open modal, fill in case ID, and submit selection