### PR TITLE
CAMS-530 Revert changes to nginx.conf

### DIFF
--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -1,50 +1,17 @@
 server {
+    #proxy_cache cache;
+    #proxy_cache_valid 200 1s;
     listen 8080;
     listen [::]:8080;
 
     root /home/site/wwwroot;
 
-    # The server_name, though required, will be ignored in the context of webapp Proxy service.
+    index index.html index.htm;
     server_name  example.com www.example.com;
     port_in_redirect off;
 
-    # TODO: Flesh this out for any file types that we explicitly want to block
-    location ~* \.(php|env|git|bak|old|tgz|zip|rar)$ {
-        return 404; # Or 403 if you want to explicitly deny
-    }
-
-    # Example using map for more complex pattern matching
-    # TODO: Flesh this out for any file types that we explicitly want to block
-    # TODO: We need to replace all nginx variables with environment variables so that they are not corrupted by deployment scripts
-    map $request_uri $block_scan {
-        "~*^/adminer\.php" 1;
-        "~*^/wp-admin" 1;
-        default 0;
-    }
-
-    # TODO: We need to replace all nginx variables with environment variables so that they are not corrupted by deployment scripts
-    if ($block_scan) {
-        return 404;
-    }
-
-    # Disable access to all dot (.) files and directories
-    location ~ /\. {
-        deny all;
-        access_log off;
-        log_not_found off;
-    }
-
-    # TODO: Ensure all static assets are served by a specific folder (e.g., /static/)
-    #location /static/ { # Adjust path as needed for your static assets
-    #    try_files ${NGINX_URI_VAR_VALUE} ${NGINX_URI_VAR_VALUE}/ =404; # Return 404 if file not found
-    #}
-
     location / {
-        #if (${NGINX_URI_VAR_VALUE} ~* "\.[a-z0-9]{2,5}$") {
-        #    try_files ${NGINX_URI_VAR_VALUE} =404;
-        #}
-        index index.html;
-        # check to see if this variable is necessary or if we can just use $uri
+        index index.html index.htm;
         try_files ${NGINX_URI_VAR_VALUE} ${NGINX_URI_VAR_VALUE}/ /index.html =404;
     }
 
@@ -53,6 +20,13 @@ server {
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /html/;
+    }
+
+    # Disable .git directory
+    location ~ /\.git {
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Security headers
@@ -64,8 +38,5 @@ server {
     #   CSP_API_SERVER_HOST               - refers to the backend api host uri
     #   CSP_USTP_ISSUE_COLLECTOR_HASH     - USTP issue collector hash
     #   CSP_CAMS_REACT_SELECT_HASH        - React-Select hash
-    add_header X-Content-Type-Options "nosniff";
-    add_header Referrer-Policy "no-referrer";
-    add_header X-XSS-Protection "1; mode=block"; # legacy, still used
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com atl.cld.prd.ust.doj.gov; connect-src 'self' ${CSP_API_SERVER_HOST} ${OKTA_URL} clientsdk.launchdarkly.us clientstream.launchdarkly.us events.launchdarkly.us js.monitor.azure.com usgovvirginia-1.in.applicationinsights.azure.us; img-src 'self' data: ; style-src 'self' '${CSP_CAMS_REACT_SELECT_HASH}' '${CSP_USTP_ISSUE_COLLECTOR_HASH}'; base-uri 'self'; form-action 'self'; frame-src 'self' ${OKTA_URL} atl.cld.prd.ust.doj.gov";
 }


### PR DESCRIPTION
Revert changes to nginx.conf

## Summary by Sourcery

Revert the overcomplicated nginx configuration to a streamlined default setup by removing unfinished file-blocking rules and extra headers, restoring standard index and try_files behavior, and consolidating security directives.

Enhancements:
- Restore index directive to include both index.html and index.htm
- Simplify the root location to use default try_files fallback
- Re-add a block to disable access to the .git directory
- Consolidate security headers into a single Content-Security-Policy entry