### PR TITLE
Add a guidelines file for Junie

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,0 +1,126 @@
+# CAMS Development Guidelines
+
+This document outlines the development guidelines for the CAMS (CAse Management System) project. These guidelines are designed to ensure consistency and quality across the codebase.
+
+## Flexion Delivery Practices
+
+CAMS follows Flexion Delivery Practices to ensure high-quality software delivery. These practices include:
+
+### Technical Debt Management
+
+- Technical debt arises from past decisions that make the system harder to change
+- Address technical debt in a timely manner to prevent compounding costs over time
+- Unaddressed technical debt creates fragility in complex systems, making it harder to implement changes
+
+### Vertical Slices
+
+- Work in vertical slices that touch all components of the system rather than treating components as separate deliverables
+- Start with a happy path that touches key components in the system
+- Add more stories in order of value
+- Complete good user stories that incrementally solve the problem represented by the vertical slice
+
+### YAGNI (You Aren't Gonna Need It)
+
+- Build only what's necessary right now—not what you think you might need later
+- Prioritize learning over guessing by building the smallest useful vertical slice first
+- Avoid speculative features when there's no current requirement
+- Keep solutions simple, using the simplest approach that works for today's needs
+
+### Option-Enabling Architecture
+
+CAMS follows the Option-enabling Software Architecture (OeSA) approach, which includes:
+
+#### Screaming Architecture
+
+- The architecture should scream "Bankruptcy Case Management System" rather than the technologies used
+- Directory structures and code organization should reflect the domain (bankruptcy case management) rather than technical implementation details
+- This applies to both frontend and backend components
+
+#### The Dependency Rule
+
+- More-important (strategic) modules should not depend on less-important (tactical) modules
+- Use interfaces to invert dependencies when necessary
+- Strategic components are abstract, high-level components critical to the product's value
+- Tactical components are concrete, detail-oriented components closer to implementation specifics
+
+#### The Good-Fences Rule
+
+- Boundaries between modules, layers, or components should remain clean, simple, and well-defined
+- Only simple data types should cross major boundaries
+- Clear boundaries limit the impact of changes to specific areas
+- Use simple data types at boundaries (e.g., strings, integers, or clearly defined DTOs)
+
+#### The Invasive-Species Rule
+
+- Control third-party dependencies to avoid entangling them with core business logic
+- Use humble objects or adapters to ensure the majority of code depends on things under our control
+- Isolate third-party components to protect application logic
+- Focus on keeping application logic independent of tactical dependencies
+
+## Markdown Guidelines
+
+- All generated markdown should be syntactically correct
+- For nested lists, use 4 spaces (not tabs) to increase indent level
+    - Like this example
+    - And this one
+        - With a deeper level
+        - Properly indented
+- Use proper heading hierarchy (# for main title, ## for sections, etc.)
+- Include blank lines between paragraphs and sections for readability
+
+## Test-Driven Development Practices
+
+- Follow test-driven development (TDD) principles
+- When making changes:
+    - Change only tests or source files in a single commit, not both
+    - Allow the developer to provide further prompts for next steps
+    - Do not enter long loops of `test -> edit -> modify test -> repeat` unless explicitly requested
+
+## Testing Guidelines
+
+### Vitest/Jest Testing
+
+- Always use the `test` function rather than the `it` function
+  ```typescript
+  // Good
+  test('should do something', () => {
+    // test code
+  });
+
+  // Avoid
+  it('should do something', () => {
+    // test code
+  });
+  ```
+
+- Prefer `restoreAllMocks` over `resetAllMocks` or `clearAllMocks`
+  ```typescript
+  // Good
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Avoid
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // or
+    vi.clearAllMocks();
+  });
+  ```
+
+### End-to-End Testing
+
+- E2E tests use Playwright
+- Configure the appropriate environment variables in the `.env` file
+- For local testing:
+  - Ensure NodeApi is running against a clean e2e database
+  - Set `CAMS_LOGIN_PROVIDER=mock` in both backend and UI environments
+- Run tests using:
+  - Headless mode: `npm run headless`
+  - With UI: `npm run ui`
+
+## ESLint Configuration
+
+- ESLint rules are set up in a modular fashion
+- Different rules apply based on which subproject the file is in
+- The configuration can be found in `eslint.config.mjs` at the root of the project

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -40,6 +40,8 @@ CAMS follows the Option-enabling Software Architecture (OeSA) approach, which in
 
 - More-important (strategic) modules should not depend on less-important (tactical) modules
 - Use interfaces to invert dependencies when necessary
+    - These interfaces are often defined in common areas
+        - For example, backend use cases typically refer to `gateways.types.ts` for their interfaces rather than the interface being defined in the same file or in a sibling file
 - Strategic components are abstract, high-level components critical to the product's value
 - Tactical components are concrete, detail-oriented components closer to implementation specifics
 
@@ -124,3 +126,13 @@ CAMS follows the Option-enabling Software Architecture (OeSA) approach, which in
 - ESLint rules are set up in a modular fashion
 - Different rules apply based on which subproject the file is in
 - The configuration can be found in `eslint.config.mjs` at the root of the project
+
+## Formatting
+
+- Files should always end in a newline
+
+## Naming Conventions
+
+### Files
+
+- Only use TypeScript Declaration files for typing npm packages with no types

--- a/backend/.junie/guidelines.md
+++ b/backend/.junie/guidelines.md
@@ -1,0 +1,108 @@
+# Backend Development Guidelines
+
+This document outlines specific guidelines for the backend project of CAMS. These guidelines should be followed in addition to the [root guidelines](../../.junie/guidelines.md).
+
+## Factory Pattern Usage
+
+### Prefer Getter Functions Over Dependency Injection
+
+- Use getter functions from `factory.ts` instead of direct dependency injection
+- The factory should decide which implementation to return based on context/configuration
+- This approach supports the Option-Enabling Architecture by isolating implementation details
+
+#### Example: Creating a Use Case
+
+```typescript
+// Good: Using a factory getter function
+import { getMyGateway } from '../../factory';
+
+export default class MyUseCase {
+  private myGateway: MyGatewayInterface;
+
+  constructor(applicationContext: ApplicationContext, myGateway?: MyGatewayInterface) {
+    // Use the provided gateway if available, otherwise get it from the factory
+    this.myGateway = myGateway ? myGateway : getMyGateway(applicationContext);
+  }
+
+  // Use case methods...
+}
+```
+
+```typescript
+// Avoid: Direct dependency injection without factory option
+import { MyGatewayImplementation } from '../../adapters/gateways/my-gateway';
+
+export default class MyUseCase {
+  private myGateway: MyGatewayInterface;
+
+  constructor(myGateway: MyGatewayInterface) {
+    this.myGateway = myGateway;
+  }
+
+  // Use case methods...
+}
+```
+
+#### Example: Implementing a Factory Getter Function
+
+```typescript
+// In factory.ts
+export const getMyGateway = (context: ApplicationContext): MyGatewayInterface => {
+  if (context.config.get('dbMock')) {
+    return new MockMyGateway();
+  } else {
+    return new MyGatewayImplementation();
+  }
+};
+```
+
+### Benefits of This Approach
+
+1. **Flexibility**: Easily switch implementations based on runtime configuration
+2. **Testability**: Simplifies testing by allowing mock implementations to be injected
+3. **Isolation**: Keeps implementation details separate from business logic
+4. **Consistency**: Provides a standard way to access dependencies throughout the application
+
+### When to Create a New Factory Getter Function
+
+Create a new factory getter function when:
+
+1. You need to access a gateway, repository, or service from multiple use cases
+2. You have multiple implementations of an interface (e.g., mock vs. real)
+3. The implementation choice depends on configuration or context
+
+## Error Handling
+
+- Use the common error types defined in `common-errors/` directory
+- Wrap external errors in appropriate CAMS error types
+- Include meaningful error messages that can be displayed to users
+- Use the `MODULE_NAME` constant to identify the source of errors
+
+```typescript
+// Good error handling
+try {
+  // Operation that might fail
+} catch (originalError) {
+  if (!isCamsError(originalError)) {
+    throw new UnknownError(MODULE_NAME, {
+      message: 'User-friendly error message',
+      originalError,
+      status: 500,
+    });
+  } else {
+    throw originalError;
+  }
+}
+```
+
+## Repository Pattern
+
+- Use the repository pattern for data access
+- Repositories should be accessed through factory getter functions
+- Include proper resource cleanup using `deferRelease` when appropriate
+
+## Testing
+
+- Mock dependencies using the provided mock implementations
+- Test both success and error paths
+- Use the factory pattern to inject mock dependencies during testing


### PR DESCRIPTION
# Purpose

We want JetBrains' AI agent `Junie` to follow predefined guidelines.

# Major Changes

Generated a guidelines file in the manner suggested by JetBrains. Also generated one in the backend directory.

# Testing/Validation

Asked Junie to implement a new API endpoint that uses a third-party API. It generated an interface, a humble object and gateway, and a controller in addition to the use case. It all seemed to follow OeA generally well.

# Notes

More guidelines files should be added with specifics for the various projects by following the pattern established in `backend/.junie/guidelines.md`.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Provide structured development guidelines for Junie by adding project-wide and backend-specific guidelines files

Documentation:
- Add project-level CAMS development guidelines in .junie/guidelines.md covering delivery practices, architecture, testing, and formatting
- Add backend-specific guidelines in backend/.junie/guidelines.md covering factory pattern usage, error handling, repository pattern, and testing