### PR TITLE
CAMS-645 Fix more trustee ID and bankruptcy software query

### DIFF
--- a/backend/lib/adapters/gateways/mongo/lists.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/lists.mongo.repository.ts
@@ -53,10 +53,7 @@ export class ListsMongoRepository extends BaseMongoRepository implements ListsRe
 
   private async getList<T = ListItem>(listName: ListNames): Promise<T[]> {
     const query = this.doc('list').equals(listName);
-    const pipeline = QueryPipeline.pipeline(
-      QueryPipeline.match(query),
-      QueryPipeline.sort({ field: { name: 'value' }, direction: 'ASCENDING' }),
-    );
+    const pipeline = QueryPipeline.pipeline(QueryPipeline.match(query));
 
     try {
       return await this.getAdapter<T>().aggregate(pipeline);

--- a/backend/lib/use-cases/lists/lists.test.ts
+++ b/backend/lib/use-cases/lists/lists.test.ts
@@ -57,6 +57,32 @@ describe('ListsUseCase tests', () => {
       expect(result).toEqual(mockSoftwareList);
     });
 
+    test('should return bankruptcy software list sorted by value', async () => {
+      // Arrange - Create unsorted mock data
+      const mockUnsortedSoftwareList: BankruptcySoftwareList = [
+        { _id: '3', list: 'bankruptcy-software', key: 'software3', value: 'Zebra Software' },
+        { _id: '1', list: 'bankruptcy-software', key: 'software1', value: 'Alpha Software' },
+        { _id: '2', list: 'bankruptcy-software', key: 'software2', value: 'Beta Software' },
+      ];
+      mockListsRepository.getBankruptcySoftwareList.mockResolvedValue(mockUnsortedSoftwareList);
+
+      // Act
+      const result = await useCase.getBankruptcySoftwareList(context);
+
+      // Assert - Verify the result is sorted by value
+      expect(Factory.getListsGateway).toHaveBeenCalledWith(context);
+      expect(mockListsRepository.getBankruptcySoftwareList).toHaveBeenCalled();
+      expect(result).toHaveLength(3);
+      expect(result[0].value).toBe('Alpha Software');
+      expect(result[1].value).toBe('Beta Software');
+      expect(result[2].value).toBe('Zebra Software');
+
+      // Additional verification that the sorting is correct
+      const sortedValues = result.map((item) => item.value);
+      const expectedSortedValues = ['Alpha Software', 'Beta Software', 'Zebra Software'];
+      expect(sortedValues).toEqual(expectedSortedValues);
+    });
+
     test('should propagate errors from the repository', async () => {
       // Arrange
       const errorMessage = 'Failed to get bankruptcy software list';

--- a/backend/lib/use-cases/lists/lists.ts
+++ b/backend/lib/use-cases/lists/lists.ts
@@ -12,7 +12,11 @@ class ListsUseCase {
   public async getBankruptcySoftwareList(
     context: ApplicationContext,
   ): Promise<BankruptcySoftwareList> {
-    return await Factory.getListsGateway(context).getBankruptcySoftwareList();
+    const softwareList = (await Factory.getListsGateway(context).getBankruptcySoftwareList()).sort(
+      (a, b) => a.value.localeCompare(b.value),
+    );
+
+    return softwareList;
   }
 
   public async createBankruptcySoftware(

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -181,7 +181,7 @@ export default function TrusteeDetailScreen() {
         <TrusteeOtherInfoForm
           banks={trustee.banks}
           software={trustee.software}
-          trusteeId={trustee.id}
+          trusteeId={trustee.trusteeId}
         />
       ),
     },


### PR DESCRIPTION
# Purpose

This PR fixes two issues
1. TrusteeOtherInfoForm was still getting the old `id` instead of `trusteeId`, causing errors when attempting to submit the form or when canceling to navigate back to the trustee profile.
2. The `list` query was sorting by `value`, which is not indexed. This was causing an error when attempting to read the list of bankruptcy software options.
# Major Changes

1. Use `trusteeId` instead of `id`
2. Sort by value in the use case instead of in the generic lists repository. Since we're fetching the entire list without concern for pagination, this serves the current need.

# Testing/Validation

Unit tests, including new unit test for sorting
Manual testing of the scenarios that had been causing errors
e2e tests run against locally-running application

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Fix trustee ID handling and adjust bankruptcy software list sorting to prevent submission errors and query failures.

Bug Fixes:
- Use trustee.trusteeId instead of id in TrusteeOtherInfoForm to restore correct navigation and form submission
- Remove MongoDB pipeline sort on non-indexed value field to eliminate list query errors

Enhancements:
- Move sorting of bankruptcy software list into the use-case layer with localeCompare for alphabetical order

Tests:
- Add unit test to verify bankruptcy software list is sorted by value