### PR TITLE
Always deploy e2e database in Flexion deploys

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -130,6 +130,5 @@ jobs:
       webappName: ${{ needs.setup.outputs.webappName }}
       environmentHash: ${{ needs.setup.outputs.environmentHash }}
       slotName: ${{ needs.setup.outputs.slotName }}
-      e2eCosmosDbExists: ${{ needs.deploy.outputs.e2eCosmosDbExists }}
       initialDeployment: ${{ needs.setup.outputs.initialDeployment }}
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/dast-scan.yml
+++ b/.github/workflows/dast-scan.yml
@@ -28,5 +28,4 @@ jobs:
       azResourceGrpAppEncrypted: ${{ needs.setup.outputs.azResourceGrpAppEncrypted }}
       ghaEnvironment: ${{ needs.setup.outputs.ghaEnvironment }}
       branchHashId: ${{ needs.setup.outputs.environmentHash }}
-      e2eCosmosDbExists: true
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -24,6 +24,5 @@ jobs:
       azResourceGrpAppEncrypted: ${{ needs.setup.outputs.azResourceGrpAppEncrypted }}
       ghaEnvironment: ${{ needs.setup.outputs.ghaEnvironment }}
       branchHashId: ${{ needs.setup.outputs.environmentHash }}
-      e2eCosmosDbExists: true
       dataflowsFunctionName: ${{ needs.setup.outputs.dataflowsFunctionName }}
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/reusable-dast.yml
+++ b/.github/workflows/reusable-dast.yml
@@ -24,9 +24,6 @@ on:
       branchHashId:
         required: true
         type: string
-      e2eCosmosDbExists:
-        required: true
-        type: string
 
 jobs:
   zap-dast-scan:

--- a/.github/workflows/reusable-database-deploy.yml
+++ b/.github/workflows/reusable-database-deploy.yml
@@ -18,17 +18,11 @@ on:
       environmentHash:
         required: true
         type: string
-    outputs:
-      e2eCosmosDbExists:
-        description: 'Does E2E Cosmos DB Already Exists before deployment'
-        value: ${{ jobs.deploy-db.outputs.e2eCosmosDbExists }}
 
 jobs:
   deploy-db:
     runs-on: ubuntu-latest
     environment: ${{ inputs.ghaEnvironment }}
-    outputs:
-      e2eCosmosDbExists: ${{ steps.e2eDbExists.outputs.e2eCosmosDbExists }}
     steps:
       - uses: actions/checkout@main
 
@@ -53,18 +47,6 @@ jobs:
           fi
           echo "e2eDatabaseName=${e2eDatabaseName}" >> $GITHUB_OUTPUT
 
-      - name: Check if E2E CosmosDb exists
-        uses: azure/cli@v2
-        id: e2eDbExists
-        with:
-          azcliversion: 2.62.0
-          inlineScript: |
-            export AZURE_CORE_USE_MSAL_HTTP_CACHE=${{ vars.AZURE_CORE_USE_MSAL_HTTP_CACHE }}
-            cmd="az cosmosdb mongodb database exists --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} -n ${{ steps.generateE2eName.outputs.e2eDatabaseName }} -g ${{ secrets.AZURE_RG }} -o tsv"
-            echo $cmd
-            e2eCosmosDbExists=$($cmd)
-            echo "e2eCosmosDbExists=${e2eCosmosDbExists}" >> $GITHUB_OUTPUT
-
       - name: Deploy Cosmos MongoDB
         id: azure-mongodb-deploy
         run: |
@@ -81,5 +63,4 @@ jobs:
             --actionGroupName ${{ secrets.AZ_ACTION_GROUP_NAME }} \
             --keyVaultName ${{ secrets.AZ_KV_APP_CONFIG_NAME }} \
             --kvResourceGroup ${{ secrets.AZ_KV_APP_CONFIG_RG_NAME }} \
-            --branchHashId ${{ inputs.environmentHash || 'DOES_NOT_EXIST' }} \
-            --e2eCosmosDbExists ${{ steps.e2eDbExists.outputs.e2eCosmosDbExists }}
+            --branchHashId ${{ inputs.environmentHash || 'DOES_NOT_EXIST' }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -27,9 +27,6 @@ on:
       branchHashId:
         required: true
         type: string
-      e2eCosmosDbExists:
-        required: true
-        type: string
 
 jobs:
   playwright-e2e-test:

--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -27,9 +27,6 @@ on:
       slotName:
         required: true
         type: string
-      e2eCosmosDbExists:
-        required: true
-        type: string
       initialDeployment:
         required: true
         type: string
@@ -176,7 +173,6 @@ jobs:
       azResourceGrpAppEncrypted: ${{ inputs.azResourceGrpAppEncrypted }}
       ghaEnvironment: ${{ inputs.ghaEnvironment }}
       branchHashId: ${{ inputs.environmentHash }}
-      e2eCosmosDbExists: ${{ inputs.e2eCosmosDbExists }}
     secrets: inherit # pragma: allowlist secret
 
   swap-webapp-deployment-slot:

--- a/.github/workflows/sub-deploy.yml
+++ b/.github/workflows/sub-deploy.yml
@@ -39,10 +39,6 @@ on:
       deployBicep:
         required: true
         type: string
-    outputs:
-      e2eCosmosDbExists:
-        description: 'Does E2E Cosmos DB Already Exists before deployment'
-        value: ${{ jobs.deploy-db.outputs.e2eCosmosDbExists }}
 
 jobs:
   deploy-infra:

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -297,11 +297,11 @@ flowchart LR
         Workflow_Inputs["Workflow Inputs"]
         Workflow_Inputs_enableBicepDeployment["enableBicepDeployment"]
         Variables["Variables"]
-        Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
+        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
         Variables_NODE_VERSION["NODE_VERSION"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
-        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
+        Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
     end
 
     subgraph continuous_deployment_workflow["Continuous Deployment"]
@@ -328,7 +328,7 @@ flowchart LR
             deploy_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>azResourceGrpNetworkEncrypted<br/>dataflowsFunctionName<br/>deployBicep<br/>deployVnet<br/>environmentHash<br/>ghaEnvironment<br/>slotName<br/>stackName<br/>webappName"]
         end
         subgraph deploy_code_slot_subgraph["Slot Code Deployment"]
-            deploy_code_slot_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>e2eCosmosDbExists<br/>environmentHash<br/>ghaEnvironment<br/>initialDeployment<br/>slotName<br/>stackName<br/>webappName"]
+            deploy_code_slot_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>environmentHash<br/>ghaEnvironment<br/>initialDeployment<br/>slotName<br/>stackName<br/>webappName"]
         end
     end
 
@@ -385,15 +385,14 @@ This diagram shows the explicit and implicit dependencies between jobs in the de
 flowchart LR
     subgraph "External Inputs"
         Workflow_Inputs["Workflow Inputs"]
+        Workflow_Inputs_environmentHash["environmentHash"]
         Workflow_Inputs_stackName["stackName"]
+        Workflow_Inputs_apiFunctionName["apiFunctionName"]
+        Workflow_Inputs_webappName["webappName"]
+        Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
         Workflow_Inputs_dataflowsFunctionName["dataflowsFunctionName"]
         Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
-        Workflow_Inputs_e2eCosmosDbExists["e2eCosmosDbExists"]
         Workflow_Inputs_slotName["slotName"]
-        Workflow_Inputs_webappName["webappName"]
-        Workflow_Inputs_environmentHash["environmentHash"]
-        Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
-        Workflow_Inputs_apiFunctionName["apiFunctionName"]
     end
 
     subgraph sub_deploy_code_slot_workflow["Deploy code for slot"]
@@ -407,7 +406,7 @@ flowchart LR
             endpoint_test_application_slot_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>environmentHash<br/>ghaEnvironment<br/>slotName<br/>stackName<br/>webappName"]
         end
         subgraph execute_e2e_test_subgraph["execute-e2e-test"]
-            execute_e2e_test_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>e2eCosmosDbExists<br/>environmentHash<br/>ghaEnvironment<br/>slotName<br/>stackName<br/>webappName"]
+            execute_e2e_test_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>environmentHash<br/>ghaEnvironment<br/>slotName<br/>stackName<br/>webappName"]
         end
         swap_webapp_deployment_slot["swap-webapp-deployment-slot"]
         swap_nodeapi_deployment_slot["swap-nodeapi-deployment-slot"]
@@ -421,7 +420,6 @@ flowchart LR
         Workflow_Inputs --> Workflow_Inputs_apiFunctionName
         Workflow_Inputs --> Workflow_Inputs_azResourceGrpAppEncrypted
         Workflow_Inputs --> Workflow_Inputs_dataflowsFunctionName
-        Workflow_Inputs --> Workflow_Inputs_e2eCosmosDbExists
         Workflow_Inputs --> Workflow_Inputs_environmentHash
         Workflow_Inputs --> Workflow_Inputs_ghaEnvironment
         Workflow_Inputs --> Workflow_Inputs_slotName
@@ -437,7 +435,6 @@ flowchart LR
     Workflow_Inputs_azResourceGrpAppEncrypted -.-> execute_e2e_test_subgraph
     Workflow_Inputs_dataflowsFunctionName -.-> deploy_code_subgraph
     Workflow_Inputs_dataflowsFunctionName -.-> execute_e2e_test_subgraph
-    Workflow_Inputs_e2eCosmosDbExists -.-> execute_e2e_test_subgraph
     Workflow_Inputs_environmentHash -.-> deploy_code_subgraph
     Workflow_Inputs_environmentHash -.-> endpoint_test_application_post_swap_subgraph
     Workflow_Inputs_environmentHash -.-> endpoint_test_application_slot_subgraph
@@ -893,11 +890,11 @@ flowchart LR
         Workflow_Inputs["Workflow Inputs"]
         Workflow_Inputs_enableBicepDeployment["enableBicepDeployment"]
         Variables["Variables"]
-        Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
+        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
         Variables_NODE_VERSION["NODE_VERSION"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
-        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
+        Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
     end
 
     subgraph continuous_deployment_workflow["Continuous Deployment"]
@@ -924,7 +921,7 @@ flowchart LR
             deploy_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>azResourceGrpNetworkEncrypted<br/>dataflowsFunctionName<br/>deployBicep<br/>deployVnet<br/>environmentHash<br/>ghaEnvironment<br/>slotName<br/>stackName<br/>webappName"]
         end
         subgraph deploy_code_slot_subgraph["Slot Code Deployment"]
-            deploy_code_slot_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>e2eCosmosDbExists<br/>environmentHash<br/>ghaEnvironment<br/>initialDeployment<br/>slotName<br/>stackName<br/>webappName"]
+            deploy_code_slot_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>environmentHash<br/>ghaEnvironment<br/>initialDeployment<br/>slotName<br/>stackName<br/>webappName"]
         end
     end
 
@@ -981,15 +978,14 @@ This diagram shows the explicit and implicit dependencies between jobs in the de
 flowchart LR
     subgraph "External Inputs"
         Workflow_Inputs["Workflow Inputs"]
+        Workflow_Inputs_environmentHash["environmentHash"]
         Workflow_Inputs_stackName["stackName"]
+        Workflow_Inputs_apiFunctionName["apiFunctionName"]
+        Workflow_Inputs_webappName["webappName"]
+        Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
         Workflow_Inputs_dataflowsFunctionName["dataflowsFunctionName"]
         Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
-        Workflow_Inputs_e2eCosmosDbExists["e2eCosmosDbExists"]
         Workflow_Inputs_slotName["slotName"]
-        Workflow_Inputs_webappName["webappName"]
-        Workflow_Inputs_environmentHash["environmentHash"]
-        Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
-        Workflow_Inputs_apiFunctionName["apiFunctionName"]
     end
 
     subgraph sub_deploy_code_slot_workflow["Deploy code for slot"]
@@ -1003,7 +999,7 @@ flowchart LR
             endpoint_test_application_slot_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>environmentHash<br/>ghaEnvironment<br/>slotName<br/>stackName<br/>webappName"]
         end
         subgraph execute_e2e_test_subgraph["execute-e2e-test"]
-            execute_e2e_test_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>e2eCosmosDbExists<br/>environmentHash<br/>ghaEnvironment<br/>slotName<br/>stackName<br/>webappName"]
+            execute_e2e_test_vars["apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>environmentHash<br/>ghaEnvironment<br/>slotName<br/>stackName<br/>webappName"]
         end
         swap_webapp_deployment_slot["swap-webapp-deployment-slot"]
         swap_nodeapi_deployment_slot["swap-nodeapi-deployment-slot"]
@@ -1017,7 +1013,6 @@ flowchart LR
         Workflow_Inputs --> Workflow_Inputs_apiFunctionName
         Workflow_Inputs --> Workflow_Inputs_azResourceGrpAppEncrypted
         Workflow_Inputs --> Workflow_Inputs_dataflowsFunctionName
-        Workflow_Inputs --> Workflow_Inputs_e2eCosmosDbExists
         Workflow_Inputs --> Workflow_Inputs_environmentHash
         Workflow_Inputs --> Workflow_Inputs_ghaEnvironment
         Workflow_Inputs --> Workflow_Inputs_slotName
@@ -1033,7 +1028,6 @@ flowchart LR
     Workflow_Inputs_azResourceGrpAppEncrypted -.-> execute_e2e_test_subgraph
     Workflow_Inputs_dataflowsFunctionName -.-> deploy_code_subgraph
     Workflow_Inputs_dataflowsFunctionName -.-> execute_e2e_test_subgraph
-    Workflow_Inputs_e2eCosmosDbExists -.-> execute_e2e_test_subgraph
     Workflow_Inputs_environmentHash -.-> deploy_code_subgraph
     Workflow_Inputs_environmentHash -.-> endpoint_test_application_post_swap_subgraph
     Workflow_Inputs_environmentHash -.-> endpoint_test_application_slot_subgraph

--- a/ops/scripts/pipeline/az-cosmos-deploy.sh
+++ b/ops/scripts/pipeline/az-cosmos-deploy.sh
@@ -16,7 +16,6 @@ set -euo pipefail # ensure job step fails in CI pipeline when error occurs
 analyticsWorkspaceId=
 actionGroupResourceGroup=
 actionGroupName=
-e2eCosmosDbExists=true
 branchHashId=''
 allowedIps='[]'
 
@@ -87,11 +86,6 @@ while [[ $# -gt 0 ]]; do
         shift 2
         ;;
 
-    --e2eCosmosDbExists)
-        e2eCosmosDbExists=$2
-        shift 2
-        ;;
-
     *)
         echo "$1"
         exit 2 # error on unknown flag/switch
@@ -110,12 +104,6 @@ if [[ ${environment} == 'Main-Gov' ]]; then
     createAlerts=true
 fi
 
-deployE2eDatabase=false
-# shellcheck disable=SC2086 # REASON: Qoutes render the e2eCosmosDbExists boolean unusable
-if [ ${e2eCosmosDbExists} != true ] && [ ${e2eCosmosDbExists} != "true" ]; then
-    deployE2eDatabase=true
-fi
-
 
 e2eDatabaseName="${database}-e2e"
 if [[ ${environment} != 'Main-Gov' ]]; then
@@ -126,9 +114,9 @@ fi
 # shellcheck disable=SC2086 # REASON: Qoutes render the CreateAlertsproperty unusable
 az deployment group create -w -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos.bicep \
     -p ./ops/cloud-deployment/params/ustp-cams-mongo-collections.parameters.json \
-    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}" e2eDatabaseName="${e2eDatabaseName}" deployE2eDatabase=$deployE2eDatabase
+    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}" e2eDatabaseName="${e2eDatabaseName}" deployE2eDatabase=true
 
 # shellcheck disable=SC2086 # REASON: Qoutes render the CreateAlerts property unusable
 az deployment group create -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-cams-cosmos.bicep \
     -p ./ops/cloud-deployment/params/ustp-cams-mongo-collections.parameters.json \
-    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}" e2eDatabaseName="${e2eDatabaseName}" deployE2eDatabase=$deployE2eDatabase
+    -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}" e2eDatabaseName="${e2eDatabaseName}" deployE2eDatabase=true


### PR DESCRIPTION
# Purpose

We always want to deploy the e2e database if we are deploying the main one, but only in Flexion environments.

# Major Changes

Remove all conditional handling of e2e db deploy from GHA workflows. 

# Testing/Validation

Run deployment.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Unconditionally deploy the E2E database in Flexion environments by removing conditional checks and related flags.

Enhancements:
- Remove e2eCosmosDbExists inputs, outputs, and conditional logic from GitHub Actions workflows and reusable pipeline configurations
- Hardcode deployE2eDatabase parameter to true in the Azure Cosmos DB deployment script
- Update operations workflow diagrams to eliminate E2E database existence variables and realign inputs