### PR TITLE
Make workflow diagram generation deterministic

### DIFF
--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -294,14 +294,14 @@ This diagram shows the explicit and implicit dependencies between jobs in the co
 ```mermaid
 flowchart LR
     subgraph "External Inputs"
+        Variables["Variables"]
+        Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
+        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
+        Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
+        Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
+        Variables_NODE_VERSION["NODE_VERSION"]
         Workflow_Inputs["Workflow Inputs"]
         Workflow_Inputs_enableBicepDeployment["enableBicepDeployment"]
-        Variables["Variables"]
-        Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
-        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
-        Variables_NODE_VERSION["NODE_VERSION"]
-        Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
-        Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
     end
 
     subgraph continuous_deployment_workflow["Continuous Deployment"]
@@ -364,17 +364,17 @@ flowchart LR
     classDef mainWorkflow fill:#f3e5f5,fill-opacity:0.15,stroke:#f3e5f5,stroke-width:1px,color:#ffffff
     classDef jobSubgraph fill:#f1f8e9,stroke:#33691e,stroke-width:2px,color:#000000
     class continuous_deployment_workflow mainWorkflow
-    class Workflow_Inputs external
     class Variables external
-    class setup_subgraph jobSubgraph
+    class Workflow_Inputs external
     class accessibility_test_subgraph jobSubgraph
-    class unit_test_frontend_subgraph jobSubgraph
-    class unit_test_backend_subgraph jobSubgraph
-    class unit_test_common_subgraph jobSubgraph
-    class security_scan job
     class build_subgraph jobSubgraph
     class deploy_subgraph jobSubgraph
     class deploy_code_slot_subgraph jobSubgraph
+    class security_scan job
+    class setup_subgraph jobSubgraph
+    class unit_test_backend_subgraph jobSubgraph
+    class unit_test_common_subgraph jobSubgraph
+    class unit_test_frontend_subgraph jobSubgraph
 ```
 
 ##### Deploy code for slot - Job Dependencies
@@ -385,14 +385,14 @@ This diagram shows the explicit and implicit dependencies between jobs in the de
 flowchart LR
     subgraph "External Inputs"
         Workflow_Inputs["Workflow Inputs"]
-        Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
-        Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
-        Workflow_Inputs_webappName["webappName"]
         Workflow_Inputs_apiFunctionName["apiFunctionName"]
+        Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
         Workflow_Inputs_dataflowsFunctionName["dataflowsFunctionName"]
-        Workflow_Inputs_slotName["slotName"]
         Workflow_Inputs_environmentHash["environmentHash"]
+        Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
+        Workflow_Inputs_slotName["slotName"]
         Workflow_Inputs_stackName["stackName"]
+        Workflow_Inputs_webappName["webappName"]
     end
 
     subgraph sub_deploy_code_slot_workflow["Deploy code for slot"]
@@ -483,17 +483,17 @@ flowchart LR
     classDef jobSubgraph fill:#f1f8e9,stroke:#33691e,stroke-width:2px,color:#000000
     class sub_deploy_code_slot_workflow mainWorkflow
     class Workflow_Inputs external
-    class deploy_code_subgraph jobSubgraph
-    class deploy_webapp_slot job
     class deploy_api_slot job
+    class deploy_code_subgraph jobSubgraph
     class deploy_dataflows_slot job
+    class deploy_webapp_slot job
+    class enable_access job
+    class endpoint_test_application_post_swap_subgraph jobSubgraph
     class endpoint_test_application_slot_subgraph jobSubgraph
     class execute_e2e_test_subgraph jobSubgraph
-    class swap_webapp_deployment_slot job
-    class swap_nodeapi_deployment_slot job
     class swap_dataflows_app_deployment_slot job
-    class endpoint_test_application_post_swap_subgraph jobSubgraph
-    class enable_access job
+    class swap_nodeapi_deployment_slot job
+    class swap_webapp_deployment_slot job
 ```
 
 ### Schedule Triggered Workflows
@@ -880,14 +880,14 @@ This diagram shows the explicit and implicit dependencies between jobs in the co
 ```mermaid
 flowchart LR
     subgraph "External Inputs"
+        Variables["Variables"]
+        Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
+        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
+        Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
+        Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
+        Variables_NODE_VERSION["NODE_VERSION"]
         Workflow_Inputs["Workflow Inputs"]
         Workflow_Inputs_enableBicepDeployment["enableBicepDeployment"]
-        Variables["Variables"]
-        Variables_CAMS_SERVER_PROTOCOL["CAMS_SERVER_PROTOCOL"]
-        Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
-        Variables_NODE_VERSION["NODE_VERSION"]
-        Variables_CAMS_SERVER_PORT["CAMS_SERVER_PORT"]
-        Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
     end
 
     subgraph continuous_deployment_workflow["Continuous Deployment"]
@@ -950,17 +950,17 @@ flowchart LR
     classDef mainWorkflow fill:#f3e5f5,fill-opacity:0.15,stroke:#f3e5f5,stroke-width:1px,color:#ffffff
     classDef jobSubgraph fill:#f1f8e9,stroke:#33691e,stroke-width:2px,color:#000000
     class continuous_deployment_workflow mainWorkflow
-    class Workflow_Inputs external
     class Variables external
-    class setup_subgraph jobSubgraph
+    class Workflow_Inputs external
     class accessibility_test_subgraph jobSubgraph
-    class unit_test_frontend_subgraph jobSubgraph
-    class unit_test_backend_subgraph jobSubgraph
-    class unit_test_common_subgraph jobSubgraph
-    class security_scan job
     class build_subgraph jobSubgraph
     class deploy_subgraph jobSubgraph
     class deploy_code_slot_subgraph jobSubgraph
+    class security_scan job
+    class setup_subgraph jobSubgraph
+    class unit_test_backend_subgraph jobSubgraph
+    class unit_test_common_subgraph jobSubgraph
+    class unit_test_frontend_subgraph jobSubgraph
 ```
 
 ##### Deploy code for slot - Job Dependencies
@@ -971,14 +971,14 @@ This diagram shows the explicit and implicit dependencies between jobs in the de
 flowchart LR
     subgraph "External Inputs"
         Workflow_Inputs["Workflow Inputs"]
-        Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
-        Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
-        Workflow_Inputs_webappName["webappName"]
         Workflow_Inputs_apiFunctionName["apiFunctionName"]
+        Workflow_Inputs_azResourceGrpAppEncrypted["azResourceGrpAppEncrypted"]
         Workflow_Inputs_dataflowsFunctionName["dataflowsFunctionName"]
-        Workflow_Inputs_slotName["slotName"]
         Workflow_Inputs_environmentHash["environmentHash"]
+        Workflow_Inputs_ghaEnvironment["ghaEnvironment"]
+        Workflow_Inputs_slotName["slotName"]
         Workflow_Inputs_stackName["stackName"]
+        Workflow_Inputs_webappName["webappName"]
     end
 
     subgraph sub_deploy_code_slot_workflow["Deploy code for slot"]
@@ -1069,17 +1069,17 @@ flowchart LR
     classDef jobSubgraph fill:#f1f8e9,stroke:#33691e,stroke-width:2px,color:#000000
     class sub_deploy_code_slot_workflow mainWorkflow
     class Workflow_Inputs external
-    class deploy_code_subgraph jobSubgraph
-    class deploy_webapp_slot job
     class deploy_api_slot job
+    class deploy_code_subgraph jobSubgraph
     class deploy_dataflows_slot job
+    class deploy_webapp_slot job
+    class enable_access job
+    class endpoint_test_application_post_swap_subgraph jobSubgraph
     class endpoint_test_application_slot_subgraph jobSubgraph
     class execute_e2e_test_subgraph jobSubgraph
-    class swap_webapp_deployment_slot job
-    class swap_nodeapi_deployment_slot job
     class swap_dataflows_app_deployment_slot job
-    class endpoint_test_application_post_swap_subgraph jobSubgraph
-    class enable_access job
+    class swap_nodeapi_deployment_slot job
+    class swap_webapp_deployment_slot job
 ```
 
 #### Stand Alone DAST Scan

--- a/ops/scripts/pipeline/workflow-diagram-generator.py
+++ b/ops/scripts/pipeline/workflow-diagram-generator.py
@@ -422,16 +422,17 @@ def analyze_dependencies(workflow: Dict) -> Dict:
 def _render_external_inputs_block(external_inputs: Dict[str, Set[str]]) -> Tuple[str, List[str]]:
     """Render the External Inputs subgraph and return its text plus the edges created.
 
-    Preserves existing ordering (iteration order of dict & sets as previously used).
+    Categories and variables are sorted alphabetically for consistent output.
     """
     if not external_inputs:
         return '', []
     block = f'{MERMAID_INDENT}subgraph "External Inputs"\n'
     edges: List[str] = []
-    for category, variables in external_inputs.items():
+    for category in sorted(external_inputs.keys()):
+        variables = external_inputs[category]
         category_id = sanitize_id(category)
         block += f'{MERMAID_DOUBLE_INDENT}{category_id}["{category}"]\n'
-        for var_name in variables:
+        for var_name in sorted(variables):
             var_id = sanitize_id(f"{category_id}_{var_name}")
             block += f'{MERMAID_DOUBLE_INDENT}{var_id}["{var_name}"]\n'
             edges.append(f'{MERMAID_DOUBLE_INDENT}{category_id} --> {var_id}')
@@ -511,9 +512,9 @@ def _build_external_edges(external_deps: Dict[str, List[Dict]], job_variables: D
 def _build_css_classes(workflow_id: str, workflow: Dict, job_variables: Dict[str, Set[str]], external_inputs: Dict[str, Set[str]]) -> str:
     css = get_dependency_css_definitions()
     css += f"{MERMAID_INDENT}class {workflow_id} mainWorkflow\n"
-    for category in external_inputs:
+    for category in sorted(external_inputs):
         css += f"{MERMAID_INDENT}class {sanitize_id(category)} external\n"
-    for job_id in workflow['jobs'].keys():
+    for job_id in sorted(workflow['jobs'].keys()):
         job_node_id = sanitize_id(job_id)
         if job_variables.get(job_id):
             css += f"{MERMAID_INDENT}class {job_node_id}_subgraph jobSubgraph\n"


### PR DESCRIPTION
# Purpose

Workflow diagrams kept changing even when changes to GitHub workflows wouldn't be expected to produce any meaningful diagram changes, simply because the generated diagram had things in a nondeterministic sort order.

# Major Changes

Sort things before writing to the diagram.

# Testing/Validation

Ran the script.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Make workflow diagram generation deterministic by alphabetically ordering external inputs and job classes and update the documentation diagrams to reflect the stable ordering.

Bug Fixes:
- Eliminate nondeterministic changes in generated workflow diagrams caused by unordered iteration of external inputs and jobs.

Enhancements:
- Sort external input categories, variables, and workflow jobs when generating Mermaid diagrams to ensure stable, repeatable output.

Documentation:
- Regenerate workflow dependency diagrams in the operations documentation to match the new deterministic ordering.