### PR TITLE
CAMS-526 Improved enter handling inside inline formatting tags 

### DIFF
--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.test.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.test.ts
@@ -307,39 +307,29 @@ describe('Editor: handleBackspaceOnEmptyContent', () => {
   });
 
   test('handles backspace properly when previousSibling firstChild has insufficient length', () => {
-    // Create multiple paragraphs so we don't hit the "only paragraph" condition
     safelySetHtml(container, '<p>First paragraph</p>');
 
-    // Create a complex DOM structure that would trigger the IndexSizeError in buggy code
-    // previousSibling has an empty firstChild but non-empty textContent
-    const complexElement = document.createElement('div');
-    const emptySpan = document.createElement('span'); // Empty firstChild with length 0
+    const complexElement = document.createElement('p');
+    const emptySpan = document.createElement('span');
     const textNode = document.createTextNode('Some content that makes textContent.length > 0');
 
     complexElement.appendChild(emptySpan);
     complexElement.appendChild(textNode);
     container.appendChild(complexElement);
 
-    // Add the paragraph with ZERO_WIDTH_SPACE AFTER the complex element
     const zeroWidthParagraph = document.createElement('p');
     zeroWidthParagraph.textContent = ZERO_WIDTH_SPACE;
     container.appendChild(zeroWidthParagraph);
 
-    // Position cursor in the zero-width paragraph
     setCursorInParagraph(zeroWidthParagraph, 1, selectionService);
 
     const event = createBackspaceEvent();
 
-    // This should NOT throw an error and should handle the backspace properly
-    expect(() => {
-      editor.handleBackspaceOnEmptyContent(event);
-    }).not.toThrow();
+    editor.handleBackspaceOnEmptyContent(event);
 
-    // Verify the event was handled
     expect(event.preventDefault).toHaveBeenCalled();
 
-    // Verify the empty paragraph was removed
-    expect(container.querySelector('p[textContent="​"]')).toBeFalsy();
+    expect(container.querySelector(`p[textContent="${ZERO_WIDTH_SPACE}"]`)).toBeFalsy();
   });
 
   test('allows normal backspace in non-empty paragraph', () => {

--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.test.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.test.ts
@@ -306,6 +306,42 @@ describe('Editor: handleBackspaceOnEmptyContent', () => {
     expect(event.preventDefault).toHaveBeenCalled();
   });
 
+  test('handles backspace properly when previousSibling firstChild has insufficient length', () => {
+    // Create multiple paragraphs so we don't hit the "only paragraph" condition
+    safelySetHtml(container, '<p>First paragraph</p>');
+
+    // Create a complex DOM structure that would trigger the IndexSizeError in buggy code
+    // previousSibling has an empty firstChild but non-empty textContent
+    const complexElement = document.createElement('div');
+    const emptySpan = document.createElement('span'); // Empty firstChild with length 0
+    const textNode = document.createTextNode('Some content that makes textContent.length > 0');
+
+    complexElement.appendChild(emptySpan);
+    complexElement.appendChild(textNode);
+    container.appendChild(complexElement);
+
+    // Add the paragraph with ZERO_WIDTH_SPACE AFTER the complex element
+    const zeroWidthParagraph = document.createElement('p');
+    zeroWidthParagraph.textContent = ZERO_WIDTH_SPACE;
+    container.appendChild(zeroWidthParagraph);
+
+    // Position cursor in the zero-width paragraph
+    setCursorInParagraph(zeroWidthParagraph, 1, selectionService);
+
+    const event = createBackspaceEvent();
+
+    // This should NOT throw an error and should handle the backspace properly
+    expect(() => {
+      editor.handleBackspaceOnEmptyContent(event);
+    }).not.toThrow();
+
+    // Verify the event was handled
+    expect(event.preventDefault).toHaveBeenCalled();
+
+    // Verify the empty paragraph was removed
+    expect(container.querySelector('p[textContent="​"]')).toBeFalsy();
+  });
+
   test('allows normal backspace in non-empty paragraph', () => {
     safelySetHtml(container, '<p>Hello world</p>');
     const paragraph = container.querySelector('p');

--- a/user-interface/src/lib/components/cams/RichTextEditor/Editor.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/Editor.ts
@@ -126,12 +126,15 @@ export class Editor {
       e.preventDefault();
       const { previousSibling } = currentParagraph;
       if (previousSibling && previousSibling.nodeType === Node.ELEMENT_NODE) {
-        const { firstChild } = previousSibling;
-        if (firstChild) {
-          range.setStart(firstChild, previousSibling.textContent?.length ?? 0);
-          currentParagraph.remove();
-          return true;
+        // Find the last text node in the previous sibling to position cursor properly
+        const lastTextNode = this.findLastTextNode(previousSibling);
+        if (lastTextNode) {
+          range.setStart(lastTextNode, lastTextNode.textContent?.length ?? 0);
+          range.collapse(true);
+          this.selectionService.setSelectionRange(range);
         }
+        currentParagraph.remove();
+        return true;
       }
     }
 
@@ -196,5 +199,25 @@ export class Editor {
       }
     }
     return false;
+  }
+
+  /**
+   * Find the last text node within an element for proper cursor positioning
+   */
+  private findLastTextNode(element: Node): Text | null {
+    if (element.nodeType === Node.TEXT_NODE) {
+      return element as Text;
+    }
+
+    // Traverse children in reverse order to find the last text node
+    for (let i = element.childNodes.length - 1; i >= 0; i--) {
+      const child = element.childNodes[i];
+      const lastTextNode = this.findLastTextNode(child);
+      if (lastTextNode) {
+        return lastTextNode;
+      }
+    }
+
+    return null;
   }
 }

--- a/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.test.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.test.ts
@@ -163,7 +163,6 @@ describe('ListNavigationService', () => {
       expect(result).toBe(true);
       expect(event.preventDefault).toHaveBeenCalled();
 
-      // Should trigger lines 144-146: else branch that inserts paragraph directly
       expect(root.querySelector('p')).toBeTruthy();
       expect(root.querySelector('p')!.textContent).toBe(ZERO_WIDTH_SPACE);
     });

--- a/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
@@ -73,9 +73,9 @@ export class ListNavigationService {
       'p',
     );
 
-    const newParagraph = this.selectionService.createElement('p');
-
+    let newParagraph: HTMLParagraphElement;
     if (currentParagraph?.parentNode) {
+      newParagraph = this.selectionService.createElement('p');
       const { leftFragment, rightFragment } = this.splitParagraphAtCursor(currentParagraph, range);
 
       // Clear the current paragraph and append the left fragment
@@ -88,6 +88,7 @@ export class ListNavigationService {
       // Insert the new paragraph after the current one
       currentParagraph.parentNode.insertBefore(newParagraph, currentParagraph.nextSibling);
     } else {
+      newParagraph = this.createEmptyParagraph();
       range.collapse(false);
       range.insertNode(newParagraph);
     }

--- a/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
@@ -73,7 +73,7 @@ export class ListNavigationService {
       'p',
     );
 
-    const newParagraph = this.createEmptyParagraph();
+    const newParagraph = this.selectionService.createElement('p');
 
     if (currentParagraph?.parentNode) {
       const { leftFragment, rightFragment } = this.splitParagraphAtCursor(currentParagraph, range);
@@ -120,7 +120,13 @@ export class ListNavigationService {
       paragraphClone,
     );
 
-    if (!cursorNodeInClone) {
+    const endCursorNodeInClone = this.findEquivalentNode(
+      range.endContainer,
+      paragraph,
+      paragraphClone,
+    );
+
+    if (!cursorNodeInClone || !endCursorNodeInClone) {
       // Fallback: put everything in left fragment
       leftFragment.appendChild(paragraphClone);
       return { leftFragment, rightFragment };
@@ -131,7 +137,7 @@ export class ListNavigationService {
     leftRange.setEnd(cursorNodeInClone, range.startOffset);
 
     // Set up the right range (from cursor to end of paragraph)
-    rightRange.setStart(cursorNodeInClone, range.startOffset);
+    rightRange.setStart(endCursorNodeInClone, range.endOffset);
     rightRange.setEnd(paragraphClone, paragraphClone.childNodes.length);
 
     // Extract the content

--- a/user-interface/src/lib/components/cams/RichTextEditor/NormalizationService.test.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/NormalizationService.test.ts
@@ -1,6 +1,7 @@
 import { NormalizationService } from './NormalizationService';
 import { MockSelectionService } from './SelectionService.humble';
 import editorUtilities from './Editor.utilities';
+import { ZERO_WIDTH_SPACE } from './Editor.constants';
 
 describe('FormattingService: normalizeInlineFormatting', () => {
   let normalizationService: NormalizationService;
@@ -129,5 +130,35 @@ describe('FormattingService: normalizeInlineFormatting', () => {
     );
     normalizationService.normalizeInlineFormatting();
     expect(editorUtilities.safelyGetHtml(container)).toBe('<p><strong>12345678</strong></p>');
+  });
+
+  test('should remove zero-width space from non-empty paragraph', () => {
+    editorUtilities.safelySetHtml(
+      container,
+      `<p>${ZERO_WIDTH_SPACE}one <strong>two</strong> three</p>`,
+    );
+    normalizationService.normalizeInlineFormatting();
+    expect(editorUtilities.safelyGetHtml(container)).toEqual(
+      '<p>one <strong>two</strong> three</p>',
+    );
+  });
+
+  test('should remove empty span tags', () => {
+    editorUtilities.safelySetHtml(container, '<p><span></span>one <strong>two</strong> three</p>');
+    normalizationService.normalizeInlineFormatting();
+    expect(editorUtilities.safelyGetHtml(container)).toEqual(
+      '<p>one <strong>two</strong> three</p>',
+    );
+  });
+
+  test('should merge text node of a non-formatting span tag with adjacent text node', () => {
+    editorUtilities.safelySetHtml(
+      container,
+      '<p><span>one</span> two <span>three</span> four<span class="underline">five</span></p>',
+    );
+    normalizationService.normalizeInlineFormatting();
+    expect(editorUtilities.safelyGetHtml(container)).toEqual(
+      '<p>one two three four<span class="underline">five</span></p>',
+    );
   });
 });


### PR DESCRIPTION
# Purpose

Improve handling of enter when the cursor is in inline formatting, including deeply nested inline formatting elements. Also improve handling of backspace on empty content and enhance normalization.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve handling of Enter and Backspace inside inline formatting by preserving nested formatting when splitting or merging paragraphs, and enhance normalization by unwrapping non-formatting spans and removing zero-width spaces.

New Features:
- Split paragraphs at cursor with full formatting preservation when pressing Enter
- Position cursor at end of previous block on Backspace by locating the last text node

Enhancements:
- Refactor ListNavigationService to use document fragments and safe HTML updates
- Add normalization steps to unwrap non-formatting spans, remove zero-width spaces, and delete empty formatting elements
- Introduce findLastTextNode utility in Editor for accurate cursor placement

Tests:
- Add tests for zero-width space removal and non-formatting span unwrapping
- Add test for Backspace handling on empty content scenario