### PR TITLE
Use a case number not inclued in the consolidation

### DIFF
--- a/test/e2e/playwright/consolidation-orders.spec.ts
+++ b/test/e2e/playwright/consolidation-orders.spec.ts
@@ -2,7 +2,6 @@ import { expect } from '@playwright/test';
 import { test } from './fixture/urlQueryString';
 import { Order, ConsolidationOrder } from '../../../common/src/cams/orders';
 import { logout } from './login/login-helpers';
-import { KNOWN_GOOD_TRANSFER_FROM_CASE_NUMBER } from '../scripts/data-generation-utils';
 
 const timeoutOption = { timeout: 30000 };
 
@@ -150,9 +149,8 @@ test.describe('Consolidation Orders', () => {
       .getByTestId('open-modal-button')
       .click();
 
-    await page
-      .getByTestId(`add-case-input-${pendingConsolidationOrder.id}`)
-      .fill(KNOWN_GOOD_TRANSFER_FROM_CASE_NUMBER);
+    const caseNumber = '29-56291';
+    await page.getByTestId(`add-case-input-${pendingConsolidationOrder.id}`).fill(caseNumber);
 
     await expect(
       page.getByTestId(`button-add-case-modal-${pendingConsolidationOrder.id}-submit-button`),


### PR DESCRIPTION
# Purpose

We want the e2e tests to pass.

# Major Changes

We use a different case number for the case to add.

# Testing/Validation

Ran e2e tests locally pointing at main staging.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
