### PR TITLE
Fix enter handling with cursor on empty list item

### DIFF
--- a/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.test.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.test.ts
@@ -69,7 +69,7 @@ describe('ListNavigationService', () => {
     });
 
     test('exits empty list item and creates paragraph', () => {
-      safelySetHtml(root, '<ul><li>Item 1</li><li></li></ul>');
+      safelySetHtml(root, `<ul><li>Item 1</li><li>${ZERO_WIDTH_SPACE}</li></ul>`);
       const emptyListItem = root.querySelectorAll('li')[1];
       setCursorInElement(emptyListItem, 0, selectionService);
 
@@ -83,7 +83,10 @@ describe('ListNavigationService', () => {
     });
 
     test('should exit empty list item and create paragraph at root when list item is empty and enter is pressed', () => {
-      safelySetHtml(root, '<ul><li>Item 1<ul><li>Nested item</li><li></li></ul></li></ul>');
+      safelySetHtml(
+        root,
+        `<ul><li>Item 1<ul><li>Nested item</li><li>${ZERO_WIDTH_SPACE}</li></ul></li></ul>`,
+      );
       const emptyListItem = root.querySelectorAll('ul ul li')[1]!;
       setCursorInElement(emptyListItem as HTMLElement, 0, selectionService);
 

--- a/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListNavigationService.ts
@@ -32,7 +32,8 @@ export class ListNavigationService {
     );
 
     if (listItem) {
-      const isEmpty = listItem.textContent?.trim() === '';
+      const trimmedTextContent = listItem.textContent?.trim();
+      const isEmpty = trimmedTextContent === ZERO_WIDTH_SPACE || trimmedTextContent === '';
       if (isEmpty) {
         e.preventDefault();
 

--- a/user-interface/src/lib/components/cams/RichTextEditor/ListService.test.ts
+++ b/user-interface/src/lib/components/cams/RichTextEditor/ListService.test.ts
@@ -314,35 +314,6 @@ describe('ListService', () => {
       expect(root.querySelectorAll('p')).toHaveLength(2);
     });
 
-    test('exits empty list item and creates paragraph', () => {
-      safelySetHtml(root, '<ul><li>Item 1</li><li></li></ul>');
-      const emptyListItem = root.querySelectorAll('li')[1];
-      setCursorInElement(emptyListItem, 0, selectionService);
-
-      const event = createEnterEvent();
-      const result = listService.handleEnterKey(event);
-
-      expect(result).toBe(true);
-      expect(event.preventDefault).toHaveBeenCalled();
-      expect(root.querySelector('p')).toBeTruthy();
-      expect(root.querySelectorAll('li')).toHaveLength(1);
-    });
-
-    test('should exit empty list item and create paragraph at root when list item is empty and enter is pressed', () => {
-      safelySetHtml(root, '<ul><li>Item 1<ul><li>Nested item</li><li></li></ul></li></ul>');
-      const emptyListItem = root.querySelectorAll('ul ul li')[1]!;
-      setCursorInElement(emptyListItem as HTMLElement, 0, selectionService);
-
-      const event = createEnterEvent();
-      const result = listService.handleEnterKey(event);
-
-      expect(result).toBe(true);
-      expect(event.preventDefault).toHaveBeenCalled();
-      expect(safelyGetHtml(root)).toEqual(
-        `<ul><li>Item 1<ul><li>Nested item</li></ul></li></ul><p>${ZERO_WIDTH_SPACE}</p>`,
-      );
-    });
-
     test('handles enter in non-empty list item normally', () => {
       safelySetHtml(root, '<ul><li>Non-empty item</li></ul>');
       const listItem = root.querySelector('li')!;
@@ -353,40 +324,6 @@ describe('ListService', () => {
 
       expect(result).toBe(false);
       expect(event.preventDefault).not.toHaveBeenCalled();
-    });
-
-    test('removes entire list when all children become empty after Enter', () => {
-      // Create a list where all items are empty/whitespace only
-      // After removing one empty item, the remaining items should all be empty too
-      root.innerHTML = ''; // Start fresh
-
-      const list = document.createElement('ul');
-
-      // First item: completely empty
-      const emptyItem1 = document.createElement('li');
-      // Second item: only whitespace
-      const emptyItem2 = document.createElement('li');
-      emptyItem2.textContent = '   '; // Only whitespace
-
-      list.appendChild(emptyItem1);
-      list.appendChild(emptyItem2);
-      root.appendChild(list);
-
-      // Position cursor in the first empty item
-      const range = selectionService.createRange();
-      range.setStart(emptyItem1, 0);
-      range.collapse(true);
-      selectionService.setSelectionRange(range);
-
-      const event = createEnterEvent();
-      const result = listService.handleEnterKey(event);
-
-      expect(result).toBe(true);
-      expect(event.preventDefault).toHaveBeenCalled();
-
-      // Should trigger lines 121-122: check if all remaining children are empty and remove the list
-      expect(root.querySelector('ul')).toBeFalsy(); // List should be removed
-      expect(root.querySelector('p')).toBeTruthy(); // Paragraph should be created
     });
 
     test('inserts paragraph directly when not in a paragraph context', () => {


### PR DESCRIPTION
# Purpose

Enter on an empty list item was sometimes not registering as "empty" because we create new list items with a zero-width space and our empty check was only for empty strings. This PR expands the empty check to look for zero-width spaces in addition to empty strings.
 
# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Handle Enter key correctly on list items containing only a zero-width space by treating them as empty, adjust detection logic in ListNavigationService, and update tests accordingly

Bug Fixes:
- Expand empty list item detection to treat zero-width space as empty content on Enter key

Tests:
- Remove legacy tests for empty string list items and update tests to use ZERO_WIDTH_SPACE
- Adjust ListNavigationService tests to expect ZERO_WIDTH_SPACE when exiting empty list items