### PR TITLE
CAMS-586 Call trustee - Link Component

### DIFF
--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.test.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.test.tsx
@@ -241,6 +241,42 @@ describe('CommsLink Component', () => {
       expect(iconLabel.getAttribute('data-icon')).toBe('custom-icon');
     });
 
+    test('renders email link with emailSubject', () => {
+      render(
+        <CommsLink
+          contact={emailContact as Omit<ContactInformation, 'address'>}
+          mode="email"
+          emailSubject="Test Subject"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('mailto:test@example.com?subject=Test%20Subject');
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('test@example.com');
+      expect(iconLabel.getAttribute('data-icon')).toBe('mail');
+    });
+
+    test('renders email link with emailSubject containing special characters', () => {
+      render(
+        <CommsLink
+          contact={emailContact as Omit<ContactInformation, 'address'>}
+          mode="email"
+          emailSubject="Test & Subject: With Special Characters?"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe(
+        'mailto:test@example.com?subject=Test%20%26%20Subject%3A%20With%20Special%20Characters%3F',
+      );
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('test@example.com');
+      expect(iconLabel.getAttribute('data-icon')).toBe('mail');
+    });
+
     test('renders email link with fallback label when email is missing', () => {
       const contactWithoutEmail: Partial<ContactInformation> = {
         phone: { number: '555-123-4567' },

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.test.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.test.tsx
@@ -289,12 +289,12 @@ describe('CommsLink Component', () => {
         />,
       );
 
-      const link = screen.getByRole('link');
-      expect(link.getAttribute('href')).toBe('mailto:undefined');
+      const link = screen.queryByRole('link');
+      expect(link).not.toBeInTheDocument();
 
       const iconLabel = screen.getByTestId('icon-label');
-      expect(iconLabel).toHaveTextContent('Email');
-      expect(iconLabel.getAttribute('data-icon')).toBe('mail');
+      expect(iconLabel).toHaveTextContent('');
+      expect(iconLabel.getAttribute('data-icon')).toBe('error');
     });
   });
 

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.test.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.test.tsx
@@ -1,0 +1,283 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import CommsLink from './CommsLink';
+import { ContactInformation } from '@common/cams/contact';
+
+// Mock the IconLabel component to simplify testing
+import * as IconLabelModule from '@/lib/components/cams/IconLabel/IconLabel';
+
+beforeEach(() => {
+  vi.spyOn(IconLabelModule, 'IconLabel').mockImplementation(
+    ({ label, icon }: { label: string; icon: string }) => (
+      <span data-testid="icon-label" data-icon={icon}>
+        {label}
+      </span>
+    ),
+  );
+});
+
+describe('CommsLink Component', () => {
+  // Test the toTelephoneUri utility function indirectly through component rendering
+  describe('toTelephoneUri function', () => {
+    const phoneContact: Partial<ContactInformation> = {
+      phone: { number: '555-123-4567' },
+    };
+
+    test('formats phone number without extension', () => {
+      render(
+        <CommsLink
+          contact={phoneContact as Omit<ContactInformation, 'address'>}
+          mode="phone-dialer"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('tel:+15551234567');
+    });
+
+    test('formats phone number with extension', () => {
+      const contactWithExtension: Partial<ContactInformation> = {
+        phone: { number: '555-123-4567', extension: '123' },
+      };
+
+      render(
+        <CommsLink
+          contact={contactWithExtension as Omit<ContactInformation, 'address'>}
+          mode="phone-dialer"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('tel:+15551234567;ext=123');
+    });
+  });
+
+  // Test each mode of the CommsLink component
+  describe('Mode: teams-chat', () => {
+    const emailContact: Partial<ContactInformation> = {
+      email: 'test@example.com',
+    };
+
+    test('renders teams-chat link with default values', () => {
+      render(
+        <CommsLink
+          contact={emailContact as Omit<ContactInformation, 'address'>}
+          mode="teams-chat"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe(
+        'msteams://teams.microsoft.com/l/chat/0/0?users=test@example.com',
+      );
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('Chat');
+      expect(iconLabel.getAttribute('data-icon')).toBe('chat');
+    });
+
+    test('renders teams-chat link with custom label and icon', () => {
+      render(
+        <CommsLink
+          contact={emailContact as Omit<ContactInformation, 'address'>}
+          mode="teams-chat"
+          label="Custom Chat"
+          icon="custom-icon"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe(
+        'msteams://teams.microsoft.com/l/chat/0/0?users=test@example.com',
+      );
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('Custom Chat');
+      expect(iconLabel.getAttribute('data-icon')).toBe('custom-icon');
+    });
+  });
+
+  describe('Mode: teams-call', () => {
+    const emailContact: Partial<ContactInformation> = {
+      email: 'test@example.com',
+    };
+
+    test('renders teams-call link with default values', () => {
+      render(
+        <CommsLink
+          contact={emailContact as Omit<ContactInformation, 'address'>}
+          mode="teams-call"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe(
+        'msteams://teams.microsoft.com/l/call/0/0?users=test@example.com',
+      );
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('Talk');
+      expect(iconLabel.getAttribute('data-icon')).toBe('forum');
+    });
+
+    test('renders teams-call link with custom label and icon', () => {
+      render(
+        <CommsLink
+          contact={emailContact as Omit<ContactInformation, 'address'>}
+          mode="teams-call"
+          label="Custom Call"
+          icon="custom-icon"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe(
+        'msteams://teams.microsoft.com/l/call/0/0?users=test@example.com',
+      );
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('Custom Call');
+      expect(iconLabel.getAttribute('data-icon')).toBe('custom-icon');
+    });
+  });
+
+  describe('Mode: phone-dialer', () => {
+    test('renders phone-dialer link with default values', () => {
+      const phoneContact: Partial<ContactInformation> = {
+        phone: { number: '555-123-4567' },
+      };
+
+      render(
+        <CommsLink
+          contact={phoneContact as Omit<ContactInformation, 'address'>}
+          mode="phone-dialer"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('tel:+15551234567');
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('555-123-4567');
+      expect(iconLabel.getAttribute('data-icon')).toBe('phone');
+    });
+
+    test('renders phone-dialer link with extension in label', () => {
+      const phoneContact: Partial<ContactInformation> = {
+        phone: { number: '555-123-4567', extension: '123' },
+      };
+
+      render(
+        <CommsLink
+          contact={phoneContact as Omit<ContactInformation, 'address'>}
+          mode="phone-dialer"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('tel:+15551234567;ext=123');
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('555-123-4567 x123');
+      expect(iconLabel.getAttribute('data-icon')).toBe('phone');
+    });
+
+    test('renders phone-dialer link with custom label and icon', () => {
+      const phoneContact: Partial<ContactInformation> = {
+        phone: { number: '555-123-4567' },
+      };
+
+      render(
+        <CommsLink
+          contact={phoneContact as Omit<ContactInformation, 'address'>}
+          mode="phone-dialer"
+          label="Custom Phone"
+          icon="custom-icon"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('tel:+15551234567');
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('Custom Phone');
+      expect(iconLabel.getAttribute('data-icon')).toBe('custom-icon');
+    });
+  });
+
+  describe('Mode: email', () => {
+    const emailContact: Partial<ContactInformation> = {
+      email: 'test@example.com',
+    };
+
+    test('renders email link with default values', () => {
+      render(
+        <CommsLink contact={emailContact as Omit<ContactInformation, 'address'>} mode="email" />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('mailto:test@example.com');
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('test@example.com');
+      expect(iconLabel.getAttribute('data-icon')).toBe('mail');
+    });
+
+    test('renders email link with custom label and icon', () => {
+      render(
+        <CommsLink
+          contact={emailContact as Omit<ContactInformation, 'address'>}
+          mode="email"
+          label="Custom Email"
+          icon="custom-icon"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('mailto:test@example.com');
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('Custom Email');
+      expect(iconLabel.getAttribute('data-icon')).toBe('custom-icon');
+    });
+
+    test('renders email link with fallback label when email is missing', () => {
+      const contactWithoutEmail: Partial<ContactInformation> = {
+        phone: { number: '555-123-4567' },
+      };
+
+      render(
+        <CommsLink
+          contact={contactWithoutEmail as Omit<ContactInformation, 'address'>}
+          mode="email"
+        />,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link.getAttribute('href')).toBe('mailto:undefined');
+
+      const iconLabel = screen.getByTestId('icon-label');
+      expect(iconLabel).toHaveTextContent('Email');
+      expect(iconLabel.getAttribute('data-icon')).toBe('mail');
+    });
+  });
+
+  // Edge case - rendering without icon
+  test('renders link without icon when icon is not provided', () => {
+    const emailContact: Partial<ContactInformation> = {
+      email: 'test@example.com',
+    };
+
+    render(
+      <CommsLink
+        contact={emailContact as Omit<ContactInformation, 'address'>}
+        mode="email"
+        label="Email Me"
+        icon={undefined}
+      />,
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveTextContent('Email Me');
+  });
+});

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
@@ -70,7 +70,7 @@ function CommsLink(props: Readonly<CommsLinkProps>) {
 
   return (
     <a href={href} className="usa-link">
-      {iconToUse ? <IconLabel label={labelToUse} icon={iconToUse} location="left" /> : labelToUse}
+      <IconLabel label={labelToUse} icon={iconToUse} location="left" />
     </a>
   );
 }

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
@@ -6,40 +6,25 @@ type CommsLinkProps = {
   mode: 'teams-chat' | 'teams-call' | 'phone-dialer' | 'email';
   label?: string;
   icon?: string;
+  emailSubject?: string;
 };
 
+const NON_DIGITS = /\D/g;
+
 function toTelephoneUri(number: string, extension?: string) {
-  const strippedNumber = number.replace(/[^\d]/g, '');
-  if (extension) {
-    return `tel:+1${strippedNumber};ext=${extension}`;
+  const strippedNumber = number.replace(NON_DIGITS, '');
+  const strippedExtension = extension?.replace(NON_DIGITS, '');
+  if (strippedExtension) {
+    return `tel:+1${strippedNumber};ext=${strippedExtension}`;
   } else {
     return `tel:+1${strippedNumber}`;
   }
 }
 
 function CommsLink(props: Readonly<CommsLinkProps>) {
-  const { contact, mode, label, icon } = props;
+  const { contact, mode, label, icon, emailSubject } = props;
   const { number, extension } = contact.phone ?? { number: '' };
   const { email } = contact;
-
-  // TODO: Sanity check the content to make sure we are not opening a malicious link.
-
-  // TODO: Add detection if teams link isn't available. Example code:
-  // function tryTeamsOrTel(phone) {
-  //   const teamsUrl = `msteams://teams.microsoft.com/l/call/0/0?users=${encodeURIComponent(phone)}`;
-  //   const telUrl   = `tel:${phone}`;
-  //
-  //   let launched = false;
-  //   const timeout = setTimeout(() => {
-  //     if (!launched) {
-  //       window.location.href = telUrl; // fallback
-  //     }
-  //   }, 1500);
-  //
-  //   window.location.href = teamsUrl;
-  //   // If Teams handles it, the browser leaves and never runs fallback.
-  //   // If not, timeout fires and we redirect to tel:
-  // }
 
   let href = 'javascript:void(0);';
   let labelToUse = '';
@@ -63,6 +48,9 @@ function CommsLink(props: Readonly<CommsLinkProps>) {
       break;
     case 'email':
       href = `mailto:${email}`;
+      if (emailSubject) {
+        href += `?subject=${encodeURIComponent(emailSubject)}`;
+      }
       labelToUse = label ?? email ?? 'Email';
       iconToUse = iconToUse ?? 'mail';
       break;

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
@@ -1,0 +1,78 @@
+import { ContactInformation } from '@common/cams/contact';
+import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
+
+type CommsLinkProps = {
+  contact: Omit<ContactInformation, 'address'>;
+  mode: 'teams-chat' | 'teams-call' | 'phone-dialer' | 'email';
+  label?: string;
+  icon?: string;
+};
+
+function toTelephoneUri(number: string, extension?: string) {
+  const strippedNumber = number.replace(/[^\d]/g, '');
+  if (extension) {
+    return `tel:+1${strippedNumber};ext=${extension}`;
+  } else {
+    return `tel:+1${strippedNumber}`;
+  }
+}
+
+function CommsLink(props: Readonly<CommsLinkProps>) {
+  const { contact, mode, label, icon } = props;
+  const { number, extension } = contact.phone ?? { number: '' };
+  const { email } = contact;
+
+  // TODO: Sanity check the content to make sure we are not opening a malicious link.
+
+  // TODO: Add detection if teams link isn't available. Example code:
+  // function tryTeamsOrTel(phone) {
+  //   const teamsUrl = `msteams://teams.microsoft.com/l/call/0/0?users=${encodeURIComponent(phone)}`;
+  //   const telUrl   = `tel:${phone}`;
+  //
+  //   let launched = false;
+  //   const timeout = setTimeout(() => {
+  //     if (!launched) {
+  //       window.location.href = telUrl; // fallback
+  //     }
+  //   }, 1500);
+  //
+  //   window.location.href = teamsUrl;
+  //   // If Teams handles it, the browser leaves and never runs fallback.
+  //   // If not, timeout fires and we redirect to tel:
+  // }
+
+  let href = 'javascript:void(0);';
+  let labelToUse = '';
+  let iconToUse = icon;
+
+  switch (mode) {
+    case 'teams-chat':
+      href = `msteams://teams.microsoft.com/l/chat/0/0?users=${email}`;
+      labelToUse = label ?? 'Chat';
+      iconToUse = iconToUse ?? 'chat';
+      break;
+    case 'teams-call':
+      href = `msteams://teams.microsoft.com/l/call/0/0?users=${email}`;
+      labelToUse = label ?? 'Talk';
+      iconToUse = iconToUse ?? 'forum';
+      break;
+    case 'phone-dialer':
+      href = toTelephoneUri(number, extension);
+      labelToUse = label ?? (extension ? `${number} x${extension}` : number);
+      iconToUse = iconToUse ?? 'phone';
+      break;
+    case 'email':
+      href = `mailto:${email}`;
+      labelToUse = label ?? email ?? 'Email';
+      iconToUse = iconToUse ?? 'mail';
+      break;
+  }
+
+  return (
+    <a href={href} className="usa-link">
+      {iconToUse ? <IconLabel label={labelToUse} icon={iconToUse} location="left" /> : labelToUse}
+    </a>
+  );
+}
+
+export default CommsLink;

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
@@ -26,7 +26,7 @@ function CommsLink(props: Readonly<CommsLinkProps>) {
   const { number, extension } = contact.phone ?? { number: '' };
   const { email } = contact;
 
-  let href = 'javascript:void(0);';
+  let href = '#';
   let labelToUse = '';
   let iconToUse = icon;
 

--- a/user-interface/src/lib/components/cams/IconLabel/IconLabel.tsx
+++ b/user-interface/src/lib/components/cams/IconLabel/IconLabel.tsx
@@ -8,7 +8,7 @@ export type IconLabelProps = {
   location?: 'left' | 'right';
 };
 
-export function IconLabel(props: IconLabelProps) {
+export function IconLabel(props: Readonly<IconLabelProps>) {
   let location = 'left';
   if (props.location) {
     location = props.location;

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -14,7 +14,6 @@ import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
 import { TrusteeFormState } from './TrusteeForm';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
-import CommsLink from '@/lib/components/cams/CommsLink/CommsLink';
 
 export default function TrusteeDetailScreen() {
   const { trusteeId } = useParams();
@@ -279,17 +278,6 @@ export default function TrusteeDetailScreen() {
                           </a>
                         </div>
                       )}
-                      {/*This div is for demonstration purposes only and should be removed.*/}
-                      <div>
-                        <CommsLink contact={trustee.internal} mode="teams-chat" />
-                        <br />
-                        <CommsLink contact={trustee.internal} mode="teams-call" />
-                        <br />
-                        <CommsLink contact={trustee.internal} mode="phone-dialer" />
-                        <br />
-                        <CommsLink contact={trustee.internal} mode="email" />
-                        <br />
-                      </div>
                     </>
                   )}
                 </div>

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -14,6 +14,7 @@ import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
 import { TrusteeFormState } from './TrusteeForm';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import CommsLink from '@/lib/components/cams/CommsLink/CommsLink';
 
 export default function TrusteeDetailScreen() {
   const { trusteeId } = useParams();
@@ -278,6 +279,17 @@ export default function TrusteeDetailScreen() {
                           </a>
                         </div>
                       )}
+                      {/*This div is for demonstration purposes only and should be removed.*/}
+                      <div>
+                        <CommsLink contact={trustee.internal} mode="teams-chat" />
+                        <br />
+                        <CommsLink contact={trustee.internal} mode="teams-call" />
+                        <br />
+                        <CommsLink contact={trustee.internal} mode="phone-dialer" />
+                        <br />
+                        <CommsLink contact={trustee.internal} mode="email" />
+                        <br />
+                      </div>
                     </>
                   )}
                 </div>


### PR DESCRIPTION
# Purpose

Enable users to place calls to Trustees from CAMS

# Major Changes

* Added a component that renders a phone dialer link that can be used on the Trustee detail screen.

# Testing/Validation

* Full test coverage.
* POC testing in the staging environment.

## Summary by Sourcery

Add a reusable CommsLink component to generate communication links for Teams chat, Teams call, phone dialing (with extension support), and email, update IconLabel to use readonly props, and include full test coverage for the new component.

New Features:
- Introduce CommsLink component to render links for Teams chat, Teams call, phone dialer, and email
- Support phone dialer URIs with optional extensions via the toTelephoneUri utility

Enhancements:
- Enforce Readonly<IconLabelProps> in the IconLabel component for prop immutability

Tests:
- Add comprehensive tests for the CommsLink component