### PR TITLE
Make sure districts dropdown closes

### DIFF
--- a/test/e2e/playwright/trustees.spec.ts
+++ b/test/e2e/playwright/trustees.spec.ts
@@ -95,13 +95,16 @@ test.describe('Trustees', () => {
       // Select the first available district option
       await districtOptions.first().click();
     }
+    const districtsExpandButton = page.locator('#trustee-districts-expand');
+    await districtsExpandButton.click();
 
     // Test chapter types selection dropdown
     const chaptersCombobox = page.locator('#trustee-chapters');
     await expect(chaptersCombobox).toBeVisible();
 
     // Click to open the dropdown
-    await chaptersCombobox.click();
+    const chaptersExpandButton = page.locator('#trustee-chapters-expand');
+    await chaptersExpandButton.click();
 
     // Verify chapter options are visible
     const chapterOptions = page.locator(


### PR DESCRIPTION
# Purpose

Sometimes the chapters combo box was not opening during e2e test.

# Major Changes

Intentionally close the districts combo box.

# Testing/Validation

Ran e2e tests locally.


# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Fix flaky E2E test by explicitly closing the districts dropdown before opening the chapters combobox in the trustees spec.

Tests:
- Close the districts dropdown via its expand button before selecting chapters
- Use a dedicated expand button selector to open the chapters combobox instead of clicking the combobox itself