### PR TITLE
CAMS-634 Add additional logging to triage issue

### DIFF
--- a/common/src/cams/session.ts
+++ b/common/src/cams/session.ts
@@ -9,6 +9,6 @@ export type CamsSession = {
 };
 
 export function getCamsUserReference<T extends CamsUserReference>(user: T): CamsUserReference {
-  const { id, name } = user;
+  const { id, name, ..._ } = user;
   return { id, name };
 }


### PR DESCRIPTION
# Purpose

Illuminate why we are seeing this error

# Major Changes

Add additional logging to the "me" endpoint response.

## Summary by Sourcery

Add detailed AppInsights telemetry for the "me" API call failures and improve session error reporting, alongside minor refactorings and cleanup

Enhancements:
- Log Api2.getMe() errors to AppInsights with error details, a custom note, and localStorage session context
- Update session state error event to include a default fallback message and note that it occurs after the "me" endpoint
- Refactor postLoginTasks and getMe into arrow functions for consistency
- Adjust getCamsUserReference to strip out any extra properties using object rest