### PR TITLE
CAMS-660 datetime and localstorage default exports

### DIFF
--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -29,7 +29,7 @@ import LocalStorage from '../utils/local-storage';
 import Api from './api';
 import MockApi2 from '../testing/mock-api2';
 import LocalCache from '../utils/local-cache';
-import { DAY, MINUTE } from '../utils/datetime';
+import DateTimeUtils from '../utils/datetime';
 import { sanitizeText } from '../utils/sanitize-text';
 import { isValidUserInput } from '@common/cams/sanitization';
 import {
@@ -323,7 +323,7 @@ async function deleteCaseNote(note: Partial<CaseNote>) {
 
 async function getCourts() {
   const path = `/courts`;
-  return withCache({ key: path, ttl: DAY }).get<CourtDivisionDetails[]>(path);
+  return withCache({ key: path, ttl: DateTimeUtils.DAY }).get<CourtDivisionDetails[]>(path);
 }
 
 async function getMe() {
@@ -342,7 +342,7 @@ async function getOfficeAssignees(officeCode: string) {
 
 async function getOffices() {
   const path = `/offices`;
-  return withCache({ key: path, ttl: DAY }).get<UstpOfficeDetails[]>(path);
+  return withCache({ key: path, ttl: DateTimeUtils.DAY }).get<UstpOfficeDetails[]>(path);
 }
 
 async function getOrders() {
@@ -396,17 +396,19 @@ async function postStaffAssignments(action: StaffAssignmentAction) {
 
 async function getRoleAndOfficeGroupNames() {
   const path = '/dev-tools/privileged-identity/groups';
-  return withCache({ key: path, ttl: MINUTE * 15 }).get<RoleAndOfficeGroupNames>(path);
+  return withCache({ key: path, ttl: DateTimeUtils.MINUTE * 15 }).get<RoleAndOfficeGroupNames>(
+    path,
+  );
 }
 
 async function getPrivilegedIdentityUsers() {
   const path = '/dev-tools/privileged-identity';
-  return withCache({ key: path, ttl: MINUTE * 15 }).get<CamsUserReference[]>(path);
+  return withCache({ key: path, ttl: DateTimeUtils.MINUTE * 15 }).get<CamsUserReference[]>(path);
 }
 
 async function getPrivilegedIdentityUser(userId: string) {
   const path = `/dev-tools/privileged-identity/${userId}`;
-  return withCache({ key: path, ttl: MINUTE * 15 }).get<PrivilegedIdentityUser>(path);
+  return withCache({ key: path, ttl: DateTimeUtils.MINUTE * 15 }).get<PrivilegedIdentityUser>(path);
 }
 
 async function putPrivilegedIdentityUser(userId: string, action: ElevatePrivilegedUserAction) {

--- a/user-interface/src/lib/utils/datetime.ts
+++ b/user-interface/src/lib/utils/datetime.ts
@@ -51,8 +51,18 @@ export function sortByDateReverse(dateA: Date | string, dateB: Date | string): n
 }
 
 // Time units expressed in seconds:
-export const SECOND = 1;
-export const MINUTE = 60;
-export const HOUR = 3600;
-export const DAY = 86400;
-export const THREE_DAYS = DAY * 3;
+const SECOND = 1;
+const MINUTE = 60;
+const HOUR = 3600;
+const DAY = 86400;
+const THREE_DAYS = DAY * 3;
+
+const DateTimeUtils = {
+  SECOND,
+  MINUTE,
+  HOUR,
+  DAY,
+  THREE_DAYS,
+};
+
+export default DateTimeUtils;

--- a/user-interface/src/lib/utils/local-cache.ts
+++ b/user-interface/src/lib/utils/local-cache.ts
@@ -1,4 +1,4 @@
-import { HOUR } from './datetime';
+import DateTimeUtils from './datetime';
 import getAppConfiguration from '@/configuration/appConfiguration';
 
 export type Cacheable<T = unknown> = {
@@ -7,7 +7,7 @@ export type Cacheable<T = unknown> = {
 };
 
 const NAMESPACE = 'cams:cache:';
-const DEFAULT_TTL = HOUR;
+const DEFAULT_TTL = DateTimeUtils.HOUR;
 const canCache = !!window.localStorage && !getAppConfiguration().disableLocalCache;
 
 function isCacheEnabled() {

--- a/user-interface/src/lib/utils/local-form-cache.ts
+++ b/user-interface/src/lib/utils/local-form-cache.ts
@@ -1,4 +1,4 @@
-import { THREE_DAYS } from './datetime';
+import DateTimeUtils from './datetime';
 import LocalCache, { Cacheable } from './local-cache';
 
 const FORM_NAMESPACE = 'form:';
@@ -12,7 +12,7 @@ function getForm<T>(key: string): Cacheable<T> | null {
 
 function saveForm(key: string, data: object) {
   const formKey = FORM_NAMESPACE + key;
-  set<object>(formKey, data, THREE_DAYS);
+  set<object>(formKey, data, DateTimeUtils.THREE_DAYS);
 }
 
 function clearForm(key: string) {

--- a/user-interface/src/lib/utils/local-storage.test.ts
+++ b/user-interface/src/lib/utils/local-storage.test.ts
@@ -1,11 +1,9 @@
 import MockData from '@common/cams/test-utilities/mock-data';
-import LocalStorage, {
-  LAST_INTERACTION_KEY,
-  LOGIN_LOCAL_STORAGE_ACK_KEY,
-  LOGIN_LOCAL_STORAGE_SESSION_KEY,
-} from './local-storage';
+import LocalStorage from './local-storage';
 
 const testSession = MockData.getCamsSession();
+const { LAST_INTERACTION_KEY, LOGIN_LOCAL_STORAGE_ACK_KEY, LOGIN_LOCAL_STORAGE_SESSION_KEY } =
+  LocalStorage;
 
 describe('Local storage', () => {
   describe('getAck', () => {

--- a/user-interface/src/lib/utils/local-storage.ts
+++ b/user-interface/src/lib/utils/local-storage.ts
@@ -1,11 +1,11 @@
 import { CamsSession } from '@common/cams/session';
 
-export const LOGIN_LOCAL_STORAGE_SESSION_KEY = 'cams:session';
-export const LOGIN_LOCAL_STORAGE_FORM_CACHE_KEY = 'cams:cache:form:';
-export const LOGIN_LOCAL_STORAGE_CACHE_KEY = 'cams:cache:';
-export const LOGIN_LOCAL_STORAGE_ACK_KEY = 'cams:ack';
-export const REFRESHING_TOKEN = 'cams:refreshing-token';
-export const LAST_INTERACTION_KEY = 'cams:last-interaction';
+const LOGIN_LOCAL_STORAGE_SESSION_KEY = 'cams:session';
+const LOGIN_LOCAL_STORAGE_FORM_CACHE_KEY = 'cams:cache:form:';
+const LOGIN_LOCAL_STORAGE_CACHE_KEY = 'cams:cache:';
+const LOGIN_LOCAL_STORAGE_ACK_KEY = 'cams:ack';
+const REFRESHING_TOKEN = 'cams:refreshing-token';
+const LAST_INTERACTION_KEY = 'cams:last-interaction';
 
 function getSession(): CamsSession | null {
   let session: CamsSession | null = null;
@@ -117,6 +117,12 @@ const LocalStorage = {
   removeRefreshingToken,
   getLastInteraction,
   setLastInteraction,
+  LOGIN_LOCAL_STORAGE_SESSION_KEY,
+  LOGIN_LOCAL_STORAGE_FORM_CACHE_KEY,
+  LOGIN_LOCAL_STORAGE_CACHE_KEY,
+  LOGIN_LOCAL_STORAGE_ACK_KEY,
+  REFRESHING_TOKEN,
+  LAST_INTERACTION_KEY,
 };
 
 export default LocalStorage;

--- a/user-interface/src/search/searchScreen.types.ts
+++ b/user-interface/src/search/searchScreen.types.ts
@@ -9,9 +9,8 @@ export type SearchScreenFormData = {
   excludeClosedCases?: boolean;
 };
 
-export const CASE_NUMBER_INVALID_ERROR_REASON = 'Must be 7 digits';
-export const AT_LEAST_ONE_SEARCH_CRITERION_ERROR_REASON =
-  'Please enter at least one search criterion';
+const CASE_NUMBER_INVALID_ERROR_REASON = 'Must be 7 digits';
+const AT_LEAST_ONE_SEARCH_CRITERION_ERROR_REASON = 'Please enter at least one search criterion';
 
 const caseNumber = [V.matches(CASE_NUMBER_REGEX, CASE_NUMBER_INVALID_ERROR_REASON)];
 

--- a/user-interface/src/trustees/forms/trusteeForms.types.ts
+++ b/user-interface/src/trustees/forms/trusteeForms.types.ts
@@ -9,23 +9,23 @@ import { VALID, validateObject, ValidationSpec, ValidatorFunction } from '@commo
 import V from '@common/cams/validators';
 
 export const ADDRESS_REQUIRED_ERROR_REASON = 'Address is required';
-export const ADDRESS_MAX_LENGTH_ERROR_REASON = 'Max length 40 characters';
-export const ZIP_CODE_ERROR_REASON = 'Must be 5 or 9 digits';
+const ADDRESS_MAX_LENGTH_ERROR_REASON = 'Max length 40 characters';
+const ZIP_CODE_ERROR_REASON = 'Must be 5 or 9 digits';
 export const PARTIAL_ADDRESS_ERROR_REASON =
   'You have entered a partial address. Please complete or clear the address fields.';
-export const TRUSTEE_NAME_REQUIRED_ERROR_REASON = 'Trustee name is required';
-export const TRUSTEE_NAME_MAX_LENGTH_ERROR_REASON = 'Max length 50 characters';
+const TRUSTEE_NAME_REQUIRED_ERROR_REASON = 'Trustee name is required';
+const TRUSTEE_NAME_MAX_LENGTH_ERROR_REASON = 'Max length 50 characters';
 export const CITY_REQUIRED_ERROR_REASON = 'City is required';
-export const CITY_MAX_LENGTH_ERROR_REASON = 'Max length 50 characters';
+const CITY_MAX_LENGTH_ERROR_REASON = 'Max length 50 characters';
 export const STATE_REQUIRED_ERROR_REASON = 'State is required';
 export const ZIP_CODE_REQUIRED_ERROR_REASON = 'ZIP Code is required';
-export const EMAIL_INVALID_ERROR_REASON = 'Must be a valid email address';
-export const EMAIL_MAX_LENGTH_ERROR_REASON = 'Max length 50 characters';
-export const PHONE_INVALID_ERROR_REASON = 'Must be a valid phone number';
-export const EXTENSION_INVALID_ERROR_REASON = 'Must be 1 to 6 digits';
-export const WEBSITE_INVALID_URL_ERROR_REASON = 'Website must be a valid URL';
-export const WEBSITE_MAX_LENGTH_ERROR_REASON = 'Max length 255 characters';
-export const PHONE_REQUIRED_WITH_EXTENSION_ERROR_REASON =
+const EMAIL_INVALID_ERROR_REASON = 'Must be a valid email address';
+const EMAIL_MAX_LENGTH_ERROR_REASON = 'Max length 50 characters';
+const PHONE_INVALID_ERROR_REASON = 'Must be a valid phone number';
+const EXTENSION_INVALID_ERROR_REASON = 'Must be 1 to 6 digits';
+const WEBSITE_INVALID_URL_ERROR_REASON = 'Website must be a valid URL';
+const WEBSITE_MAX_LENGTH_ERROR_REASON = 'Max length 255 characters';
+const PHONE_REQUIRED_WITH_EXTENSION_ERROR_REASON =
   'Phone number is required when extension is provided';
 
 export type TrusteeInternalFormData = {


### PR DESCRIPTION
# Purpose

Cleaning up unused code.

# Major Changes

- DateTimeUtils default export for time constants
- move localStorage constants into preexisting default export
- remove unused exports from Trustee form types.
# Testing/Validation

- unit tests
- builds

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Consolidate time and local storage constants into default utility exports and restrict several error message constants to internal use.

Enhancements:
- Introduce a DateTimeUtils default export encapsulating existing time unit constants and update cache clients to use it.
- Move local storage key constants into the existing LocalStorage default export and adjust tests accordingly.
- Limit various validation error message constants in trustee and search form types to internal module scope instead of public exports.