### PR TITLE
CAMS-530 Fix path to placeholder file

### DIFF
--- a/test/dast/zap_json_to_sarif.py
+++ b/test/dast/zap_json_to_sarif.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 
 default_url = "https://www.zaproxy.org/"
-placeholder_file = "test/dats/dast-scan-results.md"
+placeholder_file = "test/dast/dast-scan-results.md"
 
 def strip_html(text):
     """Remove HTML tags from text and return clean text."""


### PR DESCRIPTION
Fix path to placeholder file

## Summary by Sourcery

Bug Fixes:
- Correct placeholder_file path from 'test/dats/dast-scan-results.md' to 'test/dast/dast-scan-results.md'