### PR TITLE
CAMS-660 Remove unused exports for testing constants & trustee specs

### DIFF
--- a/backend/lib/testing/testing-constants.ts
+++ b/backend/lib/testing/testing-constants.ts
@@ -6,5 +6,3 @@ export const THROW_UNKNOWN_ERROR_CASE_ID = '999-99-99999';
 // Trustee IDs for testing
 export const NORMAL_TRUSTEE_ID = 'trustee-12345';
 export const NOT_FOUND_ERROR_TRUSTEE_ID = 'trustee-00000';
-export const THROW_PERMISSIONS_ERROR_TRUSTEE_ID = 'trustee-88888';
-export const THROW_UNKNOWN_ERROR_TRUSTEE_ID = 'trustee-99999';

--- a/backend/lib/testing/testing-utilities.ts
+++ b/backend/lib/testing/testing-utilities.ts
@@ -38,7 +38,7 @@ export async function createMockApplicationContextSession(
   return MockData.getCamsSession(override);
 }
 
-export function createMockRequest(request: Partial<CamsHttpRequest> = {}): HttpRequest {
+function createMockRequest(request: Partial<CamsHttpRequest> = {}): HttpRequest {
   const { headers, method, body, ...other } = request;
   const requestInit = {
     method: (method as CamsHttpMethod) ?? 'GET',

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -290,7 +290,7 @@ const contactInformationSpec: ValidationSpec<ContactInformation> = {
   ],
 };
 
-export const internalContactInformationSpec: ValidationSpec<ContactInformation> = {
+const internalContactInformationSpec: ValidationSpec<ContactInformation> = {
   address: [V.optional(V.nullable(V.spec(addressSpec)))],
   phone: [V.optional(V.nullable(V.spec(phoneSpec)))],
   email: [
@@ -300,7 +300,7 @@ export const internalContactInformationSpec: ValidationSpec<ContactInformation> 
   ],
 };
 
-export const trusteeSpec: ValidationSpec<TrusteeInput> = {
+const trusteeSpec: ValidationSpec<TrusteeInput> = {
   name: [V.minLength(1)],
   public: [V.optional(V.spec(contactInformationSpec))],
   internal: [V.optional(V.spec(internalContactInformationSpec))],

--- a/common/src/cams/test-utilities/attorneys.mock.ts
+++ b/common/src/cams/test-utilities/attorneys.mock.ts
@@ -18,7 +18,6 @@ const manhattanAttorneys = MockUsers.filter(
     user.user.offices[0] === REGION_02_GROUP_NY && user.user.roles[0] === CamsRole.TrialAttorney,
 ).map((user) => user.user);
 
-export const USTP_OFFICE_TRIAL_ATTORNEYS: AttorneyUser[] = [];
 export const TRIAL_ATTORNEYS: AttorneyUser[] = [
   ...manhattanAttorneys,
   {

--- a/common/src/cams/test-utilities/courts.mock.ts
+++ b/common/src/cams/test-utilities/courts.mock.ts
@@ -3380,6 +3380,3 @@ export const COURT_DIVISIONS: CourtDivisionDetails[] = [
 ];
 
 export const MANHATTAN = COURT_DIVISIONS.find((office) => office.courtDivisionCode === '081');
-export const WHITE_PLAINS = COURT_DIVISIONS.find((office) => office.courtDivisionCode === '087');
-export const BUFFALO = COURT_DIVISIONS.find((office) => office.courtDivisionCode === '091');
-export const DELAWARE = COURT_DIVISIONS.find((office) => office.courtDivisionCode === '111');

--- a/common/src/cams/test-utilities/mock-user.ts
+++ b/common/src/cams/test-utilities/mock-user.ts
@@ -11,9 +11,7 @@ export const REGION_02_GROUP_BU = MOCKED_USTP_OFFICE_DATA_MAP.get(
 export const REGION_02_GROUP_SE = MOCKED_USTP_OFFICE_DATA_MAP.get(
   'USTP_CAMS_Region_18_Office_Seattle',
 )!;
-export const REGION_03_GROUP_WL = MOCKED_USTP_OFFICE_DATA_MAP.get(
-  'USTP_CAMS_Region_3_Office_Wilmington',
-)!;
+const REGION_03_GROUP_WL = MOCKED_USTP_OFFICE_DATA_MAP.get('USTP_CAMS_Region_3_Office_Wilmington')!;
 
 export type MockUser = {
   sub: string;


### PR DESCRIPTION
# Purpose

Cleaning up unused code reports

# Major Changes

- Remove exports for unused constants in testing utilities.
- Remove exports from trustee specs only leveraged internally to the use case.

# Testing/Validation

- unit tests pass
- builds


# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove unused or internally scoped testing and trustee validation exports to clean up dead code and keep utilities internal where appropriate.

Enhancements:
- Restrict trustee validation specs and mock request helper to internal module scope instead of exporting them.
- Remove unused testing constants and court division/office mock exports from shared test utilities to reduce dead code.
- Eliminate an unused collection of trial attorney users from test mocks to simplify fixtures.

Tests:
- Rely on remaining test utilities and mocks without changing test behavior while removing unused exports.