### PR TITLE
Fix linter warnings from pre-commit ci

### DIFF
--- a/backend/lib/adapters/services/logger.service.test.ts
+++ b/backend/lib/adapters/services/logger.service.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable testing-library/no-debugging-utils
 import { LoggerImpl } from './logger.service';
 import { randomUUID } from 'crypto';
 import MockData from '../../../../common/src/cams/test-utilities/mock-data';

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BankruptcySoftware } from './BankruptcySoftware';
 import Api2 from '@/lib/models/api2';
@@ -45,7 +45,7 @@ describe('BankruptcySoftware Component Tests', () => {
     vi.restoreAllMocks();
   });
 
-  async function renderComponent() {
+  function renderComponent() {
     return render(<BankruptcySoftware />);
   }
 
@@ -153,13 +153,8 @@ describe('BankruptcySoftware Component Tests', () => {
     const input = screen.getByLabelText('Add New Software');
     const saveButton = screen.getByRole('button', { name: 'Add Software' });
 
-    await act(async () => {
-      await user.clear(input);
-    });
-
-    await act(async () => {
-      await user.click(saveButton);
-    });
+    await user.clear(input);
+    await user.click(saveButton);
 
     expect(globalAlertSpy.warning).toHaveBeenCalledWith('Software name cannot be empty.');
   });


### PR DESCRIPTION
Fix linter warnings from pre-commit ci

## Summary by Sourcery

Fix linter warnings by cleaning up test code and removing redundant asynchronous patterns

Enhancements:
- Remove unnecessary async keyword from renderComponent helper in BankruptcySoftware tests

Tests:
- Simplify BankruptcySoftware tests by eliminating redundant act() wrappers around user interactions
- Apply lint-driven cleanup in logger.service tests to satisfy pre-commit CI checks