### PR TITLE
CAMS-660 Updated export style in mongo-aggregate-renderer

### DIFF
--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
@@ -14,7 +14,7 @@ import {
   ReplaceResult,
   UpdateResult,
 } from '../../../../use-cases/gateways.types';
-import { toMongoAggregate } from './mongo-aggregate-renderer';
+import MongoAggregateRenderer from './mongo-aggregate-renderer';
 import { toMongoQuery, toMongoSort } from './mongo-query-renderer';
 import { randomUUID } from 'crypto';
 import { Document as MongoDocument, MongoServerError } from 'mongodb';
@@ -29,7 +29,7 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
   }
 
   async aggregate<U = T>(pipeline: Pipeline): Promise<U[]> {
-    const mongoQuery = toMongoAggregate(pipeline);
+    const mongoQuery = MongoAggregateRenderer.toMongoAggregate(pipeline);
     try {
       const aggregationResult = await this.collectionHumble.aggregate(mongoQuery);
 
@@ -62,7 +62,7 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
       if (!includesPagination) {
         pipeline.stages.push(QueryPipeline.paginate(page.offset, page.limit));
       }
-      const mongoAggregate = toMongoAggregate(pipeline);
+      const mongoAggregate = MongoAggregateRenderer.toMongoAggregate(pipeline);
 
       const cursor = await this.collectionHumble.aggregate(mongoAggregate);
       const result = await cursor.next();

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-aggregate-renderer.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-aggregate-renderer.test.ts
@@ -1,5 +1,5 @@
 import QueryPipeline, { Stage } from '../../../../query/query-pipeline';
-import { toMongoAggregate, toMongoFilterCondition } from './mongo-aggregate-renderer';
+import MongoAggregateRenderer from './mongo-aggregate-renderer';
 import { Condition, Field } from '../../../../query/query-builder';
 import { CaseAssignment } from '../../../../../../common/src/cams/assignments';
 
@@ -76,7 +76,7 @@ describe('aggregation query renderer tests', () => {
       queryPaginate,
     );
 
-    const actual = toMongoAggregate(query);
+    const actual = MongoAggregateRenderer.toMongoAggregate(query);
     expect(actual).toEqual(expected);
   });
 
@@ -92,7 +92,7 @@ describe('aggregation query renderer tests', () => {
       leftOperand,
       rightOperand: 'Bob Newhart',
     };
-    const actual = toMongoFilterCondition<CaseAssignment>(query);
+    const actual = MongoAggregateRenderer.toMongoFilterCondition<CaseAssignment>(query);
     expect(actual).toEqual(expected);
   });
 
@@ -117,7 +117,7 @@ describe('aggregation query renderer tests', () => {
         rightOperand: right,
       };
 
-      const actual = toMongoFilterCondition<CaseAssignment>(query);
+      const actual = MongoAggregateRenderer.toMongoFilterCondition<CaseAssignment>(query);
       expect(actual).toEqual(expected);
     },
   );
@@ -152,7 +152,7 @@ describe('aggregation query renderer tests', () => {
 
     const query = pipeline(simpleMatch, group);
 
-    const actual = toMongoAggregate(query);
+    const actual = MongoAggregateRenderer.toMongoAggregate(query);
 
     expect(actual).toEqual(expected);
   });


### PR DESCRIPTION
# Purpose

Used better export pattern we've decided to standardize.


# Testing/Validation

Tests pass.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Standardize the Mongo aggregate renderer module to use a default-exported renderer object instead of multiple named exports.

Enhancements:
- Encapsulate Mongo aggregation helper functions in a MongoAggregateRenderer object to align with the preferred export pattern.
- Update Mongo adapter and tests to consume aggregation utilities via the new MongoAggregateRenderer default export.