### PR TITLE
Update case note E2E with new selector

### DIFF
--- a/test/e2e/playwright/case-notes.spec.ts
+++ b/test/e2e/playwright/case-notes.spec.ts
@@ -36,7 +36,7 @@ test.describe('Case Notes', () => {
     await expect(page.locator('[data-testid="modal-content-case-note-form"]')).toBeVisible();
 
     await page.locator('[data-testid="case-note-title-input"]').fill(testNoteTitle);
-    await page.locator('[data-testid="case-note-formatted-editor"]').fill(testNoteContent);
+    await page.locator('[data-testid="editor-content"] > div').fill(testNoteContent);
     await expect(page.locator('[data-testid="button-case-note-form-submit-button"]')).toBeVisible();
     await page.locator('[data-testid="button-case-note-form-submit-button"]').click();
     await expect(page.locator('[data-testid="modal-content-case-note-form"]')).not.toBeVisible();
@@ -53,12 +53,12 @@ test.describe('Case Notes', () => {
     await page.locator('[data-testid="open-modal-button_case-note-edit-button_0"]').click();
 
     await expect(page.locator('[data-testid="case-note-title-input"]')).toBeVisible();
-    await expect(page.locator('[data-testid="case-note-formatted-editor"]')).toBeVisible();
+    await expect(page.locator('[data-testid="editor-content"] > div')).toBeVisible();
 
     await page.locator('[data-testid="case-note-title-input"]').clear();
     await page.locator('[data-testid="case-note-title-input"]').fill(noteTitleEdit);
-    await page.locator('[data-testid="case-note-formatted-editor"]').clear();
-    await page.locator('[data-testid="case-note-formatted-editor"]').fill(noteContentEdit);
+    await page.locator('[data-testid="editor-content"] > div').clear();
+    await page.locator('[data-testid="editor-content"] > div').fill(noteContentEdit);
 
     await expect(page.locator('[data-testid="button-case-note-form-submit-button"]')).toBeEnabled();
     await page.locator('[data-testid="button-case-note-form-submit-button"]').click();


### PR DESCRIPTION
# Purpose

We forgot to update the selector for playwright tests interacting with the new case notes rich text editor.

# Major Changes

Describe what has changed.

# Testing/Validation

Ran E2E locally and it passed

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
