### PR TITLE
CAMS-447 - no single case consolidation

### DIFF
--- a/backend/lib/use-cases/orders/orders-consolidation-approval.test.ts
+++ b/backend/lib/use-cases/orders/orders-consolidation-approval.test.ts
@@ -47,23 +47,31 @@ describe('Orders use case', () => {
         courtDivisionCode,
       },
     });
+    originalConsolidation.childCases.push(
+      MockData.getConsolidatedOrderCase({
+        override: { courtDivisionCode },
+      }),
+    );
     const mockDelete = jest.spyOn(MockMongoRepository.prototype, 'delete').mockResolvedValue();
     const leadCaseSummary = MockData.getCaseSummary({ override: { courtDivisionCode } });
     const approval: ConsolidationOrderActionApproval = {
       ...originalConsolidation,
-      approvedCases: [originalConsolidation.childCases[0].caseId],
+      approvedCases: [
+        originalConsolidation.childCases[0].caseId,
+        originalConsolidation.childCases[1].caseId,
+      ],
       leadCase: leadCaseSummary,
     };
 
     const approvedConsolidation = {
       ...originalConsolidation,
-      childCases: [originalConsolidation.childCases[0]],
+      childCases: [originalConsolidation.childCases[0], originalConsolidation.childCases[1]],
       leadCase: leadCaseSummary,
       id: crypto.randomUUID(),
     };
     const newPendingConsolidation = {
       ...originalConsolidation,
-      childCases: [originalConsolidation.childCases[1]],
+      childCases: [originalConsolidation.childCases[2]],
       id: crypto.randomUUID(),
     };
 
@@ -80,7 +88,7 @@ describe('Orders use case', () => {
     );
     const leadCaseAfter: ConsolidationOrderSummary = {
       status: 'approved',
-      childCases: [childCaseSummaries[0]],
+      childCases: [childCaseSummaries[0], childCaseSummaries[1]],
     };
     const leadCaseHistory: Partial<CaseHistory> = {
       documentType: 'AUDIT_CONSOLIDATION',
@@ -160,7 +168,7 @@ describe('Orders use case', () => {
         caseId: originalConsolidation.childCases[0].caseId,
       }),
     );
-    expect(mockCreateHistory.mock.calls[1][0]).toEqual(expect.objectContaining(leadCaseHistory));
+    expect(mockCreateHistory.mock.calls[2][0]).toEqual(expect.objectContaining(leadCaseHistory));
 
     expect(mockGetHistory).toHaveBeenCalledTimes(approval.approvedCases.length + 1);
     expect(actual).toEqual([newPendingConsolidation, approvedConsolidation]);

--- a/backend/lib/use-cases/orders/orders.test.ts
+++ b/backend/lib/use-cases/orders/orders.test.ts
@@ -531,6 +531,12 @@ describe('Orders use case', () => {
 
   test('should only approve a consolidation with a lead case and at least one child case.', async () => {
     // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
+    //const pendingConsolidation = MockData.getConsolidationOrder();
+    //const leadCase = MockData.getCaseSummary();
+    //const consolidation = MockData.buildArray(
+    //  () => MockData.getConsolidationFrom({ override: { otherCase: leadCase } }),
+    //  5,
+    //);
     expect(1).toEqual(1);
   });
 

--- a/backend/lib/use-cases/orders/orders.test.ts
+++ b/backend/lib/use-cases/orders/orders.test.ts
@@ -521,7 +521,6 @@ describe('Orders use case', () => {
   });
 
   test('should not approve a consolidation without at least one child case.', async () => {
-    // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
     const pendingConsolidation = MockData.getConsolidationOrder();
     const leadCase = MockData.getCaseSummary();
     const approval: ConsolidationOrderActionApproval = {

--- a/backend/lib/use-cases/orders/orders.test.ts
+++ b/backend/lib/use-cases/orders/orders.test.ts
@@ -4,10 +4,10 @@ import {
 } from '../../testing/testing-utilities';
 import { OrdersUseCase } from './orders';
 import {
-  getOrdersRepository,
-  getCasesRepository,
   getCasesGateway,
+  getCasesRepository,
   getConsolidationOrdersRepository,
+  getOrdersRepository,
 } from '../../factory';
 import { OrderSyncState } from '../gateways.types';
 import {
@@ -42,6 +42,8 @@ import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repo
 import { UstpDivisionMeta } from '../../../../common/src/cams/offices';
 
 describe('Orders use case', () => {
+  const ORIGINAL_ENV = process.env;
+
   const CASE_ID = '000-11-22222';
   let mockContext;
   let ordersRepo;
@@ -55,6 +57,17 @@ describe('Orders use case', () => {
     offices: [REGION_02_GROUP_NY],
   });
   const unauthorizedUser = MockData.getCamsUser({ roles: [] });
+
+  beforeAll(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      CAMS_LOGIN_PROVIDER: 'mock',
+    };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
 
   beforeEach(async () => {
     mockContext = await createMockApplicationContext();
@@ -507,6 +520,21 @@ describe('Orders use case', () => {
     expect(mockGetConsolidation).not.toHaveBeenCalled();
   });
 
+  test('should not approve a consolidation without at least one child case.', async () => {
+    // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
+    const pendingConsolidation = MockData.getConsolidationOrder();
+    const leadCase = MockData.getCaseSummary();
+    const approval: ConsolidationOrderActionApproval = {
+      ...pendingConsolidation,
+      approvedCases: [leadCase.caseId],
+      leadCase,
+      status: 'approved',
+    };
+    await expect(useCase.approveConsolidation(mockContext, approval)).rejects.toThrow(
+      'Consolidation approvals require at least one child case.',
+    );
+  });
+
   test('should throw an error if user is unauthorized to reject consolidations', async () => {
     const pendingConsolidation = MockData.getConsolidationOrder();
     const leadCase = MockData.getCaseSummary();
@@ -527,17 +555,6 @@ describe('Orders use case', () => {
       'Unauthorized',
     );
     expect(mockDelete).not.toHaveBeenCalled();
-  });
-
-  test('should only approve a consolidation with a lead case and at least one child case.', async () => {
-    // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
-    //const pendingConsolidation = MockData.getConsolidationOrder();
-    //const leadCase = MockData.getCaseSummary();
-    //const consolidation = MockData.buildArray(
-    //  () => MockData.getConsolidationFrom({ override: { otherCase: leadCase } }),
-    //  5,
-    //);
-    expect(1).toEqual(1);
   });
 
   test('should identify the user who approved the change', async () => {

--- a/backend/lib/use-cases/orders/orders.test.ts
+++ b/backend/lib/use-cases/orders/orders.test.ts
@@ -529,6 +529,11 @@ describe('Orders use case', () => {
     expect(mockDelete).not.toHaveBeenCalled();
   });
 
+  test('should only approve a consolidation with a lead case and at least one child case.', async () => {
+    // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
+    expect(1).toEqual(1);
+  });
+
   test('should identify the user who approved the change', async () => {
     const pendingConsolidation = MockData.getConsolidationOrder();
     const leadCase = MockData.getCaseSummary();

--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -405,7 +405,6 @@ export class OrdersUseCase {
     }
 
     if (status === 'approved') {
-      // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
       const assignmentUseCase = new CaseAssignmentUseCase(context);
       const leadCaseAssignmentsMap = await assignmentUseCase.findAssignmentsByCaseId([
         leadCase.caseId,

--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -331,6 +331,12 @@ export class OrdersUseCase {
       throw new UnauthorizedError(MODULE_NAME);
     }
 
+    if (includedCases.length <= 1 && status === 'approved') {
+      throw new BadRequestError(MODULE_NAME, {
+        message: 'Consolidation approvals require at least one child case.',
+      });
+    }
+
     const includedChildCases = provisionalOrder.childCases.filter((c) =>
       includedCases.includes(c.caseId),
     );

--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -399,6 +399,7 @@ export class OrdersUseCase {
     }
 
     if (status === 'approved') {
+      // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
       const assignmentUseCase = new CaseAssignmentUseCase(context);
       const leadCaseAssignmentsMap = await assignmentUseCase.findAssignmentsByCaseId([
         leadCase.caseId,

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordion.test.tsx
@@ -383,6 +383,13 @@ describe('ConsolidationOrderAccordion tests', () => {
       data: [],
     });
     renderWithProps();
+
+    // Initial button state
+    await waitFor(() => {
+      expect(findApproveButton(order.id!)).toBeDisabled();
+    });
+    expect(findRejectButton(order.id!)).toBeDisabled();
+
     const { approveButton, rejectButton } = await fillInFormToEnableVerifyButton();
     const includeAllCheckbox = document.querySelector(
       `#checkbox-case-list-${order.id}-checkbox-toggle-click-target`,
@@ -391,7 +398,7 @@ describe('ConsolidationOrderAccordion tests', () => {
     await clickCaseCheckbox(order.id!, 1);
 
     await waitFor(() => {
-      expect(approveButton).toBeEnabled();
+      expect(approveButton).toBeDisabled();
     });
     expect(rejectButton).toBeEnabled();
 
@@ -403,7 +410,7 @@ describe('ConsolidationOrderAccordion tests', () => {
 
     await setLeadCase(0);
     await waitFor(() => {
-      expect(approveButton).toBeEnabled();
+      expect(approveButton).toBeDisabled();
     });
     expect(rejectButton).toBeEnabled();
 

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderAccordionView.tsx
@@ -130,9 +130,9 @@ export function ConsolidationOrderAccordionView(props: ConsolidationOrderAccordi
               <div className="grid-col-10">
                 <p aria-details="" className="form-instructions measure-6">
                   Choose a consolidation type. Use the checkboxes to include cases in the
-                  consolidation (at least two cases), and then mark a lead case. If the lead case is
-                  not listed, enter it at the bottom. When finished, click Verify to review your
-                  changes before approving them.
+                  consolidation (at least two cases), and then mark a lead case. If a case is not
+                  listed, add it at the bottom. When finished, click Verify to review your changes
+                  before approving them.
                 </p>
                 <FormRequirementsNotice />
                 <RadioGroup

--- a/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationControlsMock.ts
@@ -103,7 +103,9 @@ export function useConsolidationControlsMock(): ConsolidationControls {
   ) => {};
 
   const clearAllCheckBoxes = () => {};
-  const disableButton = (button: Ref<ButtonRef>, state: boolean) => {};
+  const disableButton = (button: Ref<ButtonRef>, state: boolean) => {
+    button.current?.disableButton(state);
+  };
   const unsetConsolidationType = () => {};
 
   return {

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.test.ts
@@ -126,7 +126,7 @@ describe('Consolidation UseCase tests', () => {
     useCase.handleConfirmAction(action);
 
     await TestingUtilities.waitFor(() => {
-      return store.isProcessing === false;
+      return !store.isProcessing;
     });
 
     expect(putSpy).toHaveBeenCalled();
@@ -468,7 +468,7 @@ describe('Consolidation UseCase tests', () => {
       useCase.verifyCaseCanBeAdded();
 
       await waitFor(() => {
-        return store.addCaseNumberError?.length != 0 && store.foundValidCaseNumber === false;
+        return store.addCaseNumberError?.length != 0 && !store.foundValidCaseNumber;
       });
 
       expect(store.addCaseNumberError).toEqual(params.expected);
@@ -493,7 +493,7 @@ describe('Consolidation UseCase tests', () => {
     useCase.verifyCaseCanBeAdded();
 
     await waitFor(() => {
-      return store.addCaseNumberError?.length != 0 && store.foundValidCaseNumber === false;
+      return store.addCaseNumberError?.length != 0 && !store.foundValidCaseNumber;
     });
 
     expect(store.addCaseNumberError).toEqual('some server error');
@@ -518,12 +518,22 @@ describe('Consolidation UseCase tests', () => {
     useCase.verifyCaseCanBeAdded();
 
     await waitFor(() => {
-      return store.addCaseNumberError?.length != 0 && store.foundValidCaseNumber === false;
+      return store.addCaseNumberError?.length != 0 && !store.foundValidCaseNumber;
     });
 
     expect(store.addCaseNumberError).toEqual('Cannot verify case assignments. some server error');
     expect(store.isLookingForCase).toBe(false);
     expect(store.foundValidCaseNumber).toBe(false);
+  });
+
+  test('should disable the verify button if a lead case and at least once child case are not selected', async () => {
+    const disableButtonSpy = vi.spyOn(controls.approveButton.current!, 'disableButton');
+    const leadCase = MockData.getConsolidatedOrderCase();
+    store.setLeadCase(leadCase);
+    store.setConsolidationType('administrative');
+    store.setSelectedCases([leadCase]);
+    useCase.updateSubmitButtonsState();
+    expect(disableButtonSpy).toHaveBeenCalled();
   });
 
   const approvalAlerts = [{ success: true }, { success: false }];

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
@@ -222,7 +222,6 @@ const consolidationUseCase = (
   };
 
   const approveConsolidation = (action: ConfirmActionResults) => {
-    // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
     const api = useApi2();
     const genericErrorMessage =
       'An unknown error has occurred and has been logged.  Please try again later.';

--- a/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
+++ b/user-interface/src/data-verification/consolidation/consolidationsUseCase.ts
@@ -222,6 +222,7 @@ const consolidationUseCase = (
   };
 
   const approveConsolidation = (action: ConfirmActionResults) => {
+    // TODO: CAMS-447 Enforce consolidation orders must include ONE lead case and at least ONCE child case.
     const api = useApi2();
     const genericErrorMessage =
       'An unknown error has occurred and has been logged.  Please try again later.';
@@ -310,6 +311,7 @@ const consolidationUseCase = (
   const updateSubmitButtonsState = () => {
     if (store.selectedCases.length) {
       const disableApprove =
+        store.selectedCases.length <= 1 ||
         !store.isDataEnhanced ||
         store.leadCaseId === '' ||
         store.consolidationType === null ||


### PR DESCRIPTION
# Purpose

Consolidation approvals require at least one child case.

# Major Changes

* Added guard in the UI to disable the "Verify" button if a child case is not selected on consolidations.
* Added guard in the API to throw an exception if a child case is not selected on consolidation approvals.

# Testing/Validation

Added unit tests to cover the added guards.

# Notes

Optional - capture notes for nuances or future work that could be done.

## Summary by Sourcery

Enforce that consolidation approvals require at least one child case by adding guards in both the API and UI and updating tests

Bug Fixes:
- Throw a BadRequest error when approving consolidations without at least one child case in the backend
- Disable the Verify/Approve button in the UI unless a lead and at least one child case are selected

Enhancements:
- Clarify instructions text for case inclusion in consolidation accordion view
- Propagate button disable state through the consolidation controls mock

Tests:
- Add backend unit tests for the child-case guard on consolidation approvals
- Extend UI tests to cover verify button disabling on insufficient selections and adjust assertion logic

Chores:
- Mock the login provider via environment variables in Orders use case tests