### PR TITLE
Ignore both folders and symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,5 +97,7 @@ cams1.code-workspace
 .voidrules
 .junie/
 .cursor/
-.serena/
+.serena
+.serena/*
 .ai
+.ai/*


### PR DESCRIPTION
# Purpose

We want to ignore both symlinks and directories.

# Major Changes

Update the `.gitignore` to capture both.

## Summary by Sourcery

Enhancements:
- Add patterns to .gitignore to filter out symlinks and folder entries