### PR TITLE
CAMS-554 Stop split consolidation order from containing lead case

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/orders.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/orders.dxtr.gateway.ts
@@ -86,10 +86,10 @@ export class DxtrOrdersGateway implements OrdersGateway {
     try {
       const { maxTxId, chapters, regions } = this.setUpCommonParameters(txId, context);
 
-      // Get raw order which are a subset of case detail associated with a transfer order
+      // Get raw orders which are subsets of case detail associated with a transfer order
       const rawOrders = await this.getConsolidationOrders(context, txId, chapters, regions);
 
-      // Get the docket entries for transfer orders
+      // Get the docket entries for consolidation orders
       const rawDocketEntries = await this.getConsolidationOrderDocketEntries(
         context,
         txId,

--- a/docs/running.md
+++ b/docs/running.md
@@ -252,9 +252,12 @@ Admin Endpoint Pattern: `http://localhost:{port}/api/{function_name}`
 Use `curl` or your favorite API testing tool to send an HTTP request to following local Azure
 Function admin endpoints:
 
+// TODO: We need to write up adding the ApiKey auth header
+// curl -d "{}" -H "Content-Type: application/json" -H "Authorization: ApiKey 083ab6dc66238d4ec1630f2b4fc415399d29b4346a4f718b235eb592321e6050" -X POST http://localhost:7072/import/sync-orders
+
 ```sh
 # For the `orders-sync` function:
-curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:7071/api/orders-sync
+curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:7071/import/sync-orders
 
 # For the `admin` function `deleteMigrations`:
 curl -d "{\"apiKey\": \"{the admin key}\"}" -X DELETE http://localhost:7071/api/dev-tools/deleteMigrations


### PR DESCRIPTION
# Purpose

Stop split consolidation orders from being created with only a prior lead case.

# Major Changes

* Fix logic to remove lead case from remaining child cases when splitting a consolidation order.
* Fix guard from CAMS-447 requiring at lead one child case on a consolidation approval

# Testing/Validation

* Manual testing
* Unit tests updated
