### PR TITLE
CAMS-526 Add links to notes

### DIFF
--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.constants.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.constants.ts
@@ -3,8 +3,8 @@ export const ZERO_WIDTH_SPACE_REGEX = new RegExp(ZERO_WIDTH_SPACE, 'g');
 export const EMPTY_TAG_REGEX = /<(p|li|span)>\s*(?:<br\s*\/?>)*\s*<\/\1>/gi;
 export const CONTENT_INPUT_SELECTOR = '#rich-text-editor-content';
 
-export const HTTP_REG =
-  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-zA-Z0-9()]{1,6})+(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*)/g;
+export const HTTP_REG_PATTERN =
+  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-zA-Z0-9()]{1,6})+(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*[a-zA-Z0-9/])/;
 
 export const DOMPURIFY_CONFIG = {
   ALLOWED_TAGS: ['em', 'strong', 'p', 'ul', 'ol', 'li', 'br', 'span', 'a'],

--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.constants.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.constants.ts
@@ -5,8 +5,6 @@ export const CONTENT_INPUT_SELECTOR = '#rich-text-editor-content';
 
 export const HTTP_REG =
   /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-zA-Z0-9()]{1,6})+(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*)/g;
-export const CIFS_REGEX =
-  /(?:\\\\|smb:\/\/)(?:[a-zA-Z0-9\-_]+)(?:\\|\/)(?:[a-zA-Z0-9\-_$%.\s]+(?:\\|\/)?)+/g;
 
 export const DOMPURIFY_CONFIG = {
   ALLOWED_TAGS: ['em', 'strong', 'p', 'ul', 'ol', 'li', 'br', 'span', 'a'],

--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.constants.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.constants.ts
@@ -3,9 +3,14 @@ export const ZERO_WIDTH_SPACE_REGEX = new RegExp(ZERO_WIDTH_SPACE, 'g');
 export const EMPTY_TAG_REGEX = /<(p|li|span)>\s*(?:<br\s*\/?>)*\s*<\/\1>/gi;
 export const CONTENT_INPUT_SELECTOR = '#rich-text-editor-content';
 
+export const HTTP_REG =
+  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}(?:\.[a-zA-Z0-9()]{1,6})+(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*)/g;
+export const CIFS_REGEX =
+  /(?:\\\\|smb:\/\/)(?:[a-zA-Z0-9\-_]+)(?:\\|\/)(?:[a-zA-Z0-9\-_$%.\s]+(?:\\|\/)?)+/g;
+
 export const DOMPURIFY_CONFIG = {
   ALLOWED_TAGS: ['em', 'strong', 'p', 'ul', 'ol', 'li', 'br', 'span', 'a'],
-  ALLOWED_ATTR: ['href', 'class'],
+  ALLOWED_ATTR: ['href', 'class', 'target', 'rel'],
   ALLOW_DATA_ATTR: false,
   FORBID_TAGS: ['style', 'script', 'iframe', 'object', 'embed', 'form', 'input', 'button'],
   FORBID_ATTR: [

--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.ts
@@ -122,7 +122,10 @@ export class Editor {
         editorUtilities.positionCursorInEmptyParagraph(this.selectionService, currentParagraph);
         return true;
       }
-    } else if (currentParagraph.textContent === ZERO_WIDTH_SPACE) {
+    } else if (
+      currentParagraph.textContent === ZERO_WIDTH_SPACE ||
+      currentParagraph.textContent === ''
+    ) {
       e.preventDefault();
       const { previousSibling } = currentParagraph;
       if (previousSibling && previousSibling.nodeType === Node.ELEMENT_NODE) {

--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.ts
@@ -53,6 +53,10 @@ export class Editor {
     return this.listService.handleEnterKey(e);
   }
 
+  public handlePaste(e: React.ClipboardEvent<HTMLDivElement>): boolean {
+    return this.formattingService.handlePaste(e);
+  }
+
   public toggleList(type: 'ul' | 'ol'): void {
     return this.listService.toggleList(type);
   }

--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.ts
@@ -122,10 +122,7 @@ export class Editor {
         editorUtilities.positionCursorInEmptyParagraph(this.selectionService, currentParagraph);
         return true;
       }
-    } else if (
-      currentParagraph.textContent === ZERO_WIDTH_SPACE ||
-      currentParagraph.textContent === ''
-    ) {
+    } else if (currentParagraph.textContent === ZERO_WIDTH_SPACE) {
       e.preventDefault();
       const { previousSibling } = currentParagraph;
       if (previousSibling && previousSibling.nodeType === Node.ELEMENT_NODE) {

--- a/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.test.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.test.ts
@@ -322,7 +322,7 @@ describe('FormattingService: handlePaste', () => {
     const mockClipboardData = {
       getData: vi
         .fn()
-        .mockReturnValue('Visit https://www.example.com and check http://www.example.com'),
+        .mockReturnValue('Visit https://www.example.com/ and check http://www.example.com'),
     };
     const mockEvent = {
       clipboardData: mockClipboardData,
@@ -334,7 +334,7 @@ describe('FormattingService: handlePaste', () => {
     expect(result).toBe(true);
     expect(mockEvent.preventDefault).toHaveBeenCalled();
     expect(container.innerHTML).toBe(
-      '<p>Resources: Visit <a href="https://www.example.com" target="_blank" rel="noopener noreferrer">https://www.example.com</a> and check <a href="http://www.example.com" target="_blank" rel="noopener noreferrer">http://www.example.com</a></p>',
+      '<p>Resources: Visit <a href="https://www.example.com/" target="_blank" rel="noopener noreferrer">https://www.example.com/</a> and check <a href="http://www.example.com" target="_blank" rel="noopener noreferrer">http://www.example.com</a></p>',
     );
   });
 

--- a/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.test.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.test.ts
@@ -254,3 +254,135 @@ describe('FormattingService: keyboard shortcuts', () => {
     });
   });
 });
+
+describe('FormattingService: handlePaste', () => {
+  let formattingService: FormattingService;
+  let container: HTMLDivElement;
+  let selectionService: MockSelectionService;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    selectionService = new MockSelectionService();
+    formattingService = new FormattingService(container, selectionService);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  test('should wrap a valid URL in an anchor tag and set href to that URL when pasted content contains a valid URL', () => {
+    editorUtilities.safelySetHtml(container, '<p>Check this out: </p>');
+    const paragraph = container.querySelector('p')!;
+    setCursorInParagraph(paragraph, 16, selectionService);
+
+    const mockClipboardData = {
+      getData: vi.fn().mockReturnValue('https://www.example.com'),
+    };
+    const mockEvent = {
+      clipboardData: mockClipboardData,
+      preventDefault: vi.fn(),
+    } as unknown as React.ClipboardEvent<HTMLDivElement>;
+
+    const result = formattingService.handlePaste(mockEvent);
+
+    expect(result).toBe(true);
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(container.innerHTML).toContain(
+      '<a href="https://www.example.com" target="_blank" rel="noopener noreferrer">https://www.example.com</a>',
+    );
+  });
+
+  test('should not wrap anything in anchor tags when the pasted content contains nothing matching a URL', () => {
+    editorUtilities.safelySetHtml(container, '<p>Some text: </p>');
+    const paragraph = container.querySelector('p')!;
+    setCursorInParagraph(paragraph, 11, selectionService);
+
+    const mockClipboardData = {
+      getData: vi.fn().mockReturnValue('just some plain text'),
+    };
+    const mockEvent = {
+      clipboardData: mockClipboardData,
+      preventDefault: vi.fn(),
+    } as unknown as React.ClipboardEvent<HTMLDivElement>;
+
+    const result = formattingService.handlePaste(mockEvent);
+
+    expect(result).toBe(false);
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+    expect(container.innerHTML).not.toContain('<a');
+  });
+
+  test('should wrap multiple subsets of content in anchor tags and set href appropriately when pasted content contains multiple matches of URL', () => {
+    editorUtilities.safelySetHtml(container, '<p>Resources: </p>');
+    const paragraph = container.querySelector('p')!;
+    setCursorInParagraph(paragraph, 11, selectionService);
+
+    const mockClipboardData = {
+      getData: vi
+        .fn()
+        .mockReturnValue('Visit https://www.example.com and check http://www.example.com'),
+    };
+    const mockEvent = {
+      clipboardData: mockClipboardData,
+      preventDefault: vi.fn(),
+    } as unknown as React.ClipboardEvent<HTMLDivElement>;
+
+    const result = formattingService.handlePaste(mockEvent);
+
+    expect(result).toBe(true);
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(container.innerHTML).toBe(
+      '<p>Resources: Visit <a href="https://www.example.com" target="_blank" rel="noopener noreferrer">https://www.example.com</a> and check <a href="http://www.example.com" target="_blank" rel="noopener noreferrer">http://www.example.com</a></p>',
+    );
+  });
+
+  test('should preserve line breaks when pasting content', () => {
+    editorUtilities.safelySetHtml(container, '<p>Resources: </p>');
+    const paragraph = container.querySelector('p')!;
+    setCursorInParagraph(paragraph, 11, selectionService);
+
+    const mockClipboardData = {
+      getData: vi
+        .fn()
+        .mockReturnValue('Visit https://www.example.com\nand check http://www.example.com'),
+    };
+    const mockEvent = {
+      clipboardData: mockClipboardData,
+      preventDefault: vi.fn(),
+    } as unknown as React.ClipboardEvent<HTMLDivElement>;
+
+    const result = formattingService.handlePaste(mockEvent);
+
+    expect(result).toBe(true);
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(container.innerHTML).toBe(
+      '<p>Resources: Visit <a href="https://www.example.com" target="_blank" rel="noopener noreferrer">https://www.example.com</a></p><p>and check <a href="http://www.example.com" target="_blank" rel="noopener noreferrer">http://www.example.com</a></p>',
+    );
+  });
+
+  test('should preserve line breaks and move content after the cursor to a new paragraph when pasting content when there is content after the cursor', () => {
+    editorUtilities.safelySetHtml(container, '<p>Resources: Check this out: </p>');
+    const paragraph = container.querySelector('p')!;
+    setCursorInParagraph(paragraph, 11, selectionService);
+
+    const mockClipboardData = {
+      getData: vi
+        .fn()
+        .mockReturnValue('Visit https://www.example.com\nand check http://www.example.com'),
+    };
+    const mockEvent = {
+      clipboardData: mockClipboardData,
+      preventDefault: vi.fn(),
+    } as unknown as React.ClipboardEvent<HTMLDivElement>;
+
+    const result = formattingService.handlePaste(mockEvent);
+
+    expect(result).toBe(true);
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(container.innerHTML).toBe(
+      '<p>Resources: Visit <a href="https://www.example.com" target="_blank" rel="noopener noreferrer">https://www.example.com</a></p><p>and check <a href="http://www.example.com" target="_blank" rel="noopener noreferrer">http://www.example.com</a></p><p>Check this out: </p>',
+    );
+  });
+});

--- a/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.ts
@@ -79,7 +79,7 @@ export class FormattingService {
   }
 
   public handlePaste(e: React.ClipboardEvent<HTMLDivElement>): boolean {
-    const clipboardData = e.clipboardData;
+    const { clipboardData } = e;
     if (!clipboardData) {
       return false;
     }

--- a/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.ts
@@ -1,6 +1,6 @@
 import editorUtilities from './Editor.utilities';
 import { SelectionService } from './SelectionService.humble';
-import { RichTextFormat, ZERO_WIDTH_SPACE } from './Editor.constants';
+import { RichTextFormat, ZERO_WIDTH_SPACE, HTTP_REG } from './Editor.constants';
 import { NormalizationService } from './NormalizationService';
 
 export class FormattingService {
@@ -76,6 +76,144 @@ export class FormattingService {
 
     this.normalizationService.normalizeInlineFormatting();
     this.selectionService.getCurrentSelection()?.removeAllRanges();
+  }
+
+  public handlePaste(e: React.ClipboardEvent<HTMLDivElement>): boolean {
+    const clipboardData = e.clipboardData;
+    if (!clipboardData) {
+      return false;
+    }
+
+    const pastedTextRaw = clipboardData.getData('text/plain');
+    if (!pastedTextRaw) {
+      return false;
+    }
+
+    // Apply URL processing to the entire pasted content first
+    const urlMatches = Array.from(pastedTextRaw.matchAll(HTTP_REG));
+
+    let processedText = pastedTextRaw;
+    if (urlMatches.length > 0) {
+      // Sort matches by position
+      const sortedUrls = urlMatches
+        .map((match) => ({
+          text: match[0],
+          index: match.index!,
+        }))
+        .sort((a, b) => a.index - b.index);
+
+      // Build the processed content with URLs converted to anchor tags
+      let processedContent = '';
+      let lastIndex = 0;
+
+      for (const match of sortedUrls) {
+        // Add text before the match
+        processedContent += pastedTextRaw.slice(lastIndex, match.index);
+        // Add the anchor tag for the match
+        processedContent += `<a href="${match.text}" target="_blank" rel="noopener noreferrer">${match.text}</a>`;
+        lastIndex = match.index + match.text.length;
+      }
+
+      // Add any remaining text after the last match
+      processedContent += pastedTextRaw.slice(lastIndex);
+      processedText = processedContent;
+    }
+
+    // If no URLs found and single line, allow default paste behavior
+    const lines = processedText.split('\n');
+    if (!urlMatches.length && lines.length <= 1) {
+      return false;
+    }
+
+    const range = this.selectionService.getRangeAtStartOfSelection();
+    if (!range) {
+      return true;
+    }
+
+    // Find the current paragraph context
+    const currentParagraph = editorUtilities.findClosestAncestor<HTMLParagraphElement>(
+      this.root,
+      range.startContainer,
+      'p',
+    );
+
+    if (!currentParagraph) {
+      return false;
+    }
+
+    // Prevent default paste since we'll handle it
+    e.preventDefault();
+
+    // Split current paragraph if there's content after cursor
+    let afterCursorContent = '';
+    const currentParagraphRange = this.selectionService.createRange();
+    currentParagraphRange.setStart(range.endContainer, range.endOffset);
+    currentParagraphRange.setEndAfter(currentParagraph);
+
+    if (!currentParagraphRange.collapsed) {
+      const afterFragment = currentParagraphRange.extractContents();
+      afterCursorContent = afterFragment.textContent || '';
+    }
+
+    // Delete the selected content
+    range.deleteContents();
+
+    // Create elements for the paste content
+    const firstLine = lines[0];
+    const remainingLines = lines.slice(1);
+
+    // Insert first line content at cursor position
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = firstLine;
+
+    const fragment = document.createDocumentFragment();
+    while (tempDiv.firstChild) {
+      fragment.appendChild(tempDiv.firstChild);
+    }
+
+    range.insertNode(fragment);
+    range.collapse(false);
+
+    // Create new paragraphs for remaining lines
+    const newParagraphs: HTMLParagraphElement[] = [];
+
+    for (const line of remainingLines) {
+      const newP = this.selectionService.createElement('p');
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = line;
+
+      while (tempDiv.firstChild) {
+        newP.appendChild(tempDiv.firstChild);
+      }
+      newParagraphs.push(newP);
+    }
+
+    // If there was content after cursor, add it as the final paragraph
+    if (afterCursorContent) {
+      const finalP = this.selectionService.createElement('p');
+      finalP.textContent = afterCursorContent;
+      newParagraphs.push(finalP);
+    }
+
+    // Insert new paragraphs after current paragraph
+    const parent = currentParagraph.parentNode;
+    if (parent && newParagraphs.length > 0) {
+      let insertAfter = currentParagraph;
+      for (const newP of newParagraphs) {
+        parent.insertBefore(newP, insertAfter.nextSibling);
+        insertAfter = newP;
+      }
+
+      // Position cursor at the end of the last inserted paragraph
+      const lastP = newParagraphs[newParagraphs.length - 1];
+      const newRange = this.selectionService.createRange();
+      newRange.selectNodeContents(lastP);
+      newRange.collapse(false);
+      this.selectionService.setSelectionRange(newRange);
+    }
+
+    this.normalizationService.normalizeInlineFormatting();
+    return true;
   }
 
   private createRichTextElement(format: RichTextFormat): HTMLElement {

--- a/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.ts
@@ -1,6 +1,11 @@
 import editorUtilities, { safelySetHtml } from './Editor.utilities';
 import { SelectionService } from './SelectionService.humble';
-import { RichTextFormat, ZERO_WIDTH_SPACE, HTTP_REG, DOMPURIFY_CONFIG } from './Editor.constants';
+import {
+  RichTextFormat,
+  ZERO_WIDTH_SPACE,
+  HTTP_REG_PATTERN,
+  DOMPURIFY_CONFIG,
+} from './Editor.constants';
 import { NormalizationService } from './NormalizationService';
 import DOMPurify from 'dompurify';
 
@@ -91,7 +96,9 @@ export class FormattingService {
     }
 
     // Apply URL processing to the entire pasted content first
-    const urlMatches = Array.from(pastedTextRaw.matchAll(HTTP_REG));
+    // Create a new RegExp with global flag to prevent lastIndex mutation issues
+    const urlRegex = new RegExp(HTTP_REG_PATTERN.source, 'g');
+    const urlMatches = Array.from(pastedTextRaw.matchAll(urlRegex));
 
     let processedText = pastedTextRaw;
     if (urlMatches.length > 0) {

--- a/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/FormattingService.ts
@@ -1,7 +1,8 @@
-import editorUtilities from './Editor.utilities';
+import editorUtilities, { safelySetHtml } from './Editor.utilities';
 import { SelectionService } from './SelectionService.humble';
-import { RichTextFormat, ZERO_WIDTH_SPACE, HTTP_REG } from './Editor.constants';
+import { RichTextFormat, ZERO_WIDTH_SPACE, HTTP_REG, DOMPURIFY_CONFIG } from './Editor.constants';
 import { NormalizationService } from './NormalizationService';
+import DOMPurify from 'dompurify';
 
 export class FormattingService {
   private root: HTMLElement;
@@ -84,7 +85,7 @@ export class FormattingService {
       return false;
     }
 
-    const pastedTextRaw = clipboardData.getData('text/plain');
+    const pastedTextRaw = DOMPurify.sanitize(clipboardData.getData('text/plain'), DOMPURIFY_CONFIG);
     if (!pastedTextRaw) {
       return false;
     }
@@ -164,7 +165,7 @@ export class FormattingService {
 
     // Insert first line content at cursor position
     const tempDiv = document.createElement('div');
-    tempDiv.innerHTML = firstLine;
+    safelySetHtml(tempDiv, firstLine);
 
     const fragment = document.createDocumentFragment();
     while (tempDiv.firstChild) {
@@ -180,7 +181,7 @@ export class FormattingService {
     for (const line of remainingLines) {
       const newP = this.selectionService.createElement('p');
       const tempDiv = document.createElement('div');
-      tempDiv.innerHTML = line;
+      safelySetHtml(tempDiv, line);
 
       while (tempDiv.firstChild) {
         newP.appendChild(tempDiv.firstChild);

--- a/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
@@ -76,6 +76,12 @@ export class ListNavigationService {
     const newParagraph = this.createEmptyParagraph();
 
     if (currentParagraph?.parentNode) {
+      // Bisect the current text at the cursor location.
+      newParagraph.textContent =
+        currentParagraph.textContent?.slice(range.startOffset) ?? ZERO_WIDTH_SPACE;
+      currentParagraph.textContent =
+        currentParagraph.textContent?.slice(0, range.startOffset) ?? ZERO_WIDTH_SPACE;
+
       currentParagraph.parentNode.insertBefore(newParagraph, currentParagraph.nextSibling);
     } else {
       range.collapse(false);
@@ -175,7 +181,7 @@ export class ListNavigationService {
 
   private focusParagraph(paragraph: HTMLParagraphElement): void {
     const newRange = this.selectionService.createRange();
-    newRange.setStart(paragraph.firstChild!, 1);
+    newRange.setStart(paragraph.firstChild! ?? paragraph, 0);
     newRange.collapse(true);
     this.selectionService.setSelectionRange(newRange);
   }

--- a/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
@@ -77,10 +77,10 @@ export class ListNavigationService {
 
     if (currentParagraph?.parentNode) {
       // Bisect the current text at the cursor location.
-      newParagraph.textContent =
-        currentParagraph.textContent?.slice(range.startOffset) ?? ZERO_WIDTH_SPACE;
-      currentParagraph.textContent =
-        currentParagraph.textContent?.slice(0, range.startOffset) ?? ZERO_WIDTH_SPACE;
+      const newParagraphText = currentParagraph.textContent?.slice(range.startOffset);
+      const currentParagraphText = currentParagraph.textContent?.slice(0, range.startOffset);
+      newParagraph.textContent = newParagraphText ? newParagraphText : ZERO_WIDTH_SPACE;
+      currentParagraph.textContent = currentParagraphText ? currentParagraphText : ZERO_WIDTH_SPACE;
 
       currentParagraph.parentNode.insertBefore(newParagraph, currentParagraph.nextSibling);
     } else {

--- a/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
@@ -79,8 +79,8 @@ export class ListNavigationService {
       // Bisect the current text at the cursor location.
       const newParagraphText = currentParagraph.textContent?.slice(range.startOffset);
       const currentParagraphText = currentParagraph.textContent?.slice(0, range.startOffset);
-      newParagraph.textContent = newParagraphText ? newParagraphText : ZERO_WIDTH_SPACE;
-      currentParagraph.textContent = currentParagraphText ? currentParagraphText : ZERO_WIDTH_SPACE;
+      newParagraph.textContent = newParagraphText || ZERO_WIDTH_SPACE;
+      currentParagraph.textContent = currentParagraphText || ZERO_WIDTH_SPACE;
 
       currentParagraph.parentNode.insertBefore(newParagraph, currentParagraph.nextSibling);
     } else {

--- a/user-interface/src/lib/components/cams/RichTextEditor/RichTextEditor.tsx
+++ b/user-interface/src/lib/components/cams/RichTextEditor/RichTextEditor.tsx
@@ -136,6 +136,7 @@ function _RichTextEditor(props: RichTextEditorProps, ref: React.Ref<RichTextEdit
 
   const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
     if (editorRef.current?.handlePaste(e)) {
+      onChange?.(getHtml());
       return;
     }
   };

--- a/user-interface/src/lib/components/cams/RichTextEditor/RichTextEditor.tsx
+++ b/user-interface/src/lib/components/cams/RichTextEditor/RichTextEditor.tsx
@@ -134,6 +134,12 @@ function _RichTextEditor(props: RichTextEditorProps, ref: React.Ref<RichTextEdit
     }
   };
 
+  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    if (editorRef.current?.handlePaste(e)) {
+      return;
+    }
+  };
+
   return (
     <div id={`${id}-container`} className="usa-form-group rich-text-editor-container">
       {label && (
@@ -203,6 +209,7 @@ function _RichTextEditor(props: RichTextEditorProps, ref: React.Ref<RichTextEdit
         tabIndex={0}
         onInput={() => onChange?.(getHtml())}
         onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
         ref={contentRef}
         aria-labelledby={label ? `editor-label-${id}` : undefined}
         aria-describedby={ariaDescription ? `editor-hint-${id}` : undefined}

--- a/user-interface/src/lib/components/cams/RichTextEditor/RichTextIcon.tsx
+++ b/user-interface/src/lib/components/cams/RichTextEditor/RichTextIcon.tsx
@@ -1,3 +1,5 @@
+import Icon from '@/lib/components/uswds/Icon';
+
 export interface RichTextIconProps {
   name: string;
 }
@@ -11,4 +13,5 @@ export function RichTextIcon(props: RichTextIconProps) {
 const iconMap: Record<string, JSX.Element> = {
   'numbered-list': <img src="/numbered-list.svg" alt="numbered list icon" />,
   'bulleted-list': <img src="/bullet-list.svg" alt="bulleted list icon" />,
+  link: <Icon name="link"></Icon>,
 };


### PR DESCRIPTION
# Purpose

Enable users to add links to notes

# Major Changes

* Added detection logic for links
* Added copy paste logic
* Fixed issues with enter key handling

# Testing/Validation

* Manual testing
* Unit test coverage

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enable users to paste URLs into rich text notes and have them automatically converted into clickable links, while preserving multi-line formatting, splitting paragraphs correctly, and ensuring cursor and list navigation behavior remains consistent.

New Features:
- Auto-convert pasted URLs into anchor tags with proper href, target, and rel attributes
- Preserve line breaks in pasted content by creating new paragraphs and moving existing content after the cursor accordingly

Bug Fixes:
- Fix enter key handling for paragraphs containing only a zero-width space or empty text

Enhancements:
- Introduce handlePaste in FormattingService and integrate it into the Editor component
- Add HTTP regex and CIFS regex constants and extend DOMPurify config to allow link-related attributes
- Enhance ListNavigationService to split paragraphs at the cursor and fix focus offset handling on enter
- Include a link icon in the rich text toolbar

Tests:
- Add unit tests for handlePaste covering single/multiple URLs, multi-line pastes, and preservation of content after the cursor