### PR TITLE
CAMS-634 Retry calls to okta api if a first call fails

### DIFF
--- a/backend/lib/adapters/gateways/okta/okta-gateway.ts
+++ b/backend/lib/adapters/gateways/okta/okta-gateway.ts
@@ -93,10 +93,18 @@ async function getUser(accessToken: string): Promise<{ user: CamsUserReference; 
   try {
     const jwt = await verifyToken(accessToken);
 
-    const response = await fetch(userInfoUri, {
-      method: 'GET',
-      headers: { authorization: 'Bearer ' + accessToken },
-    });
+    const callOkta = async () =>
+      fetch(userInfoUri, {
+        method: 'GET',
+        headers: { authorization: 'Bearer ' + accessToken },
+      });
+
+    let response = await callOkta();
+
+    if (!response.ok) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      response = await callOkta();
+    }
 
     if (response.ok) {
       const oktaUser = (await response.json()) as OktaUserInfo;

--- a/backend/lib/adapters/gateways/okta/okta-user-group-gateway.ts
+++ b/backend/lib/adapters/gateways/okta/okta-user-group-gateway.ts
@@ -143,17 +143,15 @@ class OktaUserGroupGateway implements UserGroupGateway {
       const user = await this.oktaHumble.getUser({ userId: id });
       const groups = await this.oktaHumble.listUserGroups({ userId: id });
       const groupNames = [];
-      for await (const oktaGroup of groups) {
+      for (const oktaGroup of groups) {
         groupNames.push(oktaGroup.name);
       }
-      const camsUser = {
+      return {
         id: user.id,
         name: user.name,
         offices: await UsersHelpers.getOfficesFromGroupNames(context, groupNames),
         roles: UsersHelpers.getRolesFromGroupNames(groupNames),
       };
-      context.logger.info(MODULE_NAME, `Retrieved ${id}`, camsUser);
-      return camsUser;
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         camsStackInfo: { module: MODULE_NAME, message: 'Failed while getting user by id.' },

--- a/backend/lib/controllers/me/me.controller.ts
+++ b/backend/lib/controllers/me/me.controller.ts
@@ -12,12 +12,11 @@ export class MeController implements CamsController {
     context: ApplicationContext,
   ): Promise<CamsHttpResponseInit<CamsSession>> {
     try {
-      const response = httpSuccess({
+      return httpSuccess({
         body: {
           data: context.session,
         },
       });
-      return response;
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);
     } finally {


### PR DESCRIPTION
# Purpose

Prevent access denied messages to uses when Okta API fails to respond.

# Major Changes

* Add retry logic to the Okta Admin API Gateway

# Testing/Validation

* Unit test the retry scenario

## Summary by Sourcery

Introduce retry logic for Okta API calls on failure and simplify MeController response handling.

Enhancements:
- Retry Okta getUser call once after a 500ms delay if the initial fetch fails
- Simplify MeController to return httpSuccess directly without intermediate variable

Tests:
- Add unit test verifying Okta gateway retries on first fetch failure and succeeds on second attempt