### PR TITLE
CAMS-564 - Remove unused feature flags

### DIFF
--- a/backend/function-apps/api/case-notes/case.notes.function.test.ts
+++ b/backend/function-apps/api/case-notes/case.notes.function.test.ts
@@ -11,7 +11,6 @@ import {
 } from '../../azure/testing-helpers';
 import { UnknownError } from '../../../lib/common-errors/unknown-error';
 import { CaseNote } from '../../../../common/src/cams/cases';
-import * as featureFlags from '../../../lib/adapters/utils/feature-flag';
 
 const defaultRequestProps: Partial<CamsHttpRequest> = {
   method: 'POST',
@@ -107,61 +106,5 @@ describe('Case Notes Function Tests', () => {
 
     const response = await handler(request, context);
     expect(response).toEqual(azureHttpResponse);
-  });
-});
-
-describe('Case Notes Feature Flag Tests', () => {
-  let context;
-
-  beforeEach(() => {
-    jest
-      .spyOn(ContextCreator, 'getApplicationContextSession')
-      .mockResolvedValue(MockData.getManhattanAssignmentManagerSession());
-    context = new InvocationContext({
-      logHandler: () => {},
-      invocationId: 'id',
-    });
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
-  jest.mock('../../../lib/adapters/utils/feature-flag.ts');
-
-  test('Should return an Unauthorized Error if case-notes-enabled is false', async () => {
-    const requestOverride = {
-      body: {
-        caseId: '001-67-89123',
-      },
-    };
-
-    const expected = {
-      headers: expect.anything(),
-      jsonBody: 'Unauthorized',
-      status: 401,
-    };
-
-    const request = createMockAzureFunctionRequest({
-      ...defaultRequestProps,
-      ...requestOverride,
-    });
-
-    const { camsHttpResponse } = buildTestResponseSuccess<CaseNote[]>({
-      meta: {
-        self: request.url,
-      },
-      data: [],
-    });
-
-    jest.spyOn(featureFlags, 'getFeatureFlags').mockResolvedValue({
-      'case-notes-enabled': false,
-    });
-
-    jest.spyOn(CaseNotesController.prototype, 'handleRequest').mockResolvedValue(camsHttpResponse);
-
-    const response = await handler(request, context);
-
-    expect(response).toEqual(expect.objectContaining(expected));
   });
 });

--- a/backend/function-apps/api/case-notes/case.notes.function.ts
+++ b/backend/function-apps/api/case-notes/case.notes.function.ts
@@ -3,7 +3,6 @@ import ContextCreator from '../../azure/application-context-creator';
 import { initializeApplicationInsights } from '../../azure/app-insights';
 import { toAzureError, toAzureSuccess } from '../../azure/functions';
 import { CaseNotesController } from '../../../lib/controllers/case-notes/case.notes.controller';
-import { UnauthorizedError } from '../../../lib/common-errors/unauthorized-error';
 import { CaseNoteInput } from '../../../../common/src/cams/cases';
 
 const MODULE_NAME = 'CASE-ASSIGNMENT-FUNCTION';
@@ -24,10 +23,6 @@ export default async function handler(
     });
 
     const caseNotesController = new CaseNotesController(context);
-
-    if (context.featureFlags['case-notes-enabled'] === false) {
-      throw new UnauthorizedError(MODULE_NAME);
-    }
 
     const controllerResponse = await caseNotesController.handleRequest(context);
     return toAzureSuccess(controllerResponse);

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -12,7 +12,5 @@ export const testFeatureFlags: FeatureFlagSet = {
   'chapter-eleven-enabled': true,
   'transfer-orders-enabled': true,
   'consolidations-enabled': true,
-  'case-notes-enabled': true,
   'privileged-identity-management': true,
-  'staff-assignment-filter-enabled': true,
 };

--- a/user-interface/src/case-detail/CaseDetailNotesFilter.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailNotesFilter.test.tsx
@@ -51,15 +51,6 @@ describe('Case Note Tests', async () => {
     });
   });
 
-  test('Case Note tab should be visible', async () => {
-    renderWithProps();
-
-    await waitFor(() => {
-      const notesNavLink = screen.queryByTestId('case-notes-link');
-      expect(notesNavLink).toBeInTheDocument();
-    });
-  });
-
   test('Should search case notes properly', async () => {
     renderWithProps({ caseNotes: testNotesToFilter });
 

--- a/user-interface/src/case-detail/CaseDetailNotesFilter.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailNotesFilter.test.tsx
@@ -1,4 +1,3 @@
-import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 import { describe } from 'vitest';
 import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import CaseDetailScreen, { applyCaseNoteSortAndFilters, CaseDetailProps } from './CaseDetailScreen';
@@ -11,7 +10,6 @@ import { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 describe('Case Note Tests', async () => {
   const testCaseId = '111-11-12345';
   const testCaseDetail = MockData.getCaseDetail({ override: { caseId: testCaseId } });
-  const testEmptyCaseNotes: CaseNote[] = [];
   const testFullCaseNotes: CaseNote[] = MockData.buildArray(
     () => MockData.getCaseNote({ caseId: testCaseDetail.caseId }),
     4,
@@ -44,26 +42,7 @@ describe('Case Note Tests', async () => {
     vi.restoreAllMocks();
   });
 
-  test('Case Note tab should not be visible if feature flag is off', async () => {
-    const mockFeatureFlags = {
-      'case-notes-enabled': false,
-    };
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
-
-    renderWithProps({ caseNotes: testEmptyCaseNotes });
-
-    await waitFor(() => {
-      const notesNavLink = screen.queryByTestId('case-notes-link');
-      expect(notesNavLink).not.toBeInTheDocument();
-    });
-  });
-
-  test('Case Note tab should be visible if feature flag is on and filter notes', async () => {
-    const mockFeatureFlags = {
-      'case-notes-enabled': true,
-    };
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
-
+  test('Case Note tab should be visible', async () => {
     renderWithProps();
 
     await waitFor(() => {
@@ -72,12 +51,7 @@ describe('Case Note Tests', async () => {
     });
   });
 
-  test('Case Note tab should be visible if feature flag is on', async () => {
-    const mockFeatureFlags = {
-      'case-notes-enabled': true,
-    };
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
-
+  test('Case Note tab should be visible', async () => {
     renderWithProps();
 
     await waitFor(() => {
@@ -87,11 +61,6 @@ describe('Case Note Tests', async () => {
   });
 
   test('Should search case notes properly', async () => {
-    const mockFeatureFlags = {
-      'case-notes-enabled': true,
-    };
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
-
     renderWithProps({ caseNotes: testNotesToFilter });
 
     await waitFor(() => {
@@ -143,13 +112,8 @@ describe('Case Note Tests', async () => {
   const panelVisibleOptions = [[testFullCaseNotes], [[]]];
 
   test.each(panelVisibleOptions)(
-    'Case note search input visibility should be conditional on pressence of case notes: visible if case notes exist.',
+    'Case note search input visibility should be conditional on presence of case notes: visible if case notes exist.',
     async (testNotes: CaseNote[]) => {
-      const mockFeatureFlags = {
-        'case-notes-enabled': true,
-      };
-
-      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
       let notesNavLink;
 
       renderWithProps({ caseNotes: testNotes });
@@ -174,11 +138,6 @@ describe('Case Note Tests', async () => {
   );
 
   test('Should pass empty notes when notes are undefined', async () => {
-    const mockFeatureFlags = {
-      'case-notes-enabled': true,
-    };
-
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
     const { filteredCaseNotes, notesAlertOptions } = applyCaseNoteSortAndFilters([], {
       caseNoteSearchText: '',
       sortDirection: 'Newest',

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -27,7 +27,6 @@ import { useApi2 } from '@/lib/hooks/UseApi2';
 import { CaseAssignment } from '@common/cams/assignments';
 import { CamsRole } from '@common/cams/roles';
 import CaseNotes, { CaseNotesRef } from './panels/case-notes/CaseNotes';
-import useFeatureFlags, { CASE_NOTES_ENABLED } from '@/lib/hooks/UseFeatureFlags';
 
 const CaseDetailHeader = lazy(() => import('./panels/CaseDetailHeader'));
 const CaseDetailOverview = lazy(() => import('./panels/CaseDetailOverview'));
@@ -236,8 +235,6 @@ export interface CaseDetailProps {
 }
 
 export default function CaseDetailScreen(props: CaseDetailProps) {
-  const featureFlags = useFeatureFlags();
-  const caseNotesEnabledFlag = featureFlags[CASE_NOTES_ENABLED];
   const { caseId } = useParams();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isDocketLoading, setIsDocketLoading] = useState<boolean>(false);
@@ -761,23 +758,21 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
                       />
                     }
                   />
-                  {caseNotesEnabledFlag && (
-                    <Route
-                      path="notes"
-                      element={
-                        <CaseNotes
-                          caseId={caseId ?? ''}
-                          hasCaseNotes={hasCaseNotes}
-                          caseNotes={filteredCaseNotes}
-                          searchString={caseNoteSearchText}
-                          areCaseNotesLoading={areCaseNotesLoading}
-                          alertOptions={notesAlertOptions}
-                          onUpdateNoteRequest={handleNotesCallback}
-                          ref={caseNotesRef}
-                        />
-                      }
-                    />
-                  )}
+                  <Route
+                    path="notes"
+                    element={
+                      <CaseNotes
+                        caseId={caseId ?? ''}
+                        hasCaseNotes={hasCaseNotes}
+                        caseNotes={filteredCaseNotes}
+                        searchString={caseNoteSearchText}
+                        areCaseNotesLoading={areCaseNotesLoading}
+                        alertOptions={notesAlertOptions}
+                        onUpdateNoteRequest={handleNotesCallback}
+                        ref={caseNotesRef}
+                      />
+                    }
+                  />
                 </Routes>
               </Suspense>
               <Outlet />

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import CaseDetailNavigation, { NavState, mapNavState, setCurrentNav } from './CaseDetailNavigation';
 import { BrowserRouter } from 'react-router-dom';
-import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 
 describe('Navigation tests', () => {
   const activeNavClass = 'usa-current current';
@@ -25,11 +24,6 @@ describe('Navigation tests', () => {
     ['associated-cases-link'],
     ['case-notes-link'],
   ])('should render each navigation element in component', async (linkId: string) => {
-    const mockFeatureFlags = {
-      'case-notes-enabled': true,
-    };
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
-
     render(
       <BrowserRouter>
         <CaseDetailNavigation
@@ -50,24 +44,6 @@ describe('Navigation tests', () => {
       const activeLinks = allLinks.filter((l) => l.classList.contains('usa-current'));
       expect(activeLinks.length).toEqual(1);
     });
-  });
-
-  test('should not display CaseNotes tab if feature flag is disabled', () => {
-    const mockFeatureFlags = {
-      'case-notes-enabled': false,
-    };
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
-    render(
-      <BrowserRouter>
-        <CaseDetailNavigation
-          caseId="12345"
-          initiallySelectedNavLink={NavState.CASE_OVERVIEW}
-          showAssociatedCasesList={true}
-        />
-      </BrowserRouter>,
-    );
-    const link = screen.queryByTestId('case-notes-link');
-    expect(link).not.toBeInTheDocument();
   });
 
   test(`mapNavState should return ${NavState.CASE_OVERVIEW} when the url does not contain a path after the case number`, () => {

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
@@ -1,4 +1,3 @@
-import useFeatureFlags, { CASE_NOTES_ENABLED } from '@/lib/hooks/UseFeatureFlags';
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
@@ -44,8 +43,6 @@ export default function CaseDetailNavigation({
   className,
 }: CaseDetailNavigationProps) {
   const [activeNav, setActiveNav] = useState<NavState>(initiallySelectedNavLink);
-  const featureFlags = useFeatureFlags();
-  const caseNotesEnabledFlag = featureFlags[CASE_NOTES_ENABLED];
 
   return (
     <>
@@ -78,19 +75,17 @@ export default function CaseDetailNavigation({
               Court Docket
             </NavLink>
           </li>
-          {caseNotesEnabledFlag && (
-            <li className="usa-sidenav__item">
-              <NavLink
-                to={`/case-detail/${caseId}/notes`}
-                data-testid="case-notes-link"
-                className={'usa-nav-link ' + setCurrentNav(activeNav, NavState.CASE_NOTES)}
-                onClick={() => setActiveNav(NavState.CASE_NOTES)}
-                title="view case notes"
-              >
-                Case Notes
-              </NavLink>
-            </li>
-          )}
+          <li className="usa-sidenav__item">
+            <NavLink
+              to={`/case-detail/${caseId}/notes`}
+              data-testid="case-notes-link"
+              className={'usa-nav-link ' + setCurrentNav(activeNav, NavState.CASE_NOTES)}
+              onClick={() => setActiveNav(NavState.CASE_NOTES)}
+              title="view case notes"
+            >
+              Case Notes
+            </NavLink>
+          </li>
           <li className="usa-sidenav__item">
             <NavLink
               to={`/case-detail/${caseId}/audit-history`}

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
@@ -18,7 +18,6 @@ import LocalStorage from '@/lib/utils/local-storage';
 import { randomUUID } from 'crypto';
 import LocalFormCache from '@/lib/utils/local-form-cache';
 import { CamsSession, getCamsUserReference } from '@common/cams/session';
-import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 
 const MODAL_ID = 'modal-case-note-form';
 const TITLE_INPUT_ID = 'case-note-title-input';
@@ -438,11 +437,7 @@ describe('CaseNoteFormModal - Simple Tests', () => {
     expect(key).toBe('case-notes-123-45-67890-note-id-123');
   });
 
-  test('should respect edit note draft alert feature flag when enabled', async () => {
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
-      'edit-case-note-draft-alert': true,
-    });
-
+  test('should show edit note draft alert', async () => {
     const saveFormSpy = vi.spyOn(LocalFormCache, 'saveForm');
     const noteId = randomUUID();
 
@@ -470,39 +465,6 @@ describe('CaseNoteFormModal - Simple Tests', () => {
 
     const lastCall = saveFormSpy.mock.calls[saveFormSpy.mock.calls.length - 1];
     expect(lastCall[0]).toContain(`-${noteId}`);
-  });
-
-  test('should respect edit note draft alert feature flag when disabled', async () => {
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
-      'edit-case-note-draft-alert': false,
-    });
-
-    const saveFormSpy = vi.spyOn(LocalFormCache, 'saveForm');
-    const noteId = randomUUID();
-
-    const modalRef = React.createRef<CaseNoteFormModalRef>();
-    renderComponent(
-      modalRef,
-      {},
-      {
-        id: noteId,
-        caseId: TEST_CASE_ID,
-        title: 'Original Title',
-        content: 'Original Content',
-        mode: 'edit',
-      },
-    );
-
-    const openButton = screen.getByTestId(OPEN_BUTTON_ID);
-    await userEvent.click(openButton);
-
-    const titleInput = screen.getByTestId(TITLE_INPUT_ID);
-    await userEvent.clear(titleInput);
-    await userEvent.type(titleInput, 'Edited Title');
-
-    const saveFormCalls = saveFormSpy.mock.calls;
-    const editModeSaveFormCalls = saveFormCalls.filter((call) => call[0].includes(`-${noteId}`));
-    expect(editModeSaveFormCalls.length).toBe(0);
   });
 
   test('should initialize form with provided values', async () => {

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.tsx
@@ -14,7 +14,6 @@ import { CaseNoteInput } from '@common/cams/cases';
 import { getCamsUserReference } from '@common/cams/session';
 import LocalStorage from '@/lib/utils/local-storage';
 import LocalFormCache from '@/lib/utils/local-form-cache';
-import useFeatureFlags, { EDIT_CASE_NOTE_DRAFT_ALERT_ENABLED } from '@/lib/hooks/UseFeatureFlags';
 
 const useThrottleCallback = (callback: () => void, delay: number) => {
   const isThrottled = useRef(false);
@@ -109,9 +108,6 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
   const notesSubmissionErrorMessage = 'There was a problem submitting the case note.';
   const session = LocalStorage.getSession();
 
-  const featureFlags = useFeatureFlags();
-  const editNoteDraftAlertEnabledFlag = featureFlags[EDIT_CASE_NOTE_DRAFT_ALERT_ENABLED];
-
   function disableSubmitButton(disable: boolean) {
     const buttons = modalRef.current?.buttons;
     if (buttons?.current) {
@@ -132,14 +128,9 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
   }
 
   function saveFormData(data: CaseNoteInput) {
-    // TODO: when removing the flag, also remove the mode !== 'edit' portion of checks
-    if (
-      (mode !== 'edit' || editNoteDraftAlertEnabledFlag) &&
-      formKey &&
-      (data.title?.length > 0 || data.content?.length > 0)
-    ) {
+    if (formKey && (data.title?.length > 0 || data.content?.length > 0)) {
       LocalFormCache.saveForm(formKey, data);
-    } else if ((mode !== 'edit' || editNoteDraftAlertEnabledFlag) && formKey) {
+    } else if (formKey) {
       LocalFormCache.clearForm(formKey);
     }
     toggleButtonOnDirtyForm(initialTitle, initialContent);
@@ -164,10 +155,8 @@ function _CaseNoteFormModal(props: CaseNoteFormModalProps, ref: React.Ref<CaseNo
   function clearCaseNoteForm() {
     titleInputRef.current?.clearValue();
     contentInputRef.current?.clearValue();
-    // TODO: when removing the flag, remove the entire conditional
-    if (mode === 'create' || editNoteDraftAlertEnabledFlag) {
-      LocalFormCache.clearForm(formKey);
-    }
+    LocalFormCache.clearForm(formKey);
+
     setCaseNoteFormError('');
     alertRef.current?.hide();
     toggleButtonOnDirtyForm(initialTitle, initialContent);

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.test.tsx
@@ -11,7 +11,6 @@ import LocalStorage from '@/lib/utils/local-storage';
 import LocalFormCache from '@/lib/utils/local-form-cache';
 import Actions from '@common/cams/actions';
 import { randomUUID } from 'crypto';
-import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 
 const caseId = '000-11-22222';
 const userId = '001';
@@ -33,12 +32,7 @@ const caseNotes = [
 ];
 const caseNotesRef = React.createRef<CaseNotesRef>();
 
-function renderWithProps(props?: Partial<CaseNotesProps>, featureFlags?: Record<string, boolean>) {
-  const mockFeatureFlags = {
-    'draft-case-note-alert': true,
-    ...(featureFlags || {}),
-  };
-  vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+function renderWithProps(props?: Partial<CaseNotesProps>) {
   const defaultProps: CaseNotesProps = {
     caseId: '000-11-22222',
     hasCaseNotes: false,
@@ -255,10 +249,6 @@ describe('case note tests', () => {
   });
 
   test('should display edit note draft alert if cache holds an edit draft', async () => {
-    const featureFlags = {
-      'edit-case-note-draft-alert': true,
-    };
-
     const noteId = caseNotes[0].id!;
     const editFormKey = `case-notes-${caseId}-${noteId}`;
     const expiryDate = new Date();
@@ -280,7 +270,7 @@ describe('case note tests', () => {
       return null;
     });
 
-    renderWithProps({ caseId, hasCaseNotes: true, caseNotes }, featureFlags);
+    renderWithProps({ caseId, hasCaseNotes: true, caseNotes });
 
     await waitFor(() => {
       const caseNote = screen.getByTestId('case-note-0');
@@ -337,10 +327,6 @@ describe('case note tests', () => {
   });
 
   test('should remove edit note draft alert when edit modal is closed', async () => {
-    const featureFlags = {
-      'edit-case-note-draft-alert': true,
-    };
-
     const noteId = caseNotes[0].id!;
     const editFormKey = `case-notes-${caseId}-${noteId}`;
 
@@ -368,7 +354,7 @@ describe('case note tests', () => {
       return [];
     });
 
-    renderWithProps({ caseId, hasCaseNotes: true, caseNotes }, featureFlags);
+    renderWithProps({ caseId, hasCaseNotes: true, caseNotes });
 
     await waitFor(() => {
       const caseNote = screen.getByTestId('case-note-0');

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.tsx
@@ -21,10 +21,6 @@ import CaseNoteRemovalModal, { CaseNoteRemovalModalRef } from './CaseNoteRemoval
 import Actions from '@common/cams/actions';
 import LocalFormCache from '@/lib/utils/local-form-cache';
 import { Cacheable } from '@/lib/utils/local-cache';
-import useFeatureFlags, {
-  DRAFT_CASE_NOTE_ALERT_ENABLED,
-  EDIT_CASE_NOTE_DRAFT_ALERT_ENABLED,
-} from '@/lib/hooks/UseFeatureFlags';
 
 export function getCaseNotesInputValue(ref: TextAreaRef | null) {
   return ref?.getValue() ?? '';
@@ -62,10 +58,6 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
 
   const MINIMUM_SEARCH_CHARACTERS = 3;
 
-  const featureFlags = useFeatureFlags();
-  const draftNoteAlertEnabledFlag = featureFlags[DRAFT_CASE_NOTE_ALERT_ENABLED];
-  const editNoteDraftAlertEnabledFlag = featureFlags[EDIT_CASE_NOTE_DRAFT_ALERT_ENABLED];
-
   function mapArchiveButtonRefs() {
     openArchiveModalButtonRefs.current =
       caseNotes?.map(
@@ -95,11 +87,8 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
   function showCaseNote(note: CaseNote, idx: number) {
     const sanitizedCaseNote = sanitizeText(note.content);
     const sanitizedCaseNoteTitle = sanitizeText(note.title);
-    let draft: Cacheable<CaseNoteInput> | null = null;
-    if (editNoteDraftAlertEnabledFlag) {
-      const formKey = buildCaseNoteFormKey(note.caseId, 'edit', note.id ?? '');
-      draft = LocalFormCache.getForm<CaseNoteInput>(formKey);
-    }
+    const formKey = buildCaseNoteFormKey(note.caseId, 'edit', note.id ?? '');
+    const draft = LocalFormCache.getForm<CaseNoteInput>(formKey);
 
     return (
       <li className="case-note grid-container" key={idx} data-testid={`case-note-${idx}`}>
@@ -133,7 +122,7 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
         <div className="case-note-author" data-testid={`case-note-author-${idx}`}>
           {note.updatedBy.name}
         </div>
-        {editNoteDraftAlertEnabledFlag && draft && (
+        {draft && (
           <Alert
             id={`draft-edit-note-${note.id}`}
             message={getDraftAlertMessage(draft)}
@@ -257,11 +246,9 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
       const draftNote = LocalFormCache.getForm<CaseNoteInput>(`case-notes-${caseId}`);
       setDraftNote(draftNote);
     }
-    if (editNoteDraftAlertEnabledFlag) {
-      const updatedEditDrafts = getEditDrafts();
-      if (updatedEditDrafts.length !== editDrafts?.length) {
-        setEditDrafts(updatedEditDrafts.map((form) => form.item));
-      }
+    const updatedEditDrafts = getEditDrafts();
+    if (updatedEditDrafts.length !== editDrafts?.length) {
+      setEditDrafts(updatedEditDrafts.map((form) => form.item));
     }
   };
 
@@ -273,7 +260,7 @@ function _CaseNotes(props: CaseNotesProps, ref: React.Ref<CaseNotesRef>) {
     <div className="case-notes-panel">
       <div className="case-notes-title">
         <h3>Case Notes</h3>
-        {draftNoteAlertEnabledFlag && draftNote && (
+        {draftNote && (
           <div data-testid="draft-note-alert-test-id" className="draft-notes-alert-container">
             <Alert
               id="draft-add-note"

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -3,16 +3,12 @@ import { FeatureFlagSet, testFeatureFlags } from '@common/feature-flags';
 import { getFeatureFlagConfiguration } from '@/configuration/featureFlagConfiguration';
 import getAppConfiguration from '@/configuration/appConfiguration';
 
-export const CASE_NOTES_ENABLED = 'case-notes-enabled';
 export const CHAPTER_ELEVEN_ENABLED = 'chapter-eleven-enabled';
 export const CHAPTER_TWELVE_ENABLED = 'chapter-twelve-enabled';
 export const CONSOLIDATIONS_ENABLED = 'consolidations-enabled';
 export const PRIVILEGED_IDENTITY_MANAGEMENT = 'privileged-identity-management';
-export const STAFF_ASSIGNMENT_FILTER_ENABLED = 'staff-assignment-filter-enabled';
 export const SYSTEM_MAINTENANCE_BANNER = 'system-maintenance-banner';
 export const TRANSFER_ORDERS_ENABLED = 'transfer-orders-enabled';
-export const DRAFT_CASE_NOTE_ALERT_ENABLED = 'draft-case-note-alert';
-export const EDIT_CASE_NOTE_DRAFT_ALERT_ENABLED = 'edit-case-note-draft-alert';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();

--- a/user-interface/src/login/Login.test.tsx
+++ b/user-interface/src/login/Login.test.tsx
@@ -236,7 +236,6 @@ describe('Login', () => {
     await waitFor(() => {
       expect(screen.getByTestId('button-auo-confirm')).toBeInTheDocument();
     });
-    screen.debug();
   });
 
   test('should render OktaProvider for okta provider type', async () => {

--- a/user-interface/src/my-cases/MyCasesScreen.test.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.test.tsx
@@ -18,10 +18,7 @@ describe('MyCasesScreen', () => {
   const user: CamsUser = MockData.getCamsUser({});
 
   beforeEach(() => {
-    const mockFeatureFlags = {
-      'draft-case-note-alert': true,
-    };
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({});
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
   });
 

--- a/user-interface/src/my-cases/MyCasesScreen.test.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.test.tsx
@@ -12,13 +12,11 @@ import { formatDate, formatDateTime } from '@/lib/utils/datetime';
 import LocalFormCache from '@/lib/utils/local-form-cache';
 import { Cacheable } from '@/lib/utils/local-cache';
 import { CaseNoteInput } from '@common/cams/cases';
-import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 
 describe('MyCasesScreen', () => {
   const user: CamsUser = MockData.getCamsUser({});
 
   beforeEach(() => {
-    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({});
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
   });
 

--- a/user-interface/src/my-cases/MyCasesScreen.tsx
+++ b/user-interface/src/my-cases/MyCasesScreen.tsx
@@ -23,7 +23,6 @@ import { CaseNoteInput } from '@common/cams/cases';
 import { CaseNumber } from '@/lib/components/CaseNumber';
 import React from 'react';
 import { Cacheable } from '@/lib/utils/local-cache';
-import useFeatureFlags, { DRAFT_CASE_NOTE_ALERT_ENABLED } from '@/lib/hooks/UseFeatureFlags';
 import { formatDateTime } from '@/lib/utils/datetime';
 import { getCaseNumber } from '@/lib/utils/caseNumber';
 
@@ -36,9 +35,6 @@ export const MyCasesScreen = () => {
   const [doShowClosedCases, setDoShowClosedCases] = useState(false);
   const [draftNotesCaseIds, setDraftNotesCaseIds] = useState<string[]>([]);
   const [draftNotes, setDraftNotes] = useState<Cacheable<CaseNoteInput>[]>([]);
-
-  const featureFlags = useFeatureFlags();
-  const draftNoteAlertEnabledFlag = featureFlags[DRAFT_CASE_NOTE_ALERT_ENABLED];
 
   if (!session || !session.user.offices) {
     // TODO: This renders a blank pane with no notice to the user. Maybe this should at least return a <Stop> component with a message.
@@ -157,7 +153,7 @@ export const MyCasesScreen = () => {
           <div className="screen-heading">
             <h1 data-testid="case-list-heading">{screenTitle}</h1>
             <ScreenInfoButton infoModalRef={infoModalRef} modalId={infoModalId} />
-            {draftNoteAlertEnabledFlag && draftNotesCaseIds.length > 0 && (
+            {draftNotesCaseIds.length > 0 && (
               <div data-testid="draft-notes-alert-test-id">
                 <Alert
                   type={UswdsAlertStyle.Info}

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
@@ -61,7 +61,6 @@ describe('staff assignment filter use case tests', () => {
     mockFeatureFlags = {
       'chapter-eleven-enabled': true,
       'chapter-twelve-enabled': true,
-      'staff-assignment-filter-enabled': true,
     };
     vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
   });

--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.test.tsx
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.test.tsx
@@ -41,7 +41,6 @@ describe('StaffAssignmentScreen', () => {
     mockFeatureFlags = {
       'chapter-eleven-enabled': false,
       'chapter-twelve-enabled': false,
-      'staff-assignment-filter-enabled': true,
     };
     vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
   });

--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreenView.tsx
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreenView.tsx
@@ -3,7 +3,6 @@ import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
 import ScreenInfoButton from '@/lib/components/cams/ScreenInfoButton';
 import { Stop } from '@/lib/components/Stop';
 import Modal from '@/lib/components/uswds/modal/Modal';
-import { STAFF_ASSIGNMENT_FILTER_ENABLED } from '@/lib/hooks/UseFeatureFlags';
 import SearchResults from '@/search-results/SearchResults';
 import { StaffAssignmentHeader } from '../header/StaffAssignmentHeader';
 import AssignAttorneyModal from '../modal/AssignAttorneyModal';
@@ -61,20 +60,20 @@ export function StaffAssignmentScreenView(props: StaffAssignmentScreenViewProps)
               showHelpDeskContact
             ></Stop>
           )}
-          {viewModel.featureFlags[STAFF_ASSIGNMENT_FILTER_ENABLED] && (
-            <StaffAssignmentFilter
-              ref={viewModel.filterRef}
-              handleFilterAssignee={viewModel.handleFilterAssignee}
-            />
-          )}
           {showAssignments && (
-            <SearchResults
-              id="search-results"
-              searchPredicate={searchPredicate}
-              noResultsAlertProps={noResultsAlertProps}
-              header={StaffAssignmentHeader}
-              row={viewModel.StaffAssignmentRowClosure}
-            ></SearchResults>
+            <>
+              <StaffAssignmentFilter
+                ref={viewModel.filterRef}
+                handleFilterAssignee={viewModel.handleFilterAssignee}
+              />
+              <SearchResults
+                id="search-results"
+                searchPredicate={searchPredicate}
+                noResultsAlertProps={noResultsAlertProps}
+                header={StaffAssignmentHeader}
+                row={viewModel.StaffAssignmentRowClosure}
+              ></SearchResults>
+            </>
           )}
         </div>
         <div className="grid-col-1"></div>

--- a/user-interface/src/staff-assignment/screen/staffAssignmentUseCase.test.ts
+++ b/user-interface/src/staff-assignment/screen/staffAssignmentUseCase.test.ts
@@ -78,7 +78,6 @@ describe('staff assignment use case tests', () => {
     mockFeatureFlags = {
       'chapter-eleven-enabled': true,
       'chapter-twelve-enabled': true,
-      'staff-assignment-filter-enabled': true,
     };
     vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
   });


### PR DESCRIPTION
# Purpose

Remove unused feature flags.

# Major Changes

Removed the following feature flags:

* case-notes-enabled
* staff-assignment-filter-enabled
* draft-case-note-alert
* edit-case-note-draft-alert

# Testing/Validation

Unit tests pass

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove unused feature flags and related conditional logic across backend, UI, and tests

Enhancements:
- Remove definitions, imports, and configuration entries for unused feature flags ('case-notes-enabled', 'staff-assignment-filter-enabled', 'draft-case-note-alert', 'edit-case-note-draft-alert')
- Eliminate conditional rendering and feature-flag checks for case notes and staff assignment filter in UI components and backend functions
- Simplify the FeatureFlags hook and configuration by deleting obsolete constants

Tests:
- Remove or update unit tests and mocks that targeted the removed feature flags to reflect unconditional component behavior