### PR TITLE
Only send Slack notification for main branch

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   notify:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: (github.event.workflow_run.conclusion == 'failure') && (github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification


### PR DESCRIPTION
# Purpose

We want to reduce the number of notifications.

# Major Changes

Add a condition that the branch must be `main`.

# Testing/Validation

I'll make sure there is a failure to see if it sends the notification. Hopefully we will be able to tell prior to merging to main.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
