### PR TITLE
CAMS-555 Add Google Fonts API to Content-Security-Policy

### DIFF
--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -38,5 +38,5 @@ server {
     #   CSP_API_SERVER_HOST               - refers to the backend api host uri
     #   CSP_USTP_ISSUE_COLLECTOR_HASH     - USTP issue collector hash
     #   CSP_CAMS_REACT_SELECT_HASH        - React-Select hash
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com atl.cld.prd.ust.doj.gov; connect-src 'self' ${CSP_API_SERVER_HOST} ${OKTA_URL} clientsdk.launchdarkly.us clientstream.launchdarkly.us events.launchdarkly.us js.monitor.azure.com usgovvirginia-1.in.applicationinsights.azure.us; img-src 'self' data: ; style-src 'self' '${CSP_CAMS_REACT_SELECT_HASH}' '${CSP_USTP_ISSUE_COLLECTOR_HASH}'; base-uri 'self'; form-action 'self'; frame-src 'self' ${OKTA_URL} atl.cld.prd.ust.doj.gov";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com atl.cld.prd.ust.doj.gov; connect-src 'self' ${CSP_API_SERVER_HOST} ${OKTA_URL} clientsdk.launchdarkly.us clientstream.launchdarkly.us events.launchdarkly.us js.monitor.azure.com usgovvirginia-1.in.applicationinsights.azure.us; img-src 'self' data: ; style-src 'self' '${CSP_CAMS_REACT_SELECT_HASH}' '${CSP_USTP_ISSUE_COLLECTOR_HASH}' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; base-uri 'self'; form-action 'self'; frame-src 'self' ${OKTA_URL} atl.cld.prd.ust.doj.gov";
 }


### PR DESCRIPTION

# Purpose

We need to add google fonts to our CSP header so that we can use the Source Serif Pro font from google fonts.

# Major Changes

- CSP header definition in nginx.conf

# Testing/Validation

[Deployed to ephemeral dev environment](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/16833057640)

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
