### PR TITLE
CAMS-584 Fix E2E test and squash ComboBox bugs on Consolidations, Transfers, and TrusteeForm

### DIFF
--- a/test/e2e/playwright/trustees.spec.ts
+++ b/test/e2e/playwright/trustees.spec.ts
@@ -69,16 +69,16 @@ test.describe('Trustees', () => {
     await expect(page).toHaveURL('/trustees/create');
 
     // Verify the create form is visible
-    await expect(page.getByTestId('trustee-create-form')).toBeVisible(timeoutOption);
+    await expect(page.getByTestId('trustee-form')).toBeVisible(timeoutOption);
 
     // Verify the form title
-    await expect(page.locator('h1')).toHaveText('Add Trustee Profile');
+    await expect(page.locator('h1')).toHaveText('Add Trustee Profile (Public)');
   });
 
   test('should test form field interactions and dropdowns', async ({ page }) => {
     // Navigate to create trustee form
     await page.getByTestId('trustees-add-link').click();
-    await expect(page.getByTestId('trustee-create-form')).toBeVisible(timeoutOption);
+    await expect(page.getByTestId('trustee-form')).toBeVisible(timeoutOption);
 
     // Test district selection dropdown
     const districtCombobox = page.locator('#trustee-districts');
@@ -128,7 +128,7 @@ test.describe('Trustees', () => {
   test('should test address fields on create form', async ({ page }) => {
     // Navigate to create trustee form
     await page.getByTestId('trustees-add-link').click();
-    await expect(page.getByTestId('trustee-create-form')).toBeVisible(timeoutOption);
+    await expect(page.getByTestId('trustee-form')).toBeVisible(timeoutOption);
 
     // Test address fields
     const address1Input = page.locator('#trustee-address1');

--- a/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
+++ b/user-interface/src/data-verification/consolidation/AddCaseModal.tsx
@@ -43,6 +43,9 @@ function AddCaseForm(viewModel: AddCaseModel) {
           aria-describedby="add-case-form-instructions"
           onUpdateSelection={viewModel.handleAddCaseCourtSelectChange}
           options={viewModel.filteredOfficeRecords!}
+          selections={viewModel.filteredOfficeRecords!.filter(
+            (option) => option.value === viewModel.caseToAddCourt,
+          )}
           required={true}
           multiSelect={false}
           disabled={viewModel.isLookingForCase}
@@ -53,7 +56,6 @@ function AddCaseForm(viewModel: AddCaseModel) {
         <CaseNumberInput
           id={`add-case-input-${viewModel.orderId}`}
           data-testid={`add-case-input-${viewModel.orderId}`}
-          className="usa-input"
           onChange={viewModel.handleAddCaseNumberInputChange}
           allowPartialCaseNumber={false}
           required={true}

--- a/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
+++ b/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
@@ -272,7 +272,6 @@ function _SuggestedTransferCases(
                   <CaseNumberInput
                     id={`new-case-input-${order.id}`}
                     data-testid={`new-case-input-${order.id}`}
-                    className="usa-input"
                     value={order.docketSuggestedCaseNumber}
                     onChange={handleCaseInputChange}
                     allowPartialCaseNumber={false}

--- a/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
+++ b/user-interface/src/data-verification/transfer/SuggestedTransferCases.tsx
@@ -157,6 +157,7 @@ function _SuggestedTransferCases(
     setNewCaseNumber(order.docketSuggestedCaseNumber || null);
     setNewCaseDivision(null);
     courtSelectionRef.current?.clearSelections();
+    handleCourtSelection([]);
     caseNumberRef.current?.resetValue();
   }
 

--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -1718,10 +1718,6 @@ describe('test cams combobox', () => {
         const selections = ref.current?.getSelections();
         expect(selections).toHaveLength(2);
       });
-
-      // onUpdateSelection should not be called during imperative updates
-      // This tests the isImperativeUpdateRef logic
-      expect(onUpdateSelection).not.toHaveBeenCalled();
     });
   });
 });

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -87,9 +87,6 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
   );
   const [filter, setFilter] = useState<string | null>(null);
 
-  // Track when selections are being set imperatively to prevent callback loops
-  const isImperativeUpdateRef = useRef<boolean>(false);
-
   // ========== REFS ==========
 
   const comboBoxRef = useRef(null);
@@ -145,7 +142,6 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
   }
 
   function setSelections(values: ComboOption[]) {
-    isImperativeUpdateRef.current = true;
     setSelectedMap(new Map(values.map((value) => [value.value, value])));
     props?.onUpdateSelection?.(values);
   }
@@ -458,6 +454,16 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
       setToggleKey(null);
     }
   }, [expanded, toggleKey, setFilter, onUpdateFilter]);
+
+  useEffect(() => {
+    setSelectedMap(
+      new Map(
+        props.selections?.map((selection) => {
+          return [selection.value, selection];
+        }),
+      ),
+    );
+  }, [props.selections]);
 
   useImperativeHandle(ref, () => ({
     setSelections,

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -147,6 +147,7 @@ function ComboBoxComponent(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
   function setSelections(values: ComboOption[]) {
     isImperativeUpdateRef.current = true;
     setSelectedMap(new Map(values.map((value) => [value.value, value])));
+    props?.onUpdateSelection?.(values);
   }
 
   function clearSelections() {

--- a/user-interface/src/trustees/TrusteeForm.tsx
+++ b/user-interface/src/trustees/TrusteeForm.tsx
@@ -55,7 +55,6 @@ function TrusteeForm() {
 
   const districtComboRef = React.useRef<ComboBoxRef | null>(null);
   const statusComboRef = React.useRef<ComboBoxRef | null>(null);
-  const statusInitialized = React.useRef(false);
 
   const location = useLocation();
   const passedState = location.state as TrusteeFormState;
@@ -90,6 +89,7 @@ function TrusteeForm() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const [districtOptions, setDistrictOptions] = useState<ComboOption[]>([]);
+  const [selectedDistrictOptions, setSelectedDistrictOptions] = useState<ComboOption[]>([]);
   const [districtLoadError, setDistrictLoadError] = useState<string | null>(null);
 
   const canManage = !!session?.user?.roles?.includes(CamsRole.TrusteeAdmin);
@@ -189,7 +189,16 @@ function TrusteeForm() {
           a.label.localeCompare(b.label),
         );
 
+        const selectedOptions = districts.reduce((acc, selection) => {
+          const option = options.find((option) => option.value === selection);
+          if (option) {
+            acc.push(option);
+          }
+          return acc;
+        }, [] as ComboOption[]);
+
         setDistrictOptions(options);
+        setSelectedDistrictOptions(selectedOptions);
       })
       .catch((error) => {
         setDistrictLoadError(
@@ -197,29 +206,20 @@ function TrusteeForm() {
         );
         setDistrictOptions([]);
       });
-  }, [api]);
+  }, [api, districts]);
 
-  useEffect(() => {
-    if (districtComboRef.current) {
-      const selections = districts.reduce((acc, selection) => {
-        const option = districtOptions.find((option) => option.value === selection);
-        if (option) {
-          acc.push(option);
-        }
-        return acc;
-      }, [] as ComboOption[]);
-      districtComboRef.current.setSelections(selections);
-    }
-  }, [districtOptions, passedState.trustee?.districts, districtComboRef.current]);
-
-  const setStatusComboRef = (el: ComboBoxRef | null) => {
-    statusComboRef.current = el;
-
-    if (el && !statusInitialized.current) {
-      el.setSelections([STATUS_OPTIONS[0]]);
-      statusInitialized.current = true;
-    }
-  };
+  // useEffect(() => {
+  //   if (districtComboRef.current) {
+  //     const selections = districts.reduce((acc, selection) => {
+  //       const option = districtOptions.find((option) => option.value === selection);
+  //       if (option) {
+  //         acc.push(option);
+  //       }
+  //       return acc;
+  //     }, [] as ComboOption[]);
+  //     districtComboRef.current.setSelections(selections);
+  //   }
+  // }, [districtOptions, passedState.trustee?.districts, districtComboRef.current]);
 
   // React hooks must be called before any conditional returns
   const chapterSelections = useMemo(() => {
@@ -495,6 +495,7 @@ function TrusteeForm() {
                     name="districts"
                     label="District (Division)"
                     options={districtOptions}
+                    selections={selectedDistrictOptions}
                     onUpdateSelection={handleComboBoxUpdate<string>(
                       'districts',
                       setDistricts,
@@ -544,7 +545,7 @@ function TrusteeForm() {
                     )}
                     multiSelect={false}
                     autoComplete="off"
-                    ref={setStatusComboRef}
+                    ref={statusComboRef}
                   />
                 </div>
               </>

--- a/user-interface/src/trustees/TrusteeForm.tsx
+++ b/user-interface/src/trustees/TrusteeForm.tsx
@@ -208,19 +208,6 @@ function TrusteeForm() {
       });
   }, [api, districts]);
 
-  // useEffect(() => {
-  //   if (districtComboRef.current) {
-  //     const selections = districts.reduce((acc, selection) => {
-  //       const option = districtOptions.find((option) => option.value === selection);
-  //       if (option) {
-  //         acc.push(option);
-  //       }
-  //       return acc;
-  //     }, [] as ComboOption[]);
-  //     districtComboRef.current.setSelections(selections);
-  //   }
-  // }, [districtOptions, passedState.trustee?.districts, districtComboRef.current]);
-
   // React hooks must be called before any conditional returns
   const chapterSelections = useMemo(() => {
     return chapters.reduce((acc, selection) => {


### PR DESCRIPTION
# Purpose

E2E tests are currently suffering from multiple failures blocking deployment of other work.

# Major Changes

Describe what has changed.
- Updates to trustee for e2e test expectations
- ComboBox 
    - when the selections are set imperatively, we need to ensure the ComboBox notifies of that update via it's updateHandler from props (this fixes a bug on AddCaseModal where the case search wouldn't fire as expected with the default District value)
    - Add a useEffect to update state from props any time selections change (this is to support options that must be loaded asynchronously, e.g. district options)
- To accommodate the above, rework the TrusteeForm district options and selections to be provided via props instead of set imperatively.

# Testing/Validation

Run E2E tests locally, they all pass
update relevant unit tests
test failure conditions manually via the UI
Checked React profiler and console errors for excessive rendering / infinite update loops

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
