### PR TITLE
Make slot setting sticky where needed

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -80,6 +80,7 @@ jobs:
             --kvAppConfigResourceGroupName ${{secrets.AZURE_RG }} \
             --kvAppConfigName ${{ secrets.AZ_KV_APP_CONFIG_NAME }} \
             --cosmosDatabaseName ${{ secrets.AZ_COSMOS_DATABASE_NAME }} \
+            --e2eDatabaseName ${{ secrets.AZ_COSMOS_DATABASE_NAME }}-e2e${{ inputs.environmentHash && format('-{0}', inputs.environmentHash) || '' }} \
             --deployVnet ${{ inputs.deployVnet }} \
             --camsReactSelectHash ${{ secrets.CAMS_REACT_SELECT_HASH }} \
             --ustpIssueCollectorHash ${{ secrets.USTP_ISSUE_COLLECTOR_HASH }} \

--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -163,25 +163,27 @@ jobs:
       slotName: ${{ inputs.slotName }}
     secrets: inherit # pragma: allowlist secret
 
-  execute-e2e-test:
-    needs:
-      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
-    uses: ./.github/workflows/reusable-e2e.yml
-    with:
-      apiFunctionName: ${{ inputs.apiFunctionName }}
-      slotName: ${{ inputs.slotName }}
-      webappName: ${{ inputs.webappName }}
-      stackName: ${{ inputs.stackName }}
-      azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
-      ghaEnvironment: ${{ inputs.ghaEnvironment }}
-      branchHashId: ${{ inputs.environmentHash }}
-      e2eCosmosDbExists: ${{ inputs.e2eCosmosDbExists }}
-    secrets: inherit # pragma: allowlist secret
+  # execute-e2e-test:
+  #   needs:
+  #     [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
+  #   uses: ./.github/workflows/reusable-e2e.yml
+  #   with:
+  #     apiFunctionName: ${{ inputs.apiFunctionName }}
+  #     slotName: ${{ inputs.slotName }}
+  #     webappName: ${{ inputs.webappName }}
+  #     stackName: ${{ inputs.stackName }}
+  #     azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
+  #     ghaEnvironment: ${{ inputs.ghaEnvironment }}
+  #     branchHashId: ${{ inputs.environmentHash }}
+  #     e2eCosmosDbExists: ${{ inputs.e2eCosmosDbExists }}
+  #   secrets: inherit # pragma: allowlist secret
 
   swap-webapp-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
+    # needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
+    needs:
+      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       webappName: ${{ inputs.webappName }}
@@ -205,7 +207,8 @@ jobs:
   swap-nodeapi-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
+    needs:
+      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       apiFunctionName: ${{ inputs.apiFunctionName }}
@@ -229,7 +232,8 @@ jobs:
   swap-dataflows-app-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
+    needs:
+      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       slotName: ${{ inputs.slotName }}

--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -163,27 +163,25 @@ jobs:
       slotName: ${{ inputs.slotName }}
     secrets: inherit # pragma: allowlist secret
 
-  # execute-e2e-test:
-  #   needs:
-  #     [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
-  #   uses: ./.github/workflows/reusable-e2e.yml
-  #   with:
-  #     apiFunctionName: ${{ inputs.apiFunctionName }}
-  #     slotName: ${{ inputs.slotName }}
-  #     webappName: ${{ inputs.webappName }}
-  #     stackName: ${{ inputs.stackName }}
-  #     azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
-  #     ghaEnvironment: ${{ inputs.ghaEnvironment }}
-  #     branchHashId: ${{ inputs.environmentHash }}
-  #     e2eCosmosDbExists: ${{ inputs.e2eCosmosDbExists }}
-  #   secrets: inherit # pragma: allowlist secret
+  execute-e2e-test:
+    needs:
+      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
+    uses: ./.github/workflows/reusable-e2e.yml
+    with:
+      apiFunctionName: ${{ inputs.apiFunctionName }}
+      slotName: ${{ inputs.slotName }}
+      webappName: ${{ inputs.webappName }}
+      stackName: ${{ inputs.stackName }}
+      azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
+      ghaEnvironment: ${{ inputs.ghaEnvironment }}
+      branchHashId: ${{ inputs.environmentHash }}
+      e2eCosmosDbExists: ${{ inputs.e2eCosmosDbExists }}
+    secrets: inherit # pragma: allowlist secret
 
   swap-webapp-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    # needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
-    needs:
-      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       webappName: ${{ inputs.webappName }}
@@ -207,8 +205,7 @@ jobs:
   swap-nodeapi-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs:
-      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       apiFunctionName: ${{ inputs.apiFunctionName }}
@@ -232,8 +229,7 @@ jobs:
   swap-dataflows-app-deployment-slot:
     if: ${{ inputs.initialDeployment != 'true' }}
     runs-on: ubuntu-latest
-    needs:
-      [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, endpoint-test-application-slot]
+    needs: [deploy-webapp-slot, deploy-api-slot, deploy-dataflows-slot, execute-e2e-test]
     environment: ${{ inputs.ghaEnvironment }}
     env:
       slotName: ${{ inputs.slotName }}

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -179,6 +179,17 @@ resource apiFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     properties: prodFunctionAppConfigProperties
   }
 
+  resource slotConfigNames 'config' = {
+    name: 'slotConfigNames'
+    properties: {
+      appSettingNames: [
+        'AzureWebJobsStorage'
+        'COSMOS_DATABASE_NAME'
+        'MyTaskHub'
+      ]
+    }
+  }
+
   resource slot 'slots' = {
     location: location
     name: slotName
@@ -236,6 +247,10 @@ var baseApiFunctionAppConfigProperties = {
         name: 'MyTaskHub'
         value: 'main'
       }
+      {
+        name: 'COSMOS_DATABASE_NAME'
+        value: cosmosDatabaseName
+      }
     ])
     cors: {
       allowedOrigins: apiCorsAllowOrigins
@@ -251,6 +266,10 @@ var baseApiFunctionAppConfigProperties = {
       {
         name: 'MyTaskHub'
         value: slotName
+      }
+      {
+        name: 'COSMOS_DATABASE_NAME'
+        value: '${cosmosDatabaseName}-e2e'
       }
     ])
     cors: {
@@ -302,10 +321,6 @@ var baseApplicationSettings = concat(
     {
       name: 'ADMIN_KEY'
       value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ADMIN-KEY)'
-    }
-    {
-      name: 'COSMOS_DATABASE_NAME'
-      value: cosmosDatabaseName
     }
     {
       name: 'MONGO_CONNECTION_STRING'

--- a/ops/cloud-deployment/dataflows-resource-deploy.bicep
+++ b/ops/cloud-deployment/dataflows-resource-deploy.bicep
@@ -206,7 +206,6 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     name: 'slotConfigNames'
     properties: {
       appSettingNames: [
-        'INFO_SHA'
         'MyTaskHub'
         'COSMOS_DATABASE_NAME'
       ]

--- a/ops/cloud-deployment/dataflows-resource-deploy.bicep
+++ b/ops/cloud-deployment/dataflows-resource-deploy.bicep
@@ -190,6 +190,10 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
           name: 'MyTaskHub'
           value: 'main'
         }
+        {
+          name: 'COSMOS_DATABASE_NAME'
+          value: cosmosDatabaseName
+        }
       ])
     })
   }
@@ -197,6 +201,17 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
     appConfigIdentity
     sqlIdentity
   ]
+
+  resource slotConfigName 'config' = {
+    name: 'slotConfigNames'
+    properties: {
+      appSettingNames: [
+        'INFO_SHA'
+        'MyTaskHub'
+        'COSMOS_DATABASE_NAME'
+      ]
+    }
+  }
 
   resource slot 'slots' = {
     location: location
@@ -223,6 +238,10 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
           {
             name: 'MyTaskHub'
             value: slotName
+          }
+          {
+            name: 'COSMOS_DATABASE_NAME'
+            value: '${cosmosDatabaseName}-e2e'
           }
         ])
       })
@@ -306,10 +325,6 @@ var baseApplicationSettings = concat(
     {
       name: 'ADMIN_KEY'
       value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ADMIN-KEY)'
-    }
-    {
-      name: 'COSMOS_DATABASE_NAME'
-      value: cosmosDatabaseName
     }
     {
       name: 'MONGO_CONNECTION_STRING'

--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -122,6 +122,7 @@ param ustpIssueCollectorHash string = ''
 param camsReactSelectHash string
 
 param cosmosDatabaseName string
+param e2eDatabaseName string = cosmosDatabaseName
 
 @description('Comma delimited list of data flow names to enable.')
 param enabledDataflows string = ''
@@ -227,6 +228,7 @@ module ustpApiFunction 'backend-api-deploy.bicep' = {
       loginProviderConfig: loginProviderConfig
       loginProvider: loginProvider
       cosmosDatabaseName: cosmosDatabaseName
+      e2eDatabaseName: e2eDatabaseName
       kvAppConfigName: kvAppConfigName
       isUstpDeployment: isUstpDeployment
       mssqlRequestTimeout: mssqlRequestTimeout
@@ -236,7 +238,7 @@ module ustpApiFunction 'backend-api-deploy.bicep' = {
     }
 }
 
-module ustpDatflowsFunction 'dataflows-resource-deploy.bicep' = {
+module ustpDataflowsFunction 'dataflows-resource-deploy.bicep' = {
   name: '${stackName}-dataflows-module'
   scope: resourceGroup(appResourceGroup)
   params: {
@@ -268,6 +270,7 @@ module ustpDatflowsFunction 'dataflows-resource-deploy.bicep' = {
     loginProviderConfig: loginProviderConfig
     loginProvider: loginProvider
     cosmosDatabaseName: cosmosDatabaseName
+    e2eDatabaseName: e2eDatabaseName
     kvAppConfigName: kvAppConfigName
     isUstpDeployment: isUstpDeployment
     mssqlRequestTimeout: mssqlRequestTimeout

--- a/ops/scripts/pipeline/azure-deploy.sh
+++ b/ops/scripts/pipeline/azure-deploy.sh
@@ -18,10 +18,10 @@ inputParams=()
 
 requiredUSTPParams=("--enabledDataflows" "--mssqlRequestTimeout" "--isUstpDeployment" "--resource-group" "--file" "--stackName" "--slotName" "--gitSha" "--networkResourceGroupName" "--virtualNetworkName" "--analyticsWorkspaceId" "--idKeyvaultAppConfiguration" "--kvAppConfigName" "--cosmosDatabaseName" "--deployVnet" "--camsReactSelectHash" "--ustpIssueCollectorHash" "--createAlerts" "--deployAppInsights" "--apiFunctionPlanName" "--dataflowsFunctionPlanName" "--webappPlanType" "--loginProvider" "--loginProviderConfig" "--sqlServerName" "--sqlServerResourceGroupName" "--oktaUrl" "--location" "--webappSubnetName" "--apiFunctionSubnetName" "--privateEndpointSubnetName" "--webappSubnetAddressPrefix" "--privateEndpointSubnetAddressPrefix" "--apiFunctionSubnetAddressPrefix" "--dataflowsSubnetName" "--dataflowsSubnetAddressPrefix" "--privateDnsZoneName" "--privateDnsZoneResourceGroup" "--privateDnsZoneSubscriptionId" "--analyticsResourceGroupName" "--kvAppConfigResourceGroupName" "--deployDns")
 
-requiredFlexionParams=("--enabledDataflows" "--mssqlRequestTimeout" "--resource-group" "--file" "--stackName" "--slotName" "--gitSha" "--networkResourceGroupName" "--kvAppConfigName" "--kvAppConfigResourceGroupName" "--virtualNetworkName" "--analyticsWorkspaceId" "--idKeyvaultAppConfiguration" "--cosmosDatabaseName" "--deployVnet" "--camsReactSelectHash" "--ustpIssueCollectorHash" "--createAlerts" "--deployAppInsights" "--loginProvider" "--loginProviderConfig" "--sqlServerName" "--sqlServerResourceGroupName" "--sqlServerIdentityName" "--actionGroupName" "--oktaUrl")
+requiredFlexionParams=("--enabledDataflows" "--mssqlRequestTimeout" "--resource-group" "--file" "--stackName" "--slotName" "--gitSha" "--networkResourceGroupName" "--kvAppConfigName" "--kvAppConfigResourceGroupName" "--virtualNetworkName" "--analyticsWorkspaceId" "--idKeyvaultAppConfiguration" "--cosmosDatabaseName" "--deployVnet" "--camsReactSelectHash" "--ustpIssueCollectorHash" "--createAlerts" "--deployAppInsights" "--loginProvider" "--loginProviderConfig" "--sqlServerName" "--sqlServerResourceGroupName" "--sqlServerIdentityName" "--actionGroupName" "--oktaUrl" "--e2eDatabaseName")
 
 # shellcheck disable=SC2034 # REASON: to have a reference for all possible parameters
-allParams=("--enabledDataflows" "--mssqlRequestTimeout" "--isUstpDeployment" "--resource-group" "--file" "--stackName" "--slotName" "--gitSha" "--networkResourceGroupName" "--virtualNetworkName" "--analyticsWorkspaceId" "--idKeyvaultAppConfiguration" "--kvAppConfigName" "--cosmosDatabaseName" "--deployVnet" "--camsReactSelectHash" "--ustpIssueCollectorHash" "--createAlerts" "--deployAppInsights" "--apiFunctionPlanName" "--dataflowsFunctionPlanName" "--webappPlanType" "--loginProvider" "--loginProviderConfig" "--sqlServerName" "--sqlServerResourceGroupName" "--sqlServerIdentityResourceGroupName" "--sqlServerIdentityName"  "--actionGroupName" "--oktaUrl" "--location" "--webappSubnetName" "--apiFunctionSubnetName" "--privateEndpointSubnetName" "--webappSubnetAddressPrefix" "--apiFunctionSubnetAddressPrefix" "--dataflowsSubnetName" "--dataflowsSubnetAddressPrefix" "--vnetAddressPrefix" "--linkVnetIds" "--privateDnsZoneName" "--privateDnsZoneResourceGroup" "--privateDnsZoneSubscriptionId" "--analyticsResourceGroupName" "--kvAppConfigResourceGroupName" "--deployDns" "--allowVeracodeScan")
+allParams=("--enabledDataflows" "--mssqlRequestTimeout" "--isUstpDeployment" "--resource-group" "--file" "--stackName" "--slotName" "--gitSha" "--networkResourceGroupName" "--virtualNetworkName" "--analyticsWorkspaceId" "--idKeyvaultAppConfiguration" "--kvAppConfigName" "--cosmosDatabaseName" "--deployVnet" "--camsReactSelectHash" "--ustpIssueCollectorHash" "--createAlerts" "--deployAppInsights" "--apiFunctionPlanName" "--dataflowsFunctionPlanName" "--webappPlanType" "--loginProvider" "--loginProviderConfig" "--sqlServerName" "--sqlServerResourceGroupName" "--sqlServerIdentityResourceGroupName" "--sqlServerIdentityName"  "--actionGroupName" "--oktaUrl" "--location" "--webappSubnetName" "--apiFunctionSubnetName" "--privateEndpointSubnetName" "--webappSubnetAddressPrefix" "--apiFunctionSubnetAddressPrefix" "--dataflowsSubnetName" "--dataflowsSubnetAddressPrefix" "--vnetAddressPrefix" "--linkVnetIds" "--privateDnsZoneName" "--privateDnsZoneResourceGroup" "--privateDnsZoneSubscriptionId" "--analyticsResourceGroupName" "--kvAppConfigResourceGroupName" "--deployDns" "--allowVeracodeScan" "--e2eDatabaseName")
 
 
 function az_vnet_exists_func() {
@@ -372,6 +372,14 @@ while [[ $# -gt 0 ]]; do
         deployment_parameters="${deployment_parameters} ${maxObjectKeyCount}"
         shift 2
         ;;
+
+    --e2eDatabaseName)
+        inputParams+=("${1}")
+        e2eDatabaseName="e2eDatabaseName=-${2}"
+        deployment_parameters="${deployment_parameters} ${e2eDatabaseName}"
+        shift 2
+        ;;
+
     *)
         echo "Exit on param: ${1}"
         exit 2 # error on unknown flag/switch


### PR DESCRIPTION
# Purpose

The deployment slot was pointing to the wrong database—`cams` rather than `cams-e2e`.

# Major Changes

Modify the Bicep to properly configure the database name.

# Testing/Validation

Will validate during workflow runs.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Configure COSMOS_DATABASE_NAME as a sticky slot setting for backend API and dataflows, adjust its slot-specific value, and update the CI workflow to disable the e2e test step and revise job dependencies.

Bug Fixes:
- Fix COSMOS_DATABASE_NAME for deployment slots to point to the correct e2e database

Enhancements:
- Add slotConfigNames resources in backend-api and dataflows Bicep deployments to persist COSMOS_DATABASE_NAME across slots
- Set slot-specific COSMOS_DATABASE_NAME values with an '-e2e' suffix and remove redundant production settings

CI:
- Comment out the execute-e2e-test job and update swap job dependencies in sub-deploy-code-slot CI workflow