### PR TITLE
Fix e2e database name

### DIFF
--- a/ops/scripts/pipeline/azure-deploy.sh
+++ b/ops/scripts/pipeline/azure-deploy.sh
@@ -375,7 +375,7 @@ while [[ $# -gt 0 ]]; do
 
     --e2eDatabaseName)
         inputParams+=("${1}")
-        e2eDatabaseName="e2eDatabaseName=-${2}"
+        e2eDatabaseName="e2eDatabaseName=${2}"
         deployment_parameters="${deployment_parameters} ${e2eDatabaseName}"
         shift 2
         ;;


### PR DESCRIPTION
Remove hyphen prefix from E2E database name

## Summary by Sourcery

Bug Fixes:
- Remove leading hyphen from e2eDatabaseName parameter in azure-deploy.sh