### PR TITLE
CAMS-530 dast scan

### DIFF
--- a/.github/workflows/reusable-dast.yml
+++ b/.github/workflows/reusable-dast.yml
@@ -80,7 +80,7 @@ jobs:
           fail_action: 'false'
           allow_issue_writing: 'false'
           issue_title: 'ZAP Full Scan Report'
-          artifact_name: 'report_html.html'
+          artifact_name: 'zap-report.zip'
 
           # context_file: 'test/dast/context.context'
           # auth_script: 'test/dast/okta-login.js'
@@ -93,7 +93,7 @@ jobs:
         if: always()
         with:
           name: zap-report
-          path: report_html.html
+          path: zap-report.zip
           retention-days: 30
 
       - name: Disable GHA runner access

--- a/test/dast/rules.tsv
+++ b/test/dast/rules.tsv
@@ -1,0 +1,3 @@
+10011	IGNORE	(Cookie Without Secure Flag)
+10015	IGNORE	(Incomplete or No Cache-control and Pragma HTTP Header Set)
+40035   IGNORE  (Hidden File Found)


### PR DESCRIPTION
# Purpose

DAST Scan in CI pipeline

# Major Changes

Trying the align artifact names used by the ZAP action

## Summary by Sourcery

CI:
- Rename ZAP scan artifact from report_html.html to zap-report.zip and update upload path in the reusable DAST workflow