### PR TITLE
Configure Renovate to use the proper Node version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
   "separateMinorPatch": false,
   "rangeStrategy": "pin",
   "semanticCommits": "disabled",
+  "constraints": {
+    "node": "22.17.1"
+  },
   "packageRules": [
     {
       "description": "Automatically pin dependency ranges to exact versions",


### PR DESCRIPTION
# Purpose

Renovate needs to use our pinned Node version.

# Major Changes

Configures Renovate to use the proper version of Node.

# Testing/Validation

We have to see it in practice after merge.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhancements:
- Add Node version pin to renovate.json to ensure Renovate runs with the correct Node version