### PR TITLE
CAMS-530 Null the artifact name to stop it from being uploaded

### DIFF
--- a/.github/workflows/reusable-dast.yml
+++ b/.github/workflows/reusable-dast.yml
@@ -102,7 +102,7 @@ jobs:
           rules_file_name: 'test/dast/config/dast-rules.tsv'
           fail_action: 'false'
           allow_issue_writing: 'false'
-          artifact_name: 'zap-report'
+          artifact_name: ''
 
       - name: Convert ZAP JSON to SARIF
         run: |


### PR DESCRIPTION
Null the artifact name to stop it from being uploaded

## Summary by Sourcery

CI:
- Set artifact_name to an empty string in reusable-dast.yml to prevent uploading the ZAP report