### PR TITLE
Change name of playwright ally report artifact

### DIFF
--- a/.github/workflows/reusable-accessibility.yml
+++ b/.github/workflows/reusable-accessibility.yml
@@ -91,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
-          name: playwright-report
+          name: playwright-a11y-report
           path: ${{ inputs.path }}/playwright-report/
           retention-days: 30


### PR DESCRIPTION
# Purpose

The name of the a11y report artifact is conflicting with that of the
playwright e2e test report, causing errors on main when uploading the
e2e report. This should prevent those errors occurring.

# Major Changes

The name of the report that is uploaded for playwright a11y tests

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

CI:
- Update the reusable-accessibility.yml workflow to name the uploaded artifact playwright-a11y-report instead of playwright-report