### PR TITLE
CAMS-579: Properly define assignees during consolidation

### DIFF
--- a/backend/lib/use-cases/case-assignment/case-assignment.ts
+++ b/backend/lib/use-cases/case-assignment/case-assignment.ts
@@ -30,6 +30,7 @@ export class CaseAssignmentUseCase {
     this.queueGateway = getQueueGateway(applicationContext);
   }
 
+  // TODO: createTrialAttorneyAssignments should not take a role, or should be renamed
   public async createTrialAttorneyAssignments(
     context: ApplicationContext,
     caseId: string,

--- a/backend/lib/use-cases/case-assignment/case-assignment.ts
+++ b/backend/lib/use-cases/case-assignment/case-assignment.ts
@@ -33,7 +33,7 @@ export class CaseAssignmentUseCase {
   public async createTrialAttorneyAssignments(
     context: ApplicationContext,
     caseId: string,
-    newAssignments: CamsUserReference[],
+    newAssignees: CamsUserReference[],
     role: string,
     options: { processRoles?: CamsRole[] } = {},
   ): Promise<void> {
@@ -52,7 +52,7 @@ export class CaseAssignmentUseCase {
         message: 'User does not have appropriate access to create assignments for this office.',
       });
     }
-    await this.assignTrialAttorneys(context, caseId, newAssignments, role);
+    await this.assignTrialAttorneys(context, caseId, newAssignees, role);
 
     // Reassign all child cases if this is a joint administration lead case.
     const consolidationReferences = await casesRepo.getConsolidation(caseId);
@@ -64,19 +64,20 @@ export class CaseAssignmentUseCase {
       )
       .map((reference) => reference.otherCase.caseId);
     for (const childCaseId of childCaseIds) {
-      await this.assignTrialAttorneys(context, childCaseId, newAssignments, role);
+      await this.assignTrialAttorneys(context, childCaseId, newAssignees, role);
     }
   }
 
+  // TODO: assignTrialAttorneys should not take a role, or should be renamed
   private async assignTrialAttorneys(
     context: ApplicationContext,
     caseId: string,
-    newAssignments: CamsUserReference[],
+    newAssignees: CamsUserReference[],
     role: string,
   ): Promise<string[]> {
     const casesRepo = Factory.getCasesRepository(context);
     const assignmentRepo = Factory.getAssignmentRepository(context);
-    context.logger.info(MODULE_NAME, 'New assignments:', newAssignments);
+    context.logger.info(MODULE_NAME, 'New assignments:', newAssignees);
 
     const bCase = await casesRepo.getSyncedCase(caseId);
     const officesGateway = getOfficesGateway(context);
@@ -87,13 +88,13 @@ export class CaseAssignmentUseCase {
     const officesRepo = getOfficesRepository(context);
     const calls = [];
     const validatedAssignments: CamsUserReference[] = [];
-    newAssignments.forEach((assignment) => {
+    newAssignees.forEach((assignee) => {
       calls.push(
         officesRepo
-          .search({ officeCode, userId: assignment.id, role })
+          .search({ officeCode, userId: assignee.id, role })
           .then((response) => {
             return response.find((staff) => {
-              if (staff.roles.includes(role as CamsRole) && staff.name === assignment.name) {
+              if (staff.roles.includes(role as CamsRole) && staff.name === assignee.name) {
                 return true;
               }
             });
@@ -116,10 +117,10 @@ export class CaseAssignmentUseCase {
         }
       }
     });
-    if (validatedAssignments.length !== newAssignments.length) {
+    if (validatedAssignments.length !== newAssignees.length) {
       throw new AssignmentError(MODULE_NAME, {
         message: 'Invalid assignments found.',
-        data: { newAssignments, validatedAssignments },
+        data: { newAssignments: newAssignees, validatedAssignments },
       });
     }
 

--- a/backend/lib/use-cases/orders/orders.ts
+++ b/backend/lib/use-cases/orders/orders.ts
@@ -482,7 +482,7 @@ export class OrdersUseCase {
       ]);
       const leadCaseAssignments = leadCaseAssignmentsMap.get(leadCase.caseId) ?? [];
       const leadCaseAttorneys: CamsUserReference[] = leadCaseAssignments.map((assignment) => {
-        return { id: assignment.caseId, name: assignment.name };
+        return { id: assignment.userId, name: assignment.name };
       });
 
       const childCaseSummaries = [];
@@ -517,7 +517,7 @@ export class OrdersUseCase {
             context,
             childCase.caseId,
             leadCaseAttorneys,
-            'TrialAttorney',
+            CamsRole.TrialAttorney,
             { processRoles: [CamsRole.CaseAssignmentManager] },
           );
 

--- a/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.test.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.test.tsx
@@ -157,7 +157,7 @@ describe('test ConsolidationCasesTable component', () => {
     );
   });
 
-  test('Should display alert if a case is the lead case of another consolidation', () => {
+  test('Should display alert if a case is the lead case of another administrative consolidation', () => {
     const caseId = '11-1111';
     const props = {
       cases: [
@@ -170,6 +170,7 @@ describe('test ConsolidationCasesTable component', () => {
                 override: {
                   caseId,
                   documentType: 'CONSOLIDATION_FROM',
+                  consolidationType: 'administrative',
                 },
               }),
             ],
@@ -181,7 +182,36 @@ describe('test ConsolidationCasesTable component', () => {
     renderWithProps(props);
 
     expect(screen.getByTestId('alert-container-is-lead')).toHaveTextContent(
-      'This case is the lead case of a consolidation and can be used as the lead of this consolidation.',
+      'This case is the lead case of a joint administration consolidation and can be used as the lead of this consolidation.',
+    );
+  });
+
+  test('Should display alert if a case is the lead case of another substantive consolidation', () => {
+    const caseId = '11-1111';
+    const props = {
+      cases: [
+        MockData.getConsolidatedOrderCase({
+          override: {
+            caseId,
+            isLeadCase: true,
+            associations: [
+              MockData.getConsolidationReference({
+                override: {
+                  caseId,
+                  documentType: 'CONSOLIDATION_FROM',
+                  consolidationType: 'substantive',
+                },
+              }),
+            ],
+          },
+        }),
+      ],
+    };
+
+    renderWithProps(props);
+
+    expect(screen.getByTestId('alert-container-is-lead')).toHaveTextContent(
+      'This case is the lead case of a substantive consolidation and can be used as the lead of this consolidation.',
     );
   });
 

--- a/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.tsx
@@ -256,9 +256,7 @@ function _ConsolidationCaseTable(
                         id="is-lead"
                         inline={true}
                         show={true}
-                        message={
-                          'This case is the lead case of a consolidation and can be used as the lead of this consolidation.'
-                        }
+                        message={`This case is the lead case of a ${bCase.associations?.[0].consolidationType === 'administrative' ? 'joint administration' : 'substantive'} consolidation and can be used as the lead of this consolidation.`}
                         type={UswdsAlertStyle.Warning}
                       ></Alert>
                     )}


### PR DESCRIPTION
# Problem

We were improperly using the lead case id as the 'id' property for assignees so no valid assignments were found as we were comparing case id's to Okta user id's in the application of a filter.

# Solution

When constructing `leadCaseAttorneys` we now properly use their user id rather than the lead case id.

# Testing/Validation

We have updated the test cases to expect that the userId is what is passed in the id field when calling the assignments use case during consolidation handling.

# Other Changes

There are TODO's about the `assignTrialAttorneys` and `createTrialAttorneyAssignments` functions. They take a parameter for which role to assign, but are named as if they can only assign attorneys. We may want to either remove the parameter or rename so that it is clear that other roles would be assignable. That is outside the scope of this bug and if the latter is chosen we should ensure that they check whether the provided role is in the `AssignableRole` enum.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Fix the assignment of attorneys during consolidation by using the correct user IDs, update related methods and tests, and improve consolidation alerts to reflect administrative or substantive types.

Bug Fixes:
- Use attorney userId instead of caseId when constructing lead case assignments
- Ensure createTrialAttorneyAssignments is invoked with correct assignee identifiers rather than case identifiers

Enhancements:
- Refactor CaseAssignmentUseCase and assignTrialAttorneys methods to use newAssignees naming
- Switch to CamsRole.TrialAttorney enum instead of hardcoded string for role specification
- Update ConsolidationCasesTable component to render a dynamic alert message based on consolidation type

Tests:
- Update Orders use case tests to expect userId-based assignees and verify createTrialAttorneyAssignments call counts
- Add UI tests for administrative and substantive consolidation alert scenarios