### PR TITLE
CAMS-554 Migrate order ids

### DIFF
--- a/backend/function-apps/dataflows/dataflows.ts
+++ b/backend/function-apps/dataflows/dataflows.ts
@@ -11,6 +11,7 @@ import MigrateConsolidations from './migrations/migrate-consolidations';
 import MigrateAssignees from './migrations/migrate-assignees';
 import CaseAssignmentEvent from './events/case-assignment-event';
 import CaseClosedEvent from './events/case-closed-event';
+import MigrateOrderIds from './migrations/migrate-order-ids';
 
 /*
 
@@ -20,7 +21,7 @@ This module calls setup functions for each "registered" data flow. Each data flo
 
 A comma-delimited list of the MODULE_NAME values is required to appear in a comma-delimited list in the CAMS_ENABLED_DATAFLOWS environment variable. Due to how hyphens are interpreted in scripts, all hyphens that appear in a given MODULE_NAME must be replaced with underscores.
 
-Any module name not listed is not setup and will not appear in the list of Azure Functions in Azure Portal. This enables data flows to be setup
+Any module name not listed is not set up and will not appear in the list of Azure Functions in Azure Portal. This enables data flows to be setup
 independently across environments.
 
 The configuration is logged on startup. Example:
@@ -104,6 +105,7 @@ dataflows.register(
   MigrateCases,
   MigrateConsolidations,
   MigrateAssignees,
+  MigrateOrderIds,
 );
 
 // Log the list of registered data flows.

--- a/backend/function-apps/dataflows/migrations/migrate-order-ids.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-order-ids.ts
@@ -1,0 +1,33 @@
+import { app, InvocationContext, output } from '@azure/functions';
+import { buildFunctionName, buildQueueName, StartMessage } from '../dataflows-common';
+import ContextCreator from '../../azure/application-context-creator';
+import { STORAGE_QUEUE_CONNECTION } from '../storage-queues';
+import MigrateOrderIdsUseCase from '../../../lib/use-cases/dataflows/migrate-order-ids';
+
+const MODULE_NAME = 'MIGRATE-ORDER-IDS';
+
+const START_FUNCTION = buildFunctionName(MODULE_NAME, 'start');
+const START = output.storageQueue({
+  queueName: buildQueueName(MODULE_NAME, 'start'),
+  connection: STORAGE_QUEUE_CONNECTION,
+});
+
+async function start(_ignore: StartMessage, invocationContext: InvocationContext) {
+  const context = await ContextCreator.getApplicationContext({ invocationContext });
+  await MigrateOrderIdsUseCase.migrateOrderIds(context);
+}
+
+function setup() {
+  app.storageQueue(START_FUNCTION, {
+    connection: START.connection,
+    queueName: START.queueName,
+    handler: start,
+  });
+}
+
+const MigrateOrderIds = {
+  MODULE_NAME,
+  setup,
+};
+
+export default MigrateOrderIds;

--- a/backend/function-apps/dataflows/migrations/migrate-order-ids.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-order-ids.ts
@@ -1,8 +1,11 @@
+// TODO: Delete this module once the consolidation order `consolidationId` values have been migrated.
+
 import { app, InvocationContext, output } from '@azure/functions';
 import { buildFunctionName, buildQueueName, StartMessage } from '../dataflows-common';
 import ContextCreator from '../../azure/application-context-creator';
 import { STORAGE_QUEUE_CONNECTION } from '../storage-queues';
 import MigrateOrderIdsUseCase from '../../../lib/use-cases/dataflows/migrate-order-ids';
+import { MigrationConsolidationOrder } from '../../../lib/use-cases/gateways.types';
 
 const MODULE_NAME = 'MIGRATE-ORDER-IDS';
 
@@ -12,9 +15,25 @@ const START = output.storageQueue({
   connection: STORAGE_QUEUE_CONNECTION,
 });
 
+const UPDATE_FUNCTION = buildFunctionName(MODULE_NAME, 'update');
+const UPDATE = output.storageQueue({
+  queueName: buildQueueName(MODULE_NAME, 'update'),
+  connection: STORAGE_QUEUE_CONNECTION,
+});
+
 async function start(_ignore: StartMessage, invocationContext: InvocationContext) {
   const context = await ContextCreator.getApplicationContext({ invocationContext });
-  await MigrateOrderIdsUseCase.migrateOrderIds(context);
+  try {
+    const orderSets = await MigrateOrderIdsUseCase.migrateConsolidationOrderIds(context);
+    invocationContext.extraOutputs.set(UPDATE, orderSets);
+  } catch (error) {
+    invocationContext.log(error);
+  }
+}
+
+async function update(orders: MigrationConsolidationOrder[], invocationContext: InvocationContext) {
+  const context = await ContextCreator.getApplicationContext({ invocationContext });
+  await MigrateOrderIdsUseCase.updateConsolidationIds(context, orders);
 }
 
 function setup() {
@@ -22,6 +41,12 @@ function setup() {
     connection: START.connection,
     queueName: START.queueName,
     handler: start,
+    extraOutputs: [UPDATE],
+  });
+  app.storageQueue(UPDATE_FUNCTION, {
+    connection: UPDATE.connection,
+    queueName: UPDATE.queueName,
+    handler: update,
   });
 }
 

--- a/backend/lib/adapters/gateways/mongo/consolidations-migration.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/consolidations-migration.mongo.repository.ts
@@ -1,0 +1,79 @@
+// TODO: Delete this module once the consolidation order `consolidationId` values have been migrated.
+
+import { ConsolidationOrder } from '../../../../../common/src/cams/orders';
+import { using } from '../../../query/query-builder';
+import { ApplicationContext } from '../../types/basic';
+import { getCamsError } from '../../../common-errors/error-utilities';
+import { BaseMongoRepository } from './utils/base-mongo-repository';
+import {
+  MigrationConsolidationOrder,
+  UpdateConsolidationId,
+} from '../../../use-cases/gateways.types';
+import QueryPipeline from '../../../query/query-pipeline';
+
+const MODULE_NAME = 'CONSOLIDATIONS-MIGRATION-MONGO-REPOSITORY';
+const COLLECTION_NAME = 'consolidations';
+
+export default class ConsolidationOrdersMigrationMongoRepository extends BaseMongoRepository {
+  private static referenceCount: number = 0;
+  private static instance: ConsolidationOrdersMigrationMongoRepository;
+
+  constructor(context: ApplicationContext) {
+    super(context, MODULE_NAME, COLLECTION_NAME);
+  }
+
+  public static getInstance(context: ApplicationContext) {
+    if (!ConsolidationOrdersMigrationMongoRepository.instance) {
+      ConsolidationOrdersMigrationMongoRepository.instance =
+        new ConsolidationOrdersMigrationMongoRepository(context);
+    }
+    ConsolidationOrdersMigrationMongoRepository.referenceCount++;
+    return ConsolidationOrdersMigrationMongoRepository.instance;
+  }
+
+  public static dropInstance() {
+    if (ConsolidationOrdersMigrationMongoRepository.referenceCount > 0) {
+      ConsolidationOrdersMigrationMongoRepository.referenceCount--;
+    }
+    if (ConsolidationOrdersMigrationMongoRepository.referenceCount < 1) {
+      ConsolidationOrdersMigrationMongoRepository.instance.client.close().then();
+      ConsolidationOrdersMigrationMongoRepository.instance = null;
+    }
+  }
+
+  public release() {
+    ConsolidationOrdersMigrationMongoRepository.dropInstance();
+  }
+
+  public async list(): Promise<MigrationConsolidationOrder[]> {
+    const { include, pipeline } = QueryPipeline;
+    return this.getAdapter<MigrationConsolidationOrder>().aggregate(
+      pipeline(include({ name: 'id' }, { name: 'jobId' }, { name: 'status' })),
+    );
+  }
+
+  public async set(value: UpdateConsolidationId): Promise<UpdateConsolidationId> {
+    const { id, consolidationId } = value;
+    const doc = using<UpdateConsolidationId>();
+    const query = doc('id').equals(id);
+
+    try {
+      const adapter = this.getAdapter<ConsolidationOrder>();
+
+      const original = await adapter.findOne(query);
+
+      const copy = {
+        ...original,
+        id: crypto.randomUUID(),
+        consolidationId,
+      };
+
+      await adapter.insertOne(copy);
+      await adapter.deleteOne(query);
+
+      return value;
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME);
+    }
+  }
+}

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -58,6 +58,7 @@ import MockUserGroupGateway from './testing/mock-gateways/mock-user-group-gatewa
 import { getCamsErrorWithStack } from './common-errors/error-utilities';
 import { OfficeAssigneeMongoRepository } from './adapters/gateways/mongo/office-assignee.mongo.repository';
 import StorageQueueGateway from './adapters/gateways/storage-queue/storage-queue-gateway';
+import ConsolidationOrdersMigrationMongoRepository from './adapters/gateways/mongo/consolidations-migration.mongo.repository';
 
 let casesGateway: CasesInterface;
 let ordersGateway: OrdersGateway;
@@ -327,6 +328,15 @@ export const getQueueGateway = (_ignore: ApplicationContext): QueueGateway => {
   return StorageQueueGateway;
 };
 
+// TODO: Delete this function once the consolidation order `consolidationId` values have been migrated.
+const getConsolidationOrdersMigrationMongoRepository = (
+  context: ApplicationContext,
+): ConsolidationOrdersMigrationMongoRepository => {
+  const repo = ConsolidationOrdersMigrationMongoRepository.getInstance(context);
+  deferRelease(repo, context);
+  return repo;
+};
+
 export const Factory = {
   getAcmsGateway,
   getAttorneyGateway,
@@ -353,6 +363,7 @@ export const Factory = {
   getUserGroupGateway,
   getUsersRepository,
   getQueueGateway,
+  getConsolidationOrdersMigrationMongoRepository,
 };
 
 export default Factory;

--- a/backend/lib/query/query-pipeline.ts
+++ b/backend/lib/query/query-pipeline.ts
@@ -80,6 +80,11 @@ export type ExcludeFields = {
   fields: FieldReference<never>[];
 };
 
+export type IncludeFields = {
+  stage: 'INCLUDE';
+  fields: Field[];
+};
+
 export type Group = {
   stage: 'GROUP';
   groupBy: Field[];
@@ -120,6 +125,7 @@ export type Stage<T = never> =
   | Join
   | AddFields<T>
   | ExcludeFields
+  | IncludeFields
   | Group;
 
 export function isPipeline(obj: unknown): obj is Pipeline {
@@ -199,6 +205,10 @@ function exclude(...fields: FieldReference<never>[]): ExcludeFields {
   return { stage: 'EXCLUDE', fields };
 }
 
+function include(...fields: Field[]): IncludeFields {
+  return { stage: 'INCLUDE', fields };
+}
+
 function pipeline(...stages: Stage[]): Pipeline {
   return { stages };
 }
@@ -224,6 +234,7 @@ const QueryPipeline = {
   exclude,
   first,
   group,
+  include,
   join,
   match,
   paginate,

--- a/backend/lib/use-cases/dataflows/migrate-order-ids.ts
+++ b/backend/lib/use-cases/dataflows/migrate-order-ids.ts
@@ -1,18 +1,54 @@
+// TODO: Delete this module once the consolidation order `consolidationId` values have been migrated.
+
 import { ApplicationContext } from '../../adapters/types/basic';
+import Factory from '../../factory';
+import { MigrationConsolidationOrder } from '../gateways.types';
 
-const MODULE_NAME = 'MIGRATE-ORDER-IDS-USE-CASE';
+const mapSetParameters = (order: MigrationConsolidationOrder, idx: number) => {
+  const { id } = order;
+  const parts = [order.jobId, order.status];
+  if (order.status !== 'pending') {
+    parts.push(idx);
+  }
+  const consolidationId = parts.join('/');
 
-async function migrateOrderIds(context: ApplicationContext) {
-  // TODO: transfer order ids?
-  // TODO: consolidation order ids!
-  // TODO: consolidation status==pending <jobid>/pending/0
-  // TODO: consolidation status==approved <jobid>/approved/0
-  // TODO: consolidation status==rejected <jobid>/rejected/0
-  context.logger.info(MODULE_NAME, 'Migrated order ids.', {});
+  return { id, consolidationId };
+};
+
+async function migrateConsolidationOrderIds(context: ApplicationContext) {
+  const repo = Factory.getConsolidationOrdersMigrationMongoRepository(context);
+
+  const allOrders = await repo.list();
+  const jobIdOrdersMap = allOrders.reduce((acc, order) => {
+    const jobId = String(order.jobId);
+    if (acc.has(jobId)) {
+      acc.get(jobId).push(order);
+    } else {
+      acc.set(jobId, [order]);
+    }
+    return acc;
+  }, new Map<string, MigrationConsolidationOrder[]>());
+
+  return [...jobIdOrdersMap.values()];
+}
+
+async function updateConsolidationIds(
+  context: ApplicationContext,
+  orders: MigrationConsolidationOrder[],
+) {
+  const repo = Factory.getConsolidationOrdersMigrationMongoRepository(context);
+
+  const pending = orders.filter((order) => order.status === 'pending').map(mapSetParameters);
+  const rejected = orders.filter((order) => order.status === 'rejected').map(mapSetParameters);
+  const approved = orders.filter((order) => order.status === 'approved').map(mapSetParameters);
+  for (const setParameters of [...pending, ...rejected, ...approved]) {
+    await repo.set(setParameters);
+  }
 }
 
 const MigrateOrderIdsUseCase = {
-  migrateOrderIds,
+  migrateConsolidationOrderIds,
+  updateConsolidationIds,
 };
 
 export default MigrateOrderIdsUseCase;

--- a/backend/lib/use-cases/dataflows/migrate-order-ids.ts
+++ b/backend/lib/use-cases/dataflows/migrate-order-ids.ts
@@ -1,0 +1,18 @@
+import { ApplicationContext } from '../../adapters/types/basic';
+
+const MODULE_NAME = 'MIGRATE-ORDER-IDS-USE-CASE';
+
+async function migrateOrderIds(context: ApplicationContext) {
+  // TODO: transfer order ids?
+  // TODO: consolidation order ids!
+  // TODO: consolidation status==pending <jobid>/pending/0
+  // TODO: consolidation status==approved <jobid>/approved/0
+  // TODO: consolidation status==rejected <jobid>/rejected/0
+  context.logger.info(MODULE_NAME, 'Migrated order ids.', {});
+}
+
+const MigrateOrderIdsUseCase = {
+  migrateOrderIds,
+};
+
+export default MigrateOrderIdsUseCase;

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -258,3 +258,7 @@ export interface QueueGateway {
     queueName: LogicalQueueNames,
   ): { enqueue: (...messages: T[]) => void };
 }
+
+// TODO: Delete these types once the consolidation order `consolidationId` values have been migrated.
+export type MigrationConsolidationOrder = Pick<ConsolidationOrder, 'id' | 'jobId' | 'status'>;
+export type UpdateConsolidationId = Pick<ConsolidationOrder, 'id' | 'consolidationId'>;


### PR DESCRIPTION
# Purpose

Use deterministic consolidation Ids to allow for sync cases to be idempotent.

# Major Changes

Added a migration use case to change the UUID consolidation IDs on consolidation orders to a deterministic compound key consisting of the order jobId and status.

# Testing/Validation

Manual testing

## Summary by Sourcery

Introduce a deterministic migration for consolidation order IDs to enable idempotent syncs and extend query support for include projections.

New Features:
- Add Azure Functions dataflow (start/update) to migrate consolidation order IDs to a compound key of jobId, status, and index.
- Implement ConsolidationOrdersMigrationMongoRepository with list and set methods to batch process and update consolidation orders.

Enhancements:
- Extend query-pipeline and mongo-aggregate-renderer with an include projection stage alongside existing exclude stage.

Chores:
- Register MigrateOrderIds module in the dataflows setup and expose migration repository in the factory.
- Add TODOs to mark migration code for removal once consolidation IDs have been migrated.