### PR TITLE
Pin node version and configure GHA updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,28 @@
       "allowedVersions": "9.x"
     },
     {
+      "description": "Disable Node.js version updates - must match Azure DevOps runners",
+      "matchManagers": ["nvm"],
+      "enabled": false
+    },
+    {
+      "description": "First-party GitHub Actions with digest pinning and 14-day wait",
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": ["^actions/", "^github/"],
+      "pinDigests": true,
+      "minimumReleaseAge": "14 days",
+      "groupName": "GitHub first-party actions"
+    },
+    {
+      "description": "Third-party GitHub Actions with digest pinning, 30-day wait, and separate PRs",
+      "matchManagers": ["github-actions"],
+      "excludePackagePatterns": ["^actions/", "^github/"],
+      "pinDigests": true,
+      "minimumReleaseAge": "30 days",
+      "groupName": null,
+      "automerge": false
+    },
+    {
       "description": "Require 30-day wait for x.0.0 major versions",
       "matchUpdateTypes": ["major"],
       "matchNewValue": "/\\.0\\.0$/",


### PR DESCRIPTION
# Purpose

Claude Code says the previous errors with package-lock conflicts was caused by Renovate updating our .nvmrc file.

# Major Changes

- Add configuration to pin the Node version.

# Other Changes

- We also configure GitHub Actions updates as follows:
  - All Actions pinned to a digest.
  - Official Actions must be 14 days old to upgrade.
    - Single PR if multiple are updated.
  - 3rd Party Actions must be 30 days old to upgrade.
    - Separate PRs if multiple are updated.

# Testing/Validation

Will have to see how Renovate behaves after merging.

# Definition of Done:

- [x] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed: More important code doesn’t directly depend on less important code
- [x] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [x] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Configure Renovate to pin the Node version and enforce strict scheduling and digest pinning for GitHub Actions updates

CI:
- Pin Node version to prevent package-lock conflicts
- Pin all GitHub Actions to a specific digest
- Delay official action upgrades by 14 days and group them into a single PR
- Delay third-party action upgrades by 30 days and open separate PRs for each