### PR TITLE
Fix audit updatedBy to use userRef when updating trustees

### DIFF
--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
@@ -38,9 +38,6 @@ describe('TrusteesMongoRepository', () => {
       },
       email: 'john.doe@example.com',
     },
-    districts: ['NY'],
-    chapters: ['7-panel', '11'],
-    status: 'active',
   };
 
   beforeEach(async () => {
@@ -115,7 +112,6 @@ describe('TrusteesMongoRepository', () => {
               number: '555-0123',
             },
           },
-          status: 'active',
           documentType: 'TRUSTEE',
           createdOn: '2025-08-12T10:00:00Z',
           createdBy: mockUser,
@@ -138,7 +134,6 @@ describe('TrusteesMongoRepository', () => {
               number: '555-0456',
             },
           },
-          status: 'active',
           documentType: 'TRUSTEE',
           createdOn: '2025-08-12T11:00:00Z',
           createdBy: mockUser,
@@ -213,7 +208,6 @@ describe('TrusteesMongoRepository', () => {
             number: '555-0123',
           },
         },
-        status: 'active',
         documentType: 'TRUSTEE',
         createdOn: '2025-08-12T10:00:00Z',
         createdBy: mockUser,
@@ -317,7 +311,21 @@ describe('TrusteesMongoRepository', () => {
           },
           email: 'jane.updated@example.com',
         },
-        status: 'not active',
+        internal: {
+          address: {
+            address1: '789 Updated St',
+            city: 'Oldtown',
+            state: 'TX',
+            zipCode: '12345',
+            countryCode: 'US',
+          },
+          phone: {
+            number: '123-456-7890',
+          },
+          email: 'test@example.com',
+        },
+        banks: ['Bank 1', 'Bank 2'],
+        software: 'Software 1',
       };
 
       const updatedTrusteeDocument = {

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -482,7 +482,7 @@ function getAddress(override: Partial<Address> = {}): Address {
     city: faker.location.city(),
     state: faker.location.state({ abbreviated: true }),
     zipCode: faker.location.zipCode(),
-    countryCode: 'US',
+    countryCode: 'US' as const,
     ...override,
   };
 }


### PR DESCRIPTION
# Purpose

Correctly log the user reference of the user who updates a trustee record.

# Major Changes

* Pass only the user reference for the user in session, not the entire session user, when updating a trustee.

# Testing/Validation

* Unit tests

## Summary by Sourcery

Use the cams user reference instead of passing the full session user when creating or updating trustees to ensure correct audit logging.

Bug Fixes:
- Replace context.session.user with getCamsUserReference(context.session.user) in createTrustee and updateTrustee calls for createdBy/updatedBy fields

Enhancements:
- Simplify trusteeSpec access when building dynamicSpec in the trustees use case

Tests:
- Revise unit tests to spy on repository methods and history entries, asserting that userRef is used and raw session.user is never passed for audit fields