### PR TITLE
Fix variable declaration in py script

### DIFF
--- a/test/dast/zap_json_to_sarif.py
+++ b/test/dast/zap_json_to_sarif.py
@@ -5,7 +5,7 @@ import sys
 import uuid
 from datetime import datetime
 
-let default_url = "https://www.zaproxy.org/"
+default_url = "https://www.zaproxy.org/"
 
 
 def strip_html(text):


### PR DESCRIPTION
Fix variable declaration in python script

## Summary by Sourcery

Bug Fixes:
- Remove erroneous 'let' keyword from default_url declaration in zap_json_to_sarif.py