### PR TITLE
Add heading for key expiration section

### DIFF
--- a/docs/contributing/package-updates.md
+++ b/docs/contributing/package-updates.md
@@ -4,15 +4,15 @@ We have a GitHub Actions Workflow that automatically runs every Wednesday at 10 
 
 1. Sets up the GitHub runner with commit-signing information
 1. Iterates over NPM projects
-  1. Runs `npm update --save`
+    1. Runs `npm update --save`
 1. Commits the changes
 1. Pushes to the repository
 1. Creates a pull request
 1. Iterates over NPM projects
-  1. Runs `npm outdated`, storing the output
+    1. Runs `npm outdated`, storing the output
 1. Adds a comment to the pull request noting any packages that are outdated
 1. Iterates over NPM projects
-  1. Runs `npm audit`, storing the output
+    1. Runs `npm audit`, storing the output
 1. Adds a comment to the pull request noting any projects that had audit findings
 
 ## Commit Signing
@@ -29,26 +29,26 @@ To provide confidence in the commits being made, the commit is made and signed a
 1. Choose an expiration period
 1. Enter the name you want to be associated with the key (e.g. `GitHub Actions [Bot]`)
 1. Enter the email address associated with the account
-  1. Note that if it is desirable to obscure the actual email address you can use the GitHub account's no-reply email address
+    1. Note that if it is desirable to obscure the actual email address you can use the GitHub account's no-reply email address
 1. No entry is required for the `Comment` prompt
 1. Type `o` and the enter key
 1. Create a strong passphrase *
 1. Note the key id *
 1. Add an authentication key
-  1. Run `gpg --expert --edit-key <the key id>` without the angle brackets
-  1. Run `addkey`
-  1. Select `RSA (set your own capabilities)`
-  1. Select `a`, `s`, `e`, and finally `q` to make this key purely an authentication key
-  1. Select the same keysize as the primary key
-  1. Select the same expiration time as the primary key
-  1. Type `quit` and `y` to save changes
+    1. Run `gpg --expert --edit-key <the key id>` without the angle brackets
+    1. Run `addkey`
+    1. Select `RSA (set your own capabilities)`
+    1. Select `a`, `s`, `e`, and finally `q` to make this key purely an authentication key
+    1. Select the same keysize as the primary key
+    1. Select the same expiration time as the primary key
+    1. Type `quit` and `y` to save changes
 1. Run `gpg --armor --export <the key id>` without the angle brackets
-  1. Note the public key *
+    1. Note the public key *
 1. Run `gpg --armor --export-secret-key <the key id>` without the angle brackets
-  1. Note the private key *
+    1. Note the private key *
 1. Add the public key to GitHub at `https://github.com/settings/keys`
-  1. Click `New GPG key`
-  1. Save the public key with a memorable name
+    1. Click `New GPG key`
+    1. Save the public key with a memorable name
 1. Add the private key to the repository secret named `BOT_PRIVATE_KEY`
 1. Add the passphrase used to create the key to the repository secret named `BOT_PASSPHRASE`
 
@@ -63,8 +63,8 @@ Before the key expires, the expiration date should be extended using the followi
 1. In Git Bash, Run `gpg --edit-key <the key id>` without the angle brackets
 1. Run `expire` to extend the expiration of the primary key
 1. Run `key n` and `expire` to extend the expiration of the `n`th subkey
-  1. Repeat for all subkeys
-  1. Alternately you can run `key n` for all subkeys and then `expire` to extend all at once with a prompt to confirm editing multiple subkeys
+    1. Repeat for all subkeys
+    1. Alternately you can run `key n` for all subkeys and then `expire` to extend all at once with a prompt to confirm editing multiple subkeys
 1. Export the public and private keys as described above and store as described with one exception
-  1. It is not necessary to store the public key multiple times on the GitHub account, just the most recent
-  1. Delete and recreate the GPG key on the GitHub account
+    1. It is not necessary to store the public key multiple times on the GitHub account, just the most recent
+    1. Delete and recreate the GPG key on the GitHub account

--- a/docs/operations/slots.md
+++ b/docs/operations/slots.md
@@ -6,42 +6,28 @@ until the deployment has been validated, at which time a swap may be performed.
 
 ## Considerations
 
-Since we own both the client and the API, we do not need to version our API, but this does mean that we should
-validate that both client and API deployments have succeeded prior to swapping the new code into the production
-slot. For now, we are simply running `curl` commands to get the newly deployed client and perform a health
-check of the API in the `staging` slot. Eventually we should get to a point where we can perform some end-to-end
-testing where actions that do not create or update data are performed on the newly deployed frontend, interacting
-with the newly deployed backend.
+Since we own both the client and the API, we do not need to version our API, but this does mean that we should validate that both client and API deployments have succeeded prior to swapping the new code into the production slot. For now, we are simply running `curl` commands to get the newly deployed client and perform a health check of the API in the `staging` slot. Eventually we should get to a point where we can perform some end-to-end testing where actions that do not create or update data are performed on the newly deployed frontend, interacting with the newly deployed backend.
 
 ### Challenge
 
-The challenge we came acress when implementing slots was correctly hitting the endpoint for the appropriate slot. For the react app, we have a baked in URL at build time which points the frontend to a corresponding backend. This is problematic adequately test the integration of the webapp and backend of the new code deployed to the slot environment. We needed a solution which could handle the different endpoints properly without rebuilding the application.
+The challenge we came across when implementing slots was correctly hitting the endpoint for the appropriate slot. For the React app, we have a baked in URL at build time which points the frontend to a corresponding backend. This is problematic adequately test the integration of the webapp and backend of the new code deployed to the slot environment. We needed a solution which could handle the different endpoints properly without rebuilding the application.
 
 ### Options
 
 There are many options for how to ensure the validation of the staged client is interacting with the staged API.
 They generally involve tradeoffs so determining which method to use is not simple.
 
-- Get the hostname from configuration at runtime. This involves providing some way for the client to get a
-  configuration value, and providing a different value only for use in validation. The client runs in browsers
-  on users' machines, so the configuration value would need to come from a call to some API and only have value
-  during deployment.
-- Proxy requests in our validation runner (GitHub Actions or Azure DevOps) to hit the staged API instead of the
-  production one. This involves setting up some proxy tooling in the runner.
-- Add a header to all requests during validation. An Azure rep indicated that this would be an option. This would
-  involve setting up something very similar to a proxy to capture requests and add a header, or changing code to add
-  the header, but we would have to have some way to not do so from the users' machines.
+- Get the hostname from configuration at runtime. This involves providing some way for the client to get a configuration value and providing a different value only for use in validation. The client runs in browsers on users' machines, so the configuration value would need to come from a call to some API and only have value during deployment.
+- Proxy requests in our validation runner (GitHub Actions or Azure DevOps) to hit the staged API instead of the production one. This involves setting up some proxy tooling in the runner.
+- Add a header to all requests during validation. An Azure rep indicated that this would be an option. This would involve setting up something very similar to a proxy to capture requests and add a header, or changing code to add the header, but we would have to have some way to not do so from the users' machines.
 - Use a `x-ms-routing-name` cookie with the value set to the name of the staged slot (i.e. `staging`).
 - Create a multi-tier application in which all traffic to the API goes through the frontend server. https://learn.microsoft.com/en-us/azure/app-service/networking-features#create-multi-tier-applications
-  - The same thing could be accomplished by setting up a proxy on the frontend server, but the built-in Azure way
-    is likely a better option.
-  - Issues with this: we still have a baked in host name for .env values which is not resolved here
+    - The same thing could be accomplished by setting up a proxy on the frontend server, but the built-in Azure way is likely a better option.
+    - Issues with this: we still have a baked in host name for .env values which is not resolved here
 
 ### Implementation
 
-- `x-ms-routing-name` cookie. A request to `https://api-hostname.azurewebsites.us/?x-ms-routing-name=staging` will trigger
-  the creation of a cookie so subsequent requests will be routed to the staged API. This does require that at least
-  temporarily we set up the routing to distribute some traffic to the staged slot. This can be done by running:
+- `x-ms-routing-name` cookie. A request to `https://api-hostname.azurewebsites.us/?x-ms-routing-name=staging` will trigger the creation of a cookie so subsequent requests will be routed to the staged API. This does require that at least temporarily we set up the routing to distribute some traffic to the staged slot. This can be done by running:
 
 ```shell
 az webapp traffic-routing set --distribution staging=0 --name <app name> --resource-group <resource group name>

--- a/docs/ui-components/Combobox.md
+++ b/docs/ui-components/Combobox.md
@@ -4,63 +4,63 @@
 
 ### Multi-Select Dropdown Combobox
 
-- Height of dropdown list should be a maximum of 50% of the view height
-- If combo box is above the half-way line of the view, the dropdown list should open downward.
-- If combo box is below the half-way line of the view, the dropdown list should open upward above
-  the input field.
-- Hovering over items in dropdown list should high-light them with a light background and a border
-  to provide visual feedback.
-- Selecting an item in the dropdown list should high-light it with a colored background and border.
-  - The color used for high-light must conform with accessibility rules.
-  - The color used for high-light should be different than those used for hover.
+- Height of the dropdown list should be a maximum of 50% of the view height
+- If the combo box is above the half-way line of the view, the dropdown list should open downward.
+- If the combo box is below the half-way line of the view, the dropdown list should open upward above
+    the input field.
+- Hovering over items in the dropdown list should highlight them with a light background and a border
+    to provide visual feedback.
+- Selecting an item in the dropdown list should highlight it with a colored background and border.
+    - The color used for highlight must conform with accessibility rules.
+    - The color used for highlight should be different from those used for hover.
 - A checkmark should be placed on the right side of items which are selected as a selection
-  indicator.
+    indicator.
 - Once an item is selected, a "pill" with the selected label should appear between the combobox
-  label and the combobox element.
+    label and the combobox element.
 - The pills should be clickable with an "x" icon on the right and should highlight on hover.
 - Clicking on a pill will remove the pill and deselect the associated item in the dropdown list.
 - A clear-all button should appear next to the pills
 - Clicking the clear-all button should remove all pills and clear all selected items out of the
-  dropdown list.
+    dropdown list.
 - Clearing all pills should close the dropdown list.
-- Hitting escape key while focused on the input field should close the dropdown list, leave focus on
-  the input field, and clear text out of input.
-- Clicking outside of combobox should close the dropdown list and clear the input field but should
-  NOT focus on the input field.
+- Hitting the escape key while focused on the input field should close the dropdown list, leave focus on
+    the input field, and clear text out of input.
+- Clicking outside the combobox should close the dropdown list and clear the input field but should
+    NOT focus on the input field.
 - Clicking on the toggle button should open or close the dropdown list and put the focus on the
-  input field.
+    input field.
 - The arrow icon on the toggle button should change directions depending on whether the dropdown
-  list is open or closed. It should be pointing down when closed and pointing up when open.
-- If the dropdown list is open, and the input field is in focus, then pressing the Tab key should
-  highlight the first item in the dropdown list. Pressing the tab key a second time should close the
-  dropdown and focus on the next element on the screen.
+    list is open or closed. It should be pointing down when closed and pointing up when open.
+- If the dropdown list is open and the input field is in focus, then pressing the Tab key should
+    highlight the first item in the dropdown list. Pressing the tab key a second time should close the
+    dropdown and focus on the next element on the screen.
 - If the dropdown is already closed, then pressing the tab key should focus on the next element on
-  the screen and should not open the dropdown list.
+    the screen and should not open the dropdown list.
 - If the dropdown list is closed, then typing characters on the keyboard should open the dropdown
-  list.
+    list.
 - Up and down arrow cursor keys should traverse the list and return to the input field, in either
-  direction.
-- Pressing Enter key while focused on an element in the dropdown list should select that option,
-  high-light it, place a check next to it, and add a pill for that selected item.
-- Pressing Escape key while focused on an element in the dropdown list should close the dropdown
-  list and focus on the input field.
+    direction.
+- Pressing the Enter key while focused on an element in the dropdown list should select that option,
+    highlight it, place a check next to it, and add a pill for that selected item.
+- Pressing the Escape key while focused on an element in the dropdown list should close the dropdown
+    list and focus on the input field.
 - All pills and items in the dropdown list should use a pointer finger icon when hovering over them.
 - Typing text into the input field should filter the dropdown items below the input field.
 - Filtered items in the dropdown list should be hidden (display: none), but the arrow keys should
-  work as they do when the list is not filtered. Typing down arrow should move from the input field
-  to the first unfiltered item in the list or from the last unfiltered item in the list to the input
-  field. Likewise, pressing Up arrow key should move from the first unfiltered item in the list to
-  the input field, or from the input field to the last unfiltered item in the list.
+    work as they do when the list is not filtered. Typing down arrow should move from the input field
+    to the first unfiltered item in the list or from the last unfiltered item in the list to the input
+    field. Likewise, pressing the Up arrow key should move from the first unfiltered item in the list to
+    the input field, or from the input field to the last unfiltered item in the list.
 - When focus leaves the combobox and moves to another element on screen, the input field in the
-  combobox should be cleared.
+    combobox should be cleared.
 - Tabbing from another area of the screen to the combo box should first focus on the select item
-  pills, then the clear button, then the actual combo box input. If there are no items currently
-  selected, then focus should go directly to the combo box input. to the pills, and after traversing
-  the pills, should move on to the clear button, and after the clear button, on to the remaining
-  components on the screen in their normal traversal order.
-- Pressing Enter key while on the clear button should clear the selections (both the pills and the
-  dropdown list selections).
-- Pressing Enter key on a pill should remove the pill and clear associated selection out of dropdown
-  list.
-  - If the pill was the last pill in the list, then the focus should go to the previous pill.
-  - If the pill was not the last one in the list, then the focus should go to the next pill.
+    pills, then the clear button, then the actual combo box input. If there are no items currently
+    selected, then focus should go directly to the combo box input. to the pills, and after traversing
+    the pills, should move on to the clear button, and after the clear button, on to the remaining
+    components on the screen in their normal traversal order.
+- Pressing the Enter key while on the clear button should clear the selections (both the pills and the
+    dropdown list selections).
+- Pressing the Enter key on a pill should remove the pill and clear associated selection out of the dropdown
+    list.
+    - If the pill was the last pill in the list, then the focus should go to the previous pill.
+    - If the pill was not the last one in the list, then the focus should go to the next pill.


### PR DESCRIPTION
# Purpose

We want the key expiration portion of the docs to be more noticeable.

# Major Changes

- Add a heading to the portion of the doc about key expiration.
- Fix indentation of ordered lists in markdown.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Documentation:
- Introduce a level-3 “Key Expiration” heading above the expiration instructions in the package-updates doc