### PR TITLE
CAMS-550: Add AssignableRole and validate against it

### DIFF
--- a/backend/lib/controllers/case-assignment/case.assignment.controller.ts
+++ b/backend/lib/controllers/case-assignment/case.assignment.controller.ts
@@ -3,7 +3,7 @@ import { CaseAssignmentUseCase } from '../../use-cases/case-assignment/case-assi
 import { AssignmentError } from '../../use-cases/case-assignment/assignment.exception';
 import { CaseAssignment } from '../../../../common/src/cams/assignments';
 import { CamsUserReference } from '../../../../common/src/cams/users';
-import { CamsRole } from '../../../../common/src/cams/roles';
+import { AssignableRole } from '../../../../common/src/cams/roles';
 import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
 import HttpStatusCodes from '../../../../common/src/api/http-status-codes';
 import { CamsController } from '../controller';
@@ -11,8 +11,7 @@ import { getCamsError } from '../../common-errors/error-utilities';
 import { finalizeDeferrable } from '../../deferrable/finalize-deferrable';
 
 const MODULE_NAME = 'ASSIGNMENT-CONTROLLER';
-const INVALID_ROLE_MESSAGE =
-  'Invalid role for the attorney. Requires role to be a TrialAttorney for case assignment.';
+const INVALID_ROLE_MESSAGE = 'The provided role is not an assignable role.';
 const VALID_CASEID_PATTERN = RegExp(/^[\dA-Z]{3}-\d{2}-\d{5}$/);
 const INVALID_CASEID_MESSAGE = 'caseId must be formatted like 01-12345.';
 
@@ -70,7 +69,7 @@ export class CaseAssignmentController implements CamsController {
     }
     if (!role) {
       badParams.push('role');
-    } else if (!(role in CamsRole)) {
+    } else if (!(role in AssignableRole)) {
       messages.push(INVALID_ROLE_MESSAGE);
     }
     if (badParams.length > 0) {

--- a/common/src/cams/roles.ts
+++ b/common/src/cams/roles.ts
@@ -5,3 +5,7 @@ export enum CamsRole {
   TrialAttorney = 'TrialAttorney',
   DataVerifier = 'DataVerifier',
 }
+
+export enum AssignableRole {
+  TrialAttorney = CamsRole.TrialAttorney,
+}


### PR DESCRIPTION
# Purpose

We want to ensure that case assignments include appropriate roles.

# Major Changes

- Add an `AssignableRole` enum which leverages the `CamsRole` values.
- Validate that the assigned role is an `AssignableRole`, not simply a `CamsRole`.

# Testing/Validation

Update automated tests to check not only a non-existent role, but also the non-assignable roles.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Restrict case assignment roles to a new AssignableRole enum and update validation logic and tests

Enhancements:
- Add AssignableRole enum mapped from CamsRole to define permissible case assignment roles
- Update case assignment controller to validate against AssignableRole and revise invalid-role error message

Tests:
- Parameterize invalid-role tests to cover non-assignable CamsRole values and expect the new error message