### PR TITLE
CAMS-582: Add PhoneNumberInput for better UX

### DIFF
--- a/common/src/cams/regex.ts
+++ b/common/src/cams/regex.ts
@@ -5,7 +5,6 @@ export function escapeRegExCharacters(str: string): string {
 export const EMAIL_REGEX =
   /^(?:[a-z0-9+_-]+(?:\.[a-z0-9+_-]+)*)@(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))+$/i;
 
-export const PHONE_REGEX =
-  /^[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*\d[()\s\-.]*$/;
+export const PHONE_REGEX = /^\d{3}-\d{3}-\d{4}$/;
 
 export const EXTENSION_REGEX = /^\d{1,6}$/;

--- a/user-interface/src/lib/components/PhoneNumberInput.test.tsx
+++ b/user-interface/src/lib/components/PhoneNumberInput.test.tsx
@@ -27,50 +27,69 @@ describe('PhoneNumberInput', () => {
   });
 
   test('should properly handle value imperatives', async () => {
-    const ref = React.createRef<InputRef>();
-    render(
-      <PhoneNumberInput onChange={vi.fn()} id={'phone-number-input'} ref={ref}></PhoneNumberInput>,
-    );
+    const id = 'phone-number-input';
+    const outputId = 'phone-number-output';
+    const phoneNumber = '123-456-7890';
+    const blank = '';
 
-    ref.current?.setValue('123-456-7890');
-    await waitFor(() => {
-      expect(ref.current?.getValue()).toBe('123-456-7890');
-    });
-    ref.current?.clearValue();
-    await waitFor(() => {
-      expect(ref.current?.getValue()).toBe('');
-    });
-    ref.current?.setValue('123-456-7890');
-    await waitFor(() => {
-      expect(ref.current?.getValue()).toBe('123-456-7890');
-    });
-    ref.current?.resetValue();
-    await waitFor(() => {
-      expect(ref.current?.getValue()).toBe('');
-    });
-  });
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
 
-  test('should properly handle reset with value in props', async () => {
-    const ref = React.createRef<InputRef>();
-    render(
-      <PhoneNumberInput
-        onChange={vi.fn()}
-        id={'phone-number-input'}
-        ref={ref}
-        value={'123-456-7890'}
-      ></PhoneNumberInput>,
-    );
+    const Wrapper = () => {
+      const ref = React.createRef<InputRef>();
 
+      return (
+        <>
+          <div id={outputId} data-testid={outputId}></div>
+          <PhoneNumberInput
+            onChange={vi.fn()}
+            id={'phone-number-input'}
+            data-testid={id}
+            ref={ref}
+          ></PhoneNumberInput>
+          <button onClick={() => ref.current?.setValue(phoneNumber)}>Set Value</button>
+          <button onClick={() => ref.current?.clearValue()}>Clear Value</button>
+          <button onClick={() => ref.current?.resetValue()}>Reset Value</button>
+          <button
+            onClick={() => {
+              window.alert(ref.current!.getValue());
+            }}
+          >
+            Get Value
+          </button>
+        </>
+      );
+    };
+
+    render(<Wrapper />);
+
+    await user.click(screen.getByText('Set Value'));
     await waitFor(() => {
-      expect(ref.current?.getValue()).toBe('123-456-7890');
+      expect(screen.getByTestId(id)).toHaveValue(phoneNumber);
     });
-    ref.current?.clearValue();
+
+    await user.click(screen.getByText('Clear Value'));
     await waitFor(() => {
-      expect(ref.current?.getValue()).toBe('');
+      expect(screen.getByTestId(id)).toHaveValue(blank);
     });
-    ref.current?.resetValue();
+
+    await user.click(screen.getByText('Set Value'));
     await waitFor(() => {
-      expect(ref.current?.getValue()).toBe('123-456-7890');
+      expect(screen.getByTestId(id)).toHaveValue(phoneNumber);
+    });
+
+    await user.click(screen.getByText('Clear Value'));
+    await waitFor(() => {
+      expect(screen.getByTestId(id)).toHaveValue(blank);
+    });
+
+    await user.click(screen.getByText('Set Value'));
+    await waitFor(() => {
+      expect(screen.getByTestId(id)).toHaveValue(phoneNumber);
+    });
+
+    await user.click(screen.getByText('Get Value'));
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(phoneNumber);
     });
   });
 });

--- a/user-interface/src/lib/components/PhoneNumberInput.test.tsx
+++ b/user-interface/src/lib/components/PhoneNumberInput.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import PhoneNumberInput from '@/lib/components/PhoneNumberInput';
+import userEvent from '@testing-library/user-event';
+import { InputRef } from '@/lib/type-declarations/input-fields';
+import React from 'react';
+
+describe('PhoneNumberInput', () => {
+  const user = userEvent.setup();
+  test('should only accept numbers', async () => {
+    render(<PhoneNumberInput onChange={vi.fn()} id={'phone-number-input'}></PhoneNumberInput>);
+
+    const input = screen.getByTestId('phone-number-input');
+
+    await user.type(input, 'abc');
+    expect(input).toHaveValue('');
+
+    await user.type(input, '123abc');
+    expect(input).toHaveValue('123');
+
+    await user.clear(input);
+    await user.type(input, '1234567890');
+    expect(input).toHaveValue('123-456-7890');
+
+    await user.clear(input);
+    await user.type(input, '123456sdgg7890123456789012345()678---901234567890');
+    expect(input).toHaveValue('123-456-7890');
+  });
+
+  test('should properly handle value imperatives', async () => {
+    const ref = React.createRef<InputRef>();
+    render(
+      <PhoneNumberInput onChange={vi.fn()} id={'phone-number-input'} ref={ref}></PhoneNumberInput>,
+    );
+
+    ref.current?.setValue('123-456-7890');
+    await waitFor(() => {
+      expect(ref.current?.getValue()).toBe('123-456-7890');
+    });
+    ref.current?.clearValue();
+    await waitFor(() => {
+      expect(ref.current?.getValue()).toBe('');
+    });
+    ref.current?.setValue('123-456-7890');
+    await waitFor(() => {
+      expect(ref.current?.getValue()).toBe('123-456-7890');
+    });
+    ref.current?.resetValue();
+    await waitFor(() => {
+      expect(ref.current?.getValue()).toBe('');
+    });
+  });
+
+  test('should properly handle reset with value in props', async () => {
+    const ref = React.createRef<InputRef>();
+    render(
+      <PhoneNumberInput
+        onChange={vi.fn()}
+        id={'phone-number-input'}
+        ref={ref}
+        value={'123-456-7890'}
+      ></PhoneNumberInput>,
+    );
+
+    await waitFor(() => {
+      expect(ref.current?.getValue()).toBe('123-456-7890');
+    });
+    ref.current?.clearValue();
+    await waitFor(() => {
+      expect(ref.current?.getValue()).toBe('');
+    });
+    ref.current?.resetValue();
+    await waitFor(() => {
+      expect(ref.current?.getValue()).toBe('123-456-7890');
+    });
+  });
+});

--- a/user-interface/src/lib/components/PhoneNumberInput.tsx
+++ b/user-interface/src/lib/components/PhoneNumberInput.tsx
@@ -1,0 +1,74 @@
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import Input, { InputProps } from './uswds/Input';
+import { InputRef } from '../type-declarations/input-fields';
+
+export function validatePhoneNumberInput(ev: React.ChangeEvent<HTMLInputElement>) {
+  const digitsOnly = (ev.target.value.match(/\d/g) ?? []).slice(0, 10);
+
+  let joinedInput = '';
+  const len = digitsOnly.length;
+  if (len > 0) {
+    joinedInput = digitsOnly.slice(0, Math.min(3, len)).join('');
+  }
+  if (len >= 4) {
+    joinedInput += '-' + digitsOnly.slice(3, Math.min(6, len)).join('');
+  }
+  if (len >= 7) {
+    joinedInput += '-' + digitsOnly.slice(6, 10).join('');
+  }
+
+  if (len === 0) {
+    joinedInput = '';
+  }
+
+  const fullPhonePattern = /^\d{3}-\d{3}-\d{4}$/;
+  const phoneNumber = fullPhonePattern.test(joinedInput) ? joinedInput : undefined;
+  return { phoneNumber, joinedInput };
+}
+
+type PhoneNumberInputProps = Omit<InputProps, 'onChange' | 'onFocus'> & {
+  onChange: (phoneNumber?: string) => void;
+  onFocus?: (ev: React.FocusEvent<HTMLElement>) => void;
+};
+
+function PhoneNumberInputComponent(props: PhoneNumberInputProps, ref: React.Ref<InputRef>) {
+  const { onChange, ...otherProps } = props;
+
+  const forwardedRef = useRef<InputRef>(null);
+  const clearValue = () => forwardedRef.current?.clearValue();
+  const resetValue = () => forwardedRef.current?.resetValue();
+  const setValue = (value: string) => forwardedRef.current?.setValue(value);
+  const getValue = () => forwardedRef.current?.getValue() ?? '';
+  const disable = (value: boolean) => forwardedRef.current?.disable(value);
+  const focus = () => forwardedRef.current?.focus();
+
+  useImperativeHandle(ref, () => ({
+    clearValue,
+    resetValue,
+    setValue,
+    getValue,
+    disable,
+    focus,
+  }));
+
+  return (
+    <Input
+      {...otherProps}
+      ref={forwardedRef}
+      onChange={(ev) => {
+        const { phoneNumber, joinedInput } = validatePhoneNumberInput(ev);
+        forwardedRef?.current?.setValue(joinedInput);
+        onChange(phoneNumber);
+      }}
+      includeClearButton={true}
+      ariaDescription="Example: 123-456-7890"
+      placeholder="___-___-____"
+      aria-placeholder=""
+      type="tel"
+      inputMode="numeric"
+    ></Input>
+  );
+}
+
+const PhoneNumberInput = forwardRef(PhoneNumberInputComponent);
+export default PhoneNumberInput;

--- a/user-interface/src/trustees/TrusteeCreateForm.test.tsx
+++ b/user-interface/src/trustees/TrusteeCreateForm.test.tsx
@@ -389,7 +389,7 @@ describe('TrusteeCreateForm', () => {
       });
     });
 
-    test('validates phone format when provided', async () => {
+    test('validates phone format', async () => {
       renderWithRouter();
 
       const phoneInput = screen.getByTestId('trustee-phone');
@@ -399,7 +399,7 @@ describe('TrusteeCreateForm', () => {
       await userEvent.tab(); // Trigger blur
 
       await waitFor(() => {
-        expect(screen.getByText('Please enter a valid phone number')).toBeInTheDocument();
+        expect(screen.getByText('Phone is required')).toBeInTheDocument();
       });
 
       // Test valid phone format - error should disappear
@@ -408,7 +408,7 @@ describe('TrusteeCreateForm', () => {
       await userEvent.tab();
 
       await waitFor(() => {
-        expect(screen.queryByText('Please enter a valid phone number')).not.toBeInTheDocument();
+        expect(screen.queryByText('Phone is required')).not.toBeInTheDocument();
       });
     });
 
@@ -477,7 +477,7 @@ describe('TrusteeCreateForm', () => {
             zipCode: TEST_TRUSTEE_DATA.zipCode,
             countryCode: 'US',
           },
-          phone: '(555) 123-4567',
+          phone: '555-123-4567',
           email: TEST_TRUSTEE_DATA.email,
           status: 'active',
         });
@@ -523,7 +523,7 @@ describe('TrusteeCreateForm', () => {
             zipCode: TEST_TRUSTEE_DATA.zipCode,
             countryCode: 'US',
           },
-          phone: '(555) 123-4567',
+          phone: '555-123-4567',
           email: TEST_TRUSTEE_DATA.email,
           status: 'active',
         });
@@ -1017,7 +1017,7 @@ describe('TrusteeCreateForm', () => {
             zipCode: TEST_TRUSTEE_DATA.zipCode,
             countryCode: 'US',
           },
-          phone: '(555) 123-4567',
+          phone: '555-123-4567',
           email: TEST_TRUSTEE_DATA.email,
           status: 'active',
         });

--- a/user-interface/src/trustees/TrusteeCreateForm.tsx
+++ b/user-interface/src/trustees/TrusteeCreateForm.tsx
@@ -19,7 +19,6 @@ import { Stop } from '@/lib/components/Stop';
 import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
 import PhoneNumberInput from '@/lib/components/PhoneNumberInput';
 
-// Chapter type options - Complete list with Panel/Non-Panel distinctions
 const CHAPTER_OPTIONS: ComboOption<ChapterType>[] = [
   { value: '7-panel', label: '7 - Panel' },
   { value: '7-non-panel', label: '7 - Non-Panel' },
@@ -62,14 +61,12 @@ export default function TrusteeCreateForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  // District options state
   const [districtOptions, setDistrictOptions] = useState<ComboOption[]>([]);
   const [districtLoadError, setDistrictLoadError] = useState<string | null>(null);
 
   const canManage = !!session?.user?.roles?.includes(CamsRole.TrusteeAdmin);
   const navigate = useCamsNavigator();
 
-  // Load district options from API
   useEffect(() => {
     setDistrictLoadError(null);
     api
@@ -81,10 +78,8 @@ export default function TrusteeCreateForm() {
 
         const courts = response.data;
 
-        // Transform court divisions to district options
         const districtMap = new Map<string, ComboOption>();
         courts.forEach((court: CourtDivisionDetails) => {
-          // Use courtId as both value and create a readable label
           const label = `${court.courtName} (${court.courtDivisionName})`;
           districtMap.set(court.courtDivisionCode, {
             value: court.courtDivisionCode,
@@ -152,10 +147,8 @@ export default function TrusteeCreateForm() {
     setter: React.Dispatch<React.SetStateAction<string>>,
   ) {
     const { value, name } = event.target;
-    // Update state immediately for responsive UI
     setter(value);
 
-    // Debounce only the validation to avoid excessive API calls
     debounce(() => {
       validateFieldAndUpdate(name, value);
     }, 300);
@@ -165,7 +158,6 @@ export default function TrusteeCreateForm() {
     setErrorMessage(null);
     clearErrors();
 
-    // Validate form before submission
     const formData = getFormData();
 
     setIsSubmitting(true);
@@ -195,8 +187,6 @@ export default function TrusteeCreateForm() {
     } catch (e) {
       const errorMsg = e instanceof Error ? e.message : 'Could not create trustee.';
       setErrorMessage(errorMsg);
-
-      // Show error notification
       globalAlert?.error(`Failed to create trustee: ${errorMsg}`);
     } finally {
       setIsSubmitting(false);
@@ -295,10 +285,7 @@ export default function TrusteeCreateForm() {
                   label="State"
                   onUpdateSelection={(selectedOptions) => {
                     const selectedValue = selectedOptions[0] ? selectedOptions[0].value : '';
-                    // Update state immediately for responsive UI
                     setState(selectedValue);
-
-                    // Debounce only the validation
                     debounce(() => {
                       validateFieldAndUpdate('state', selectedValue);
                     }, 300);
@@ -317,10 +304,7 @@ export default function TrusteeCreateForm() {
                   value={zipCode}
                   onChange={(e) => {
                     const { value } = e.target;
-                    // Update state immediately for responsive UI
                     setZipCode(value);
-
-                    // Debounce only the validation
                     debounce(() => {
                       validateFieldAndUpdate('zipCode', value);
                     }, 300);
@@ -336,7 +320,6 @@ export default function TrusteeCreateForm() {
           <div className="grid-col-6">
             <div className="grid-row grid-gap-lg">
               <div className="grid-col-4">
-                {/* Replace plain Input with PhoneNumberInput for formatted phone numbers */}
                 <PhoneNumberInput
                   id="trustee-phone"
                   name="phone"
@@ -345,7 +328,6 @@ export default function TrusteeCreateForm() {
                     const next = value ?? '';
                     setPhone(next);
                     debounce(() => {
-                      // Validate using the string as-is; shared PHONE_REGEX accepts formatted numbers
                       validateFieldAndUpdate('phone', next);
                     }, 300);
                   }}

--- a/user-interface/src/trustees/TrusteeCreateForm.tsx
+++ b/user-interface/src/trustees/TrusteeCreateForm.tsx
@@ -17,6 +17,7 @@ import UsStatesComboBox from '@/lib/components/combobox/UsStatesComboBox';
 import useDebounce from '@/lib/hooks/UseDebounce';
 import { Stop } from '@/lib/components/Stop';
 import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
+import PhoneNumberInput from '@/lib/components/PhoneNumberInput';
 
 // Chapter type options - Complete list with Panel/Non-Panel distinctions
 const CHAPTER_OPTIONS: ComboOption<ChapterType>[] = [
@@ -335,16 +336,22 @@ export default function TrusteeCreateForm() {
           <div className="grid-col-6">
             <div className="grid-row grid-gap-lg">
               <div className="grid-col-4">
-                <Input
+                {/* Replace plain Input with PhoneNumberInput for formatted phone numbers */}
+                <PhoneNumberInput
                   id="trustee-phone"
                   name="phone"
                   label="Phone"
-                  value={phone}
-                  onChange={(e) => handleFieldChange(e, setPhone)}
+                  onChange={(value) => {
+                    const next = value ?? '';
+                    setPhone(next);
+                    debounce(() => {
+                      // Validate using the string as-is; shared PHONE_REGEX accepts formatted numbers
+                      validateFieldAndUpdate('phone', next);
+                    }, 300);
+                  }}
                   errorMessage={fieldErrors['phone']}
                   autoComplete="off"
-                  type="tel"
-                  ariaDescription="Example: (123)456-7890"
+                  ariaDescription="Example: 123-456-7890"
                   required
                 />
               </div>

--- a/user-interface/src/trustees/UseTrusteeFormValidation.test.ts
+++ b/user-interface/src/trustees/UseTrusteeFormValidation.test.ts
@@ -7,7 +7,7 @@ const VALID_FORM_DATA = {
   address1: '123 Main St',
   city: 'Springfield',
   state: 'IL',
-  phone: '(555) 123-4567',
+  phone: '555-123-4567',
   email: 'test@example.com',
   status: 'active' as const,
 };
@@ -40,7 +40,7 @@ const COMPLETE_VALID_FORM_DATA = {
   city: 'Springfield',
   state: 'Illinois',
   zipCode: '62704',
-  phone: '(555) 123-4567',
+  phone: '555-123-4567',
   email: 'jane.doe@example.com',
   status: 'active' as const,
 };
@@ -56,7 +56,6 @@ const ERROR_MESSAGES = {
   EMAIL_REQUIRED: 'Email is required',
   EMAIL_INVALID: 'Email must be a valid email address',
   PHONE_REQUIRED: 'Phone is required',
-  PHONE_INVALID: 'Please enter a valid phone number',
   EXTENSION_INVALID: 'Extension must be 1 to 6 digits',
 };
 
@@ -133,12 +132,10 @@ describe('useTrusteeFormValidation', () => {
       value: 'user@@double.com',
       expectedValue: ERROR_MESSAGES.EMAIL_INVALID,
     },
-    { field: 'phone', value: '(555) 123-4567', expectedValue: null },
-    { field: 'phone', value: '5551234567', expectedValue: null },
     { field: 'phone', value: '555-123-4567', expectedValue: null },
     { field: 'phone', value: '', expectedValue: ERROR_MESSAGES.PHONE_REQUIRED },
-    { field: 'phone', value: 'abc', expectedValue: ERROR_MESSAGES.PHONE_INVALID },
-    { field: 'phone', value: '123', expectedValue: ERROR_MESSAGES.PHONE_INVALID },
+    { field: 'phone', value: 'abc', expectedValue: ERROR_MESSAGES.PHONE_REQUIRED },
+    { field: 'phone', value: '123', expectedValue: ERROR_MESSAGES.PHONE_REQUIRED },
     { field: 'extension', value: '123', expectedValue: null },
     { field: 'extension', value: '1', expectedValue: null },
     { field: 'extension', value: '123456', expectedValue: null },
@@ -209,7 +206,7 @@ describe('useTrusteeFormValidation', () => {
 
     const validationResult = result.current.isFormValidAndComplete(COMPLETE_VALID_FORM_DATA);
 
-    expect(validationResult).toBe(true);
+    expect(validationResult).toBeTruthy();
   });
 
   test('validates trimmed values', () => {
@@ -217,6 +214,6 @@ describe('useTrusteeFormValidation', () => {
 
     const validationResult = result.current.isFormValidAndComplete(SPACES_FORM_DATA);
 
-    expect(validationResult).toBe(false);
+    expect(validationResult).toBeFalsy();
   });
 });

--- a/user-interface/src/trustees/UseTrusteeFormValidation.ts
+++ b/user-interface/src/trustees/UseTrusteeFormValidation.ts
@@ -44,11 +44,8 @@ function validateField(field: string, value: string): string | null {
       return null;
 
     case 'phone':
-      if (!trimmedValue) {
+      if (!trimmedValue || !PHONE_REGEX.test(trimmedValue)) {
         return 'Phone is required';
-      }
-      if (!PHONE_REGEX.test(trimmedValue)) {
-        return 'Please enter a valid phone number';
       }
       return null;
 


### PR DESCRIPTION
# Purpose

The previous phone regex was accepting an arbitrary number of dashes, parens, and spaces.

# Major Changes

Adds a PhoneNumberInput component which handles automatically entering dashes after the area code and local prefix.

# Testing/Validation

Added and updated automated tests and verified locally.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add PhoneNumberInput component to autoformat and strictly validate phone numbers in XXX-XXX-XXXX format, replace existing phone fields in trustee form, and update validation logic and tests accordingly

New Features:
- Introduce PhoneNumberInput component to automatically format user input into XXX-XXX-XXXX pattern

Enhancements:
- Replace plain phone Input in TrusteeCreateForm with PhoneNumberInput and add debounced validation
- Update PHONE_REGEX to enforce a strict dash-separated format and simplify phone validation messaging
- Refactor useTrusteeFormValidation to treat empty or invalid phone values uniformly as required

Tests:
- Update trustee form and validation tests to use dash-separated phone values and new error messages
- Add unit tests for PhoneNumberInput component behavior