### PR TITLE
Wait for container restart

### DIFF
--- a/ops/scripts/pipeline/slots/az-func-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-func-slot-deploy.sh
@@ -79,6 +79,8 @@ az functionapp config access-restriction add -g "${app_rg}" -n "${app_name}" --s
 az functionapp config access-restriction add -g "${app_rg}" -n "${app_name}" --rule-name "${rule_name}" --action Allow --ip-address "${agent_ip}" --priority 232 --scm-site true 1>/dev/null
 # Configure info sha
 az functionapp config appsettings set -g "${app_rg}" -n "${app_name}" --slot "${slot_name}" --settings "INFO_SHA=${commitSha}"
+# Gives some extra time for prior management operation to complete before starting deployment
+sleep 10
 # Construct and execute deployment command
 cmd="az functionapp deployment source config-zip -g ${app_rg} -n ${app_name} --slot ${slot_name} --src ${artifact_path}"
 if [[ ${enable_debug} == 'true' ]]; then


### PR DESCRIPTION
# Purpose

We were trying to deploy while the container was still restarting.

# Major Changes

Wait for a bit to allow the container to finish restart.

# Testing/Validation

Verified deployment worked.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Bug Fixes:
- Add a 10-second sleep to the Azure Function slot deployment script to ensure the container has restarted before deployment