### PR TITLE
Remove the .zip extension from the artifact name

### DIFF
--- a/.github/workflows/reusable-dast.yml
+++ b/.github/workflows/reusable-dast.yml
@@ -80,7 +80,7 @@ jobs:
           fail_action: 'false'
           allow_issue_writing: 'false'
           issue_title: 'ZAP Full Scan Report'
-          artifact_name: 'zap-report.zip'
+          artifact_name: 'zap-report'
 
           # context_file: 'test/dast/context.context'
           # auth_script: 'test/dast/okta-login.js'


### PR DESCRIPTION
# Purpose

DAST scan in CI pipeline

# Major Changes

* Removed .zip extension from artifact name config since .zip is added by the ZAP action.

## Summary by Sourcery

Enhancements:
- Drop the .zip extension from the 'zap-report' artifact_name since the ZAP action appends .zip automatically