### PR TITLE
CAMS-615: Configure slot during code deploy

### DIFF
--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -112,7 +112,8 @@ jobs:
           -g ${{ steps.rgApp.outputs.out }} \
           -n ${{ inputs.apiFunctionName }} \
           --src ./${{ inputs.apiFunctionName }}.zip \
-          --slotName ${{ inputs.slotName }}
+          --slotName ${{ inputs.slotName }} \
+          --commitSha ${{ github.sha }}
 
   deploy-dataflows-slot:
     runs-on: ubuntu-latest
@@ -146,7 +147,8 @@ jobs:
           -g ${{ steps.rgApp.outputs.out }} \
           -n ${{ inputs.dataflowsFunctionName }} \
           --src ./${{ inputs.dataflowsFunctionName }}.zip \
-          --slotName ${{ inputs.slotName }}
+          --slotName ${{ inputs.slotName }} \
+          --commitSha ${{ github.sha }}
 
   endpoint-test-application-slot:
     needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot]

--- a/ops/scripts/pipeline/slots/az-func-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-func-slot-deploy.sh
@@ -45,6 +45,11 @@ while [[ $# -gt 0 ]]; do
         shift 2
         ;;
 
+    --commitSha)
+        commitSha="${2}"
+        shift 2
+        ;;
+
     *)
         exit 2 # error on unknown flag/switch
         ;;
@@ -72,6 +77,8 @@ agent_ip=$(curl -s --retry 3 --retry-delay 30 --retry-all-errors https://api.ipi
 echo "Adding rule: ${rule_name} to webapp"
 az functionapp config access-restriction add -g "${app_rg}" -n "${app_name}" --slot "${slot_name}" --rule-name "${rule_name}" --action Allow --ip-address "${agent_ip}" --priority 232 --scm-site true 1>/dev/null
 az functionapp config access-restriction add -g "${app_rg}" -n "${app_name}" --rule-name "${rule_name}" --action Allow --ip-address "${agent_ip}" --priority 232 --scm-site true 1>/dev/null
+# Configure info sha
+az functionapp config appsettings set -g "${app_rg}" -n "${app_name}" --slot "${slot_name}" --settings "INFO_SHA=${commitSha}"
 # Construct and execute deployment command
 cmd="az functionapp deployment source config-zip -g ${app_rg} -n ${app_name} --slot ${slot_name} --src ${artifact_path}"
 if [[ ${enable_debug} == 'true' ]]; then


### PR DESCRIPTION
# Purpose

We are not configuring the slot with the commit sha.

# Major Changes

Update the `az-app-slot-deploy.sh` code deploy script to configure the `INFO_SHA` variable prior to deployment.

# Testing/Validation

Will validate by deploying.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Configure Azure function app slot deployments to include the commit SHA as an INFO_SHA app setting by extending the deployment script and updating the CI workflows

Enhancements:
- Accept a new --commitSha flag in the Azure function slot deployment script to capture the Git commit SHA
- Configure the INFO_SHA application setting on function app slots using the provided commit SHA before deploying

CI:
- Update GitHub Actions workflows for API and dataflows slot deployments to pass the current commit SHA to the deploy script