### PR TITLE
CAMS-555 Remove flag for change to transfers display

### DIFF
--- a/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailAssociatedCases.tsx
@@ -7,7 +7,6 @@ import './CaseDetailAssociatedCases.scss';
 import { getCaseNumber } from '@/lib/utils/caseNumber';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { CaseDetail } from '@common/cams/cases';
-import useFeatureFlags, { VIEW_TRUSTEE_ON_CASE } from '@/lib/hooks/UseFeatureFlags';
 
 export interface CaseDetailAssociatedCasesProps {
   caseDetail: CaseDetail;
@@ -17,7 +16,6 @@ export interface CaseDetailAssociatedCasesProps {
 
 export default function CaseDetailAssociatedCases(props: CaseDetailAssociatedCasesProps) {
   const { caseDetail, associatedCases, isAssociatedCasesLoading } = props;
-  const featureFlags = useFeatureFlags();
   const consolidation = associatedCases.filter(
     (c) => c.documentType === 'CONSOLIDATION_FROM' || c.documentType === 'CONSOLIDATION_TO',
   ) as Consolidation[];
@@ -44,67 +42,59 @@ export default function CaseDetailAssociatedCases(props: CaseDetailAssociatedCas
           message="We are unable to retrieve associated cases at this time. Please try again later. If the problem persists, please submit a feedback request describing the issue."
         ></Alert>
       )}
-      {featureFlags[VIEW_TRUSTEE_ON_CASE] && (
+      {isAmbiguousTransfer && (
         <>
-          {isAmbiguousTransfer && (
-            <>
-              <h3>Transferred Case</h3>
-              <p data-testid="ambiguous-transfer-text">
-                This case was transferred {isAmbiguousTransferOut ? 'to' : 'from'} another court.
-                Review the docket for further details.
-              </p>
-            </>
-          )}
-          {isVerifiedTransfer && (
-            <div className="case-card-list">
-              <ul className="usa-list usa-list--unstyled transfers case-card">
-                {caseDetail.transfers
-                  ?.sort(sortTransfers)
-                  .map((transfer: Transfer, idx: number) => {
-                    return (
-                      <li key={idx} className="transfer">
-                        <div className="case-card">
-                          <h3 data-testid={`verified-transfer-header_${idx}`}>
-                            Transferred {transfer.documentType === 'TRANSFER_FROM' ? 'from' : 'to'}
-                          </h3>
-                          <div>
-                            <span className="case-detail-item-name">Case Number:</span>
-                            <CaseNumber
-                              caseId={transfer.otherCase.caseId}
-                              className="usa-link case-detail-item-value"
-                              data-testid={`case-detail-transfer-link-${idx}`}
-                            />
-                          </div>
-                          <div className="transfer-court">
-                            <span className="case-detail-item-name">
-                              {transfer.documentType === 'TRANSFER_FROM' ? 'Previous' : 'New'}{' '}
-                              Court:
-                            </span>
-                            <span
-                              className="case-detail-item-value"
-                              data-testid={`case-detail-transfer-court-${idx}`}
-                            >
-                              {transfer.otherCase.courtName} -{' '}
-                              {transfer.otherCase.courtDivisionName}
-                            </span>
-                          </div>
-                          <div>
-                            <span className="case-detail-item-name">Order Filed:</span>
-                            <span
-                              className="case-detail-item-value"
-                              data-testid={`case-detail-transfer-order-${idx}`}
-                            >
-                              {formatDate(transfer.orderDate)}
-                            </span>
-                          </div>
-                        </div>
-                      </li>
-                    );
-                  })}
-              </ul>
-            </div>
-          )}
+          <h3>Transferred Case</h3>
+          <p data-testid="ambiguous-transfer-text">
+            This case was transferred {isAmbiguousTransferOut ? 'to' : 'from'} another court. Review
+            the docket for further details.
+          </p>
         </>
+      )}
+      {isVerifiedTransfer && (
+        <div className="case-card-list">
+          <ul className="usa-list usa-list--unstyled transfers case-card">
+            {caseDetail.transfers?.sort(sortTransfers).map((transfer: Transfer, idx: number) => {
+              return (
+                <li key={idx} className="transfer">
+                  <div className="case-card">
+                    <h3 data-testid={`verified-transfer-header_${idx}`}>
+                      Transferred {transfer.documentType === 'TRANSFER_FROM' ? 'from' : 'to'}
+                    </h3>
+                    <div>
+                      <span className="case-detail-item-name">Case Number:</span>
+                      <CaseNumber
+                        caseId={transfer.otherCase.caseId}
+                        className="usa-link case-detail-item-value"
+                        data-testid={`case-detail-transfer-link-${idx}`}
+                      />
+                    </div>
+                    <div className="transfer-court">
+                      <span className="case-detail-item-name">
+                        {transfer.documentType === 'TRANSFER_FROM' ? 'Previous' : 'New'} Court:
+                      </span>
+                      <span
+                        className="case-detail-item-value"
+                        data-testid={`case-detail-transfer-court-${idx}`}
+                      >
+                        {transfer.otherCase.courtName} - {transfer.otherCase.courtDivisionName}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="case-detail-item-name">Order Filed:</span>
+                      <span
+                        className="case-detail-item-value"
+                        data-testid={`case-detail-transfer-order-${idx}`}
+                      >
+                        {formatDate(transfer.orderDate)}
+                      </span>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
       )}
       {!isAssociatedCasesLoading && consolidation.length > 0 && (
         <>

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.test.tsx
@@ -38,10 +38,8 @@ describe('Case Detail Header tests', () => {
     basicRender(testCaseDetail, true);
 
     const isLoadingH1 = screen.getByTestId('case-detail-heading');
-    const isLoadingH2 = screen.getByTestId('loading-h2');
 
     expect(isLoadingH1).toContainHTML('Loading Case Details...');
-    expect(isLoadingH2).toBeInTheDocument();
   });
 
   test('should render case detail info when isLoading is false', () => {
@@ -198,16 +196,6 @@ describe('feature flag true', () => {
     const childIcon = screen.getByTestId('member-case-icon');
     expect(childIcon).toBeInTheDocument();
   });
-
-  test('should render loading info when isLoading is true and VIEW_TRUSTEE_ON_CASE is enabled', () => {
-    basicRender(testCaseDetail, true);
-
-    const isLoadingH1 = screen.getByTestId('case-detail-heading');
-    const isLoadingH2 = screen.getByTestId('loading-h2');
-
-    expect(isLoadingH1).toContainHTML('Loading Case Details...');
-    expect(isLoadingH2).toBeInTheDocument();
-  });
 });
 
 describe('feature flag false', () => {
@@ -216,6 +204,16 @@ describe('feature flag false', () => {
       [FeatureFlagHook.VIEW_TRUSTEE_ON_CASE]: false,
     };
     vi.spyOn(FeatureFlagHook, 'default').mockReturnValue(mockFeatureFlags);
+  });
+
+  test('should render loading info when isLoading is true and VIEW_TRUSTEE_ON_CASE is disabled', () => {
+    basicRender(testCaseDetail, true);
+
+    const isLoadingH1 = screen.getByTestId('case-detail-heading');
+    const isLoadingH2 = screen.getByTestId('loading-h2');
+
+    expect(isLoadingH1).toContainHTML('Loading Case Details...');
+    expect(isLoadingH2).toBeInTheDocument();
   });
 
   test('should render properly with false', () => {

--- a/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailHeader.tsx
@@ -85,7 +85,7 @@ export default function CaseDetailHeader(props: Readonly<CaseDetailHeaderProps>)
                   <h1
                     className="case-number text-no-wrap display-inline-block margin-right-1"
                     title="Case ID"
-                    aria-label="Case ID"
+                    aria-label={`Case ID ${props.caseId}`}
                     data-testid="case-detail-heading"
                   >
                     {props.caseId}{' '}
@@ -122,28 +122,13 @@ export default function CaseDetailHeader(props: Readonly<CaseDetailHeaderProps>)
             </div>
           </div>
 
-          {props.isLoading && (
-            <div className="grid-row grid-gap-lg" data-testid="loading-h2">
-              <div className="grid-col-12">
-                <h2
-                  className="case-number text-no-wrap"
-                  title="Case ID"
-                  aria-label="Case ID"
-                  data-testid="case-detail-heading-title"
-                >
-                  {props.caseDetail?.caseTitle}
-                </h2>
-              </div>
-            </div>
-          )}
-
           {!props.isLoading && (
             <div className="grid-row grid-gap-lg" data-testid="h2-with-case-info">
               <div className="grid-col">
                 <h2
                   className="case-number text-no-wrap"
-                  title="Case ID"
-                  aria-label="Case ID"
+                  title="Case title"
+                  aria-label={`Case title ${props.caseDetail?.caseTitle}`}
                   data-testid="case-detail-heading-title"
                 >
                   {props.caseDetail?.caseTitle}

--- a/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailNavigation.tsx
@@ -80,7 +80,7 @@ export default function CaseDetailNavigation({
                 title="view trustee and assigned staff details for the current case"
                 end
               >
-                Trustee & Assigned Staff
+                Assigned Staff & Trustee
               </NavLink>
             </li>
           )}

--- a/user-interface/src/case-detail/panels/CaseDetailOverview.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailOverview.tsx
@@ -1,7 +1,7 @@
 import { getCaseNumber } from '@/lib/utils/caseNumber';
-import { formatDate, sortByDateReverse } from '@/lib/utils/datetime';
+import { formatDate } from '@/lib/utils/datetime';
 import { CaseNumber } from '@/lib/components/CaseNumber';
-import { isJointAdministrationChildCase, Transfer } from '@common/cams/events';
+import { isJointAdministrationChildCase } from '@common/cams/events';
 import { CaseDetail, isChildCase, isLeadCase } from '@common/cams/cases';
 import { consolidationTypeMap } from '@/lib/utils/labels';
 import { UswdsButtonStyle } from '@/lib/components/uswds/Button';
@@ -36,22 +36,11 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
   const assignmentModalRef = useRef<AssignAttorneyModalRef>(null);
   const openModalButtonRef = useRef<OpenModalButtonRef>(null);
 
-  function sortTransfers(a: Transfer, b: Transfer) {
-    return sortByDateReverse(a.orderDate, b.orderDate);
-  }
-
   function handleCaseAssignment(props: AssignAttorneyModalCallbackProps) {
     onCaseAssignment(props);
     assignmentModalRef.current?.hide();
     openModalButtonRef.current?.focus();
   }
-
-  const isAmbiguousTransferIn =
-    !!caseDetail.petitionCode && ['TI', 'TV'].includes(caseDetail.petitionCode);
-  const isAmbiguousTransferOut = !!caseDetail.transferDate;
-  const isAmbiguousTransfer =
-    caseDetail.transfers?.length === 0 && (isAmbiguousTransferIn || isAmbiguousTransferOut);
-  const isVerifiedTransfer = !!caseDetail.transfers?.length && caseDetail.transfers.length > 0;
 
   return (
     <>
@@ -342,68 +331,6 @@ export default function CaseDetailOverview(props: CaseDetailOverviewProps) {
                   </span>
                 </div>
               </div>
-            </>
-          )}
-          {!featureFlags[VIEW_TRUSTEE_ON_CASE] && (
-            <>
-              {isAmbiguousTransfer && (
-                <>
-                  <h3>Transferred Case</h3>
-                  <p data-testid="ambiguous-transfer-text">
-                    This case was transferred {isAmbiguousTransferOut ? 'to' : 'from'} another
-                    court. Review the docket for further details.
-                  </p>
-                </>
-              )}
-              {isVerifiedTransfer && (
-                <>
-                  <h3 data-testid="verified-transfer-header">Transferred Case</h3>
-                  <ul className="usa-list usa-list--unstyled transfers case-card">
-                    {caseDetail.transfers
-                      ?.sort(sortTransfers)
-                      .map((transfer: Transfer, idx: number) => {
-                        return (
-                          <li key={idx} className="transfer">
-                            <h4>
-                              Transferred{' '}
-                              {transfer.documentType === 'TRANSFER_FROM' ? 'from' : 'to'}:
-                            </h4>
-                            <div>
-                              <span className="case-detail-item-name">Case Number:</span>
-                              <CaseNumber
-                                caseId={transfer.otherCase.caseId}
-                                className="usa-link case-detail-item-value"
-                                data-testid={`case-detail-transfer-link-${idx}`}
-                              />
-                            </div>
-                            <div className="transfer-court">
-                              <span className="case-detail-item-name">
-                                {transfer.documentType === 'TRANSFER_FROM' ? 'Previous' : 'New'}{' '}
-                                Court:
-                              </span>
-                              <span
-                                className="case-detail-item-value"
-                                data-testid={`case-detail-transfer-court-${idx}`}
-                              >
-                                {transfer.otherCase.courtName} -{' '}
-                                {transfer.otherCase.courtDivisionName}
-                              </span>
-                            </div>
-                            <div>
-                              <span className="case-detail-item-name">Order Filed:</span>
-                              <span
-                                className="case-detail-item-value"
-                                data-testid={`case-detail-transfer-order-${idx}`}
-                              >
-                                {formatDate(transfer.orderDate)}
-                              </span>
-                            </div>
-                          </li>
-                        );
-                      })}
-                  </ul>
-                </>
-              )}
             </>
           )}
         </div>

--- a/user-interface/src/lib/components/cams/RawSvgIcon.tsx
+++ b/user-interface/src/lib/components/cams/RawSvgIcon.tsx
@@ -9,6 +9,7 @@ export function GavelIcon() {
       width="1rem"
       height="1rem"
       className="gavel-icon"
+      aria-label="Gavel Icon"
     >
       {/*!Font
         Awesome Free v7.0.0 by @fontawesome - https://fontawesome.com License -
@@ -27,6 +28,7 @@ export function LeadCaseIcon() {
       height="28"
       viewBox="0 0 22 28"
       xmlns="http://www.w3.org/2000/svg"
+      aria-label="Lead Case Icon"
     >
       <path d="M0 25.5V2C0 0.89543 0.895431 0 2 0H15.125L22 6.875V25.5C22 26.6046 21.1046 27.5 20 27.5H2C0.895431 27.5 0 26.6046 0 25.5Z" />
       <path d="M16.5 17.875V22H8.25V17.875H12.1999H16.5ZM9.625 5.5V22H5.5V5.5H9.625Z" />
@@ -45,6 +47,7 @@ export function MemberCaseIcon() {
       viewBox="0 0 22 28"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
+      aria-label="Associated Case Icon"
     >
       <path d="M0 25.5V2C0 0.89543 0.895431 0 2 0H15.125L22 6.875V25.5C22 26.6046 21.1046 27.5 20 27.5H2C0.895431 27.5 0 26.6046 0 25.5Z" />
       <path d="M15.125 5.875V1.375L20.625 6.875H16.125C15.5727 6.875 15.125 6.42728 15.125 5.875Z" />

--- a/user-interface/src/lib/components/uswds/Tag.test.tsx
+++ b/user-interface/src/lib/components/uswds/Tag.test.tsx
@@ -14,7 +14,6 @@ describe('Tag', () => {
     expect(tag.tagName).toBe('SPAN');
     expect(tag).toHaveClass(TAG_BASE_CLASS);
     expect(tag).toHaveClass('usa-tag--big');
-    expect(tag).toHaveAttribute('tabIndex', '0');
   });
 
   test('should use custom id when provided', () => {
@@ -97,20 +96,6 @@ describe('Tag', () => {
     expect(tag).toHaveAttribute('title', 'Custom Title');
   });
 
-  test('should apply custom tabIndex when provided', () => {
-    render(<Tag tabIndex={-1}>Test Tag</Tag>);
-
-    const tag = screen.getByTestId('tag-test');
-    expect(tag).toHaveAttribute('tabIndex', '-1');
-  });
-
-  test('should apply tabIndex 0 by default when not provided', () => {
-    render(<Tag>Test Tag</Tag>);
-
-    const tag = screen.getByTestId('tag-test');
-    expect(tag).toHaveAttribute('tabIndex', '0');
-  });
-
   test('should pass through other HTML span props', () => {
     render(
       <Tag role="button" aria-label="Custom Label" data-custom="custom-value">
@@ -160,7 +145,6 @@ describe('Tag', () => {
         uswdsStyle={UswdsTagStyle.Primary}
         className="extra-custom-class another-class"
         title="Complex Tag"
-        tabIndex={0}
       >
         Complex Content
       </Tag>,
@@ -174,7 +158,6 @@ describe('Tag', () => {
     expect(tag).toHaveClass('extra-custom-class');
     expect(tag).toHaveClass('another-class');
     expect(tag).toHaveAttribute('title', 'Complex Tag');
-    expect(tag).toHaveAttribute('tabIndex', '0');
     expect(tag).toHaveTextContent('Complex Content');
   });
 

--- a/user-interface/src/lib/components/uswds/Tag.tsx
+++ b/user-interface/src/lib/components/uswds/Tag.tsx
@@ -25,8 +25,6 @@ const Tag = (props: TagProps) => {
     classes.push(className);
   }
 
-  const tabIndex = props.tabIndex ?? 0;
-
   const tagId = id ?? `tag-id-${Math.floor(Math.random() * 10000)}`;
   const testId = id ?? 'test';
   return (
@@ -36,7 +34,6 @@ const Tag = (props: TagProps) => {
       className={classes.join(' ')}
       data-testid={`tag-${testId}`}
       title={title}
-      tabIndex={tabIndex}
     >
       {children}
     </span>

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.test.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.test.ts
@@ -83,10 +83,6 @@ const mockStore: AssignAttorneyModalStore = {
 const useCase = assignAttorneyModalUseCase(mockStore, mockControls);
 
 describe('assignAttorneyModalUseCase tests', () => {
-  test.skip('', async () => {
-    //
-  });
-
   describe('test handleFocus', () => {
     test('handleFocus should scroll input element into view if the input is above the visible screen', async () => {
       const mockInput = document.createElement('input');


### PR DESCRIPTION
# Purpose

Part of this was leaking out from the flag, but since it's relatively unrelated to viewing a trustee on a case, just remove it from behind the flag anyway.

# Major Changes

Move of transfer information from case overview to associated cases was removed from behind the view-trustee-on-case feature flag.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove the VIEW_TRUSTEE_ON_CASE feature flag guard around transfer information, ensuring transfer details are always shown in both overview and associated cases panels and cleaning up related code and tests.

Enhancements:
- Always display case transfer details without relying on the VIEW_TRUSTEE_ON_CASE feature flag
- Remove feature flag imports, conditional branches, and redundant transfer sort helpers from overview and associated cases panels

Tests:
- Delete outdated transfer display tests in CaseDetailOverview that were gated by the feature flag