### PR TITLE
CAMS-530 Use placeholder file for physical locations in SARIF report

### DIFF
--- a/test/dast/dast-scan-results.md
+++ b/test/dast/dast-scan-results.md
@@ -1,0 +1,3 @@
+# DAST Scan Results
+This file serves as a reference point for DAST scan findings.
+The actual issues were detected in the running application, not in source code.

--- a/test/dast/zap_json_to_sarif.py
+++ b/test/dast/zap_json_to_sarif.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 
 default_url = "https://www.zaproxy.org/"
-
+placeholder_file = "test/dats/dast-scan-results.md"
 
 def strip_html(text):
     """Remove HTML tags from text and return clean text."""
@@ -77,6 +77,15 @@ def zap_json_to_sarif(zap_json):
                 "message": {"text": name},
                 "locations": [
                     {
+                        "physicalLocation": {
+                            "artifactLocation": {
+                                "uri": placeholder_file
+                            },
+                            "region": {
+                                "startLine": 1,
+                                "startColumn": 1
+                            }
+                        },
                         "logicalLocations": [
                             {
                                 "kind": "url",


### PR DESCRIPTION
Use placeholder file for physical locations in SARIF report

## Summary by Sourcery

Use a placeholder file for SARIF physicalLocation entries in DAST scan conversion

Enhancements:
- Include a placeholder file path in physicalLocation.artifactLocation.uri for SARIF reports

Tests:
- Add test/dast/dast-scan-results.md as the placeholder file and update zap_json_to_sarif test to reference it