### PR TITLE
CAMS-660 Remove unused exports for mongo and mock oauth2

### DIFF
--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
@@ -371,7 +371,7 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
   }
 }
 
-export function createOrGetId<T>(item: CamsItem<T>): CamsItem<T> {
+function createOrGetId<T>(item: CamsItem<T>): CamsItem<T> {
   return {
     id: randomUUID(),
     ...item,

--- a/backend/lib/humble-objects/mongo-humble.ts
+++ b/backend/lib/humble-objects/mongo-humble.ts
@@ -99,9 +99,3 @@ export type DocumentQuery = {
 };
 
 export type AggregateQuery = MongoDocument;
-
-export function isMongoDocumentArray(arr: unknown): arr is MongoDocument[] {
-  return (
-    Array.isArray(arr) && arr.every((item) => item && typeof item === 'object' && '_id' in item)
-  );
-}

--- a/backend/lib/testing/mock-gateways/mock-oauth2-gateway.ts
+++ b/backend/lib/testing/mock-gateways/mock-oauth2-gateway.ts
@@ -4,7 +4,7 @@ import { ForbiddenError } from '../../common-errors/forbidden-error';
 import MockUsers, { MockUser } from '../../../../common/src/cams/test-utilities/mock-user';
 import { CamsUser } from '../../../../common/src/cams/users';
 import { CamsRole } from '../../../../common/src/cams/roles';
-import { CamsJwt, CamsJwtClaims, CamsJwtHeader } from '../../../../common/src/cams/jwt';
+import { CamsJwt, CamsJwtClaims } from '../../../../common/src/cams/jwt';
 import { OpenIdConnectGateway } from '../../adapters/types/authorization';
 import { MOCKED_USTP_OFFICES_ARRAY } from '../../../../common/src/cams/offices';
 import { nowInSeconds } from '../../../../common/src/date-helper';
@@ -37,25 +37,6 @@ export async function mockAuthentication(context: ApplicationContext): Promise<s
 
   const token = jwt.sign(claims, key);
   return token;
-}
-
-export async function verifyToken(accessToken: string): Promise<CamsJwt> {
-  const payload = jwt.verify(accessToken, key) as jwt.JwtPayload;
-  const claims: CamsJwtClaims = {
-    iss: payload.iss!,
-    sub: payload.sub!,
-    aud: payload.aud!,
-    exp: payload.exp!,
-    groups: payload.groups!,
-    ...payload,
-  };
-
-  const header: CamsJwtHeader = { typ: '' };
-  const camsJwt: CamsJwt = {
-    claims,
-    header,
-  };
-  return camsJwt;
 }
 
 function addSuperUserOffices(user: CamsUser) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -678,6 +678,7 @@
       "integrity": "sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -688,6 +689,7 @@
       "integrity": "sha512-X63hI1bxl5ohelzr0LY5coufyl0LJNthld+abwxpCoo6Gq+hSqhKwci7MUWkXo67mzgUK6YFByhmaHmUcuBJmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.48.1",
@@ -718,6 +720,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -922,6 +925,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1682,6 +1686,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1742,6 +1747,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3630,6 +3636,7 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4379,6 +4386,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
# Purpose

Cleaning up unused/dead code

# Major Changes

Remove unecessary export from mongo adapter
Remove unused functions from mongo humble and mock oauth2 gateway

# Testing/Validation

Builds and unit tests pass.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Clean up unused Mongo and mock OAuth2 code by removing dead exports and helper functions.

Enhancements:
- Remove the unused verifyToken helper from the mock OAuth2 gateway used in tests.
- Remove the unused isMongoDocumentArray helper from the Mongo humble object module.
- Restrict the Mongo createOrGetId helper to internal use by making it a non-exported function.