### PR TITLE
CAMS-555 Move Transfers info to Associated Cases view

### DIFF
--- a/user-interface/src/case-detail/CaseDetailScreen.scss
+++ b/user-interface/src/case-detail/CaseDetailScreen.scss
@@ -1,9 +1,8 @@
 @use '../styles/theme';
 
 .case-detail {
-  h3 {
-    margin: 0;
-    line-height: 1.5;
+  h1 {
+    margin: 1rem 0.5rem 1rem 0;
   }
 
   h2 {
@@ -11,8 +10,9 @@
     margin-bottom: 1rem;
   }
 
-  h1 {
-    margin: 1rem 0.5rem 1rem 0;
+  h3 {
+    margin: 0;
+    line-height: 1.5;
   }
 
   h4 {

--- a/user-interface/src/case-detail/CaseDetailScreen.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.test.tsx
@@ -98,7 +98,7 @@ describe('Case Detail screen tests', () => {
 
     await waitFor(() => {
       const chapter = screen.getByTestId('case-chapter');
-      expect(chapter.innerHTML).toEqual('Voluntary&nbsp;Chapter&nbsp;15');
+      expect(chapter.innerHTML).toEqual('Voluntary Chapter 15');
     });
   });
 

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -535,8 +535,9 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
                   caseId={caseId}
                   initiallySelectedNavLink={navState}
                   showAssociatedCasesList={
-                    caseBasicInfo.consolidation !== undefined &&
-                    caseBasicInfo.consolidation.length > 0
+                    (caseBasicInfo.consolidation !== undefined &&
+                      caseBasicInfo.consolidation.length > 0) ||
+                    (caseBasicInfo.transfers !== undefined && caseBasicInfo.transfers.length > 0)
                   }
                 />
                 {hasDocketEntries && navState === NavState.COURT_DOCKET && (
@@ -776,6 +777,7 @@ export default function CaseDetailScreen(props: CaseDetailProps) {
                     path="associated-cases"
                     element={
                       <CaseDetailAssociatedCases
+                        caseDetail={caseBasicInfo}
                         associatedCases={associatedCases}
                         isAssociatedCasesLoading={isAssociatedCasesLoading}
                       />

--- a/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.test.tsx
@@ -1,11 +1,17 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { MockData } from '@common/cams/test-utilities/mock-data';
 import CaseDetailAssociatedCases from './CaseDetailAssociatedCases';
-import { ConsolidationFrom, ConsolidationTo, EventCaseReference } from '@common/cams/events';
+import {
+  ConsolidationFrom,
+  ConsolidationTo,
+  EventCaseReference,
+  Transfer,
+} from '@common/cams/events';
 import { ConsolidationType } from '@common/cams/orders';
 import { BrowserRouter } from 'react-router-dom';
 import { getCaseNumber } from '@/lib/utils/caseNumber';
 import { formatDate } from '@/lib/utils/datetime';
+import { CaseDetail } from '@common/cams/cases';
 
 function getAssociatedCasesMock(caseId: string, consolidationType: ConsolidationType) {
   return [
@@ -43,10 +49,22 @@ function getAssociatedCasesMock(caseId: string, consolidationType: Consolidation
 }
 
 describe('associated cases tests', () => {
-  function renderComponent(mock: EventCaseReference[], isLoading: boolean) {
+  function renderComponent(
+    mock: EventCaseReference[],
+    isLoading: boolean,
+    caseDetail?: CaseDetail,
+  ) {
+    if (!caseDetail) {
+      caseDetail = MockData.getCaseDetail();
+    }
+
     render(
       <BrowserRouter>
-        <CaseDetailAssociatedCases associatedCases={mock} isAssociatedCasesLoading={isLoading} />
+        <CaseDetailAssociatedCases
+          caseDetail={caseDetail}
+          associatedCases={mock}
+          isAssociatedCasesLoading={isLoading}
+        />
       </BrowserRouter>,
     );
   }
@@ -83,14 +101,12 @@ describe('associated cases tests', () => {
 
     const sortedMock = sortMock(mock);
 
-    let header3, header4;
+    let header3;
     await waitFor(() => {
       header3 = document.querySelector('.associated-cases h3');
-      header4 = document.querySelector('.associated-cases h4');
     });
 
-    expect(header3).toHaveTextContent('Consolidated cases (4)');
-    expect(header4).toHaveTextContent('Substantive Consolidation');
+    expect(header3).toHaveTextContent('Substantive Consolidation (4)');
 
     const tableRow3Cells = document.querySelectorAll('#associated-cases-table tr:nth-child(3) td');
     expect(tableRow3Cells[0]).toHaveTextContent(
@@ -136,5 +152,120 @@ describe('associated cases tests', () => {
 
     expect(row3Int).toBeGreaterThan(row2Int);
     expect(row4Int).toBeGreaterThan(row3Int);
+  });
+
+  describe('Transferred case information tests', () => {
+    const BASE_TEST_CASE_DETAIL = MockData.getCaseDetail();
+    const OLD_CASE_ID = '111-20-11111';
+    const TEST_CASE_ID = '101-23-12345';
+    const NEW_CASE_ID = '222-24-00001';
+    const TRANSFER_FROM: Transfer = {
+      caseId: TEST_CASE_ID,
+      otherCase: MockData.getCaseSummary({ override: { caseId: OLD_CASE_ID } }),
+      orderDate: '01-04-2023',
+      documentType: 'TRANSFER_FROM',
+    };
+
+    const TRANSFER_TO: Transfer = {
+      caseId: TEST_CASE_ID,
+      otherCase: MockData.getCaseSummary({ override: { caseId: NEW_CASE_ID } }),
+      orderDate: '01-12-2024',
+      documentType: 'TRANSFER_TO',
+    };
+
+    test('should display information about case being transfered out when there is no verified transfer', async () => {
+      renderComponent([], false, { ...BASE_TEST_CASE_DETAIL, transferDate: '2024-12-01' });
+
+      expect(screen.queryByTestId('verified-transfer-header')).not.toBeInTheDocument();
+      const ambiguousTransferText = screen.queryByTestId('ambiguous-transfer-text');
+      expect(ambiguousTransferText).toHaveTextContent(
+        'This case was transferred to another court. Review the docket for further details.',
+      );
+    });
+
+    test('should display information about case being transferred in when there is no verified transfer', async () => {
+      renderComponent([], false, { ...BASE_TEST_CASE_DETAIL, petitionCode: 'TI' });
+
+      expect(screen.queryByTestId('verified-transfer-header')).not.toBeInTheDocument();
+      const ambiguousTransferText = screen.queryByTestId('ambiguous-transfer-text');
+      expect(ambiguousTransferText).toHaveTextContent(
+        'This case was transferred from another court. Review the docket for further details.',
+      );
+    });
+
+    test('should display old case information', () => {
+      renderComponent([], false, { ...BASE_TEST_CASE_DETAIL, transfers: [TRANSFER_FROM] });
+
+      expect(screen.queryByTestId('ambiguous-transfer-text')).not.toBeInTheDocument();
+
+      const oldCaseIdLink = screen.queryByTestId('case-detail-transfer-link-0');
+      expect(oldCaseIdLink).toBeInTheDocument();
+      expect(oldCaseIdLink?.textContent).toEqual(getCaseNumber(OLD_CASE_ID));
+
+      const oldCaseOrderDate = screen.queryByTestId('case-detail-transfer-order-0');
+      expect(oldCaseOrderDate).toBeInTheDocument();
+      expect(oldCaseOrderDate?.textContent).toEqual(formatDate(TRANSFER_FROM.orderDate));
+
+      const oldCaseCourt = screen.queryByTestId('case-detail-transfer-court-0');
+      expect(oldCaseCourt).toBeInTheDocument();
+      expect(oldCaseCourt?.textContent).toEqual(
+        `${TRANSFER_FROM.otherCase.courtName} - ${TRANSFER_FROM.otherCase.courtDivisionName}`,
+      );
+    });
+
+    test('should display new case information', () => {
+      renderComponent([], false, { ...BASE_TEST_CASE_DETAIL, transfers: [TRANSFER_TO] });
+
+      expect(screen.queryByTestId('ambiguous-transfer-text')).not.toBeInTheDocument();
+
+      const newCaseNumberLink = screen.queryByTestId('case-detail-transfer-link-0');
+      expect(newCaseNumberLink).toBeInTheDocument();
+      expect(newCaseNumberLink?.textContent).toEqual(getCaseNumber(NEW_CASE_ID));
+
+      const newCaseOrderDate = screen.queryByTestId('case-detail-transfer-order-0');
+      expect(newCaseOrderDate).toBeInTheDocument();
+      expect(newCaseOrderDate?.textContent).toEqual(formatDate(TRANSFER_TO.orderDate));
+
+      const newCaseCourt = screen.queryByTestId('case-detail-transfer-court-0');
+      expect(newCaseCourt).toBeInTheDocument();
+      expect(newCaseCourt?.textContent).toEqual(
+        `${TRANSFER_TO.otherCase.courtName} - ${TRANSFER_TO.otherCase.courtDivisionName}`,
+      );
+    });
+
+    test('should display old and new case information', () => {
+      renderComponent([], false, {
+        ...BASE_TEST_CASE_DETAIL,
+        transfers: [TRANSFER_TO, TRANSFER_FROM],
+      });
+
+      const newCaseNumberLink = screen.queryByTestId('case-detail-transfer-link-0');
+      expect(newCaseNumberLink).toBeInTheDocument();
+      expect(newCaseNumberLink?.textContent).toEqual(getCaseNumber(NEW_CASE_ID));
+
+      const newCaseOrderDate = screen.queryByTestId('case-detail-transfer-order-0');
+      expect(newCaseOrderDate).toBeInTheDocument();
+      expect(newCaseOrderDate?.textContent).toEqual(formatDate(TRANSFER_TO.orderDate));
+
+      const newCaseCourt = screen.queryByTestId('case-detail-transfer-court-0');
+      expect(newCaseCourt).toBeInTheDocument();
+      expect(newCaseCourt?.textContent).toEqual(
+        `${TRANSFER_TO.otherCase.courtName} - ${TRANSFER_TO.otherCase.courtDivisionName}`,
+      );
+
+      const oldCaseIdLink = screen.queryByTestId('case-detail-transfer-link-1');
+      expect(oldCaseIdLink).toBeInTheDocument();
+      expect(oldCaseIdLink?.textContent).toEqual(getCaseNumber(OLD_CASE_ID));
+
+      const oldCaseOrderDate = screen.queryByTestId('case-detail-transfer-order-1');
+      expect(oldCaseOrderDate).toBeInTheDocument();
+      expect(oldCaseOrderDate?.textContent).toEqual(formatDate(TRANSFER_FROM.orderDate));
+
+      const oldCaseCourt = screen.queryByTestId('case-detail-transfer-court-1');
+      expect(oldCaseCourt).toBeInTheDocument();
+      expect(oldCaseCourt?.textContent).toEqual(
+        `${TRANSFER_FROM.otherCase.courtName} - ${TRANSFER_FROM.otherCase.courtDivisionName}`,
+      );
+    });
   });
 });

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.test.tsx
@@ -56,7 +56,7 @@ describe('Case Detail Header tests', () => {
     expect(isLoadingH2).toContainHTML(testCaseDetail.caseTitle);
     expect(isFinishedH2).toBeInTheDocument();
     expect(caseChapter.innerHTML).toEqual(
-      `${testCaseDetail.petitionLabel}&nbsp;Chapter&nbsp;${testCaseDetail.chapter}`,
+      `${testCaseDetail.petitionLabel} Chapter ${testCaseDetail.chapter}`,
     );
   });
 
@@ -163,7 +163,7 @@ describe('feature flag true', () => {
     expect(isLoadingH2).toContainHTML(testCaseDetail.caseTitle);
     expect(isFinishedH2).toBeInTheDocument();
     expect(caseChapter.innerHTML).toEqual(
-      `${testCaseDetail.petitionLabel}&nbsp;Chapter&nbsp;${testCaseDetail.chapter}`,
+      `${testCaseDetail.petitionLabel} Chapter ${testCaseDetail.chapter}`,
     );
   });
 
@@ -230,7 +230,7 @@ describe('feature flag false', () => {
     expect(isLoadingH2).toContainHTML(testCaseDetail.caseTitle);
     expect(isFinishedH2).toBeInTheDocument();
     expect(caseChapter.innerHTML).toEqual(
-      `${testCaseDetail.petitionLabel}&nbsp;Chapter&nbsp;${testCaseDetail.chapter}`,
+      `${testCaseDetail.petitionLabel} Chapter ${testCaseDetail.chapter}`,
     );
   });
 });

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
@@ -25,8 +25,7 @@ export default function CaseDetailHeader(props: Readonly<CaseDetailHeaderProps>)
   if (props.caseDetail?.chapter) {
     chapterInformationParts.push('Chapter', props.caseDetail?.chapter);
   }
-  // u00A0 is a non-breaking space. Using &nbsp; in the string literal does not display correctly.
-  const chapterInformation = chapterInformationParts.join('\u00A0');
+  const chapterInformation = chapterInformationParts.join(' ');
 
   const judgeInformation = props.caseDetail?.judgeName;
   const appEl = document.querySelector('.App');

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
@@ -106,17 +106,6 @@ export default function CaseDetailNavigation({
               Case Notes
             </NavLink>
           </li>
-          <li className="usa-sidenav__item">
-            <NavLink
-              to={`/case-detail/${caseId}/audit-history`}
-              data-testid="audit-history-link"
-              className={'usa-nav-link ' + setCurrentNav(activeNav, NavState.AUDIT_HISTORY)}
-              onClick={() => setActiveNav(NavState.AUDIT_HISTORY)}
-              title="view case audit history"
-            >
-              Change History
-            </NavLink>
-          </li>
           {showAssociatedCasesList && (
             <li className="usa-sidenav__item">
               <NavLink
@@ -130,6 +119,17 @@ export default function CaseDetailNavigation({
               </NavLink>
             </li>
           )}
+          <li className="usa-sidenav__item">
+            <NavLink
+              to={`/case-detail/${caseId}/audit-history`}
+              data-testid="audit-history-link"
+              className={'usa-nav-link ' + setCurrentNav(activeNav, NavState.AUDIT_HISTORY)}
+              onClick={() => setActiveNav(NavState.AUDIT_HISTORY)}
+              title="view case audit history"
+            >
+              Change History
+            </NavLink>
+          </li>
         </ul>
       </nav>
     </>

--- a/user-interface/src/case-detail/panels/CaseDetailOverview.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailOverview.tsx
@@ -145,19 +145,21 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
               </div>
             </div>
           )}
-          <div className="judge-information case-card">
-            <h3>Judge</h3>
-            {caseDetail.judgeName && (
-              <div className="case-detail-judge-name" data-testid="case-detail-judge-name">
-                {caseDetail.judgeName}
-              </div>
-            )}
-            {!caseDetail.judgeName && (
-              <div className="case-detail-judge-name" data-testid="case-detail-no-judge-name">
-                {informationUnavailable}
-              </div>
-            )}
-          </div>
+          {!featureFlags[VIEW_TRUSTEE_ON_CASE] && (
+            <div className="judge-information case-card">
+              <h3>Judge</h3>
+              {caseDetail.judgeName && (
+                <div className="case-detail-judge-name" data-testid="case-detail-judge-name">
+                  {caseDetail.judgeName}
+                </div>
+              )}
+              {!caseDetail.judgeName && (
+                <div className="case-detail-judge-name" data-testid="case-detail-no-judge-name">
+                  {informationUnavailable}
+                </div>
+              )}
+            </div>
+          )}
         </div>
         <div className="case-card-list">
           <div className="debtor-information case-card">
@@ -342,59 +344,66 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
               </div>
             </>
           )}
-          {isAmbiguousTransfer && (
+          {!featureFlags[VIEW_TRUSTEE_ON_CASE] && (
             <>
-              <h3>Transferred Case</h3>
-              <p data-testid="ambiguous-transfer-text">
-                This case was transferred {isAmbiguousTransferOut ? 'to' : 'from'} another court.
-                Review the docket for further details.
-              </p>
-            </>
-          )}
-          {isVerifiedTransfer && (
-            <>
-              <h3 data-testid="verified-transfer-header">Transferred Case</h3>
-              <ul className="usa-list usa-list--unstyled transfers case-card">
-                {caseDetail.transfers
-                  ?.sort(sortTransfers)
-                  .map((transfer: Transfer, idx: number) => {
-                    return (
-                      <li key={idx} className="transfer">
-                        <h4>
-                          Transferred {transfer.documentType === 'TRANSFER_FROM' ? 'from' : 'to'}:
-                        </h4>
-                        <div>
-                          <span className="case-detail-item-name">Case Number:</span>
-                          <CaseNumber
-                            caseId={transfer.otherCase.caseId}
-                            className="usa-link case-detail-item-value"
-                            data-testid={`case-detail-transfer-link-${idx}`}
-                          />
-                        </div>
-                        <div className="transfer-court">
-                          <span className="case-detail-item-name">
-                            {transfer.documentType === 'TRANSFER_FROM' ? 'Previous' : 'New'} Court:
-                          </span>
-                          <span
-                            className="case-detail-item-value"
-                            data-testid={`case-detail-transfer-court-${idx}`}
-                          >
-                            {transfer.otherCase.courtName} - {transfer.otherCase.courtDivisionName}
-                          </span>
-                        </div>
-                        <div>
-                          <span className="case-detail-item-name">Order Filed:</span>
-                          <span
-                            className="case-detail-item-value"
-                            data-testid={`case-detail-transfer-order-${idx}`}
-                          >
-                            {formatDate(transfer.orderDate)}
-                          </span>
-                        </div>
-                      </li>
-                    );
-                  })}
-              </ul>
+              {isAmbiguousTransfer && (
+                <>
+                  <h3>Transferred Case</h3>
+                  <p data-testid="ambiguous-transfer-text">
+                    This case was transferred {isAmbiguousTransferOut ? 'to' : 'from'} another
+                    court. Review the docket for further details.
+                  </p>
+                </>
+              )}
+              {isVerifiedTransfer && (
+                <>
+                  <h3 data-testid="verified-transfer-header">Transferred Case</h3>
+                  <ul className="usa-list usa-list--unstyled transfers case-card">
+                    {caseDetail.transfers
+                      ?.sort(sortTransfers)
+                      .map((transfer: Transfer, idx: number) => {
+                        return (
+                          <li key={idx} className="transfer">
+                            <h4>
+                              Transferred{' '}
+                              {transfer.documentType === 'TRANSFER_FROM' ? 'from' : 'to'}:
+                            </h4>
+                            <div>
+                              <span className="case-detail-item-name">Case Number:</span>
+                              <CaseNumber
+                                caseId={transfer.otherCase.caseId}
+                                className="usa-link case-detail-item-value"
+                                data-testid={`case-detail-transfer-link-${idx}`}
+                              />
+                            </div>
+                            <div className="transfer-court">
+                              <span className="case-detail-item-name">
+                                {transfer.documentType === 'TRANSFER_FROM' ? 'Previous' : 'New'}{' '}
+                                Court:
+                              </span>
+                              <span
+                                className="case-detail-item-value"
+                                data-testid={`case-detail-transfer-court-${idx}`}
+                              >
+                                {transfer.otherCase.courtName} -{' '}
+                                {transfer.otherCase.courtDivisionName}
+                              </span>
+                            </div>
+                            <div>
+                              <span className="case-detail-item-name">Order Filed:</span>
+                              <span
+                                className="case-detail-item-value"
+                                data-testid={`case-detail-transfer-order-${idx}`}
+                              >
+                                {formatDate(transfer.orderDate)}
+                              </span>
+                            </div>
+                          </li>
+                        );
+                      })}
+                  </ul>
+                </>
+              )}
             </>
           )}
         </div>

--- a/user-interface/vitest.config.mts
+++ b/user-interface/vitest.config.mts
@@ -42,6 +42,8 @@ export default defineConfig({
         ...coverageConfigDefaults.exclude,
         './src/initialize.ts',
         './envToConfig.js',
+        './playwright.config.ts',
+        './playwright-report/',
       ],
       thresholds: {
         branches: 90,


### PR DESCRIPTION
# Purpose

Since Transfers are also a form of "association", lump them into the "Associated Cases" view along with consolidations for clarity.

# Major Changes
- Transfers now display on Associated Cases view
- Includes some visual tweaks to consolidations table 
- updates to test coverage config
# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Integrate transfer events into the Associated Cases view under a feature flag, refine consolidation headers and navigation layout, standardize formatting of chapter information, update styles, and extend tests accordingly

New Features:
- Display case transfer information in the Associated Cases panel
- Introduce a feature flag to toggle trustee-related UI elements including judge info and transfers

Enhancements:
- Combine consolidation type and count into a single heading in the Associated Cases view
- Reorder the Change History link in navigation to below the Associated Cases section
- Standardize chapter formatting by replacing non-breaking spaces with regular spaces
- Adjust heading styles in SCSS for consistent margins and line-height

Build:
- Exclude Playwright files from test coverage reporting in the Vitest config

Tests:
- Add unit tests for ambiguous and verified transfers display in the Associated Cases view
- Update header and screen tests to expect space-separated chapter formatting