### PR TITLE
CAMS-555 Add Trustee and Assigned Staff view to Case Details screen

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
@@ -69,6 +69,16 @@ describe('Test DXTR Gateway', () => {
       taxId: '12-3456789',
     };
 
+    const expectedTrustee = {
+      name: 'John Q. Smith',
+      address1: '123 Main St',
+      address2: 'Apt 17',
+      address3: '',
+      cityStateZipCountry: 'Queens NY 12345 USA',
+      phone: '101-345-8765',
+      email: 'john.smith@example.com',
+    };
+
     const expectedDebtorAttorney = {
       name: 'James Brown Esq.',
       address1: '456 South St',
@@ -90,6 +100,7 @@ describe('Test DXTR Gateway', () => {
         debtorTypeCode: 'CB',
         debtorTypeLabel: expectedDebtorTypeLabel,
         regionId: '04',
+        trustee: expectedTrustee,
       },
     });
 
@@ -142,6 +153,14 @@ describe('Test DXTR Gateway', () => {
       message: '',
     };
 
+    const mockQueryTrustee: QueryResults = {
+      success: true,
+      results: {
+        recordset: [expectedTrustee],
+      },
+      message: '',
+    };
+
     const mockQueryDebtorAttorney: QueryResults = {
       success: true,
       results: {
@@ -160,6 +179,10 @@ describe('Test DXTR Gateway', () => {
 
     querySpy.mockImplementationOnce(async () => {
       return Promise.resolve(mockTransactionResults);
+    });
+
+    querySpy.mockImplementationOnce(async () => {
+      return Promise.resolve(mockQueryTrustee);
     });
 
     querySpy.mockImplementationOnce(async () => {
@@ -328,6 +351,22 @@ describe('Test DXTR Gateway', () => {
       message: '',
     };
 
+    const expectedTrustee = {
+      name: 'John Q. Smith',
+      address1: '123 Main St',
+      address2: 'Apt 17',
+      address3: '',
+      cityStateZipCountry: 'Queens NY 12345 USA',
+    };
+
+    const mockQueryTrustee: QueryResults = {
+      success: true,
+      results: {
+        recordset: [expectedTrustee],
+      },
+      message: '',
+    };
+
     const expectedDebtorAttorney = {
       name: 'James Brown Esq.',
       address1: '456 South St',
@@ -353,6 +392,10 @@ describe('Test DXTR Gateway', () => {
 
     querySpy.mockImplementationOnce(async () => {
       return Promise.resolve(mockTransactionResults);
+    });
+
+    querySpy.mockImplementationOnce(async () => {
+      return Promise.resolve(mockQueryTrustee);
     });
 
     querySpy.mockImplementationOnce(async () => {

--- a/common/src/cams/cases.ts
+++ b/common/src/cams/cases.ts
@@ -1,4 +1,4 @@
-import { DebtorAttorney, Party } from './parties';
+import { DebtorAttorney, Party, Trustee } from './parties';
 import { ConsolidationFrom, ConsolidationTo, TransferFrom, TransferTo } from './events';
 import { CaseAssignment } from './assignments';
 import { Auditable } from './auditable';
@@ -46,6 +46,7 @@ export type CaseDetail = CaseSummary & {
   consolidation?: Array<ConsolidationTo | ConsolidationFrom>;
   debtorAttorney?: DebtorAttorney;
   judgeName?: string;
+  trustee?: Trustee;
 };
 
 export type CaseDocketEntryDocument = {

--- a/common/src/cams/parties.ts
+++ b/common/src/cams/parties.ts
@@ -22,3 +22,8 @@ export type DebtorAttorney = Omit<Party, 'taxId' | 'ssn'> & {
   email?: string;
   office?: string;
 };
+
+export type Trustee = Omit<Party, 'taxId' | 'ssn'> & {
+  phone?: string;
+  email?: string;
+};

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -20,7 +20,7 @@ import {
   RawConsolidationOrder,
   TransferOrder,
 } from '../orders';
-import { DebtorAttorney, Party } from '../parties';
+import { DebtorAttorney, Party, Trustee } from '../parties';
 import { COURT_DIVISIONS } from './courts.mock';
 import { TRIAL_ATTORNEYS } from './attorneys.mock';
 import { ConsolidationOrderSummary } from '../history';
@@ -508,6 +508,21 @@ function getDocketEntry(override: Partial<CaseDocketEntry> = {}): CaseDocketEntr
   };
 }
 
+function getTrustee(override: Partial<Trustee> = {}): Trustee {
+  return {
+    name: faker.person.fullName(),
+    address1: faker.location.streetAddress(),
+    address2: faker.location.secondaryAddress(),
+    address3: '',
+    cityStateZipCountry: `${faker.location.city()}, ${faker.location.state({
+      abbreviated: true,
+    })}, ${faker.location.zipCode()}, US`,
+    phone: faker.phone.number(),
+    email: faker.internet.email(),
+    ...override,
+  };
+}
+
 function getStaffAssignee(override: Partial<Staff> = {}) {
   return {
     id: randomId(),
@@ -829,6 +844,7 @@ export const MockData = {
   someDateAfterThisDate,
   someDateBeforeThisDate,
   getCaseSyncEvent,
+  getTrustee,
 };
 
 export default MockData;

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -14,4 +14,5 @@ export const testFeatureFlags: FeatureFlagSet = {
   'consolidations-enabled': true,
   'privileged-identity-management': true,
   'format-case-notes': true,
+  'view-trustee-on-case': true,
 };

--- a/user-interface/.pa11yci
+++ b/user-interface/.pa11yci
@@ -17,7 +17,6 @@
         "click element [data-testid='open-modal-button_0']"
       ]
     },
-    "http://localhost:3000/case-detail/101-23-44461/",
     {
       "url": "http://localhost:3000/case-detail/101-23-44461/court-docket/",
       "actions": [

--- a/user-interface/src/case-detail/CaseDetailScreen.scss
+++ b/user-interface/src/case-detail/CaseDetailScreen.scss
@@ -2,7 +2,7 @@
 
 .case-detail {
   h3 {
-    margin-top: 0;
+    margin: 0;
     line-height: 1.5;
   }
 
@@ -23,13 +23,20 @@
     margin-left: 0.25rem;
     vertical-align: middle;
   }
+  .case-detail-container {
+    display: flex;
+    column-gap: 5rem;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
   .case-card-list {
     .case-card {
       line-height: 1.5;
-
-      h3 {
-        margin-bottom: 0.5rem;
-      }
+      padding-bottom: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      row-gap: 0.5rem;
 
       li.transfer {
         margin-bottom: 1rem;
@@ -45,9 +52,6 @@
     }
   }
   .assigned-staff-list {
-    .case-detail-region-id {
-      padding-bottom: 0.5rem;
-    }
     .individual-assignee {
       .vertical-divider {
         padding: 0 0.5rem;

--- a/user-interface/src/case-detail/CaseDetailScreen.scss
+++ b/user-interface/src/case-detail/CaseDetailScreen.scss
@@ -1,9 +1,22 @@
 @use '../styles/theme';
 
 .case-detail {
+  h3 {
+    margin-top: 0;
+    line-height: 1.5;
+  }
+
   h4 {
     margin-block-start: 0;
     margin-block-end: 0;
+  }
+
+  .case-detail-content {
+    .grid-gap-lg {
+      .case-card-list:first-child {
+        padding-left: 0;
+      }
+    }
   }
 
   .link-icon {

--- a/user-interface/src/case-detail/CaseDetailScreen.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.test.tsx
@@ -10,6 +10,7 @@ import { MockAttorneys } from '@common/cams/test-utilities/attorneys.mock';
 import * as detailHeader from './panels/CaseDetailHeader';
 import MockData from '@common/cams/test-utilities/mock-data';
 import testingUtilities from '@/lib/testing/testing-utilities';
+import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 import MockApi2 from '@/lib/testing/mock-api2';
 
 const caseId = '101-23-12345';
@@ -51,6 +52,10 @@ describe('Case Detail screen tests', () => {
       ...env,
       CAMS_USE_FAKE_API: 'true',
     };
+    const mockFeatureFlags = {
+      [FeatureFlagHook.VIEW_TRUSTEE_ON_CASE]: false,
+    };
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
   });
 
   function renderWithProps(props?: Partial<CaseDetail>, notes: CaseNote[] = []) {

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -729,7 +729,7 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
                 )}
               </div>
             </div>
-            <div className="grid-col-8" aria-live="polite">
+            <div className="grid-col-8 case-detail-content" aria-live="polite">
               <Suspense fallback={<LoadingSpinner />}>
                 <Routes>
                   <Route

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -27,6 +27,7 @@ import { useApi2 } from '@/lib/hooks/UseApi2';
 import { CaseAssignment } from '@common/cams/assignments';
 import { CamsRole } from '@common/cams/roles';
 import CaseNotes, { CaseNotesRef } from './panels/case-notes/CaseNotes';
+import CaseDetailTrusteeAndAssignedStaff from './panels/CaseDetailTrusteeAndAssignedStaff';
 
 const CaseDetailHeader = lazy(() => import('./panels/CaseDetailHeader'));
 const CaseDetailOverview = lazy(() => import('./panels/CaseDetailOverview'));
@@ -729,6 +730,19 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
                           caseBasicInfo?.closedDate,
                         )}
                         onCaseAssignment={handleCaseAssignment}
+                      />
+                    }
+                  />
+                  <Route
+                    path="trustee-and-assigned-staff"
+                    element={
+                      <CaseDetailTrusteeAndAssignedStaff
+                        caseDetail={caseBasicInfo}
+                        onCaseAssignment={function (
+                          _props: AssignAttorneyModalCallbackProps,
+                        ): void {
+                          throw new Error('Function not implemented.');
+                        }}
                       />
                     }
                   />

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -62,7 +62,9 @@ export function findDocketLimits(docket: CaseDocket): DocketLimits {
   const dateRange: DateRange = { start: undefined, end: undefined };
   const documentRange: DocumentRange = { first: 0, last: 0 };
 
-  if (!docket.length) return { dateRange, documentRange };
+  if (!docket.length) {
+    return { dateRange, documentRange };
+  }
 
   const firstEntryWithDocument = docket.find((entry) => {
     return !!entry.documentNumber;
@@ -99,8 +101,12 @@ export function notesSorterClosure(sortDirection: SortDirection) {
 }
 
 function dateRangeFilter(docketEntry: CaseDocketEntry, dateRange: DateRange) {
-  if (dateRange.start && docketEntry.dateFiled < dateRange.start) return false;
-  if (dateRange.end && docketEntry.dateFiled > dateRange.end) return false;
+  if (dateRange.start && docketEntry.dateFiled < dateRange.start) {
+    return false;
+  }
+  if (dateRange.end && docketEntry.dateFiled > dateRange.end) {
+    return false;
+  }
   return true;
 }
 
@@ -112,7 +118,9 @@ function docketSearchFilter(docketEntry: CaseDocketEntry, searchString: string) 
 }
 
 function documentNumberFilter(docketEntry: CaseDocketEntry, documentNumber: number) {
-  if (docketEntry.documentNumber === documentNumber) return docketEntry;
+  if (docketEntry.documentNumber === documentNumber) {
+    return docketEntry;
+  }
 }
 
 function notesSearchFilter(note: CaseNote, searchString: string) {
@@ -123,7 +131,9 @@ function notesSearchFilter(note: CaseNote, searchString: string) {
 }
 
 function facetFilter(docketEntry: CaseDocketEntry, selectedFacets: string[]) {
-  if (selectedFacets.length === 0) return docketEntry;
+  if (selectedFacets.length === 0) {
+    return docketEntry;
+  }
   return selectedFacets.includes(docketEntry.summaryText);
 }
 
@@ -199,7 +209,7 @@ export function applyDocketEntrySortAndFilters(
 function summaryTextFacetReducer(acc: CaseDocketSummaryFacets, de: CaseDocketEntry) {
   if (acc.has(de.summaryText)) {
     const facet = acc.get(de.summaryText)!;
-    facet.count = facet.count + 1;
+    facet.count += 1;
     acc.set(de.summaryText, facet);
   } else {
     acc.set(de.summaryText, { text: de.summaryText, count: 1 });
@@ -223,7 +233,9 @@ export function getSummaryFacetList(facets: CaseDocketSummaryFacets) {
     return { value: key, label: `${key} (${facet.count})` };
   });
   return facetOptions.sort((a, b) => {
-    if (a.label === b.label) return 0;
+    if (a.label === b.label) {
+      return 0;
+    }
     return a.label < b.label ? -1 : 1;
   });
 }

--- a/user-interface/src/case-detail/panels/CaseDetailAuditHistory.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailAuditHistory.tsx
@@ -123,43 +123,41 @@ export default function CaseDetailAuditHistory(props: CaseDetailAuditHistoryProp
 
   return (
     <div className="case-audit-history">
-      <div className="history-type-title">
-        <h3>Change History</h3>
-        {isAuditHistoryLoading && <LoadingIndicator />}
-        {!isAuditHistoryLoading && (
-          <>
-            {caseHistory.length < 1 && (
-              <div data-testid="empty-assignments-test-id">
-                <Alert
-                  message="No changes have been made to this case."
-                  type={UswdsAlertStyle.Info}
-                  role={'status'}
-                  timeout={0}
-                  title=""
-                  show={true}
-                  inline={true}
-                />
-              </div>
-            )}
-            {caseHistory.length > 0 && (
-              <table data-testid="history-table" className="usa-table usa-table--borderless">
-                <thead>
-                  <tr>
-                    <th>Change</th>
-                    <th>Previous</th>
-                    <th>New</th>
-                    <th>Changed by</th>
-                    <th>Date</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <>{renderCaseHistory()}</>
-                </tbody>
-              </table>
-            )}
-          </>
-        )}
-      </div>
+      <h3>Change History</h3>
+      {isAuditHistoryLoading && <LoadingIndicator />}
+      {!isAuditHistoryLoading && (
+        <>
+          {caseHistory.length < 1 && (
+            <div data-testid="empty-assignments-test-id">
+              <Alert
+                message="No changes have been made to this case."
+                type={UswdsAlertStyle.Info}
+                role={'status'}
+                timeout={0}
+                title=""
+                show={true}
+                inline={true}
+              />
+            </div>
+          )}
+          {caseHistory.length > 0 && (
+            <table data-testid="history-table" className="usa-table usa-table--borderless">
+              <thead>
+                <tr>
+                  <th>Change</th>
+                  <th>Previous</th>
+                  <th>New</th>
+                  <th>Changed by</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <>{renderCaseHistory()}</>
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.scss
@@ -1,8 +1,6 @@
 @use '../../styles/abstracts/colors';
 
 #case-detail-court-docket-panel {
-  margin-left: 2rem;
-
   .docket-entries-main-header {
     margin-bottom: 2rem;
   }

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import useFeatureFlags, { VIEW_TRUSTEE } from '@/lib/hooks/UseFeatureFlags';
 
 export function mapNavState(path: string) {
   const cleanPath = path.replace(/\/$/, '').split('/');
@@ -45,6 +46,8 @@ export default function CaseDetailNavigation({
 }: CaseDetailNavigationProps) {
   const [activeNav, setActiveNav] = useState<NavState>(initiallySelectedNavLink);
 
+  const featureFlags = useFeatureFlags();
+
   return (
     <>
       <nav
@@ -65,20 +68,22 @@ export default function CaseDetailNavigation({
               Case Overview
             </NavLink>
           </li>
-          <li className="usa-sidenav__item">
-            <NavLink
-              to={`/case-detail/${caseId}/trustee-and-assigned-staff`}
-              data-testid="case-trustee-and-assigned-staff-link"
-              className={
-                'usa-nav-link ' + setCurrentNav(activeNav, NavState.TRUSTEE_AND_ASSIGNED_STAFF)
-              }
-              onClick={() => setActiveNav(NavState.TRUSTEE_AND_ASSIGNED_STAFF)}
-              title="view trustee and assigned staff details for the current case"
-              end
-            >
-              Trustee & Assigned Staff
-            </NavLink>
-          </li>
+          {featureFlags[VIEW_TRUSTEE] && (
+            <li className="usa-sidenav__item">
+              <NavLink
+                to={`/case-detail/${caseId}/trustee-and-assigned-staff`}
+                data-testid="case-trustee-and-assigned-staff-link"
+                className={
+                  'usa-nav-link ' + setCurrentNav(activeNav, NavState.TRUSTEE_AND_ASSIGNED_STAFF)
+                }
+                onClick={() => setActiveNav(NavState.TRUSTEE_AND_ASSIGNED_STAFF)}
+                title="view trustee and assigned staff details for the current case"
+                end
+              >
+                Trustee & Assigned Staff
+              </NavLink>
+            </li>
+          )}
           <li className="usa-sidenav__item">
             <NavLink
               to={`/case-detail/${caseId}/court-docket`}

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
@@ -26,6 +26,7 @@ export interface CaseDetailNavigationProps {
 
 export enum NavState {
   CASE_OVERVIEW,
+  TRUSTEE_AND_ASSIGNED_STAFF,
   COURT_DOCKET,
   AUDIT_HISTORY,
   ASSOCIATED_CASES,
@@ -62,6 +63,20 @@ export default function CaseDetailNavigation({
               end
             >
               Case Overview
+            </NavLink>
+          </li>
+          <li className="usa-sidenav__item">
+            <NavLink
+              to={`/case-detail/${caseId}/trustee-and-assigned-staff`}
+              data-testid="case-trustee-and-assigned-staff-link"
+              className={
+                'usa-nav-link ' + setCurrentNav(activeNav, NavState.TRUSTEE_AND_ASSIGNED_STAFF)
+              }
+              onClick={() => setActiveNav(NavState.TRUSTEE_AND_ASSIGNED_STAFF)}
+              title="view trustee and assigned staff details for the current case"
+              end
+            >
+              Trustee & Assigned Staff
             </NavLink>
           </li>
           <li className="usa-sidenav__item">

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import useFeatureFlags, { VIEW_TRUSTEE } from '@/lib/hooks/UseFeatureFlags';
+import useFeatureFlags, { VIEW_TRUSTEE_ON_CASE } from '@/lib/hooks/UseFeatureFlags';
 
 export function mapNavState(path: string) {
   const cleanPath = path.replace(/\/$/, '').split('/');
@@ -68,7 +68,7 @@ export default function CaseDetailNavigation({
               Case Overview
             </NavLink>
           </li>
-          {featureFlags[VIEW_TRUSTEE] && (
+          {featureFlags[VIEW_TRUSTEE_ON_CASE] && (
             <li className="usa-sidenav__item">
               <NavLink
                 to={`/case-detail/${caseId}/trustee-and-assigned-staff`}

--- a/user-interface/src/case-detail/panels/CaseDetailOverview.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailOverview.test.tsx
@@ -291,11 +291,11 @@ describe('Case detail basic information panel', () => {
       expect(screen.queryByTestId('verified-transfer-header')).not.toBeInTheDocument();
       const ambiguousTransferText = screen.queryByTestId('ambiguous-transfer-text');
       expect(ambiguousTransferText).toHaveTextContent(
-        'This case was transfered to another court. Review the docket for further details.',
+        'This case was transferred to another court. Review the docket for further details.',
       );
     });
 
-    test('should display information about case being transfered in when there is no verified transfer', async () => {
+    test('should display information about case being transferred in when there is no verified transfer', async () => {
       const transferredCase = {
         ...BASE_TEST_CASE_DETAIL,
         petitionCode: 'TI',
@@ -305,7 +305,7 @@ describe('Case detail basic information panel', () => {
       expect(screen.queryByTestId('verified-transfer-header')).not.toBeInTheDocument();
       const ambiguousTransferText = screen.queryByTestId('ambiguous-transfer-text');
       expect(ambiguousTransferText).toHaveTextContent(
-        'This case was transfered from another court. Review the docket for further details.',
+        'This case was transferred from another court. Review the docket for further details.',
       );
     });
 

--- a/user-interface/src/case-detail/panels/CaseDetailOverview.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailOverview.test.tsx
@@ -14,6 +14,7 @@ import LocalStorage from '@/lib/utils/local-storage';
 import { ResponseBody } from '@common/api/response';
 import Api2 from '@/lib/models/api2';
 import testingUtilities from '@/lib/testing/testing-utilities';
+import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 
 const TEST_CASE_ID = '101-23-12345';
 const OLD_CASE_ID = '111-20-11111';
@@ -90,12 +91,32 @@ describe('Case detail basic information panel', () => {
     );
   }
 
+  beforeEach(() => {
+    const mockFeatureFlags = {
+      [FeatureFlagHook.VIEW_TRUSTEE_ON_CASE]: false,
+    };
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('With expected case detail properties', () => {
     test('should show debtor counsel office', () => {
       renderWithProps();
       const element = screen.queryByTestId('case-detail-debtor-counsel-office');
       expect(element).toBeInTheDocument();
       expect(element?.textContent).toEqual(BASE_TEST_CASE_DETAIL.debtorAttorney?.office);
+    });
+
+    test('should not show assigned staff information if the feature flag is disabled', () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        [FeatureFlagHook.VIEW_TRUSTEE_ON_CASE]: true,
+      });
+      renderWithProps();
+      const element = document.querySelector('.assigned-staff-information');
+      expect(element).not.toBeInTheDocument();
     });
 
     test('should show edit button and open the staff assignment modal if the user is a case assignment manager', () => {

--- a/user-interface/src/case-detail/panels/CaseDetailOverview.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailOverview.tsx
@@ -55,9 +55,9 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
 
   return (
     <>
-      <div className="grid-row grid-gap-lg">
-        <span className="case-card-list grid-col-6">
-          <div className="date-information padding-bottom-4 case-card">
+      <div className="grid-col-12 tablet:grid-col-10 desktop:grid-col-8 case-detail-container">
+        <span className="case-card-list">
+          <div className="date-information case-card">
             <h3>Dates</h3>
             <div className="date-list">
               <ul className="usa-list usa-list--unstyled">
@@ -93,7 +93,7 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
             </div>
           </div>
           {!featureFlags[VIEW_TRUSTEE_ON_CASE] && (
-            <div className="assigned-staff-information padding-bottom-4 case-card">
+            <div className="assigned-staff-information case-card">
               <h3>
                 Assigned Staff{' '}
                 {Actions.contains(caseDetail, Actions.ManageAssignments) &&
@@ -145,7 +145,7 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
               </div>
             </div>
           )}
-          <div className="judge-information padding-bottom-4 case-card">
+          <div className="judge-information case-card">
             <h3>Judge</h3>
             {caseDetail.judgeName && (
               <div className="case-detail-judge-name" data-testid="case-detail-judge-name">
@@ -159,85 +159,83 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
             )}
           </div>
         </span>
-        <span className="case-card-list grid-col-6">
-          <div className="debtor-information padding-bottom-4 case-card">
+        <span className="case-card-list">
+          <div className="debtor-information case-card">
             <h3>Debtor</h3>
-            <ul className="usa-list usa-list--unstyled">
-              <li data-testid="case-detail-debtor-name" aria-label="debtor name">
-                {caseDetail.debtor.name}
-              </li>
-              {caseDetail.debtor.taxId && (
-                <li
-                  data-testid="case-detail-debtor-taxId"
-                  aria-label="debtor employer identification number"
-                >
-                  <span className="case-detail-item-name">EIN:</span>
-                  <span className="case-detail-item-value">{caseDetail.debtor.taxId}</span>
-                </li>
-              )}
-              {caseDetail.debtor.ssn && (
-                <li data-testid="case-detail-debtor-ssn" aria-label="debtor social security number">
-                  <span className="case-detail-item-name">SSN/ITIN:</span>
-                  <span className="case-detail-item-value">{caseDetail.debtor.ssn}</span>
-                </li>
-              )}
-              {!caseDetail.debtor.taxId && !caseDetail.debtor.ssn && (
-                <li
-                  data-testid="case-detail-debtor-no-taxids"
-                  aria-label="debtor tax identification"
-                >
-                  {taxIdUnavailable}
-                </li>
-              )}
-              <li data-testid="case-detail-debtor-type" aria-label="debtor type">
-                {caseDetail.debtorTypeLabel}
-              </li>
-            </ul>
-            {caseDetail.debtor.address1 && (
-              <div data-testid="case-detail-debtor-address1" aria-label="debtor address line 1">
-                {caseDetail.debtor.address1}
-              </div>
-            )}
-            {caseDetail.debtor.address2 && (
-              <div data-testid="case-detail-debtor-address2" aria-label="debtor address line 2">
-                {caseDetail.debtor.address2}
-              </div>
-            )}
-            {caseDetail.debtor.address3 && (
-              <div data-testid="case-detail-debtor-address3" aria-label="debtor address line 3">
-                {caseDetail.debtor.address3}
-              </div>
-            )}
-            {caseDetail.debtor.cityStateZipCountry && (
+            <div data-testid="case-detail-debtor-name" aria-label="debtor name">
+              {caseDetail.debtor.name}
+            </div>
+            {caseDetail.debtor.taxId && (
               <div
-                data-testid="case-detail-debtor-cityStateZipCountry"
-                aria-label="debtor city, state, zip, country"
+                data-testid="case-detail-debtor-taxId"
+                aria-label="debtor employer identification number"
               >
-                {caseDetail.debtor.cityStateZipCountry}
+                <span className="case-detail-item-name">EIN:</span>
+                <span className="case-detail-item-value">{caseDetail.debtor.taxId}</span>
               </div>
             )}
+            {caseDetail.debtor.ssn && (
+              <div
+                data-testid="case-detail-debtor-ssn"
+                aria-label="debtor social security number or individual taxpayer identification number"
+              >
+                <span className="case-detail-item-name">SSN/ITIN:</span>
+                <span className="case-detail-item-value">{caseDetail.debtor.ssn}</span>
+              </div>
+            )}
+            {!caseDetail.debtor.taxId && !caseDetail.debtor.ssn && (
+              <div
+                data-testid="case-detail-debtor-no-taxids"
+                aria-label="debtor tax identification"
+              >
+                {taxIdUnavailable}
+              </div>
+            )}
+            <div data-testid="case-detail-debtor-type" aria-label="debtor type">
+              {caseDetail.debtorTypeLabel}
+            </div>
+            <div>
+              {caseDetail.debtor.address1 && (
+                <div data-testid="case-detail-debtor-address1" aria-label="debtor address line 1">
+                  {caseDetail.debtor.address1}
+                </div>
+              )}
+              {caseDetail.debtor.address2 && (
+                <div data-testid="case-detail-debtor-address2" aria-label="debtor address line 2">
+                  {caseDetail.debtor.address2}
+                </div>
+              )}
+              {caseDetail.debtor.address3 && (
+                <div data-testid="case-detail-debtor-address3" aria-label="debtor address line 3">
+                  {caseDetail.debtor.address3}
+                </div>
+              )}
+              {caseDetail.debtor.cityStateZipCountry && (
+                <div
+                  data-testid="case-detail-debtor-cityStateZipCountry"
+                  aria-label="debtor city, state, zip, country"
+                >
+                  {caseDetail.debtor.cityStateZipCountry}
+                </div>
+              )}
+            </div>
           </div>
-          <div className="debtor-counsel-information padding-bottom-4 case-card">
+          <div className="debtor-counsel-information case-card">
             <h3>Debtor&apos;s Counsel</h3>
             {caseDetail.debtorAttorney && (
               <>
-                <div
-                  className="padding-bottom-1"
-                  data-testid="case-detail-debtor-counsel-name"
-                  aria-label="debtor counsel name"
-                >
+                <div data-testid="case-detail-debtor-counsel-name" aria-label="debtor counsel name">
                   {caseDetail.debtorAttorney.name}
                 </div>
                 {caseDetail.debtorAttorney.office && (
                   <div
-                    className="padding-bottom-1"
                     data-testid="case-detail-debtor-counsel-office"
                     aria-label="debtor counsel office"
                   >
                     {caseDetail.debtorAttorney.office}
                   </div>
                 )}
-                <div className="padding-bottom-1">
+                <div>
                   {caseDetail.debtorAttorney.address1 && (
                     <div
                       data-testid="case-detail-debtor-counsel-address1"
@@ -273,7 +271,6 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
                 </div>
                 {caseDetail.debtorAttorney.phone && (
                   <div
-                    className="padding-bottom-1"
                     data-testid="case-detail-debtor-counsel-phone"
                     aria-label="debtor counsel phone"
                   >
@@ -282,7 +279,6 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
                 )}
                 {caseDetail.debtorAttorney.email && (
                   <div
-                    className="padding-bottom-1"
                     data-testid="case-detail-debtor-counsel-email"
                     aria-label="debtor counsel email"
                   >
@@ -350,7 +346,7 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
             <>
               <h3>Transferred Case</h3>
               <p data-testid="ambiguous-transfer-text">
-                This case was transfered {isAmbiguousTransferOut ? 'to' : 'from'} another court.
+                This case was transferred {isAmbiguousTransferOut ? 'to' : 'from'} another court.
                 Review the docket for further details.
               </p>
             </>

--- a/user-interface/src/case-detail/panels/CaseDetailOverview.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailOverview.tsx
@@ -18,6 +18,7 @@ import { AttorneyUser } from '@common/cams/users';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
 import Icon from '@/lib/components/uswds/Icon';
 import { OpenModalButtonRef } from '../../lib/components/uswds/modal/modal-refs';
+import useFeatureFlags, { VIEW_TRUSTEE_ON_CASE } from '@/lib/hooks/UseFeatureFlags';
 
 const informationUnavailable = 'Information is not available.';
 const taxIdUnavailable = 'Tax ID information is not available.';
@@ -30,6 +31,7 @@ export interface CaseDetailOverviewProps {
 
 export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
   const { caseDetail, showReopenDate, onCaseAssignment } = props;
+  const featureFlags = useFeatureFlags();
 
   const assignmentModalRef = useRef<AssignAttorneyModalRef>(null);
   const openModalButtonRef = useRef<OpenModalButtonRef>(null);
@@ -90,57 +92,59 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
               </ul>
             </div>
           </div>
-          <div className="assigned-staff-information padding-bottom-4 case-card">
-            <h3>
-              Assigned Staff{' '}
-              {Actions.contains(caseDetail, Actions.ManageAssignments) &&
-                caseDetail.chapter === '15' && (
-                  <OpenModalButton
-                    uswdsStyle={UswdsButtonStyle.Unstyled}
-                    modalId={'assignmentModalId'}
-                    modalRef={assignmentModalRef}
-                    ref={openModalButtonRef}
-                    openProps={{ bCase: caseDetail, callback: handleCaseAssignment }}
-                    ariaLabel="Edit assigned staff"
-                    title="Open Staff Assignment window"
+          {!featureFlags[VIEW_TRUSTEE_ON_CASE] && (
+            <div className="assigned-staff-information padding-bottom-4 case-card">
+              <h3>
+                Assigned Staff{' '}
+                {Actions.contains(caseDetail, Actions.ManageAssignments) &&
+                  caseDetail.chapter === '15' && (
+                    <OpenModalButton
+                      uswdsStyle={UswdsButtonStyle.Unstyled}
+                      modalId={'assignmentModalId'}
+                      modalRef={assignmentModalRef}
+                      ref={openModalButtonRef}
+                      openProps={{ bCase: caseDetail, callback: handleCaseAssignment }}
+                      ariaLabel="Edit assigned staff"
+                      title="Open Staff Assignment window"
+                    >
+                      <IconLabel icon="edit" label="Edit" />
+                    </OpenModalButton>
+                  )}
+              </h3>
+              <div className="assigned-staff-list">
+                {caseDetail.regionId && (
+                  <div
+                    className="case-detail-region-id"
+                    data-testid="case-detail-region-id"
+                    aria-label="assigned region and office"
                   >
-                    <IconLabel icon="edit" label="Edit" />
-                  </OpenModalButton>
+                    Region {caseDetail.regionId.replace(/^0*/, '')} - {caseDetail.officeName} Office
+                  </div>
                 )}
-            </h3>
-            <div className="assigned-staff-list">
-              {caseDetail.regionId && (
-                <div
-                  className="case-detail-region-id"
-                  data-testid="case-detail-region-id"
-                  aria-label="assigned region and office"
-                >
-                  Region {caseDetail.regionId.replace(/^0*/, '')} - {caseDetail.officeName} Office
-                </div>
-              )}
-              {(typeof caseDetail.assignments === 'undefined' ||
-                caseDetail.assignments.length === 0) && (
-                <span className="unassigned-placeholder">(unassigned)</span>
-              )}
-              {caseDetail.assignments && caseDetail.assignments.length > 0 && (
-                <ul className="usa-list usa-list--unstyled">
-                  {caseDetail.assignments &&
-                    caseDetail.assignments.length > 0 &&
-                    (caseDetail.assignments as Array<AttorneyUser>)?.map(
-                      (staff: AttorneyUser, idx: number) => {
-                        return (
-                          <li key={idx} className="individual-assignee">
-                            <span className="assignee-name">{staff.name}</span>
-                            <span className="vertical-divider"> | </span>
-                            <span className="assignee-role">Trial Attorney</span>
-                          </li>
-                        );
-                      },
-                    )}
-                </ul>
-              )}
+                {(typeof caseDetail.assignments === 'undefined' ||
+                  caseDetail.assignments.length === 0) && (
+                  <span className="unassigned-placeholder">(unassigned)</span>
+                )}
+                {caseDetail.assignments && caseDetail.assignments.length > 0 && (
+                  <ul className="usa-list usa-list--unstyled">
+                    {caseDetail.assignments &&
+                      caseDetail.assignments.length > 0 &&
+                      (caseDetail.assignments as Array<AttorneyUser>)?.map(
+                        (staff: AttorneyUser, idx: number) => {
+                          return (
+                            <li key={idx} className="individual-assignee">
+                              <span className="assignee-name">{staff.name}</span>
+                              <span className="vertical-divider"> | </span>
+                              <span className="assignee-role">Trial Attorney</span>
+                            </li>
+                          );
+                        },
+                      )}
+                  </ul>
+                )}
+              </div>
             </div>
-          </div>
+          )}
           <div className="judge-information padding-bottom-4 case-card">
             <h3>Judge</h3>
             {caseDetail.judgeName && (
@@ -154,6 +158,8 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
               </div>
             )}
           </div>
+        </span>
+        <span className="case-card-list grid-col-6">
           <div className="debtor-information padding-bottom-4 case-card">
             <h3>Debtor</h3>
             <ul className="usa-list usa-list--unstyled">
@@ -298,8 +304,6 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
               </div>
             )}
           </div>
-        </span>
-        <span className="case-card-list grid-col-6">
           {!!caseDetail.consolidation?.length && caseDetail.consolidation.length > 0 && (
             <>
               <h3>Consolidation</h3>

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
@@ -208,7 +208,7 @@ describe('CaseDetailTrusteeAndAssignedStaff', () => {
       expect(trusteeName?.textContent).toEqual(TEST_TRUSTEE.name);
     });
 
-    test('should display trustee email as mailto link with proper subject', () => {
+    test('should display trustee email as mailto link with proper subject and icon', () => {
       renderWithProps();
       const emailElement = screen.queryByTestId('case-detail-trustee-email');
       expect(emailElement).toBeInTheDocument();
@@ -219,11 +219,8 @@ describe('CaseDetailTrusteeAndAssignedStaff', () => {
       expect(emailLink?.getAttribute('href')).toEqual(
         `mailto:${TEST_TRUSTEE.email}?subject=${getCaseNumber(BASE_TEST_CASE_DETAIL.caseId)} - ${BASE_TEST_CASE_DETAIL.caseTitle}`,
       );
-    });
 
-    test('should display email with mail icon', () => {
-      renderWithProps();
-      const emailElement = screen.queryByTestId('case-detail-trustee-email');
+      // Verify mail icon is present
       const mailIcon = emailElement?.querySelector('.link-icon');
       expect(mailIcon).toBeInTheDocument();
     });
@@ -354,58 +351,6 @@ describe('CaseDetailTrusteeAndAssignedStaff', () => {
 
       const childCaseMessage = screen.queryByTestId('alert-message');
       expect(childCaseMessage).not.toBeInTheDocument();
-    });
-
-    test('should properly initialize AssignAttorneyModal with correct props', () => {
-      renderWithProps();
-      const modal = document.querySelector('.usa-modal-wrapper');
-      expect(modal).toBeInTheDocument();
-
-      const assignModal = screen.getByTestId(`modal-${assignmentModalId}`);
-      expect(assignModal).toBeInTheDocument();
-    });
-  });
-
-  describe('Edge Cases and Props Handling', () => {
-    test('should handle required props correctly', () => {
-      expect(() => {
-        renderWithProps({
-          caseDetail: BASE_TEST_CASE_DETAIL,
-          onCaseAssignment: vi.fn(),
-        });
-      }).not.toThrow();
-    });
-
-    test('should handle empty assignments array properly', () => {
-      const caseDetailEmptyAssignments = {
-        ...BASE_TEST_CASE_DETAIL,
-        assignments: [],
-      };
-      renderWithProps({ caseDetail: caseDetailEmptyAssignments });
-
-      const placeholder = screen.getByText('(unassigned)');
-      expect(placeholder).toBeInTheDocument();
-
-      const assignmentList = document.querySelector('.usa-list');
-      expect(assignmentList).not.toBeInTheDocument();
-    });
-
-    test('should handle missing region and office data', () => {
-      const caseDetailNoRegionOffice = MockData.getCaseDetail({
-        override: {
-          ...BASE_TEST_CASE_DETAIL,
-          regionId: '',
-          officeName: '',
-        },
-      });
-      renderWithProps({ caseDetail: caseDetailNoRegionOffice });
-
-      const regionElement = screen.queryByTestId('case-detail-region-id');
-      expect(regionElement).not.toBeInTheDocument();
-
-      // Should still render the assigned staff section
-      const heading = screen.getByRole('heading', { name: /assigned staff/i });
-      expect(heading).toBeInTheDocument();
     });
   });
 });

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
@@ -1,0 +1,411 @@
+import { BrowserRouter } from 'react-router-dom';
+import CaseDetailTrusteeAndAssignedStaff, {
+  CaseDetailTrusteeAndAssignedStaffProps,
+} from './CaseDetailTrusteeAndAssignedStaff';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { getCaseNumber } from '@/lib/utils/caseNumber';
+import { CaseDetail } from '@common/cams/cases';
+import { MockData } from '@common/cams/test-utilities/mock-data';
+import Actions from '@common/cams/actions';
+import { AttorneyUser, CamsUser } from '@common/cams/users';
+import { MockAttorneys } from '@common/cams/test-utilities/attorneys.mock';
+import { CamsRole } from '@common/cams/roles';
+import LocalStorage from '@/lib/utils/local-storage';
+import { ResponseBody } from '@common/api/response';
+import Api2 from '@/lib/models/api2';
+import testingUtilities from '@/lib/testing/testing-utilities';
+import { Consolidation } from '@common/cams/events';
+
+const TEST_CASE_ID = '101-23-12345';
+const TEST_TRIAL_ATTORNEY_1 = MockAttorneys.Brian;
+const TEST_ASSIGNMENT_1 = MockData.getAttorneyAssignment({ ...TEST_TRIAL_ATTORNEY_1 });
+const TEST_TRIAL_ATTORNEY_2 = MockAttorneys.Carl;
+const TEST_ASSIGNMENT_2 = MockData.getAttorneyAssignment({ ...TEST_TRIAL_ATTORNEY_2 });
+const TEST_TRUSTEE = MockData.getTrustee();
+
+const BASE_TEST_CASE_DETAIL = MockData.getCaseDetail({
+  override: {
+    caseId: TEST_CASE_ID,
+    chapter: '15',
+    assignments: [TEST_ASSIGNMENT_1, TEST_ASSIGNMENT_2],
+    trustee: TEST_TRUSTEE,
+    _actions: [Actions.ManageAssignments],
+  },
+});
+
+const CONSOLIDATE_TO: Consolidation = {
+  caseId: TEST_CASE_ID,
+  otherCase: MockData.getCaseSummary({ override: { caseId: '222-24-00001' } }),
+  orderDate: '01-12-2024',
+  consolidationType: 'administrative',
+  documentType: 'CONSOLIDATION_TO',
+  updatedBy: MockData.getCamsUser(),
+  updatedOn: '01-12-2024',
+};
+
+const attorneyList: AttorneyUser[] = MockData.buildArray(MockData.getAttorneyUser, 2);
+
+describe('CaseDetailTrusteeAndAssignedStaff', () => {
+  const attorneyListResponse: ResponseBody<AttorneyUser[]> = {
+    meta: { self: 'self-url' },
+    data: attorneyList,
+  };
+  vi.spyOn(Api2, 'getAttorneys').mockResolvedValue(attorneyListResponse);
+
+  function renderWithProps(props?: Partial<CaseDetailTrusteeAndAssignedStaffProps>) {
+    const defaultProps: CaseDetailTrusteeAndAssignedStaffProps = {
+      caseDetail: BASE_TEST_CASE_DETAIL,
+      onCaseAssignment: vi.fn(),
+    };
+
+    const renderProps = { ...defaultProps, ...props };
+    render(
+      <BrowserRouter>
+        <CaseDetailTrusteeAndAssignedStaff {...renderProps} />
+      </BrowserRouter>,
+    );
+  }
+
+  describe('Assigned Staff Section', () => {
+    test('should render the assigned staff section with proper heading', () => {
+      renderWithProps();
+      const heading = screen.getByRole('heading', { name: /assigned staff/i });
+      expect(heading).toBeInTheDocument();
+    });
+
+    test('should show region and office information when available', () => {
+      renderWithProps();
+      const regionElement = screen.queryByTestId('case-detail-region-id');
+      expect(regionElement).toBeInTheDocument();
+      expect(regionElement?.textContent).toEqual(
+        `Region ${BASE_TEST_CASE_DETAIL.regionId?.replace(/^0*/, '')} - ${BASE_TEST_CASE_DETAIL.officeName} Office`,
+      );
+    });
+
+    test('should not show region information when not available', () => {
+      const caseDetailNoRegion = MockData.getCaseDetail({
+        override: {
+          ...BASE_TEST_CASE_DETAIL,
+          regionId: '',
+          officeName: '',
+        },
+      });
+      renderWithProps({ caseDetail: caseDetailNoRegion });
+      const regionElement = screen.queryByTestId('case-detail-region-id');
+      expect(regionElement).not.toBeInTheDocument();
+    });
+
+    test('should show unassigned placeholder when no assignments exist', () => {
+      const caseDetailNoAssignments = {
+        ...BASE_TEST_CASE_DETAIL,
+        assignments: [],
+      };
+      renderWithProps({ caseDetail: caseDetailNoAssignments });
+      const placeholder = screen.getByText('(unassigned)');
+      expect(placeholder).toBeInTheDocument();
+    });
+
+    test('should show unassigned placeholder when assignments is undefined', () => {
+      const caseDetailUndefinedAssignments = {
+        ...BASE_TEST_CASE_DETAIL,
+        assignments: undefined,
+      };
+      renderWithProps({ caseDetail: caseDetailUndefinedAssignments });
+      const placeholder = screen.getByText('(unassigned)');
+      expect(placeholder).toBeInTheDocument();
+    });
+
+    test('should render list of assigned staff with names and roles', () => {
+      renderWithProps();
+
+      // Check that assignments are rendered
+      const assigneeNames = screen.getAllByText((_content, element) => {
+        return element?.classList.contains('assignee-name') || false;
+      });
+      expect(assigneeNames).toHaveLength(2);
+      expect(assigneeNames[0]).toHaveTextContent(TEST_TRIAL_ATTORNEY_1.name);
+      expect(assigneeNames[1]).toHaveTextContent(TEST_TRIAL_ATTORNEY_2.name);
+
+      // Check that roles are shown
+      const roles = screen.getAllByText('Trial Attorney');
+      expect(roles).toHaveLength(2);
+    });
+
+    test('should show edit button when user has ManageAssignments action and case is chapter 15', () => {
+      const user: CamsUser = MockData.getCamsUser({
+        roles: [CamsRole.CaseAssignmentManager],
+      });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
+
+      renderWithProps();
+      const editButton = screen.getByTestId('open-modal-button');
+      expect(editButton).toBeInTheDocument();
+      expect(editButton).toBeVisible();
+    });
+
+    test('should not show edit button when user lacks ManageAssignments action', () => {
+      const caseDetailNoActions = {
+        ...BASE_TEST_CASE_DETAIL,
+        _actions: [],
+      };
+      renderWithProps({ caseDetail: caseDetailNoActions });
+      const editButton = screen.queryByTestId('open-modal-button');
+      expect(editButton).not.toBeInTheDocument();
+    });
+
+    test('should not show edit button for non-chapter 15 cases', () => {
+      const caseDetailChapter7 = {
+        ...BASE_TEST_CASE_DETAIL,
+        chapter: '7',
+      };
+      renderWithProps({ caseDetail: caseDetailChapter7 });
+      const editButton = screen.queryByTestId('open-modal-button');
+      expect(editButton).not.toBeInTheDocument();
+    });
+
+    test('should open assignment modal when edit button is clicked', () => {
+      const user: CamsUser = MockData.getCamsUser({
+        roles: [CamsRole.CaseAssignmentManager],
+      });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
+
+      renderWithProps();
+      const modal = document.querySelector('.usa-modal-wrapper');
+      expect(modal).toBeInTheDocument();
+      expect(modal).not.toHaveClass('is-visible');
+
+      const editButton = screen.getByTestId('open-modal-button');
+      fireEvent.click(editButton);
+
+      const attorneyModal = document.querySelector('.assign-attorney-modal');
+      expect(attorneyModal).toBeInTheDocument();
+      expect(attorneyModal).toBeVisible();
+      expect(modal).toHaveClass('is-visible');
+    });
+  });
+
+  describe('Trustee Section', () => {
+    test('should render trustee section when trustee data exists', () => {
+      renderWithProps();
+      const trusteeHeading = screen.getByRole('heading', { name: /trustee/i });
+      expect(trusteeHeading).toBeInTheDocument();
+    });
+
+    test('should not render trustee section when no trustee data', () => {
+      const caseDetailNoTrustee = {
+        ...BASE_TEST_CASE_DETAIL,
+        trustee: undefined,
+      };
+      renderWithProps({ caseDetail: caseDetailNoTrustee });
+      const trusteeHeading = screen.queryByRole('heading', { name: /trustee/i });
+      expect(trusteeHeading).not.toBeInTheDocument();
+    });
+
+    test('should display trustee name', () => {
+      renderWithProps();
+      const trusteeName = document.querySelector('.trustee-name');
+      expect(trusteeName).toBeInTheDocument();
+      expect(trusteeName?.textContent).toEqual(TEST_TRUSTEE.name);
+    });
+
+    test('should display trustee email as mailto link with proper subject', () => {
+      renderWithProps();
+      const emailElement = screen.queryByTestId('case-detail-trustee-email');
+      expect(emailElement).toBeInTheDocument();
+
+      const emailLink = emailElement?.querySelector('a');
+      expect(emailLink).toBeInTheDocument();
+      expect(emailLink?.textContent).toContain(TEST_TRUSTEE.email);
+      expect(emailLink?.getAttribute('href')).toEqual(
+        `mailto:${TEST_TRUSTEE.email}?subject=${getCaseNumber(BASE_TEST_CASE_DETAIL.caseId)} - ${BASE_TEST_CASE_DETAIL.caseTitle}`,
+      );
+    });
+
+    test('should display email with mail icon', () => {
+      renderWithProps();
+      const emailElement = screen.queryByTestId('case-detail-trustee-email');
+      const mailIcon = emailElement?.querySelector('.link-icon');
+      expect(mailIcon).toBeInTheDocument();
+    });
+
+    test('should not display email section when trustee has no email', () => {
+      const trusteeNoEmail = { ...TEST_TRUSTEE, email: undefined };
+      const caseDetailNoEmail = {
+        ...BASE_TEST_CASE_DETAIL,
+        trustee: trusteeNoEmail,
+      };
+      renderWithProps({ caseDetail: caseDetailNoEmail });
+      const emailElement = screen.queryByTestId('case-detail-trustee-email');
+      expect(emailElement).not.toBeInTheDocument();
+    });
+
+    test('should display trustee phone number', () => {
+      renderWithProps();
+      const phoneElement = document.querySelector('.trustee-phone-number');
+      expect(phoneElement).toBeInTheDocument();
+      expect(phoneElement?.textContent).toEqual(TEST_TRUSTEE.phone);
+    });
+
+    test('should display all trustee address fields', () => {
+      renderWithProps();
+
+      const addressElements = document.querySelectorAll('.trustee-address');
+      expect(addressElements).toHaveLength(3);
+      expect(addressElements[0]?.textContent).toEqual(TEST_TRUSTEE.address1);
+      expect(addressElements[1]?.textContent).toEqual(TEST_TRUSTEE.address2);
+      expect(addressElements[2]?.textContent).toEqual(TEST_TRUSTEE.address3);
+
+      const cityStateElement = document.querySelector('.trustee-city');
+      expect(cityStateElement).toBeInTheDocument();
+      expect(cityStateElement?.textContent).toEqual(TEST_TRUSTEE.cityStateZipCountry);
+    });
+
+    test('should handle partial trustee address data gracefully', () => {
+      const partialTrustee = {
+        ...TEST_TRUSTEE,
+        address2: undefined,
+        address3: undefined,
+      };
+      const caseDetailPartialAddress = {
+        ...BASE_TEST_CASE_DETAIL,
+        trustee: partialTrustee,
+      };
+      renderWithProps({ caseDetail: caseDetailPartialAddress });
+
+      const addressElements = document.querySelectorAll('.trustee-address');
+      expect(addressElements).toHaveLength(3); // Elements still exist
+      expect(addressElements[0]?.textContent).toEqual(partialTrustee.address1);
+      expect(addressElements[1]?.textContent).toEqual(''); // Empty for undefined address2
+      expect(addressElements[2]?.textContent).toEqual(''); // Empty for undefined address3
+    });
+  });
+
+  describe('Modal and Assignment Functionality', () => {
+    const assignmentModalId = 'assignmentModalId';
+
+    test('should call handleCaseAssignment callback when assignment is completed', async () => {
+      const apiResult = {
+        data: undefined,
+      };
+      vi.spyOn(Api2, 'postStaffAssignments').mockResolvedValue(apiResult);
+
+      const onCaseAssignment = vi.fn();
+      renderWithProps({ onCaseAssignment });
+
+      const assignedStaffEditButton = screen.getByTestId('open-modal-button');
+      fireEvent.click(assignedStaffEditButton);
+
+      const modal = screen.getByTestId(`modal-${assignmentModalId}`);
+      await waitFor(() => {
+        expect(modal).toBeVisible();
+      });
+
+      await testingUtilities.selectCheckbox('0-checkbox');
+
+      const submitButton = screen.getByTestId(`button-${assignmentModalId}-submit-button`);
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(onCaseAssignment).toHaveBeenCalledWith(
+          expect.objectContaining({
+            apiResult,
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(modal).toHaveClass('is-hidden');
+      });
+    });
+
+    test('should show joint administration warning for child cases', async () => {
+      const caseDetail: CaseDetail = { ...BASE_TEST_CASE_DETAIL, consolidation: [CONSOLIDATE_TO] };
+      const onCaseAssignment = vi.fn();
+      renderWithProps({
+        caseDetail,
+        onCaseAssignment,
+      });
+
+      const assignedStaffEditButton = screen.getByTestId('open-modal-button');
+      fireEvent.click(assignedStaffEditButton);
+
+      const modal = screen.getByTestId(`modal-${assignmentModalId}`);
+      await waitFor(() => {
+        expect(modal).toBeVisible();
+      });
+
+      const childCaseMessage = screen.getByTestId('alert-message');
+      expect(childCaseMessage).toHaveTextContent(
+        'The assignees for this case will not match the lead case.',
+      );
+    });
+
+    test('should not show joint administration warning for non-child cases', async () => {
+      const onCaseAssignment = vi.fn();
+      renderWithProps({ onCaseAssignment });
+
+      const assignedStaffEditButton = screen.getByTestId('open-modal-button');
+      fireEvent.click(assignedStaffEditButton);
+
+      const modal = screen.getByTestId(`modal-${assignmentModalId}`);
+      await waitFor(() => {
+        expect(modal).toBeVisible();
+      });
+
+      const childCaseMessage = screen.queryByTestId('alert-message');
+      expect(childCaseMessage).not.toBeInTheDocument();
+    });
+
+    test('should properly initialize AssignAttorneyModal with correct props', () => {
+      renderWithProps();
+      const modal = document.querySelector('.usa-modal-wrapper');
+      expect(modal).toBeInTheDocument();
+
+      const assignModal = screen.getByTestId(`modal-${assignmentModalId}`);
+      expect(assignModal).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases and Props Handling', () => {
+    test('should handle required props correctly', () => {
+      expect(() => {
+        renderWithProps({
+          caseDetail: BASE_TEST_CASE_DETAIL,
+          onCaseAssignment: vi.fn(),
+        });
+      }).not.toThrow();
+    });
+
+    test('should handle empty assignments array properly', () => {
+      const caseDetailEmptyAssignments = {
+        ...BASE_TEST_CASE_DETAIL,
+        assignments: [],
+      };
+      renderWithProps({ caseDetail: caseDetailEmptyAssignments });
+
+      const placeholder = screen.getByText('(unassigned)');
+      expect(placeholder).toBeInTheDocument();
+
+      const assignmentList = document.querySelector('.usa-list');
+      expect(assignmentList).not.toBeInTheDocument();
+    });
+
+    test('should handle missing region and office data', () => {
+      const caseDetailNoRegionOffice = MockData.getCaseDetail({
+        override: {
+          ...BASE_TEST_CASE_DETAIL,
+          regionId: '',
+          officeName: '',
+        },
+      });
+      renderWithProps({ caseDetail: caseDetailNoRegionOffice });
+
+      const regionElement = screen.queryByTestId('case-detail-region-id');
+      expect(regionElement).not.toBeInTheDocument();
+
+      // Should still render the assigned staff section
+      const heading = screen.getByRole('heading', { name: /assigned staff/i });
+      expect(heading).toBeInTheDocument();
+    });
+  });
+});

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
@@ -1,0 +1,143 @@
+import { isJointAdministrationChildCase } from '@common/cams/events';
+import { CaseDetail } from '@common/cams/cases';
+import { UswdsButtonStyle } from '@/lib/components/uswds/Button';
+import AssignAttorneyModal from '@/staff-assignment/modal/AssignAttorneyModal';
+import {
+  AssignAttorneyModalCallbackProps,
+  AssignAttorneyModalRef,
+} from '@/staff-assignment/modal/assignAttorneyModal.types';
+import { OpenModalButton } from '@/lib/components/uswds/modal/OpenModalButton';
+import { useRef } from 'react';
+import { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import Actions from '@common/cams/actions';
+import { AttorneyUser } from '@common/cams/users';
+import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
+import { OpenModalButtonRef } from '../../lib/components/uswds/modal/modal-refs';
+import { getCaseNumber } from '@/lib/utils/caseNumber';
+import Icon from '@/lib/components/uswds/Icon';
+
+export interface CaseDetailTrusteeAndAssignedStaffProps {
+  caseDetail: CaseDetail;
+  onCaseAssignment: (props: AssignAttorneyModalCallbackProps) => void;
+}
+
+export default function CaseDetailTrusteeAndAssignedStaff(
+  props: CaseDetailTrusteeAndAssignedStaffProps,
+) {
+  const { caseDetail, onCaseAssignment } = props;
+
+  const assignmentModalRef = useRef<AssignAttorneyModalRef>(null);
+  const openModalButtonRef = useRef<OpenModalButtonRef>(null);
+
+  function handleCaseAssignment(props: AssignAttorneyModalCallbackProps) {
+    onCaseAssignment(props);
+    assignmentModalRef.current?.hide();
+    openModalButtonRef.current?.focus();
+  }
+
+  return (
+    <>
+      <div className="grid-row grid-gap-lg">
+        <span className="case-card-list grid-col-6">
+          {caseDetail.trustee && (
+            <div className="assigned-staff-information padding-bottom-4 case-card">
+              <h3>Trustee</h3>
+              <span className="trustee-name">{caseDetail.trustee.name}</span>
+              <span className="trustee-phone-number">{caseDetail.trustee.phone}</span>
+              <span className="trustee-address">{caseDetail.trustee.address1}</span>
+              <span className="trustee-address">{caseDetail.trustee.address2}</span>
+              <span className="trustee-address">{caseDetail.trustee.address3}</span>
+              <div
+                className="city-state-postal-code"
+                aria-label="trustee city, state, zip, country"
+              >
+                <span className="trustee-city">{caseDetail.trustee.cityStateZipCountry}</span>,
+              </div>
+              {caseDetail.trustee.email && (
+                <div
+                  className="padding-bottom-1"
+                  data-testid="case-detail-trustee-email"
+                  aria-label="trustee email"
+                >
+                  <a
+                    href={`mailto:${caseDetail.trustee.email}?subject=${getCaseNumber(
+                      caseDetail.caseId,
+                    )} - ${caseDetail.caseTitle}`}
+                  >
+                    {caseDetail.trustee.email}
+                    <Icon className="link-icon" name="mail_outline" />
+                  </a>
+                </div>
+              )}
+            </div>
+          )}
+          <div className="assigned-staff-information padding-bottom-4 case-card">
+            <h3>
+              Assigned Staff{' '}
+              {Actions.contains(caseDetail, Actions.ManageAssignments) &&
+                caseDetail.chapter === '15' && (
+                  <OpenModalButton
+                    uswdsStyle={UswdsButtonStyle.Unstyled}
+                    modalId={'assignmentModalId'}
+                    modalRef={assignmentModalRef}
+                    ref={openModalButtonRef}
+                    openProps={{ bCase: caseDetail, callback: handleCaseAssignment }}
+                    ariaLabel="Edit assigned staff"
+                    title="Open Staff Assignment window"
+                  >
+                    <IconLabel icon="edit" label="Edit" />
+                  </OpenModalButton>
+                )}
+            </h3>
+            <div className="assigned-staff-list">
+              {caseDetail.regionId && (
+                <div
+                  className="case-detail-region-id"
+                  data-testid="case-detail-region-id"
+                  aria-label="assigned region and office"
+                >
+                  Region {caseDetail.regionId.replace(/^0*/, '')} - {caseDetail.officeName} Office
+                </div>
+              )}
+              {(typeof caseDetail.assignments === 'undefined' ||
+                caseDetail.assignments.length === 0) && (
+                <span className="unassigned-placeholder">(unassigned)</span>
+              )}
+              {caseDetail.assignments && caseDetail.assignments.length > 0 && (
+                <ul className="usa-list usa-list--unstyled">
+                  {caseDetail.assignments &&
+                    caseDetail.assignments.length > 0 &&
+                    (caseDetail.assignments as Array<AttorneyUser>)?.map(
+                      (staff: AttorneyUser, idx: number) => {
+                        return (
+                          <li key={idx} className="individual-assignee">
+                            <span className="assignee-name">{staff.name}</span>
+                            <span className="vertical-divider"> | </span>
+                            <span className="assignee-role">Trial Attorney</span>
+                          </li>
+                        );
+                      },
+                    )}
+                </ul>
+              )}
+            </div>
+          </div>
+        </span>
+      </div>
+      <AssignAttorneyModal
+        ref={assignmentModalRef}
+        modalId={'assignmentModalId'}
+        alertMessage={
+          isJointAdministrationChildCase(caseDetail.consolidation)
+            ? {
+                message: 'The assignees for this case will not match the lead case.',
+                type: UswdsAlertStyle.Warning,
+                timeOut: 0,
+              }
+            : undefined
+        }
+        assignmentChangeCallback={() => {}}
+      ></AssignAttorneyModal>
+    </>
+  );
+}

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
@@ -38,39 +38,7 @@ export default function CaseDetailTrusteeAndAssignedStaff(
   return (
     <>
       <div className="grid-row grid-gap-lg">
-        <span className="case-card-list grid-col-6">
-          {caseDetail.trustee && (
-            <div className="assigned-staff-information padding-bottom-4 case-card">
-              <h3>Trustee</h3>
-              <span className="trustee-name">{caseDetail.trustee.name}</span>
-              <span className="trustee-phone-number">{caseDetail.trustee.phone}</span>
-              <span className="trustee-address">{caseDetail.trustee.address1}</span>
-              <span className="trustee-address">{caseDetail.trustee.address2}</span>
-              <span className="trustee-address">{caseDetail.trustee.address3}</span>
-              <div
-                className="city-state-postal-code"
-                aria-label="trustee city, state, zip, country"
-              >
-                <span className="trustee-city">{caseDetail.trustee.cityStateZipCountry}</span>,
-              </div>
-              {caseDetail.trustee.email && (
-                <div
-                  className="padding-bottom-1"
-                  data-testid="case-detail-trustee-email"
-                  aria-label="trustee email"
-                >
-                  <a
-                    href={`mailto:${caseDetail.trustee.email}?subject=${getCaseNumber(
-                      caseDetail.caseId,
-                    )} - ${caseDetail.caseTitle}`}
-                  >
-                    {caseDetail.trustee.email}
-                    <Icon className="link-icon" name="mail_outline" />
-                  </a>
-                </div>
-              )}
-            </div>
-          )}
+        <div className="case-card-list grid-col-6">
           <div className="assigned-staff-information padding-bottom-4 case-card">
             <h3>
               Assigned Staff{' '}
@@ -122,7 +90,45 @@ export default function CaseDetailTrusteeAndAssignedStaff(
               )}
             </div>
           </div>
-        </span>
+        </div>
+        <div className="case-card-list grid-col-6">
+          {caseDetail.trustee && (
+            <div className="assigned-staff-information padding-bottom-4 case-card">
+              <h3>Trustee</h3>
+              <div className="trustee-name padding-bottom-1">{caseDetail.trustee.name}</div>
+              {caseDetail.trustee.email && (
+                <div
+                  className="padding-bottom-1"
+                  data-testid="case-detail-trustee-email"
+                  aria-label="trustee email"
+                >
+                  <a
+                    href={`mailto:${caseDetail.trustee.email}?subject=${getCaseNumber(
+                      caseDetail.caseId,
+                    )} - ${caseDetail.caseTitle}`}
+                  >
+                    {caseDetail.trustee.email}
+                    <Icon className="link-icon" name="mail_outline" />
+                  </a>
+                </div>
+              )}
+              <div className="padding-bottom-1 trustee-phone-number">
+                {caseDetail.trustee.phone}
+              </div>
+              <div className="padding-bottom-1">
+                <div className="trustee-address">{caseDetail.trustee.address1}</div>
+                <div className="trustee-address">{caseDetail.trustee.address2}</div>
+                <div className="trustee-address">{caseDetail.trustee.address3}</div>
+                <div
+                  className="city-state-postal-code"
+                  aria-label="trustee city, state, zip, country"
+                >
+                  <span className="trustee-city">{caseDetail.trustee.cityStateZipCountry}</span>,
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
       <AssignAttorneyModal
         ref={assignmentModalRef}

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
@@ -37,9 +37,9 @@ export default function CaseDetailTrusteeAndAssignedStaff(
 
   return (
     <>
-      <div className="grid-row grid-gap-lg">
-        <div className="case-card-list grid-col-6">
-          <div className="assigned-staff-information padding-bottom-4 case-card">
+      <div className="grid-col-12 tablet:grid-col-10 desktop:grid-col-8 case-detail-container">
+        <div className="case-card-list">
+          <div className="assigned-staff-information case-card">
             <h3>
               Assigned Staff{' '}
               {Actions.contains(caseDetail, Actions.ManageAssignments) &&
@@ -57,16 +57,16 @@ export default function CaseDetailTrusteeAndAssignedStaff(
                   </OpenModalButton>
                 )}
             </h3>
+            {caseDetail.regionId && (
+              <div
+                className="case-detail-region-id"
+                data-testid="case-detail-region-id"
+                aria-label="assigned region and office"
+              >
+                Region {caseDetail.regionId.replace(/^0*/, '')} - {caseDetail.officeName} Office
+              </div>
+            )}
             <div className="assigned-staff-list">
-              {caseDetail.regionId && (
-                <div
-                  className="case-detail-region-id"
-                  data-testid="case-detail-region-id"
-                  aria-label="assigned region and office"
-                >
-                  Region {caseDetail.regionId.replace(/^0*/, '')} - {caseDetail.officeName} Office
-                </div>
-              )}
               {(typeof caseDetail.assignments === 'undefined' ||
                 caseDetail.assignments.length === 0) && (
                 <span className="unassigned-placeholder">(unassigned)</span>
@@ -91,17 +91,13 @@ export default function CaseDetailTrusteeAndAssignedStaff(
             </div>
           </div>
         </div>
-        <div className="case-card-list grid-col-6">
+        <div className="case-card-list">
           {caseDetail.trustee && (
-            <div className="assigned-staff-information padding-bottom-4 case-card">
+            <div className="assigned-staff-information case-card">
               <h3>Trustee</h3>
-              <div className="trustee-name padding-bottom-1">{caseDetail.trustee.name}</div>
+              <div className="trustee-name">{caseDetail.trustee.name}</div>
               {caseDetail.trustee.email && (
-                <div
-                  className="padding-bottom-1"
-                  data-testid="case-detail-trustee-email"
-                  aria-label="trustee email"
-                >
+                <div data-testid="case-detail-trustee-email" aria-label="trustee email">
                   <a
                     href={`mailto:${caseDetail.trustee.email}?subject=${getCaseNumber(
                       caseDetail.caseId,
@@ -112,10 +108,8 @@ export default function CaseDetailTrusteeAndAssignedStaff(
                   </a>
                 </div>
               )}
-              <div className="padding-bottom-1 trustee-phone-number">
-                {caseDetail.trustee.phone}
-              </div>
-              <div className="padding-bottom-1">
+              <div className="trustee-phone-number">{caseDetail.trustee.phone}</div>
+              <div>
                 <div className="trustee-address">{caseDetail.trustee.address1}</div>
                 <div className="trustee-address">{caseDetail.trustee.address2}</div>
                 <div className="trustee-address">{caseDetail.trustee.address3}</div>

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.scss
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.scss
@@ -1,8 +1,6 @@
 @use '../../../styles/abstracts/colors';
 
 .case-notes-panel {
-  margin-left: 2rem;
-
   .draft-notes-alert-container {
     padding-bottom: .5rem;
   }

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -10,7 +10,7 @@ export const PRIVILEGED_IDENTITY_MANAGEMENT = 'privileged-identity-management';
 export const SYSTEM_MAINTENANCE_BANNER = 'system-maintenance-banner';
 export const TRANSFER_ORDERS_ENABLED = 'transfer-orders-enabled';
 export const FORMAT_CASE_NOTES = 'format-case-notes';
-export const VIEW_TRUSTEE = 'view-trustee';
+export const VIEW_TRUSTEE_ON_CASE = 'view-trustee-on-case';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -10,6 +10,7 @@ export const PRIVILEGED_IDENTITY_MANAGEMENT = 'privileged-identity-management';
 export const SYSTEM_MAINTENANCE_BANNER = 'system-maintenance-banner';
 export const TRANSFER_ORDERS_ENABLED = 'transfer-orders-enabled';
 export const FORMAT_CASE_NOTES = 'format-case-notes';
+export const VIEW_TRUSTEE = 'view-trustee';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -58,6 +58,10 @@ const caseDetails = MockData.getCaseDetail({
     caseTitle: 'Test Case Title',
     petitionLabel: 'Voluntary',
     caseId: '101-12-12345',
+    trustee: {
+      name: 'Test Trustee',
+      cityStateZipCountry: 'New York, NY 10001, USA',
+    },
   },
 });
 const courts = MockData.getCourts().slice(0, 5);

--- a/user-interface/test/accessibility/case-details.test.ts
+++ b/user-interface/test/accessibility/case-details.test.ts
@@ -1,0 +1,32 @@
+import test, { expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Case Details', () => {
+  test.describe.configure({ retries: 0, mode: 'serial' });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`http://localhost:3000/case-detail/123-12-12345`);
+  });
+
+  const CASE_NUMBER_SELECTOR = 'h2.case-number';
+  const ANALYZE_DELAY = 1000; // Delay in ms to wait for any transitions to complete to minimize false failures.
+
+  test('case overview should not have accessibility issues', async ({ page }) => {
+    expect(page.locator(CASE_NUMBER_SELECTOR)).toBeVisible();
+
+    await page.waitForTimeout(ANALYZE_DELAY);
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+
+  test('trustee and assigned staff should not have accessibility issues', async ({ page }) => {
+    expect(page.locator(CASE_NUMBER_SELECTOR)).toBeVisible();
+
+    await page.locator('[data-testid="case-trustee-and-assigned-staff-link"]').click();
+    expect(page.locator('.trustee-name')).toBeVisible();
+
+    await page.waitForTimeout(ANALYZE_DELAY);
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Purpose

In order to show the trustee information related to a particular case and as part of overhauling the UX of the case detail screens, we added a Trustee and Assigned Staff subsection.


# Major Changes

- Added "Trustee and Assigned Staff" (feature flagged).
- Removed "Assigned Staff" from Case Overview (feature flagged)
- Made "Trustee and Assigned Staff" and "Case Overview" more responsive
- Added trustee information to the case detail endpoint.

# Testing/Validation

- Unit tests
- Manual verification of the view in the front end.

# Notes

Future PRs will capture further enhancements to the case detail views as part of this story. 

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add a feature‐flagged Trustee & Assigned Staff view to the Case Details screen, extend the backend to return trustee information, refactor the existing overview layout for responsiveness and flag gating, update navigation links, and cover all changes with new and updated tests.

New Features:
- Introduce a feature‐flagged Trustee & Assigned Staff panel and route on the Case Detail screen
- Expose trustee data (including phone and email) via the backend case detail API
- Define a Trustee type and add mock data support for trustees

Enhancements:
- Refactor CaseDetailOverview for improved responsiveness and conditionally hide the legacy Assigned Staff section under the new feature flag
- Update side navigation to surface the Trustee & Assigned Staff link when enabled

Tests:
- Add DXTR gateway tests for trustee queries and callback logic
- Add comprehensive unit tests for the new Trustee & Assigned Staff component and update existing overview tests to reflect transfer wording and layout changes