### PR TITLE
Hide case notes formatting behind feature flag

### DIFF
--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -13,4 +13,5 @@ export const testFeatureFlags: FeatureFlagSet = {
   'transfer-orders-enabled': true,
   'consolidations-enabled': true,
   'privileged-identity-management': true,
+  'format-case-notes': true,
 };

--- a/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNoteFormModal.test.tsx
@@ -19,6 +19,7 @@ import { randomUUID } from 'crypto';
 import LocalFormCache from '@/lib/utils/local-form-cache';
 import { CamsSession, getCamsUserReference } from '@common/cams/session';
 import { ZERO_WIDTH_SPACE } from '@/lib/components/cams/RichTextEditor/Editor.constants';
+import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 
 const MODAL_ID = 'modal-case-note-form';
 const TITLE_INPUT_ID = 'case-note-title-input';
@@ -37,6 +38,10 @@ describe('CaseNoteFormModal - Simple Tests', () => {
     session = MockData.getCamsSession();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
     vi.spyOn(LocalFormCache, 'getForm').mockReturnValue({ expiresAfter: 1, value: {} });
+    const mockFeatureFlags = {
+      [FeatureFlagHook.FORMAT_CASE_NOTES]: true,
+    };
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
   });
 
   afterEach(() => {

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -9,6 +9,7 @@ export const CONSOLIDATIONS_ENABLED = 'consolidations-enabled';
 export const PRIVILEGED_IDENTITY_MANAGEMENT = 'privileged-identity-management';
 export const SYSTEM_MAINTENANCE_BANNER = 'system-maintenance-banner';
 export const TRANSFER_ORDERS_ENABLED = 'transfer-orders-enabled';
+export const FORMAT_CASE_NOTES = 'format-case-notes';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();


### PR DESCRIPTION
# Purpose

We need to hide the new rich text editor for formatting case notes behind the feature flag for format case notes.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Gate the new rich text formatting for case notes behind a feature flag and update component logic and tests to support both rich text and plain text editors.

Enhancements:
- Gate the new rich text editor behind the FORMAT_CASE_NOTES flag, falling back to a plain textarea when disabled
- Add getCaseNotesRichTextContentValue helper and refactor form handlers (validation, clearing, disabling, submission) to support both editor modes
- Export and initialize the FORMAT_CASE_NOTES constant in the feature-flag configuration and useFeatureFlags hook

Tests:
- Mock and validate FORMAT_CASE_NOTES behavior in CaseNoteFormModal tests