### PR TITLE
CAMS-554 Change format of consolidationId in the orders use case

### DIFF
--- a/backend/lib/adapters/gateways/mongo/consolidations-migration.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/consolidations-migration.mongo.repository.test.ts
@@ -1,0 +1,191 @@
+import { jest } from '@jest/globals';
+import ConsolidationOrdersMigrationMongoRepository from './consolidations-migration.mongo.repository';
+import { createMockApplicationContext } from '../../../testing/testing-utilities';
+import { ApplicationContext } from '../../types/basic';
+import {
+  MigrationConsolidationOrder,
+  UpdateConsolidationId,
+} from '../../../use-cases/gateways.types';
+import QueryPipeline from '../../../query/query-pipeline';
+
+describe('ConsolidationOrdersMigrationMongoRepository', () => {
+  let mockContext: ApplicationContext;
+  let repository: ConsolidationOrdersMigrationMongoRepository;
+  let mockAdapter;
+
+  beforeEach(async () => {
+    jest.spyOn(global.crypto, 'randomUUID').mockReturnValue('0-0-0-0-0');
+    mockContext = await createMockApplicationContext();
+
+    // Reset the singleton instance before each test
+    // @ts-expect-error - Accessing private static property for testing
+    ConsolidationOrdersMigrationMongoRepository.instance = null;
+    // @ts-expect-error - Accessing private static property for testing
+    ConsolidationOrdersMigrationMongoRepository.referenceCount = 0;
+
+    repository = ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
+
+    // Mock the adapter methods
+    mockAdapter = {
+      aggregate: jest.fn(),
+      findOne: jest.fn(),
+      insertOne: jest.fn(),
+      deleteOne: jest.fn(),
+    };
+
+    // Mock getAdapter to return our mock adapter
+    // @ts-expect-error - Accessing protected property for testing
+    jest.spyOn(repository, 'getAdapter').mockReturnValue(mockAdapter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getInstance', () => {
+    test('should create a new instance when one does not exist', () => {
+      // Reset the singleton instance
+      // @ts-expect-error - Accessing private static property for testing
+      ConsolidationOrdersMigrationMongoRepository.instance = null;
+      // @ts-expect-error - Accessing private static property for testing
+      ConsolidationOrdersMigrationMongoRepository.referenceCount = 0;
+
+      const instance = ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
+
+      expect(instance).toBeInstanceOf(ConsolidationOrdersMigrationMongoRepository);
+      // @ts-expect-error - Accessing private static property for testing
+      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(1);
+    });
+
+    test('should return the existing instance when one exists', () => {
+      const firstInstance = ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
+      const secondInstance = ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
+
+      expect(firstInstance).toBe(secondInstance);
+      // @ts-expect-error - Accessing private static property for testing
+      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(3);
+    });
+  });
+
+  describe('dropInstance', () => {
+    test('should decrement the reference count', () => {
+      // Get two instances to increase the reference count to 2
+      ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
+      ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
+
+      // @ts-expect-error - Accessing private static property for testing
+      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(3);
+
+      ConsolidationOrdersMigrationMongoRepository.dropInstance();
+
+      // @ts-expect-error - Accessing private static property for testing
+      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(2);
+    });
+
+    test('should close the client and set instance to null when reference count is 0', () => {
+      // @ts-expect-error - Accessing private static property for testing
+      const mockClose = jest.fn().mockResolvedValue(undefined);
+      // @ts-expect-error - Accessing protected property for testing
+      repository.client = { close: mockClose };
+
+      ConsolidationOrdersMigrationMongoRepository.dropInstance();
+
+      // @ts-expect-error - Accessing private static property for testing
+      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(0);
+      expect(mockClose).toHaveBeenCalled();
+      // @ts-expect-error - Accessing private static property for testing
+      expect(ConsolidationOrdersMigrationMongoRepository.instance).toBeNull();
+    });
+  });
+
+  describe('release', () => {
+    test('should call dropInstance', () => {
+      const dropInstanceSpy = jest.spyOn(
+        ConsolidationOrdersMigrationMongoRepository,
+        'dropInstance',
+      );
+
+      repository.release();
+
+      expect(dropInstanceSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('list', () => {
+    test('should call aggregate with the correct pipeline', async () => {
+      const mockOrders: MigrationConsolidationOrder[] = [
+        { id: '1', jobId: 1000, status: 'pending' },
+        { id: '2', jobId: 2000, status: 'approved' },
+      ];
+
+      mockAdapter.aggregate.mockResolvedValue(mockOrders);
+
+      const result = await repository.list();
+
+      expect(mockAdapter.aggregate).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockOrders);
+
+      // Verify the pipeline includes the correct fields
+      const pipelineArg = mockAdapter.aggregate.mock.calls[0][0];
+      expect(pipelineArg).toBeDefined();
+
+      // Check that the pipeline includes id, jobId, and status fields
+      const { include, pipeline } = QueryPipeline;
+      const expectedPipeline = pipeline(
+        include({ name: 'id' }, { name: 'jobId' }, { name: 'status' }),
+      );
+      expect(JSON.stringify(pipelineArg)).toEqual(JSON.stringify(expectedPipeline));
+    });
+  });
+
+  describe('set', () => {
+    test('should update a consolidation order with a new consolidationId', async () => {
+      const updateValue: UpdateConsolidationId = {
+        id: 'order-123',
+        consolidationId: 'new-consolidation-id',
+      };
+
+      const originalOrder = {
+        id: 'order-123',
+        jobId: 1000,
+        status: 'pending',
+        // other properties
+      };
+
+      mockAdapter.findOne.mockResolvedValue(originalOrder);
+      mockAdapter.insertOne.mockResolvedValue('new-id');
+      mockAdapter.deleteOne.mockResolvedValue(1);
+
+      const result = await repository.set(updateValue);
+
+      // Check that findOne was called with the correct query
+      expect(mockAdapter.findOne).toHaveBeenCalledTimes(1);
+
+      // Check that insertOne was called with the correct data
+      expect(mockAdapter.insertOne).toHaveBeenCalledTimes(1);
+      expect(mockAdapter.insertOne).toHaveBeenCalledWith({
+        ...originalOrder,
+        id: '0-0-0-0-0', // From our mocked randomUUID
+        consolidationId: 'new-consolidation-id',
+      });
+
+      // Check that deleteOne was called with the correct query
+      expect(mockAdapter.deleteOne).toHaveBeenCalledTimes(1);
+
+      // Check that the result is the input value
+      expect(result).toEqual(updateValue);
+    });
+
+    test('should throw an error if the operation fails', async () => {
+      const updateValue: UpdateConsolidationId = {
+        id: 'order-123',
+        consolidationId: 'new-consolidation-id',
+      };
+
+      const error = new Error('Database error');
+      mockAdapter.findOne.mockRejectedValue(error);
+
+      await expect(repository.set(updateValue)).rejects.toThrow();
+    });
+  });
+});

--- a/backend/lib/adapters/gateways/mongo/consolidations-migration.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/consolidations-migration.mongo.repository.test.ts
@@ -16,13 +16,6 @@ describe('ConsolidationOrdersMigrationMongoRepository', () => {
   beforeEach(async () => {
     jest.spyOn(global.crypto, 'randomUUID').mockReturnValue('0-0-0-0-0');
     mockContext = await createMockApplicationContext();
-
-    // Reset the singleton instance before each test
-    // @ts-expect-error - Accessing private static property for testing
-    ConsolidationOrdersMigrationMongoRepository.instance = null;
-    // @ts-expect-error - Accessing private static property for testing
-    ConsolidationOrdersMigrationMongoRepository.referenceCount = 0;
-
     repository = ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
 
     // Mock the adapter methods
@@ -39,76 +32,8 @@ describe('ConsolidationOrdersMigrationMongoRepository', () => {
   });
 
   afterEach(() => {
+    repository?.release();
     jest.clearAllMocks();
-  });
-
-  describe('getInstance', () => {
-    test('should create a new instance when one does not exist', () => {
-      // Reset the singleton instance
-      // @ts-expect-error - Accessing private static property for testing
-      ConsolidationOrdersMigrationMongoRepository.instance = null;
-      // @ts-expect-error - Accessing private static property for testing
-      ConsolidationOrdersMigrationMongoRepository.referenceCount = 0;
-
-      const instance = ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
-
-      expect(instance).toBeInstanceOf(ConsolidationOrdersMigrationMongoRepository);
-      // @ts-expect-error - Accessing private static property for testing
-      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(1);
-    });
-
-    test('should return the existing instance when one exists', () => {
-      const firstInstance = ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
-      const secondInstance = ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
-
-      expect(firstInstance).toBe(secondInstance);
-      // @ts-expect-error - Accessing private static property for testing
-      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(3);
-    });
-  });
-
-  describe('dropInstance', () => {
-    test('should decrement the reference count', () => {
-      // Get two instances to increase the reference count to 2
-      ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
-      ConsolidationOrdersMigrationMongoRepository.getInstance(mockContext);
-
-      // @ts-expect-error - Accessing private static property for testing
-      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(3);
-
-      ConsolidationOrdersMigrationMongoRepository.dropInstance();
-
-      // @ts-expect-error - Accessing private static property for testing
-      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(2);
-    });
-
-    test('should close the client and set instance to null when reference count is 0', () => {
-      // @ts-expect-error - Accessing private static property for testing
-      const mockClose = jest.fn().mockResolvedValue(undefined);
-      // @ts-expect-error - Accessing protected property for testing
-      repository.client = { close: mockClose };
-
-      ConsolidationOrdersMigrationMongoRepository.dropInstance();
-
-      // @ts-expect-error - Accessing private static property for testing
-      expect(ConsolidationOrdersMigrationMongoRepository.referenceCount).toBe(0);
-      expect(mockClose).toHaveBeenCalled();
-      // @ts-expect-error - Accessing private static property for testing
-      expect(ConsolidationOrdersMigrationMongoRepository.instance).toBeNull();
-    });
-  });
-
-  describe('release', () => {
-    test('should call dropInstance', () => {
-      const dropInstanceSpy = jest.spyOn(
-        ConsolidationOrdersMigrationMongoRepository,
-        'dropInstance',
-      );
-
-      repository.release();
-
-      expect(dropInstanceSpy).toHaveBeenCalled();
-    });
   });
 
   describe('list', () => {

--- a/backend/lib/adapters/gateways/mongo/consolidations.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/consolidations.mongo.repository.ts
@@ -5,6 +5,7 @@ import { ConsolidationOrdersRepository } from '../../../use-cases/gateways.types
 import { ApplicationContext } from '../../types/basic';
 import { getCamsError } from '../../../common-errors/error-utilities';
 import { BaseMongoRepository } from './utils/base-mongo-repository';
+import { escapeRegExCharacters } from '../../../../../common/src/cams/regex';
 
 const MODULE_NAME = 'CONSOLIDATIONS-MONGO-REPOSITORY';
 const COLLECTION_NAME = 'consolidations';
@@ -131,7 +132,8 @@ export default class ConsolidationOrdersMongoRepository<
   public async count(keyRoot: string): Promise<number> {
     const doc = using<ConsolidationOrder>();
     try {
-      const query = doc('consolidationId').regex(new RegExp(keyRoot));
+      const regex = new RegExp(`^${escapeRegExCharacters(keyRoot)}`);
+      const query = doc('consolidationId').regex(regex);
       return await this.getAdapter<T>().countDocuments(query);
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);

--- a/backend/lib/adapters/gateways/mongo/consolidations.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/consolidations.mongo.repository.ts
@@ -127,4 +127,14 @@ export default class ConsolidationOrdersMongoRepository<
       throw getCamsError(originalError, MODULE_NAME);
     }
   }
+
+  public async count(keyRoot: string): Promise<number> {
+    const doc = using<ConsolidationOrder>();
+    try {
+      const query = doc('consolidationId').regex(new RegExp(keyRoot));
+      return await this.getAdapter<T>().countDocuments(query);
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME);
+    }
+  }
 }

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -195,4 +195,8 @@ export class MockMongoRepository
   getDistinctAssigneesByOffice(_ignore: any): Promise<CamsUserReference[]> {
     throw new Error('Method not implemented.');
   }
+
+  count(_ignore: any): Promise<number> {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/backend/lib/use-cases/dataflows/migrate-order-ids.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-order-ids.test.ts
@@ -30,7 +30,7 @@ describe('MigrateOrderIdsUseCase', () => {
   });
 
   describe('migrateConsolidationOrderIds', () => {
-    it('should group orders by jobId', async () => {
+    test('should group orders by jobId', async () => {
       // Arrange
       const mockOrders: MigrationConsolidationOrder[] = [
         { id: '1', jobId: 1000, status: 'pending' },
@@ -56,7 +56,7 @@ describe('MigrateOrderIdsUseCase', () => {
       ]);
     });
 
-    it('should handle empty orders list', async () => {
+    test('should handle empty orders list', async () => {
       // Arrange
       mockRepo.list.mockResolvedValue([]);
 
@@ -69,7 +69,7 @@ describe('MigrateOrderIdsUseCase', () => {
   });
 
   describe('updateConsolidationIds', () => {
-    it('should update consolidation IDs for all orders based on status', async () => {
+    test('should update consolidation IDs for all orders based on status', async () => {
       // Arrange
       const mockOrders: MigrationConsolidationOrder[] = [
         { id: '1', jobId: 1000, status: 'pending' },
@@ -92,7 +92,7 @@ describe('MigrateOrderIdsUseCase', () => {
       expect(mockRepo.set).toHaveBeenCalledWith({ id: '3', consolidationId: '1000/rejected/0' });
     });
 
-    it('should handle empty orders list', async () => {
+    test('should handle empty orders list', async () => {
       // Arrange
       const mockOrders: MigrationConsolidationOrder[] = [];
 
@@ -103,7 +103,7 @@ describe('MigrateOrderIdsUseCase', () => {
       expect(mockRepo.set).not.toHaveBeenCalled();
     });
 
-    it('should process orders in correct order: pending, rejected, approved', async () => {
+    test('should process orders in correct order: pending, rejected, approved', async () => {
       // Arrange
       mockRepo.set.mockImplementation((params) => {
         return Promise.resolve(params);
@@ -136,7 +136,7 @@ describe('MigrateOrderIdsUseCase', () => {
   });
 
   describe('mapSetParameters', () => {
-    it('should create consolidationId without index for pending status', () => {
+    test('should create consolidationId without index for pending status', () => {
       // This is testing the private function indirectly through updateConsolidationIds
       const mockOrder: MigrationConsolidationOrder = {
         id: '1',
@@ -158,7 +158,7 @@ describe('MigrateOrderIdsUseCase', () => {
       });
     });
 
-    it('should include index in consolidationId for non-pending statuses', async () => {
+    test('should include index in consolidationId for non-pending statuses', async () => {
       // Arrange
       const mockOrders: MigrationConsolidationOrder[] = [
         { id: '1', jobId: 1000, status: 'approved' },

--- a/backend/lib/use-cases/dataflows/migrate-order-ids.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-order-ids.test.ts
@@ -1,0 +1,186 @@
+import MigrateOrderIdsUseCase from './migrate-order-ids';
+import Factory from '../../factory';
+import { MigrationConsolidationOrder } from '../gateways.types';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { ApplicationContext } from '../../adapters/types/basic';
+
+describe('MigrateOrderIdsUseCase', () => {
+  let mockContext: ApplicationContext;
+  const mockRepo = {
+    list: jest.fn(),
+    set: jest.fn(),
+  };
+  let factorySpy;
+
+  beforeEach(async () => {
+    mockContext = await createMockApplicationContext();
+    jest.clearAllMocks();
+    mockRepo.list.mockReset();
+    mockRepo.set.mockReset();
+
+    factorySpy = jest
+      .spyOn(Factory, 'getConsolidationOrdersMigrationMongoRepository')
+      // @ts-expect-error mockRepo does not mock inherited functions.
+      .mockReturnValue(mockRepo);
+  });
+
+  afterEach(() => {
+    // Restore the original implementation
+    factorySpy.mockRestore();
+  });
+
+  describe('migrateConsolidationOrderIds', () => {
+    it('should group orders by jobId', async () => {
+      // Arrange
+      const mockOrders: MigrationConsolidationOrder[] = [
+        { id: '1', jobId: 1000, status: 'pending' },
+        { id: '2', jobId: 1000, status: 'approved' },
+        { id: '3', jobId: 2000, status: 'rejected' },
+      ];
+      mockRepo.list.mockResolvedValue(mockOrders);
+
+      // Act
+      const result = await MigrateOrderIdsUseCase.migrateConsolidationOrderIds(mockContext);
+
+      // Assert
+      expect(Factory.getConsolidationOrdersMigrationMongoRepository).toHaveBeenCalledWith(
+        mockContext,
+      );
+      expect(mockRepo.list).toHaveBeenCalled();
+      expect(result).toEqual([
+        [
+          { id: '1', jobId: 1000, status: 'pending' },
+          { id: '2', jobId: 1000, status: 'approved' },
+        ],
+        [{ id: '3', jobId: 2000, status: 'rejected' }],
+      ]);
+    });
+
+    it('should handle empty orders list', async () => {
+      // Arrange
+      mockRepo.list.mockResolvedValue([]);
+
+      // Act
+      const result = await MigrateOrderIdsUseCase.migrateConsolidationOrderIds(mockContext);
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('updateConsolidationIds', () => {
+    it('should update consolidation IDs for all orders based on status', async () => {
+      // Arrange
+      const mockOrders: MigrationConsolidationOrder[] = [
+        { id: '1', jobId: 1000, status: 'pending' },
+        { id: '2', jobId: 1000, status: 'approved' },
+        { id: '3', jobId: 1000, status: 'rejected' },
+      ];
+
+      // Act
+      await MigrateOrderIdsUseCase.updateConsolidationIds(mockContext, mockOrders);
+
+      // Assert
+      expect(Factory.getConsolidationOrdersMigrationMongoRepository).toHaveBeenCalledWith(
+        mockContext,
+      );
+
+      // Check that set was called for each order with correct parameters
+      expect(mockRepo.set).toHaveBeenCalledTimes(3);
+      expect(mockRepo.set).toHaveBeenCalledWith({ id: '1', consolidationId: '1000/pending' });
+      expect(mockRepo.set).toHaveBeenCalledWith({ id: '2', consolidationId: '1000/approved/0' });
+      expect(mockRepo.set).toHaveBeenCalledWith({ id: '3', consolidationId: '1000/rejected/0' });
+    });
+
+    it('should handle empty orders list', async () => {
+      // Arrange
+      const mockOrders: MigrationConsolidationOrder[] = [];
+
+      // Act
+      await MigrateOrderIdsUseCase.updateConsolidationIds(mockContext, mockOrders);
+
+      // Assert
+      expect(mockRepo.set).not.toHaveBeenCalled();
+    });
+
+    it('should process orders in correct order: pending, rejected, approved', async () => {
+      // Arrange
+      mockRepo.set.mockImplementation((params) => {
+        return Promise.resolve(params);
+      });
+
+      const mockOrders: MigrationConsolidationOrder[] = [
+        { id: '1', jobId: 1000, status: 'approved' },
+        { id: '2', jobId: 1000, status: 'rejected' },
+        { id: '3', jobId: 1000, status: 'pending' },
+      ];
+
+      // Act
+      await MigrateOrderIdsUseCase.updateConsolidationIds(mockContext, mockOrders);
+
+      // Assert
+      expect(mockRepo.set).toHaveBeenCalledTimes(3);
+      const calls = mockRepo.set.mock.calls.map((call) => call[0]);
+
+      // First call should be pending order
+      expect(calls[0]).toEqual({ id: '3', consolidationId: '1000/pending' });
+
+      // Check that orders were processed in expected groups
+      expect(
+        calls.some((call) => call.id === '2' && call.consolidationId === '1000/rejected/0'),
+      ).toBeTruthy();
+      expect(
+        calls.some((call) => call.id === '1' && call.consolidationId === '1000/approved/0'),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('mapSetParameters', () => {
+    it('should create consolidationId without index for pending status', () => {
+      // This is testing the private function indirectly through updateConsolidationIds
+      const mockOrder: MigrationConsolidationOrder = {
+        id: '1',
+        jobId: 1000,
+        status: 'pending',
+      };
+
+      mockRepo.set.mockImplementation((params) => {
+        return Promise.resolve(params);
+      });
+
+      // Act
+      MigrateOrderIdsUseCase.updateConsolidationIds(mockContext, [mockOrder]);
+
+      // Assert
+      expect(mockRepo.set).toHaveBeenCalledWith({
+        id: '1',
+        consolidationId: '1000/pending',
+      });
+    });
+
+    it('should include index in consolidationId for non-pending statuses', async () => {
+      // Arrange
+      const mockOrders: MigrationConsolidationOrder[] = [
+        { id: '1', jobId: 1000, status: 'approved' },
+        { id: '2', jobId: 1000, status: 'rejected' },
+      ];
+
+      mockRepo.set.mockImplementation((params) => {
+        return Promise.resolve(params);
+      });
+
+      // Act
+      await MigrateOrderIdsUseCase.updateConsolidationIds(mockContext, mockOrders);
+
+      // Assert
+      expect(mockRepo.set).toHaveBeenCalledWith({
+        id: '1',
+        consolidationId: '1000/approved/0',
+      });
+      expect(mockRepo.set).toHaveBeenCalledWith({
+        id: '2',
+        consolidationId: '1000/rejected/0',
+      });
+    });
+  });
+});

--- a/backend/lib/use-cases/dataflows/migrate-order-ids.ts
+++ b/backend/lib/use-cases/dataflows/migrate-order-ids.ts
@@ -3,16 +3,13 @@
 import { ApplicationContext } from '../../adapters/types/basic';
 import Factory from '../../factory';
 import { MigrationConsolidationOrder } from '../gateways.types';
+import { generateConsolidationId } from '../../../../common/src/cams/orders';
 
 const mapSetParameters = (order: MigrationConsolidationOrder, idx: number) => {
-  const { id } = order;
-  const parts = [order.jobId, order.status];
-  if (order.status !== 'pending') {
-    parts.push(idx);
-  }
-  const consolidationId = parts.join('/');
-
-  return { id, consolidationId };
+  return {
+    id: order.id,
+    consolidationId: generateConsolidationId(order.jobId, order.status, idx),
+  };
 };
 
 async function migrateConsolidationOrderIds(context: ApplicationContext) {

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -91,7 +91,9 @@ export interface ConsolidationOrdersRepository<T = ConsolidationOrder>
     Reads<T>,
     Deletes,
     Updates<T, T>,
-    Releasable {}
+    Releasable {
+  count: (keyRoot: string) => Promise<number>;
+}
 
 export interface UserSessionCacheRepository<T = CamsSession>
   extends Reads<T>,

--- a/backend/lib/use-cases/orders/orders-consolidation-approval.test.ts
+++ b/backend/lib/use-cases/orders/orders-consolidation-approval.test.ts
@@ -33,6 +33,11 @@ describe('Orders use case', () => {
     mockContext.session = await createMockApplicationContextSession({ user: authorizedUser });
     casesRepo = getCasesRepository(mockContext);
     useCase = new OrdersUseCase(mockContext);
+
+    jest.spyOn(MockMongoRepository.prototype, 'count').mockResolvedValue(0);
+    jest
+      .spyOn(MockMongoRepository.prototype, 'create')
+      .mockImplementation((order) => Promise.resolve(order));
   });
 
   afterEach(() => {

--- a/backend/lib/use-cases/orders/orders.test.ts
+++ b/backend/lib/use-cases/orders/orders.test.ts
@@ -77,6 +77,11 @@ describe('Orders use case', () => {
     casesGateway = getCasesGateway(mockContext);
     consolidationRepo = getConsolidationOrdersRepository(mockContext);
     useCase = new OrdersUseCase(mockContext);
+
+    jest.spyOn(MockMongoRepository.prototype, 'count').mockResolvedValue(0);
+    jest
+      .spyOn(MockMongoRepository.prototype, 'create')
+      .mockImplementation((order) => Promise.resolve(order));
   });
 
   afterEach(() => {

--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -6,6 +6,7 @@ import {
   ConsolidationOrderActionRejection,
   ConsolidationOrderCase,
   ConsolidationType,
+  generateConsolidationId,
   getCaseSummaryFromConsolidationOrderCase,
   getCaseSummaryFromTransferOrder,
   isTransferOrder,
@@ -421,12 +422,14 @@ export class OrdersUseCase {
       leadCase,
     };
 
-    const keyComponents = [newConsolidation.jobId, newConsolidation.status];
-    const keyRoot = keyComponents.join('/');
-
-    const count = await consolidationsRepo.count(keyRoot);
-    keyComponents.push(count);
-    newConsolidation.consolidationId = keyComponents.join('/');
+    const count = await consolidationsRepo.count(
+      generateConsolidationId(newConsolidation.jobId, newConsolidation.status),
+    );
+    newConsolidation.consolidationId = generateConsolidationId(
+      newConsolidation.jobId,
+      newConsolidation.status,
+      count,
+    );
 
     const createdConsolidation = await consolidationsRepo.create(newConsolidation);
     response.push(createdConsolidation as ConsolidationOrder);
@@ -549,7 +552,7 @@ export class OrdersUseCase {
     }
 
     jobToCaseMap.forEach((caseSummaries, jobId) => {
-      const consolidationId = [jobId, 'pending'].join('/');
+      const consolidationId = generateConsolidationId(jobId, 'pending');
       const firstOrder = [...caseSummaries.values()].reduce((prior, next) =>
         sortDatesReverse(prior.orderDate, next.orderDate) <= 0 ? prior : next,
       );

--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -550,9 +550,9 @@ export class OrdersUseCase {
 
     jobToCaseMap.forEach((caseSummaries, jobId) => {
       const consolidationId = [jobId, 'pending'].join('/');
-      const firstOrder = [...caseSummaries.values()].sort((a, b) =>
-        sortDatesReverse(a.orderDate, b.orderDate),
-      )[0];
+      const firstOrder = [...caseSummaries.values()].reduce((prior, next) =>
+        sortDatesReverse(prior.orderDate, next.orderDate) <= 0 ? prior : next,
+      );
       const consolidationOrder: ConsolidationOrder = {
         consolidationId,
         orderType: 'consolidation',

--- a/common/src/cams/orders.test.ts
+++ b/common/src/cams/orders.test.ts
@@ -1,12 +1,14 @@
 import {
   ConsolidationOrderActionApproval,
   ConsolidationOrderActionRejection,
+  generateConsolidationId,
   getCaseSummaryFromConsolidationOrderCase,
   getCaseSummaryFromTransferOrder,
   isConsolidationOrder,
   isConsolidationOrderApproval,
   isConsolidationOrderRejection,
   isTransferOrder,
+  OrderStatus,
 } from './orders';
 import { MockData } from './test-utilities/mock-data';
 import { isConsolidationHistory } from './history';
@@ -113,5 +115,21 @@ describe('orders model tests', () => {
     for (const idx in rawConsolidationOnlyProperties) {
       expect(summary).not.toHaveProperty(rawConsolidationOnlyProperties[idx]);
     }
+  });
+
+  describe('generateConsolidationId', () => {
+    const idTests = [
+      [[1000, 'pending'], '1000/pending'],
+      [[1000, 'pending', 0], '1000/pending'],
+      [[2000, 'approved', 0], '2000/approved/0'],
+      [[2000, 'approved', 10], '2000/approved/10'],
+      [[3000, 'rejected', 1], '3000/rejected/1'],
+    ];
+    test.each(idTests)(
+      'should generate expected consolidation id for %s',
+      (args: [number, OrderStatus, number | undefined], expected: string) => {
+        expect(generateConsolidationId(...args)).toEqual(expected);
+      },
+    );
   });
 });

--- a/common/src/cams/orders.ts
+++ b/common/src/cams/orders.ts
@@ -195,6 +195,8 @@ export function generateConsolidationId(
   index?: number,
 ): string {
   const parts = [jobId, status];
-  if (index !== undefined && status !== 'pending') parts.push(index);
+  if (index !== undefined && status !== 'pending') {
+    parts.push(index);
+  }
   return parts.join('/');
 }

--- a/common/src/cams/orders.ts
+++ b/common/src/cams/orders.ts
@@ -188,3 +188,13 @@ export type RawOrderSync = {
 export type FlexibleTransferOrderAction = Partial<TransferOrderAction> & {
   newCase?: Partial<CaseSummary>;
 };
+
+export function generateConsolidationId(
+  jobId: number,
+  status: OrderStatus,
+  index?: number,
+): string {
+  const parts = [jobId, status];
+  if (index !== undefined && status !== 'pending') parts.push(index);
+  return parts.join('/');
+}

--- a/common/src/cams/regex.test.ts
+++ b/common/src/cams/regex.test.ts
@@ -1,0 +1,30 @@
+import { escapeRegExCharacters } from './regex';
+
+describe('regex', () => {
+  describe('escapeRegExCharacters', () => {
+    const expressions = [
+      ['.', '\\.'],
+      ['*', '\\*'],
+      ['+', '\\+'],
+      ['?', '\\?'],
+      ['^', '\\^'],
+      ['$', '\\$'],
+      ['{', '\\{'],
+      ['}', '\\}'],
+      ['(', '\\('],
+      [')', '\\)'],
+      ['|', '\\|'],
+      ['[', '\\['],
+      [']', '\\]'],
+      ['\\', '\\\\'],
+      [
+        'a.b*c+d?e^f$g{h}i(j)k|l[m]n\\o',
+        'a\\.b\\*c\\+d\\?e\\^f\\$g\\{h\\}i\\(j\\)k\\|l\\[m\\]n\\\\o',
+      ],
+      ['normal text', 'normal text'],
+    ];
+    test.each(expressions)('should escape regex special character %s', (expression, expected) => {
+      expect(escapeRegExCharacters(expression)).toEqual(expected);
+    });
+  });
+});

--- a/common/src/cams/regex.ts
+++ b/common/src/cams/regex.ts
@@ -1,0 +1,3 @@
+export function escapeRegExCharacters(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/user-interface/src/lib/utils/caseNumber.test.ts
+++ b/user-interface/src/lib/utils/caseNumber.test.ts
@@ -4,7 +4,7 @@ import MockData from '@common/cams/test-utilities/mock-data';
 import { waitFor } from '@testing-library/react';
 
 describe('Formatting case id', () => {
-  it('Should get case number from case id', async () => {
+  test('Should get case number from case id', async () => {
     const caseId = '081-11-22222';
     const caseNumber = '11-22222';
 
@@ -12,7 +12,7 @@ describe('Formatting case id', () => {
     expect(actual).toEqual(caseNumber);
   });
 
-  it('Should get case number from case id when the division is not present', async () => {
+  test('Should get case number from case id when the division is not present', async () => {
     const caseId = '11-22222';
     const caseNumber = '11-22222';
 
@@ -20,7 +20,7 @@ describe('Formatting case id', () => {
     expect(actual).toEqual(caseNumber);
   });
 
-  it('Should handle undefined input', async () => {
+  test('Should handle undefined input', async () => {
     const actual = getCaseNumber(undefined);
     expect(actual).toEqual('');
   });


### PR DESCRIPTION
# Purpose

Use a deterministic consolidation ID rather than a UUID to prevent order duplication.

# Major Changes

* Changed the use case to create consolidation Ids using the {jobid} / {status} / {index} pattern.
* Changed the use case to look for existing orders with the same key to increment indexes to create unique keys.
* Changed the use case to look for existing pending orders matching the pending key before creating a new order.

# Testing/Validation

* Manual testing
* Unit tests fixed

## Summary by Sourcery

Replace random consolidation IDs with a deterministic “jobId/status/index” pattern and prevent duplicate consolidations by counting existing keys before creation. Update repository interface and implementation to support counting, adjust order-creation and audit logic to only write new entries, and update tests to mock the new count behavior.

New Features:
- Generate consolidation IDs using a deterministic “jobId/status/index” scheme instead of UUIDs.

Enhancements:
- Prevent duplicate consolidation orders by counting existing keys and only creating new ones when count is zero.
- Only record audit history for newly written consolidation orders.
- Compute a simple “jobId/pending” key root for pending consolidations in the job-to-case mapping.

Tests:
- Mock the new repository count and create methods in consolidation-related unit tests.

Chores:
- Add a count(keyRoot: string) method to the ConsolidationOrdersRepository interface and its mock and Mongo implementations.

## Summary by Sourcery

Use a deterministic jobId/status/index pattern for consolidation IDs, prevent duplicates by counting existing orders, adjust use-case logic to only create and audit new consolidations, update repository interfaces and implementations, migrate old IDs, and expand tests to cover the new behavior

New Features:
- Introduce generateConsolidationId to create deterministic consolidation IDs from jobId/status/index
- Add count method to ConsolidationOrdersRepository interface and implementations for counting existing IDs

Bug Fixes:
- Prevent duplicate consolidation orders by checking repository count before creating new entries

Enhancements:
- Only write audit history for consolidation orders that are newly persisted
- Select the earliest order date when mapping pending consolidations
- Migrate existing consolidation IDs to the new pattern via generateConsolidationId in the migration script
- Add escapeRegExCharacters utility to safely construct regex queries for ID counting

Tests:
- Add unit tests for generateConsolidationId and escapeRegExCharacters
- Update consolidation-related tests to mock repository count and conditional creation/audit logic

Chores:
- Implement count method in Mongo repository and mock gateway
- Update gateways.types to include count and remove redundant type definitions