### PR TITLE
CAMS -530 Schedule the DAST scan to run automatically

### DIFF
--- a/.github/workflows/dast-scan.yml
+++ b/.github/workflows/dast-scan.yml
@@ -2,7 +2,11 @@ name: Stand Alone DAST Scan
 
 concurrency: ${{ github.ref }}-${{ github.workflow }}
 
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+      # Every Monday morning at 8 AM ET
+  workflow_dispatch:
 
 jobs:
   setup:

--- a/.github/workflows/reusable-dast.yml
+++ b/.github/workflows/reusable-dast.yml
@@ -72,7 +72,6 @@ jobs:
 
       - name: Prepare ZAP Context File
         env:
-          # BASE_URL: "https://${{ inputs.webappName }}-${{ inputs.slotName }}.azurewebsites.us"
           BASE_URL: "https://ustp-cams-webapp.azurewebsites.us/"
           OKTA_USERNAME: "${{ secrets.OKTA_USER_NAME }}"
           OKTA_PASSWORD: "${{ secrets.OKTA_PASSWORD }}"


### PR DESCRIPTION
Schedule the DAST scan to run automatically

## Summary by Sourcery

Schedule the DAST scan workflow to run weekly on Mondays at 8 AM ET and clean up the reusable DAST workflow configuration

New Features:
- Add cron schedule to trigger DAST scan every Monday at 8 AM ET

Enhancements:
- Retain manual workflow dispatch for DAST scan
- Remove commented out BASE_URL environment variable in reusable DAST workflow