### PR TITLE
CAMS-530 Remove bogus physical url in order to import sarif into github

### DIFF
--- a/test/dast/zap_json_to_sarif.py
+++ b/test/dast/zap_json_to_sarif.py
@@ -77,11 +77,6 @@ def zap_json_to_sarif(zap_json):
                 "message": {"text": name},
                 "locations": [
                     {
-                        "physicalLocation": {
-                            "artifactLocation": {
-                                "uri": uri
-                            }
-                        },
                         "logicalLocations": [
                             {
                                 "kind": "url",


### PR DESCRIPTION
Remove bogus physical url in order to import sarif into github

## Summary by Sourcery

Bug Fixes:
- Remove the physicalLocation.artifactLocation URI block from the SARIF output to enable successful GitHub import