### PR TITLE
End workflow diagram file with a single newline

### DIFF
--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -298,10 +298,10 @@ flowchart LR
         Workflow_Inputs_enableBicepDeployment["enableBicepDeployment"]
         Variables["Variables"]
         Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
-        Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
-        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
         Variables_NODE_VERSION["NODE_VERSION"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
+        Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
+        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
     end
 
     subgraph continuous_deployment_workflow["Continuous Deployment"]
@@ -385,15 +385,15 @@ This diagram shows the explicit and implicit dependencies between jobs in the de
 flowchart LR
     subgraph "External Inputs"
         Workflow_Inputs["Workflow Inputs"]
-        Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
         Workflow_Inputs_stackName["stackName"]
-        Workflow_Inputs_slotName["slotName"]
-        Workflow_Inputs_environmentHash["environmentHash"]
-        Workflow_Inputs_e2eCosmosDbExists["e2eCosmosDbExists"]
-        Workflow_Inputs_apiFunctionName["apiFunctionName"]
         Workflow_Inputs_dataflowsFunctionName["dataflowsFunctionName"]
+        Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
+        Workflow_Inputs_e2eCosmosDbExists["e2eCosmosDbExists"]
+        Workflow_Inputs_slotName["slotName"]
         Workflow_Inputs_webappName["webappName"]
+        Workflow_Inputs_environmentHash["environmentHash"]
         Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
+        Workflow_Inputs_apiFunctionName["apiFunctionName"]
     end
 
     subgraph sub_deploy_code_slot_workflow["Deploy code for slot"]
@@ -894,10 +894,10 @@ flowchart LR
         Workflow_Inputs_enableBicepDeployment["enableBicepDeployment"]
         Variables["Variables"]
         Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
-        Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
-        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
         Variables_NODE_VERSION["NODE_VERSION"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
+        Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
+        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
     end
 
     subgraph continuous_deployment_workflow["Continuous Deployment"]
@@ -981,15 +981,15 @@ This diagram shows the explicit and implicit dependencies between jobs in the de
 flowchart LR
     subgraph "External Inputs"
         Workflow_Inputs["Workflow Inputs"]
-        Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
         Workflow_Inputs_stackName["stackName"]
-        Workflow_Inputs_slotName["slotName"]
-        Workflow_Inputs_environmentHash["environmentHash"]
-        Workflow_Inputs_e2eCosmosDbExists["e2eCosmosDbExists"]
-        Workflow_Inputs_apiFunctionName["apiFunctionName"]
         Workflow_Inputs_dataflowsFunctionName["dataflowsFunctionName"]
+        Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
+        Workflow_Inputs_e2eCosmosDbExists["e2eCosmosDbExists"]
+        Workflow_Inputs_slotName["slotName"]
         Workflow_Inputs_webappName["webappName"]
+        Workflow_Inputs_environmentHash["environmentHash"]
         Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
+        Workflow_Inputs_apiFunctionName["apiFunctionName"]
     end
 
     subgraph sub_deploy_code_slot_workflow["Deploy code for slot"]

--- a/ops/scripts/pipeline/workflow-diagram-generator.py
+++ b/ops/scripts/pipeline/workflow-diagram-generator.py
@@ -724,6 +724,7 @@ def main():
     trigger_diagrams = generate_all_trigger_diagrams(workflows)
     workflow_dispatch_diagrams = generate_workflow_dispatch_diagrams(workflows)
     output_text, triggers = compile_output(summary, workflows, trigger_diagrams, workflow_dispatch_diagrams)
+    output_text = output_text.rstrip('\n') + '\n'
     with open(output_file, 'w', encoding='utf-8') as f:
         f.write(output_text)
     print(f"Workflow diagrams generated: {output_file}")


### PR DESCRIPTION
# Purpose

The workflow triggered by changing GHA workflow files was annoying.

1. I make a change to a yaml file in the `.github/workflows` directory and try to commit.
2. pre-commit causes the scripts to run to update the markdown file.
3. I git add the file and try to commit.
4. The `end-of-file-fixer` hook removes a newline.
5. I git add the file again and try to commit which now works.

# Major Changes

After compiling the workflow diagrams markdown file content we strip `\n`'s and add a single one.

# Testing/Validation

Ran the script which now produces a file that passes the `end-of-file-fixer` hook.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Ensure the workflow diagram generator produces a file ending with a single newline and update the diagram markdown accordingly

Enhancements:
- Strip all trailing newlines from the generated workflow diagram and append exactly one newline
- Regenerate the workflow-diagram markdown file to reflect the updated newline handling