### PR TITLE
CAMS-547: draft note visibility

### DIFF
--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
@@ -2,6 +2,7 @@ import CaseNoteFormModal, {
   CaseNoteFormModalOpenProps,
   CaseNoteFormModalProps,
   CaseNoteFormModalRef,
+  CaseNoteFormMode,
   getCaseNotesInputValue,
 } from './CaseNoteFormModal';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -52,6 +53,7 @@ describe('CaseNoteFormModal - Simple Tests', () => {
       content: '',
       initialTitle: '',
       initialContent: '',
+      mode: 'create',
     };
 
     const openRenderProps = { ...defaultOpenProps, ...openProps };
@@ -139,6 +141,7 @@ describe('CaseNoteFormModal - Simple Tests', () => {
         caseId: TEST_CASE_ID,
         title: note.title,
         content: note.content,
+        mode: 'edit',
       },
     );
 
@@ -235,6 +238,7 @@ describe('CaseNoteFormModal - Simple Tests', () => {
         caseId: TEST_CASE_ID,
         title: 'Original Title',
         content: 'Original Content',
+        mode: 'edit',
       },
     );
 
@@ -394,21 +398,25 @@ describe('CaseNoteFormModal - Simple Tests', () => {
     expect(result).toEqual('');
   });
 
-  const modeCases = [['create'], ['edit']];
-  test.each(modeCases)('should call close callback with %s mode', async (mode: string) => {
-    const onModalClosedSpy = vi.fn();
-    const modalRef = React.createRef<CaseNoteFormModalRef>();
-    renderComponent(
-      modalRef,
-      { onModalClosed: onModalClosedSpy },
-      { id: mode === 'edit' ? '123' : undefined },
-    );
+  const modeCases: { mode: CaseNoteFormMode }[] = [{ mode: 'create' }, { mode: 'edit' }];
+  test.each(modeCases)(
+    'should call close callback with $mode mode',
+    async (args: { mode: CaseNoteFormMode }) => {
+      const { mode } = args;
+      const onModalClosedSpy = vi.fn();
+      const modalRef = React.createRef<CaseNoteFormModalRef>();
+      renderComponent(
+        modalRef,
+        { onModalClosed: onModalClosedSpy },
+        { id: mode === 'edit' ? '123' : undefined, mode },
+      );
 
-    const openButton = screen.getByTestId(OPEN_BUTTON_ID);
-    await userEvent.click(openButton);
-    const cancelButton = screen.getByTestId(CANCEL_BUTTON_ID);
-    expect(cancelButton).toBeVisible();
-    await userEvent.click(cancelButton);
-    expect(onModalClosedSpy).toHaveBeenCalledWith(TEST_CASE_ID, mode);
-  });
+      const openButton = screen.getByTestId(OPEN_BUTTON_ID);
+      await userEvent.click(openButton);
+      const cancelButton = screen.getByTestId(CANCEL_BUTTON_ID);
+      expect(cancelButton).toBeVisible();
+      await userEvent.click(cancelButton);
+      expect(onModalClosedSpy).toHaveBeenCalledWith(TEST_CASE_ID, mode);
+    },
+  );
 });

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
@@ -101,9 +101,12 @@ async function setUpAndLoadFromCache(cachedTitle: string, cachedContent: string)
   const note = MockData.getCaseNote();
   const modalRef = React.createRef<CaseNoteFormModalRef>();
   vi.spyOn(LocalFormCache, 'getForm').mockReturnValue({
-    caseId: note.caseId,
-    title: cachedTitle,
-    content: cachedContent,
+    value: {
+      caseId: note.caseId,
+      title: cachedTitle,
+      content: cachedContent,
+    },
+    expiresAfter: 1,
   });
   const saveFormSpy = vi.spyOn(LocalFormCache, 'saveForm');
   const clearFormSpy = vi.spyOn(LocalFormCache, 'clearForm');
@@ -158,7 +161,7 @@ describe('case note tests', () => {
     vi.resetModules();
     session = MockData.getCamsSession();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
-    vi.spyOn(LocalFormCache, 'getForm').mockReturnValue({});
+    vi.spyOn(LocalFormCache, 'getForm').mockReturnValue({ expiresAfter: 1, value: {} });
   });
 
   afterEach(() => {

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
@@ -14,6 +14,7 @@ import { CaseNoteInput } from '@common/cams/cases';
 import { getCamsUserReference } from '@common/cams/session';
 import LocalStorage from '@/lib/utils/local-storage';
 import LocalFormCache from '@/lib/utils/local-form-cache';
+import { Cacheable } from '@/lib/utils/local-cache';
 
 const useThrottleCallback = (callback: () => void, delay: number) => {
   const isThrottled = useRef(false);
@@ -103,12 +104,12 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
   }
 
   function toggleButtonOnDirtyForm() {
-    const cachedData = LocalFormCache.getForm(formKey) as CaseNoteInput;
+    const cachedData = LocalFormCache.getForm(formKey) as Cacheable<CaseNoteInput>;
     const dirty =
       cachedData &&
       formValuesFromShowOptions &&
-      (formValuesFromShowOptions.title !== cachedData.title ||
-        formValuesFromShowOptions.content !== cachedData.content);
+      (formValuesFromShowOptions.title !== cachedData.value.title ||
+        formValuesFromShowOptions.content !== cachedData.value.content);
     disableSubmitButton(!dirty);
   }
 
@@ -268,14 +269,14 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
       titleInputRef.current?.setValue(showProps.title ?? '');
       contentInputRef.current?.setValue(showProps.content ?? '');
 
-      const formData = LocalFormCache.getForm(formKey) as CaseNoteInput;
+      const formData = LocalFormCache.getForm(formKey) as Cacheable<CaseNoteInput>;
       if (
         formData &&
-        formData.caseId === showProps.caseId &&
-        (formData.title?.length > 0 || formData.content?.length > 0)
+        formData.value.caseId === showProps.caseId &&
+        (formData.value.title?.length > 0 || formData.value.content?.length > 0)
       ) {
-        titleInputRef.current?.setValue(formData.title);
-        contentInputRef.current?.setValue(formData.content);
+        titleInputRef.current?.setValue(formData.value.title);
+        contentInputRef.current?.setValue(formData.value.content);
       }
 
       if (modalRef.current?.show) {

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
@@ -63,6 +63,7 @@ export interface CaseNoteFormModalRef extends ModalRefType {
 export type CaseNoteFormModalProps = {
   modalId: string;
   alertMessage?: AlertDetails;
+  onModalClosed?: (caseId: string) => void;
 };
 
 const defaultModalOpenOptions: CaseNoteFormModalOpenProps = {
@@ -114,10 +115,12 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
   }
 
   function saveFormData(data: CaseNoteInput) {
-    if (data.title?.length > 0 || data.content?.length > 0) {
+    if ((formKey && data.title?.length > 0) || data.content?.length > 0) {
       LocalFormCache.saveForm(formKey, data);
     } else {
-      LocalFormCache.clearForm(formKey);
+      if (formKey) {
+        LocalFormCache.clearForm(formKey);
+      }
     }
     toggleButtonOnDirtyForm();
   }
@@ -249,7 +252,10 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
     },
     cancelButton: {
       label: cancelButtonLabel,
-      onClick: clearCaseNoteForm,
+      onClick: () => {
+        clearCaseNoteForm();
+        hide();
+      },
     },
   };
 
@@ -293,6 +299,11 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
     if (modalRef.current?.hide) {
       modalRef.current?.hide({});
     }
+
+    if (modalOpenOptions.caseId && props.onModalClosed) {
+      props.onModalClosed(modalOpenOptions.caseId);
+    }
+
     setFormValuesFromShowOptions(null);
     setModalOpenOptions(defaultModalOpenOptions);
   }

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
@@ -121,7 +121,7 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
   }
 
   function saveFormData(data: CaseNoteInput) {
-    if ((formKey && data.title?.length > 0) || data.content?.length > 0) {
+    if (formKey && (data.title?.length > 0 || data.content?.length > 0)) {
       LocalFormCache.saveForm(formKey, data);
     } else if (formKey) {
       LocalFormCache.clearForm(formKey);

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
@@ -64,7 +64,7 @@ export interface CaseNoteFormModalRef extends ModalRefType {
 export type CaseNoteFormModalProps = {
   modalId: string;
   alertMessage?: AlertDetails;
-  onModalClosed?: (caseId: string) => void;
+  onModalClosed?: (caseId: string, mode: 'create' | 'edit') => void;
 };
 
 const defaultModalOpenOptions: CaseNoteFormModalOpenProps = {
@@ -92,6 +92,7 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
   const [caseNoteFormError, setCaseNoteFormError] = useState<string>('');
   const [initialTitle, setInitialTitle] = useState<string>('');
   const [initialContent, setInitialContent] = useState<string>('');
+  const [mode, setMode] = useState<'create' | 'edit'>('create');
   const alertRef = useRef<AlertRefType>(null);
 
   const modalRef = useRef<ModalRefType>(null);
@@ -265,6 +266,7 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
 
   function show(showProps: CaseNoteFormModalOpenProps) {
     setNoteModalTitle(`${showProps.id ? 'Edit' : 'Create'} Case Note`);
+    setMode(showProps.id ? 'edit' : 'create');
     setCancelButtonLabel(`${showProps.id ? 'Cancel' : 'Discard'}`);
     if (showProps) {
       const formKey = buildCaseNoteFormKey(showProps.caseId);
@@ -291,7 +293,7 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
     }
 
     if (modalOpenOptions.caseId && props.onModalClosed) {
-      props.onModalClosed(modalOpenOptions.caseId);
+      props.onModalClosed(modalOpenOptions.caseId, mode);
     }
 
     setModalOpenOptions(defaultModalOpenOptions);

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.scss
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.scss
@@ -3,6 +3,10 @@
 .case-notes-panel {
   margin-left: 2rem;
 
+  .draft-notes-alert-container {
+    padding-bottom: .5rem;
+  }
+
   .case-notes-form-container {
     padding-bottom: 2rem;
   }
@@ -23,6 +27,10 @@
 
       .case-note-title-and-date {
         padding-bottom: 1rem;
+
+        .case-note-header {
+          padding-right: 1.5rem;
+        }
 
         .case-note-date {
           font-style: italic;

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.test.tsx
@@ -253,7 +253,7 @@ describe('case note tests', () => {
     expect(draftNoteAlert).toHaveTextContent(/you have a draft case note/i);
   });
 
-  test('should update remove draft alert when modal is closed', async () => {
+  test('should remove draft alert when modal is closed', async () => {
     const mockCachedNote = {
       value: {
         caseId,

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.test.tsx
@@ -8,6 +8,7 @@ import { InputRef } from '@/lib/type-declarations/input-fields';
 import React from 'react';
 import Input from '@/lib/components/uswds/Input';
 import LocalStorage from '@/lib/utils/local-storage';
+import LocalFormCache from '@/lib/utils/local-form-cache';
 import Actions from '@common/cams/actions';
 import { randomUUID } from 'crypto';
 
@@ -224,5 +225,33 @@ describe('test utilities', () => {
     const result2 = getCaseNotesInputValue(null);
     expect(result2).toEqual('');
     expect(typeof result2).toEqual('string');
+  });
+
+  test('should display info alert if cache holds a case note for the case', async () => {
+    // Define the buildCaseNoteFormKey function (same as in CaseNoteFormModal.tsx)
+    function buildCaseNoteFormKey(caseId: string) {
+      return `case-notes-${caseId}`;
+    }
+
+    // Mock LocalFormCache.getForm to return a cached note
+    const mockCachedNote = {
+      caseId,
+      title: 'Draft Note Title',
+      content: 'Draft Note Content',
+    };
+    vi.spyOn(LocalFormCache, 'getForm').mockImplementation((key: string) => {
+      if (key === buildCaseNoteFormKey(caseId)) {
+        return mockCachedNote;
+      }
+      return null;
+    });
+
+    // Render the component
+    renderWithProps({ caseId });
+
+    // Check for the info alert
+    const draftNoteAlert = await screen.findByTestId('draft-note-alert-test-id');
+    expect(draftNoteAlert).toBeInTheDocument();
+    expect(draftNoteAlert).toHaveTextContent(/you have a draft case note/i);
   });
 });

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -220,8 +220,8 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
     setDraftNote(draftNote);
   }, []);
 
-  const handleModalClosed = (eventCaseId: string) => {
-    if (eventCaseId === caseId) {
+  const handleModalClosed = (eventCaseId: string, edit: boolean = false) => {
+    if (eventCaseId === caseId && !edit) {
       const draftNote = LocalFormCache.getForm<Cacheable<CaseNoteInput>>(`case-notes-${caseId}`);
       setDraftNote(draftNote);
     }
@@ -231,7 +231,6 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
     <div className="case-notes-panel">
       <div className="case-notes-title">
         <h3>Case Notes</h3>
-        {/* Check for draft case notes and display a notification if one exists */}
         {draftNoteAlertEnabledFlag && draftNote && (
           <div data-testid="draft-note-alert-test-id" className="draft-notes-alert-container">
             <Alert

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -216,13 +216,13 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
   }, [focusId, openEditModalButtonRefs.current]);
 
   useEffect(() => {
-    const draftNote = LocalFormCache.getForm<Cacheable<CaseNoteInput>>(`case-notes-${caseId}`);
+    const draftNote = LocalFormCache.getForm<CaseNoteInput>(`case-notes-${caseId}`);
     setDraftNote(draftNote);
   }, []);
 
   const handleModalClosed = (eventCaseId: string, edit: boolean = false) => {
     if (eventCaseId === caseId && !edit) {
-      const draftNote = LocalFormCache.getForm<Cacheable<CaseNoteInput>>(`case-notes-${caseId}`);
+      const draftNote = LocalFormCache.getForm<CaseNoteInput>(`case-notes-${caseId}`);
       setDraftNote(draftNote);
     }
   };

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -17,6 +17,7 @@ import CaseNoteFormModal, {
 } from '@/case-detail/panels/case-notes/CaseNoteFormModal';
 import CaseNoteRemovalModal, { CaseNoteRemovalModalRef } from './CaseNoteRemovalModal';
 import Actions from '@common/cams/actions';
+import LocalFormCache from '@/lib/utils/local-form-cache';
 
 export function getCaseNotesInputValue(ref: TextAreaRef | null) {
   return ref?.getValue() ?? '';
@@ -46,9 +47,14 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
   useMemo(mapArchiveButtonRefs, [caseNotes]);
   useMemo(mapEditButtonRefs, [caseNotes]);
   const [focusId, setFocusId] = useState<string | null>(null);
+  const [hasDraftNote, setHasDraftNote] = useState<boolean>(false);
   const removeConfirmationModalId = 'remove-note-modal';
   const editNoteModalId = 'edit-note-modal';
   const addNoteModalId = 'add-note-modal';
+
+  function buildCaseNoteFormKey(caseId: string) {
+    return `case-notes-${caseId}`;
+  }
 
   const MINIMUM_SEARCH_CHARACTERS = 3;
 
@@ -204,10 +210,29 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
     }
   }, [focusId, openEditModalButtonRefs.current]);
 
+  useEffect(() => {
+    const hasDraft = !!LocalFormCache.getForm(buildCaseNoteFormKey(caseId));
+    setHasDraftNote(hasDraft);
+  }, [caseId]);
+
   return (
     <div className="case-notes-panel">
       <div className="case-notes-title">
         <h3>Case Notes</h3>
+        {/* Check for draft case notes and display a notification if one exists */}
+        {hasDraftNote && (
+          <div data-testid="draft-note-alert-test-id">
+            <Alert
+              message="You have a draft case note. Click 'Add' to continue editing."
+              type={UswdsAlertStyle.Info}
+              role={'status'}
+              timeout={0}
+              title="Draft Note Available"
+              show={true}
+              inline={true}
+            />
+          </div>
+        )}
         <OpenModalButton
           className="add-button"
           id={'case-note-add-button'}

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -138,6 +138,8 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
                 title: note.title,
                 content: note.content,
                 callback: onUpdateNoteRequest,
+                initialTitle: note.title,
+                initialContent: note.content,
               }}
               ariaLabel={`Edit note titled ${note.title}`}
             >
@@ -159,6 +161,8 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
                 caseId: note.caseId,
                 buttonId: `case-note-remove-button-${idx}`,
                 callback: onUpdateNoteRequest,
+                initialTitle: note.title,
+                initialContent: note.content,
               }}
               ariaLabel={`Remove note titled ${note.title}`}
             >
@@ -251,8 +255,12 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
           ref={openAddModalButtonRef}
           openProps={{
             caseId,
+            title: draftNote?.value.title ?? '',
+            content: draftNote?.value.content ?? '',
             buttonId: `case-note-add-button`,
             callback: onUpdateNoteRequest,
+            initialTitle: '',
+            initialContent: '',
           }}
           onClick={() => {
             setFocusId('');

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -214,8 +214,14 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
   useEffect(() => {
     const draftNote = LocalFormCache.getForm<Cacheable<CaseNoteInput>>(`case-notes-${caseId}`);
     setDraftNote(draftNote);
-    // TODO: consider emitting an event when the modal closes which triggers this
   }, []);
+
+  const handleModalClosed = (eventCaseId: string) => {
+    if (eventCaseId === caseId) {
+      const draftNote = LocalFormCache.getForm<Cacheable<CaseNoteInput>>(`case-notes-${caseId}`);
+      setDraftNote(draftNote);
+    }
+  };
 
   return (
     <div className="case-notes-panel">
@@ -286,7 +292,11 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
           </>
         )}
       </div>
-      <CaseNoteFormModal ref={caseNoteModalRef} modalId="case-note-modal"></CaseNoteFormModal>
+      <CaseNoteFormModal
+        ref={caseNoteModalRef}
+        modalId="case-note-modal"
+        onModalClosed={handleModalClosed}
+      ></CaseNoteFormModal>
       <CaseNoteRemovalModal
         ref={removeConfirmationModalRef}
         modalId={removeConfirmationModalId}

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -220,8 +220,8 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
     setDraftNote(draftNote);
   }, []);
 
-  const handleModalClosed = (eventCaseId: string, edit: boolean = false) => {
-    if (eventCaseId === caseId && !edit) {
+  const handleModalClosed = (eventCaseId: string, mode: 'create' | 'edit') => {
+    if (eventCaseId === caseId && mode !== 'edit') {
       const draftNote = LocalFormCache.getForm<CaseNoteInput>(`case-notes-${caseId}`);
       setDraftNote(draftNote);
     }

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -14,6 +14,7 @@ import { OpenModalButtonRef } from '@/lib/components/uswds/modal/modal-refs';
 import Icon from '@/lib/components/uswds/Icon';
 import CaseNoteFormModal, {
   CaseNoteFormModalRef,
+  CaseNoteFormMode,
 } from '@/case-detail/panels/case-notes/CaseNoteFormModal';
 import CaseNoteRemovalModal, { CaseNoteRemovalModalRef } from './CaseNoteRemovalModal';
 import Actions from '@common/cams/actions';
@@ -140,6 +141,7 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
                 callback: onUpdateNoteRequest,
                 initialTitle: note.title,
                 initialContent: note.content,
+                mode: 'edit',
               }}
               ariaLabel={`Edit note titled ${note.title}`}
             >
@@ -220,8 +222,8 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
     setDraftNote(draftNote);
   }, []);
 
-  const handleModalClosed = (eventCaseId: string, mode: 'create' | 'edit') => {
-    if (eventCaseId === caseId && mode !== 'edit') {
+  const handleModalClosed = (eventCaseId: string, mode: CaseNoteFormMode) => {
+    if (eventCaseId === caseId && mode === 'create') {
       const draftNote = LocalFormCache.getForm<CaseNoteInput>(`case-notes-${caseId}`);
       setDraftNote(draftNote);
     }
@@ -260,6 +262,7 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
             callback: onUpdateNoteRequest,
             initialTitle: '',
             initialContent: '',
+            mode: 'create',
           }}
           onClick={() => {
             setFocusId('');

--- a/user-interface/src/lib/components/CaseNumber.test.tsx
+++ b/user-interface/src/lib/components/CaseNumber.test.tsx
@@ -60,4 +60,19 @@ describe('CaseNumber component', () => {
     expect(span).toBeInTheDocument();
     expect(span.attributes.getNamedItem('class')?.value).toEqual(className);
   });
+
+  test('should open a specific tab if specified', () => {
+    renderWithProps({ ...defaultProps, tab: 'notes', openLinkIn: 'same-window' });
+
+    const link = screen.getByTestId(linkTestId);
+    expect(link).toBeInTheDocument();
+    expect(link.attributes.getNamedItem('href')?.value).toEqual(`/case-detail/${caseId}/notes`);
+    expect(link.attributes.getNamedItem('title')?.value).toEqual(
+      `View case number ${caseId} details`,
+    );
+
+    const span = screen.getByTestId(testId);
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveTextContent(expectedTextContent);
+  });
 });

--- a/user-interface/src/lib/components/CaseNumber.tsx
+++ b/user-interface/src/lib/components/CaseNumber.tsx
@@ -6,10 +6,11 @@ export type CaseNumberProps = JSX.IntrinsicElements['span'] & {
   renderAs?: 'link' | 'span';
   openLinkIn?: 'same-window' | 'new-window';
   'data-testid'?: string;
+  tab?: string;
 };
 
 export function CaseNumber(props: CaseNumberProps) {
-  const { caseId, renderAs = 'link', openLinkIn = 'new-window', ...otherProps } = props;
+  const { caseId, renderAs = 'link', openLinkIn = 'new-window', tab, ...otherProps } = props;
   const span = <span {...otherProps}>{getCaseNumber(caseId)}</span>;
   if (renderAs === 'link') {
     const target = openLinkIn === 'new-window' ? `CAMS-case-detail-${caseId}` : '_self';
@@ -17,7 +18,7 @@ export function CaseNumber(props: CaseNumberProps) {
     return (
       <Link
         data-testid={dataTestId}
-        to={`/case-detail/${caseId}/`}
+        to={`/case-detail/${caseId}/${tab ?? ''}`}
         className={`usa-link`}
         title={`View case number ${props.caseId} details`}
         target={target}

--- a/user-interface/src/lib/components/uswds/modal/SubmitCancelButtonGroup.tsx
+++ b/user-interface/src/lib/components/uswds/modal/SubmitCancelButtonGroup.tsx
@@ -44,38 +44,36 @@ function SubmitCancelButtonGroupComponent(
   }));
 
   return (
-    <>
-      <ul className={classes}>
-        {submitButton && (
-          <li className="usa-button-group__item">
-            <Button
-              id={`${modalId}-submit-button`}
-              ref={toggleSubmitButtonRef}
-              uswdsStyle={submitButton.uswdsStyle ?? UswdsButtonStyle.Default}
-              className={submitButton.className ?? ''}
-              onClick={submitButton.onClick}
-              onKeyDown={submitButton.onKeyDown}
-              disabled={submitButton.disabled ?? false}
-            >
-              {submitButton.label.length > 0 ? submitButton.label : 'Submit'}
-            </Button>
-          </li>
-        )}
-        {cancelButton && (
-          <li className="usa-button-group__item">
-            <Button
-              id={`${modalId}-cancel-button`}
-              uswdsStyle={cancelButton.uswdsStyle ?? UswdsButtonStyle.Unstyled}
-              className={cancelButtonClassName}
-              onClick={cancelButton.onClick ?? close}
-              onKeyDown={cancelButton.onKeyDown}
-            >
-              {cancelButton.label.length > 0 ? cancelButton.label : 'Go back'}
-            </Button>
-          </li>
-        )}
-      </ul>
-    </>
+    <ul className={classes}>
+      {submitButton && (
+        <li className="usa-button-group__item">
+          <Button
+            id={`${modalId}-submit-button`}
+            ref={toggleSubmitButtonRef}
+            uswdsStyle={submitButton.uswdsStyle ?? UswdsButtonStyle.Default}
+            className={submitButton.className ?? ''}
+            onClick={submitButton.onClick}
+            onKeyDown={submitButton.onKeyDown}
+            disabled={submitButton.disabled ?? false}
+          >
+            {submitButton.label.length > 0 ? submitButton.label : 'Submit'}
+          </Button>
+        </li>
+      )}
+      {cancelButton && (
+        <li className="usa-button-group__item">
+          <Button
+            id={`${modalId}-cancel-button`}
+            uswdsStyle={cancelButton.uswdsStyle ?? UswdsButtonStyle.Unstyled}
+            className={cancelButtonClassName}
+            onClick={cancelButton.onClick ?? close}
+            onKeyDown={cancelButton.onKeyDown}
+          >
+            {cancelButton.label.length > 0 ? cancelButton.label : 'Go back'}
+          </Button>
+        </li>
+      )}
+    </ul>
   );
 }
 

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -11,6 +11,7 @@ export const PRIVILEGED_IDENTITY_MANAGEMENT = 'privileged-identity-management';
 export const STAFF_ASSIGNMENT_FILTER_ENABLED = 'staff-assignment-filter-enabled';
 export const SYSTEM_MAINTENANCE_BANNER = 'system-maintenance-banner';
 export const TRANSFER_ORDERS_ENABLED = 'transfer-orders-enabled';
+export const DRAFT_CASE_NOTE_ALERT_ENABLED = 'draft-case-note-alert';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();

--- a/user-interface/src/lib/models/api2.cache.test.ts
+++ b/user-interface/src/lib/models/api2.cache.test.ts
@@ -17,7 +17,7 @@ describe('Api2 cache enabled', () => {
     const cacheGetSpy = vi
       .spyOn(cacheModule.LocalCache, 'get')
       .mockReturnValueOnce(null)
-      .mockReturnValue({ data: [] });
+      .mockReturnValue({ expiresAfter: 1, value: { data: [] } });
     const cacheSetSpy = vi.spyOn(cacheModule.LocalCache, 'set').mockResolvedValue(true);
     const fetchSpy = vi.spyOn(apiModule.default, 'get').mockResolvedValue({ data: [] });
 

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -214,7 +214,7 @@ function withCache(cacheOptions: CacheOptions): Pick<GenericApiClient, 'get'> {
       if (LocalCache.isCacheEnabled()) {
         const cached = LocalCache.get<ResponseBody<T>>(key);
         if (cached) {
-          return Promise.resolve(cached);
+          return Promise.resolve(cached.value);
         } else {
           const response = await api().get<T>(path, options);
           LocalCache.set<ResponseBody<T>>(key, response, cacheOptions.ttl);

--- a/user-interface/src/lib/utils/datetime.ts
+++ b/user-interface/src/lib/utils/datetime.ts
@@ -55,4 +55,4 @@ export const SECOND = 1;
 export const MINUTE = 60;
 export const HOUR = 3600;
 export const DAY = 86400;
-export const THREE_DAYS = 86400 * 3;
+export const THREE_DAYS = DAY * 3;

--- a/user-interface/src/lib/utils/datetime.ts
+++ b/user-interface/src/lib/utils/datetime.ts
@@ -55,3 +55,4 @@ export const SECOND = 1;
 export const MINUTE = 60;
 export const HOUR = 3600;
 export const DAY = 86400;
+export const THREE_DAYS = 86400 * 3;

--- a/user-interface/src/lib/utils/local-cache.test.ts
+++ b/user-interface/src/lib/utils/local-cache.test.ts
@@ -103,7 +103,7 @@ describe('LocalCache', () => {
 
     LocalCache.set(key, value, ttl);
     const result = LocalCache.get(key);
-    expect(result).toBe(value);
+    expect(result).toEqual({ value, expiresAfter: expect.any(Number) });
   });
 
   test('should return null if the cache is expired', () => {
@@ -149,7 +149,10 @@ describe('LocalCache', () => {
 
     LocalCache.purge();
 
-    expect(LocalCache.get(validKey)).toBe('validValue');
+    expect(LocalCache.get(validKey)).toEqual({
+      value: 'validValue',
+      expiresAfter: expect.any(Number),
+    });
     expect(LocalCache.get(expiredKey)).toBeNull();
     expect(window.localStorage.getItem(otherNonCacheKey)).toEqual('test');
 

--- a/user-interface/src/lib/utils/local-cache.test.ts
+++ b/user-interface/src/lib/utils/local-cache.test.ts
@@ -3,7 +3,12 @@ import LocalCache from './local-cache';
 import { mockLocalStorage } from '../testing/mock-local-storage';
 
 describe('LocalCache', () => {
+  const cacheItem = {
+    foo: 'bar',
+  };
+
   beforeAll(() => {
+    vi.stubEnv('CAMS_DISABLE_LOCAL_CACHE', 'false');
     vi.stubGlobal('localStorage', mockLocalStorage);
   });
 
@@ -160,12 +165,82 @@ describe('LocalCache', () => {
     vi.useRealTimers();
   });
 
-  test('should return false if localStorage is disabled', () => {
-    vi.stubGlobal('localStorage', null);
-
-    const result = LocalCache.set('disabledKey', 'disabledValue');
-    expect(result).toBe(false);
+  test('should return empty array when no items exist', () => {
+    const pattern = /^foo/;
+    const result = LocalCache.getByKeyPattern(pattern);
+    expect(result).toEqual([]);
   });
+
+  test('should return empty array when no items match pattern', () => {
+    // Save items with keys that don't match the pattern
+    LocalCache.set('bar1', cacheItem);
+    LocalCache.set('bar2', cacheItem);
+    LocalCache.set('baz', cacheItem);
+
+    const pattern = /^foo/;
+    const result = LocalCache.getByKeyPattern(pattern);
+    expect(result).toEqual([]);
+  });
+
+  test('should return matching items when some items match pattern', () => {
+    LocalCache.set('foo1', { id: 1 });
+    LocalCache.set('foo2', { id: 2 });
+    LocalCache.set('bar', { id: 3 });
+
+    const pattern = /^foo/;
+    const result = LocalCache.getByKeyPattern(pattern);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { key: 'foo1', item: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+        { key: 'foo2', item: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+      ]),
+    );
+  });
+
+  test('should return all items when all items match pattern', () => {
+    // Save items with keys that all match the pattern
+    LocalCache.set('case-notes-123', { id: 1 });
+    LocalCache.set('case-notes-456', { id: 2 });
+    LocalCache.set('case-notes-789', { id: 3 });
+
+    const pattern = /^case-notes-/;
+    const result = LocalCache.getByKeyPattern(pattern);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { key: 'case-notes-123', item: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+        { key: 'case-notes-456', item: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+        { key: 'case-notes-789', item: { value: { id: 3 }, expiresAfter: expect.any(Number) } },
+      ]),
+    );
+  });
+
+  test('should match items using complex regex patterns', () => {
+    // Save items with various keys
+    LocalCache.set('case-notes-123', { id: 1 });
+    LocalCache.set('case-notes-456', { id: 2 });
+    LocalCache.set('other-form-789', { id: 3 });
+    LocalCache.set('form-123-notes', { id: 4 });
+
+    // Pattern that matches keys containing 'notes' followed by a dash and numbers
+    const pattern = /notes-\d+$/;
+    const result = LocalCache.getByKeyPattern(pattern);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { key: 'case-notes-123', item: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+        { key: 'case-notes-456', item: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+      ]),
+    );
+  });
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // Tests below this line should always be executed last because of vi.stubGlobal.
+  //////////////////////////////////////////////////////////////////////////////////
 
   test('should check if cache is disabled if the local storage API is not available', async () => {
     vi.stubGlobal('localStorage', null);
@@ -186,6 +261,20 @@ describe('LocalCache', () => {
     vi.stubGlobal('localStorage', mockLocalStorage);
     const reloaded = await import('./local-cache');
     expect(reloaded.LocalCache.isCacheEnabled()).toBeTruthy();
+  });
+
+  test('should return false if localStorage is disabled', () => {
+    vi.stubGlobal('localStorage', null);
+
+    const result = LocalCache.getByKeyPattern(/^foo/);
+    expect(result).toHaveLength(0);
+  });
+
+  test('should return empty array if localStorage is disabled', () => {
+    vi.stubGlobal('localStorage', null);
+
+    const result = LocalCache.set('disabledKey', 'disabledValue');
+    expect(result).toBe(false);
   });
 
   test('should safely handle exceptions', () => {

--- a/user-interface/src/lib/utils/local-cache.ts
+++ b/user-interface/src/lib/utils/local-cache.ts
@@ -62,7 +62,7 @@ function getByKeyPattern<T>(pattern: RegExp): Array<{ key: string; item: Cacheab
   const items: Array<{ key: string; item: Cacheable<T> }> = [];
 
   const regExString = pattern.source.replace('^', `^${NAMESPACE}`);
-  const _pattern = new RegExp(regExString);
+  const _pattern = new RegExp(regExString, pattern.flags);
 
   if (!window.localStorage) {
     return items;

--- a/user-interface/src/lib/utils/local-cache.ts
+++ b/user-interface/src/lib/utils/local-cache.ts
@@ -1,12 +1,12 @@
 import { HOUR } from './datetime';
 import getAppConfiguration from '@/configuration/appConfiguration';
 
-type Cachable<T = unknown> = {
+export type Cacheable<T = unknown> = {
   expiresAfter: number;
   value: T;
 };
 
-const NAMESPACE = 'cams:cache:';
+export const NAMESPACE = 'cams:cache:';
 const DEFAULT_TTL = HOUR;
 const canCache = !!window.localStorage && !getAppConfiguration().disableLocalCache;
 
@@ -27,7 +27,7 @@ function purge() {
       }
 
       keysToPurge.forEach((key) => {
-        const cached = JSON.parse(window.localStorage.getItem(key)!) as Cachable;
+        const cached = JSON.parse(window.localStorage.getItem(key)!) as Cacheable;
         if (cached && cached.expiresAfter < Date.now()) {
           window.localStorage.removeItem(key);
         }
@@ -38,15 +38,15 @@ function purge() {
   }
 }
 
-function get<T>(key: string): T | null {
+function get<T>(key: string): Cacheable<T> | null {
   try {
-    let value: T | null = null;
+    let value: Cacheable<T> | null = null;
     if (canCache) {
       const json = window.localStorage.getItem(NAMESPACE + key);
       if (json) {
-        const cached = JSON.parse(json) as Cachable<T>;
+        const cached = JSON.parse(json) as Cacheable<T>;
         if (cached.expiresAfter > Date.now()) {
-          value = cached.value;
+          value = cached;
         } else {
           window.localStorage.removeItem(NAMESPACE + key);
         }
@@ -62,7 +62,7 @@ function set<T>(key: string, value: T, ttlSeconds: number = DEFAULT_TTL): boolea
   try {
     let success = false;
     if (canCache) {
-      const cachable: Cachable<T> = {
+      const cachable: Cacheable<T> = {
         expiresAfter: Date.now() + ttlSeconds * 1000,
         value,
       };

--- a/user-interface/src/lib/utils/local-form-cache.test.ts
+++ b/user-interface/src/lib/utils/local-form-cache.test.ts
@@ -31,7 +31,7 @@ describe('LocalFormCache', () => {
     LocalFormCache.saveForm(testKey, formData);
 
     const actual = LocalFormCache.getForm(testKey);
-    expect(actual).toEqual(formData);
+    expect(actual).toEqual({ value: formData, expiresAfter: expect.any(Number) });
   });
 
   test('should remove all form data', () => {
@@ -43,5 +43,93 @@ describe('LocalFormCache', () => {
 
     LocalFormCache.removeAll();
     expect(mockLocalStorage.length).toEqual(0);
+  });
+
+  describe('getFormsByPattern', () => {
+    test('should return empty array when no forms exist', () => {
+      const pattern = /^foo/;
+      const result = LocalFormCache.getFormsByPattern(pattern);
+      expect(result).toEqual([]);
+    });
+
+    test('should return empty array when no forms match pattern', () => {
+      // Save forms with keys that don't match the pattern
+      LocalFormCache.saveForm('bar1', formData);
+      LocalFormCache.saveForm('bar2', formData);
+      LocalFormCache.saveForm('baz', formData);
+
+      const pattern = /^foo/;
+      const result = LocalFormCache.getFormsByPattern(pattern);
+      expect(result).toEqual([]);
+    });
+
+    test('should return matching forms when some forms match pattern', () => {
+      LocalFormCache.saveForm('foo1', { id: 1 });
+      LocalFormCache.saveForm('foo2', { id: 2 });
+      LocalFormCache.saveForm('bar', { id: 3 });
+
+      const pattern = /^foo/;
+      const result = LocalFormCache.getFormsByPattern(pattern);
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          { key: 'foo1', form: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+          { key: 'foo2', form: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+        ]),
+      );
+    });
+
+    test('should return all forms when all forms match pattern', () => {
+      // Save forms with keys that all match the pattern
+      LocalFormCache.saveForm('case-notes-123', { id: 1 });
+      LocalFormCache.saveForm('case-notes-456', { id: 2 });
+      LocalFormCache.saveForm('case-notes-789', { id: 3 });
+
+      const pattern = /^case-notes-/;
+      const result = LocalFormCache.getFormsByPattern(pattern);
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          { key: 'case-notes-123', form: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+          { key: 'case-notes-456', form: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+          { key: 'case-notes-789', form: { value: { id: 3 }, expiresAfter: expect.any(Number) } },
+        ]),
+      );
+    });
+
+    test('should match forms using complex regex patterns', () => {
+      // Save forms with various keys
+      LocalFormCache.saveForm('case-notes-123', { id: 1 });
+      LocalFormCache.saveForm('case-notes-456', { id: 2 });
+      LocalFormCache.saveForm('other-form-789', { id: 3 });
+      LocalFormCache.saveForm('form-123-notes', { id: 4 });
+
+      // Pattern that matches keys containing 'notes' followed by a dash and numbers
+      const pattern = /notes-\d+$/;
+      const result = LocalFormCache.getFormsByPattern(pattern);
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          { key: 'case-notes-123', form: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+          { key: 'case-notes-456', form: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+        ]),
+      );
+    });
+
+    test('should skip keys where getForm returns null', () => {
+      LocalFormCache.saveForm('foo1', { id: 1 });
+      LocalFormCache.saveForm('foo2', null as unknown as object);
+
+      const pattern = /^foo/;
+      const result = LocalFormCache.getFormsByPattern(pattern);
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual([
+        { key: 'foo1', form: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+      ]);
+    });
   });
 });

--- a/user-interface/src/lib/utils/local-form-cache.test.ts
+++ b/user-interface/src/lib/utils/local-form-cache.test.ts
@@ -74,8 +74,8 @@ describe('LocalFormCache', () => {
       expect(result).toHaveLength(2);
       expect(result).toEqual(
         expect.arrayContaining([
-          { key: 'foo1', form: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
-          { key: 'foo2', form: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+          { key: 'foo1', item: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+          { key: 'foo2', item: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
         ]),
       );
     });
@@ -92,9 +92,9 @@ describe('LocalFormCache', () => {
       expect(result).toHaveLength(3);
       expect(result).toEqual(
         expect.arrayContaining([
-          { key: 'case-notes-123', form: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
-          { key: 'case-notes-456', form: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
-          { key: 'case-notes-789', form: { value: { id: 3 }, expiresAfter: expect.any(Number) } },
+          { key: 'case-notes-123', item: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+          { key: 'case-notes-456', item: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+          { key: 'case-notes-789', item: { value: { id: 3 }, expiresAfter: expect.any(Number) } },
         ]),
       );
     });
@@ -113,23 +113,10 @@ describe('LocalFormCache', () => {
       expect(result).toHaveLength(2);
       expect(result).toEqual(
         expect.arrayContaining([
-          { key: 'case-notes-123', form: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
-          { key: 'case-notes-456', form: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
+          { key: 'case-notes-123', item: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
+          { key: 'case-notes-456', item: { value: { id: 2 }, expiresAfter: expect.any(Number) } },
         ]),
       );
-    });
-
-    test('should skip keys where getForm returns null', () => {
-      LocalFormCache.saveForm('foo1', { id: 1 });
-      LocalFormCache.saveForm('foo2', null as unknown as object);
-
-      const pattern = /^foo/;
-      const result = LocalFormCache.getFormsByPattern(pattern);
-
-      expect(result).toHaveLength(1);
-      expect(result).toEqual([
-        { key: 'foo1', form: { value: { id: 1 }, expiresAfter: expect.any(Number) } },
-      ]);
     });
   });
 });

--- a/user-interface/src/lib/utils/local-form-cache.ts
+++ b/user-interface/src/lib/utils/local-form-cache.ts
@@ -1,9 +1,9 @@
 import { THREE_DAYS } from './datetime';
-import LocalCache, { Cacheable, NAMESPACE } from './local-cache';
+import LocalCache, { Cacheable } from './local-cache';
 
 const FORM_NAMESPACE = 'form:';
 
-const { get, set, remove, removeNamespace } = LocalCache;
+const { get, getByKeyPattern, set, remove, removeNamespace } = LocalCache;
 
 function getForm<T extends Cacheable>(key: string): T | null {
   const formKey = FORM_NAMESPACE + key;
@@ -24,27 +24,14 @@ function removeAll() {
   removeNamespace(FORM_NAMESPACE);
 }
 
-function getFormsByPattern<T extends Cacheable>(pattern: RegExp): Array<{ key: string; form: T }> {
-  const forms: Array<{ key: string; form: T }> = [];
-
-  if (!window.localStorage) return forms;
-
-  for (let i = 0; i < window.localStorage.length; i++) {
-    const fullKey = window.localStorage.key(i);
-
-    if (fullKey && fullKey.startsWith(NAMESPACE + FORM_NAMESPACE)) {
-      const key = fullKey.substring(NAMESPACE.length + FORM_NAMESPACE.length);
-
-      if (pattern.test(key)) {
-        const form = getForm<T>(key);
-        if (form && form.value) {
-          forms.push({ key, form });
-        }
-      }
-    }
-  }
-
-  return forms;
+function getFormsByPattern<T>(pattern: RegExp): Array<{ key: string; item: Cacheable<T> }> {
+  const regExString = pattern.source.replace('^', `^${FORM_NAMESPACE}`);
+  return getByKeyPattern<T>(new RegExp(regExString)).map((cached) => {
+    return {
+      key: cached.key.replace(FORM_NAMESPACE, ''),
+      item: cached.item,
+    };
+  });
 }
 
 const LocalFormCache = {

--- a/user-interface/src/lib/utils/local-form-cache.ts
+++ b/user-interface/src/lib/utils/local-form-cache.ts
@@ -5,9 +5,9 @@ const FORM_NAMESPACE = 'form:';
 
 const { get, getByKeyPattern, set, remove, removeNamespace } = LocalCache;
 
-function getForm<T extends Cacheable>(key: string): T | null {
+function getForm<T>(key: string): Cacheable<T> | null {
   const formKey = FORM_NAMESPACE + key;
-  return get<object>(formKey) as T;
+  return get<object>(formKey) as Cacheable<T>;
 }
 
 function saveForm(key: string, data: object) {

--- a/user-interface/src/lib/utils/local-form-cache.ts
+++ b/user-interface/src/lib/utils/local-form-cache.ts
@@ -26,7 +26,7 @@ function removeAll() {
 
 function getFormsByPattern<T>(pattern: RegExp): Array<{ key: string; item: Cacheable<T> }> {
   const regExString = pattern.source.replace('^', `^${FORM_NAMESPACE}`);
-  return getByKeyPattern<T>(new RegExp(regExString)).map((cached) => {
+  return getByKeyPattern<T>(new RegExp(regExString, pattern.flags)).map((cached) => {
     return {
       key: cached.key.replace(FORM_NAMESPACE, ''),
       item: cached.item,

--- a/user-interface/src/my-cases/MyCasesScreen.scss
+++ b/user-interface/src/my-cases/MyCasesScreen.scss
@@ -13,6 +13,10 @@
     }
   }
 
+  .draft-notes-alert-message {
+    display: inline-block;
+  }
+
   .case-status {
     margin-bottom: 1.5rem;
 

--- a/user-interface/src/my-cases/MyCasesScreen.test.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.test.tsx
@@ -118,7 +118,7 @@ describe('MyCasesScreen', () => {
       cachedValues: [
         {
           key: 'foo1',
-          form: {
+          item: {
             expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
             value: { title: 'title', content: 'content', caseId: '081-00-12345' },
           },
@@ -132,14 +132,14 @@ describe('MyCasesScreen', () => {
       cachedValues: [
         {
           key: 'foo1',
-          form: {
+          item: {
             expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
             value: { title: 'title', content: 'content', caseId: '081-00-12345' },
           },
         },
         {
           key: 'foo2',
-          form: {
+          item: {
             expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
             value: { title: 'title', content: 'content', caseId: '081-00-54321' },
           },
@@ -153,21 +153,21 @@ describe('MyCasesScreen', () => {
       cachedValues: [
         {
           key: 'foo1',
-          form: {
+          item: {
             expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
             value: { title: 'title', content: 'content', caseId: '081-00-12345' },
           },
         },
         {
           key: 'foo2',
-          form: {
+          item: {
             expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
             value: { title: 'title', content: 'content', caseId: '081-00-54321' },
           },
         },
         {
           key: 'foo3',
-          form: {
+          item: {
             expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
             value: { title: 'title', content: 'content', caseId: '081-00-54322' },
           },
@@ -180,7 +180,7 @@ describe('MyCasesScreen', () => {
     (args: {
       caseName: string;
       expectedAlertText: string;
-      cachedValues: Array<{ key: string; form: Cacheable<CaseNoteInput> }>;
+      cachedValues: Array<{ key: string; item: Cacheable<CaseNoteInput> }>;
     }) => {
       vi.spyOn(LocalFormCache, 'getFormsByPattern').mockImplementation((_pattern: RegExp) => {
         return args.cachedValues;

--- a/user-interface/src/my-cases/MyCasesScreen.test.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.test.tsx
@@ -9,11 +9,19 @@ import { CamsRole } from '@common/cams/roles';
 import Api2 from '@/lib/models/api2';
 import { getCaseNumber } from '@/lib/utils/caseNumber';
 import { formatDate } from '@/lib/utils/datetime';
+import LocalFormCache from '@/lib/utils/local-form-cache';
+import { Cacheable } from '@/lib/utils/local-cache';
+import { CaseNoteInput } from '@common/cams/cases';
+import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 
 describe('MyCasesScreen', () => {
   const user: CamsUser = MockData.getCamsUser({});
 
   beforeEach(() => {
+    const mockFeatureFlags = {
+      'draft-case-note-alert': true,
+    };
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
   });
 
@@ -101,4 +109,91 @@ describe('MyCasesScreen', () => {
     expect(body?.childNodes.length).toEqual(1);
     expect(body?.childNodes[0]).toContainHTML(expectedDiv);
   });
+
+  const now = new Date().toISOString();
+  const cachedNotesCases = [
+    {
+      caseName: '1 case note',
+      expectedAlertText: 'You have a draft case note on case 00-12345. It will expire on',
+      cachedValues: [
+        {
+          key: 'foo1',
+          form: {
+            expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
+            value: { title: 'title', content: 'content', caseId: '081-00-12345' },
+          },
+        },
+      ],
+    },
+    {
+      caseName: '2 case notes',
+      expectedAlertText:
+        'You have draft case notes on cases 00-12345 and 00-54321. The draft on case number',
+      cachedValues: [
+        {
+          key: 'foo1',
+          form: {
+            expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
+            value: { title: 'title', content: 'content', caseId: '081-00-12345' },
+          },
+        },
+        {
+          key: 'foo2',
+          form: {
+            expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
+            value: { title: 'title', content: 'content', caseId: '081-00-54321' },
+          },
+        },
+      ],
+    },
+    {
+      caseName: '3 case notes',
+      expectedAlertText:
+        'You have draft case notes on cases 00-12345, 00-54321, and 00-54322. The draft on case number',
+      cachedValues: [
+        {
+          key: 'foo1',
+          form: {
+            expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
+            value: { title: 'title', content: 'content', caseId: '081-00-12345' },
+          },
+        },
+        {
+          key: 'foo2',
+          form: {
+            expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
+            value: { title: 'title', content: 'content', caseId: '081-00-54321' },
+          },
+        },
+        {
+          key: 'foo3',
+          form: {
+            expiresAfter: new Date(MockData.someDateAfterThisDate(now, 10)).valueOf(),
+            value: { title: 'title', content: 'content', caseId: '081-00-54322' },
+          },
+        },
+      ],
+    },
+  ];
+  test.each(cachedNotesCases)(
+    'should display alert if cache holds $caseName',
+    (args: {
+      caseName: string;
+      expectedAlertText: string;
+      cachedValues: Array<{ key: string; form: Cacheable<CaseNoteInput> }>;
+    }) => {
+      vi.spyOn(LocalFormCache, 'getFormsByPattern').mockImplementation((_pattern: RegExp) => {
+        return args.cachedValues;
+      });
+
+      render(
+        <BrowserRouter>
+          <MyCasesScreen></MyCasesScreen>
+        </BrowserRouter>,
+      );
+      const alertMessage = document.querySelector('.draft-notes-alert-message');
+      expect(alertMessage).toBeInTheDocument();
+      expect(alertMessage).toHaveTextContent(args.expectedAlertText);
+    },
+  );
 });

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -81,7 +81,7 @@ export const MyCasesScreen = () => {
         <span className="draft-notes-alert-message">
           You have a draft case note on case{' '}
           <span className="text-no-wrap">
-            <CaseNumber caseId={draftNotesCaseIds[0]} />
+            <CaseNumber caseId={draftNotesCaseIds[0]} tab="notes" />
           </span>
           . <em>It will expire on {formatDateTime(new Date(draftNotes[0].expiresAfter))}</em>.
         </span>
@@ -91,11 +91,11 @@ export const MyCasesScreen = () => {
         <span className="draft-notes-alert-message">
           You have draft case notes on cases{' '}
           <span className="text-no-wrap">
-            <CaseNumber caseId={draftNotesCaseIds[0]} />
+            <CaseNumber caseId={draftNotesCaseIds[0]} tab="notes" />
           </span>{' '}
           and{' '}
           <span className="text-no-wrap">
-            <CaseNumber caseId={draftNotesCaseIds[1]} />
+            <CaseNumber caseId={draftNotesCaseIds[1]} tab="notes" />
           </span>
           .{' '}
           <em>
@@ -115,13 +115,13 @@ export const MyCasesScreen = () => {
               {index > 0 && ', '}
 
               <span className="text-no-wrap">
-                <CaseNumber caseId={id} />
+                <CaseNumber caseId={id} tab="notes" />
               </span>
             </React.Fragment>
           ))}
           , and{' '}
           <span className="text-no-wrap">
-            <CaseNumber caseId={lastCaseId} />
+            <CaseNumber caseId={lastCaseId} tab="notes" />
           </span>
           .{' '}
           <em>

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -137,11 +137,10 @@ export const MyCasesScreen = () => {
 
   useEffect(() => {
     const caseNotePattern = /^case-notes-/;
-    const draftNotesFound =
-      LocalFormCache.getFormsByPattern<Cacheable<CaseNoteInput>>(caseNotePattern);
-    setDraftNotes(draftNotesFound.map((cache) => cache.form));
+    const draftNotesFound = LocalFormCache.getFormsByPattern<CaseNoteInput>(caseNotePattern);
+    setDraftNotes(draftNotesFound.map((cache) => cache.item));
     const ids: string[] = draftNotesFound.map((record) => {
-      return record.form.value.caseId;
+      return record.item.value.caseId;
     });
 
     setDraftNotesCaseIds(ids);


### PR DESCRIPTION
# Purpose

When users have draft notes, it should be easier for them to find and address them.

# Major Changes

- Add an in-line alert to the CaseNotes view when a draft exists.
- Add an in-line alert to the MyCases screen displaying links to all draft notes for the user.
- Correct disable logic for case note `Save` button.
- Add the ability to link to a case details tab.

# Testing/Validation

- Update automated tests.
- Validate locally.

# Notes

The in-line alerts are behind the `draft-case-note-alert` feature flag.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Implement draft note visibility enhancements by showing inline alerts for drafts in both the CaseNotes panel and MyCases list, add support for linking directly to specific case detail tabs, correct Save button disable logic in the note modal, and refactor caching utilities to a unified Cacheable abstraction.

New Features:
- Show inline draft-note alerts in the CaseNotes panel when a draft exists
- Display an inline alert in MyCases listing links to cases with draft notes and expiry info
- Allow CaseNumber links to open a specific tab within case details

Bug Fixes:
- Fix Save button disable logic in CaseNoteFormModal to consider both title/content and initial values

Enhancements:
- Add onModalClosed callback to CaseNoteFormModal for notifying when the modal closes
- Refactor LocalCache and LocalFormCache to use a unified Cacheable type and introduce pattern-based retrieval of cached items

Tests:
- Update existing tests and add new tests for draft-note alerts in CaseNotes and MyCasesScreen
- Add tests for LocalCache.getByKeyPattern and LocalFormCache.getFormsByPattern
- Add tests for CaseNumber component’s tab linking
- Enhance modal tests to cover initial state, dirty detection, and callback invocation