### PR TITLE
Wait a bit before filling password

### DIFF
--- a/test/e2e/playwright/auth-setup.ts
+++ b/test/e2e/playwright/auth-setup.ts
@@ -46,6 +46,7 @@ async function oktaLogin(page: Page) {
 
   const password = page.locator('input[name="credentials.passcode"]').first();
   await expect(password).toBeVisible();
+  await page.waitForTimeout(300);
   await password.fill(OKTA_PASSWORD);
 
   const submit = page.locator('input[type=submit]').first();


### PR DESCRIPTION
# Purpose

We were encountering errors in the Okta login during e2e tests.

# Major Changes

Wait a bit to let the form validation work.

# Testing/Validation

Login succeeded during e2e test runs.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Tests:
- Insert a 300ms wait before filling the password input in the Okta login E2E test to avoid validation errors