### PR TITLE
CAMS-634 Add additional logging on redirect errors

### DIFF
--- a/user-interface/src/login/providers/okta/OktaSession.tsx
+++ b/user-interface/src/login/providers/okta/OktaSession.tsx
@@ -28,7 +28,10 @@ export function OktaSession(props: Readonly<OktaSessionProps>) {
         if (error.message !== 'Unable to parse a token from the url') {
           appInsights.trackEvent(
             { name: 'Okta redirect error' },
-            { ...error, note: `Access Denied log entry will follow this one.` },
+            {
+              error: { message: error.message, name: error.name },
+              note: `Access Denied log entry will follow this one.`,
+            },
           );
           setCallbackError(error);
         }

--- a/user-interface/src/login/providers/okta/OktaSession.tsx
+++ b/user-interface/src/login/providers/okta/OktaSession.tsx
@@ -8,7 +8,7 @@ import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 export type OktaSessionProps = PropsWithChildren;
 
-export function OktaSession(props: OktaSessionProps) {
+export function OktaSession(props: Readonly<OktaSessionProps>) {
   const { appInsights } = getAppInsights();
   const [redirectComplete, setRedirectComplete] = useState<boolean>(false);
   const [callbackError, setCallbackError] = useState<Error | null>(null);
@@ -24,9 +24,12 @@ export function OktaSession(props: OktaSessionProps) {
       })
       .catch((e) => {
         const error = e as Error;
-        appInsights.trackEvent({ name: 'Okta redirect error' }, { status: 'error level 0' });
         // Only report if the error is not the parse error during the continuation redirects.
         if (error.message !== 'Unable to parse a token from the url') {
+          appInsights.trackEvent(
+            { name: 'Okta redirect error' },
+            { ...error, note: `Access Denied log entry will follow this one.` },
+          );
           setCallbackError(error);
         }
       });


### PR DESCRIPTION
# Purpose

Increased logging on redirect errors from Okta

# Major Changes

Added error to AppInsights log

## Summary by Sourcery

Enhance error telemetry for Okta redirect failures and enforce immutability of session props

Enhancements:
- Enforce Readonly on OktaSession props to ensure immutability
- Augment AppInsights tracking of Okta redirect errors with full error details and a contextual note