### PR TITLE
CAMS-579: Include additional cases

### DIFF
--- a/backend/lib/adapters/gateways/mongo/cases.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/cases.mongo.repository.ts
@@ -194,7 +194,7 @@ export class CasesMongoRepository extends BaseMongoRepository implements CasesRe
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         camsStackInfo: {
           message:
-            'Unable to create assignment history. Please try again later. If the problem persists, please contact USTP support.',
+            'Unable to create case history. Please try again later. If the problem persists, please contact USTP support.',
           module: MODULE_NAME,
         },
       });

--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -396,7 +396,9 @@ export class OrdersUseCase {
     const gateway = getCasesGateway(context);
     for (const caseId of additionalCaseIds) {
       const summary = await gateway.getCaseSummary(context, caseId);
-      includedChildCases.push({ ...summary, docketEntries: [], orderDate: '' });
+      if (summary) {
+        includedChildCases.push({ ...summary, docketEntries: [], orderDate: '' });
+      }
     }
 
     if (status === 'approved') {
@@ -573,10 +575,12 @@ export class OrdersUseCase {
 
     jobToCaseMap.forEach((caseSummaries, jobId) => {
       const consolidationId = generateConsolidationId(jobId, 'pending');
-      const firstOrder = [...caseSummaries.values()].reduce(
-        (prior, next) => (sortDatesReverse(prior.orderDate, next.orderDate) <= 0 ? prior : next),
-        {} as ConsolidationOrderCase,
-      );
+      const firstOrder = [...caseSummaries.values()].reduce((prior, next) => {
+        if (!prior) {
+          return next;
+        }
+        return sortDatesReverse(prior.orderDate, next.orderDate) <= 0 ? prior : next;
+      }, null);
       const consolidationOrder: ConsolidationOrder = {
         consolidationId,
         orderType: 'consolidation',


### PR DESCRIPTION
# Problem

Previously we were only performing some actions on cases that were already in the provisional order, and those seemingly only sometimes.

# Solution

Now we retrieve case summaries for cases added to the form by the user—and any that may not have been found by our previous logic—and write history and associations for them.

# Testing/Validation

Added and updated automated tests.

# Other Changes

These changes include debug statements intended to determine the root cause for the scenario where cases are included in the original order and selected by the user. I think the new logic will effectively operate as a failsafe given that we are not logging any errors, but I will want to know why some included cases are not getting documents written.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhance the consolidation approval flow to include user-added cases not in the provisional order and update tests accordingly

New Features:
- Retrieve and include summaries for additional cases not present in the provisional consolidation order
- Ensure createConsolidationTo, createConsolidationFrom, and case history records are created for these additional cases

Bug Fixes:
- Correct error message text to reference "case history" instead of "assignment history"

Enhancements:
- Introduce debug logging of provisional order details and included case IDs for troubleshooting

Tests:
- Add and update unit tests to verify that consolidation actions and audit histories cover both provisional and additional cases
- Assert that createConsolidationTo/From and case history calls occur for each approved case, including new additions