### PR TITLE
CAMS-660 Removed unused exports for some gateways and controller

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/orders.dxtr.gateway.test.ts
+++ b/backend/lib/adapters/gateways/dxtr/orders.dxtr.gateway.test.ts
@@ -1,11 +1,10 @@
 import * as database from '../../utils/database';
 import { createMockApplicationContext } from '../../../testing/testing-utilities';
 import { QueryResults } from '../../types/database';
-import {
+import DxtrOrdersGateway, {
   DxtrOrder,
   DxtrOrderDocketEntry,
   DxtrOrderDocument,
-  DxtrOrdersGateway,
   dxtrOrdersSorter,
 } from './orders.dxtr.gateway';
 import { ApplicationContext } from '../../types/basic';

--- a/backend/lib/adapters/gateways/dxtr/orders.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/orders.dxtr.gateway.ts
@@ -38,9 +38,9 @@ const REGIONS_TO_SYNC = [
   '21',
 ];
 
-export interface DxtrTransfer extends TransferOrder, DxtrOrder {}
+interface DxtrTransfer extends TransferOrder, DxtrOrder {}
 
-export interface DxtrConsolidation extends RawConsolidationOrder, DxtrOrder {}
+interface DxtrConsolidation extends RawConsolidationOrder, DxtrOrder {}
 
 export interface DxtrOrder {
   dxtrCaseId: string;
@@ -66,7 +66,7 @@ export function dxtrOrdersSorter(a: { orderDate: string }, b: { orderDate: strin
   return a.orderDate < b.orderDate ? -1 : 1;
 }
 
-export class DxtrOrdersGateway implements OrdersGateway {
+class DxtrOrdersGateway implements OrdersGateway {
   async getOrderSync(context: ApplicationContext, txId: string): Promise<RawOrderSync> {
     const transfers = await this.getTransferOrderSync(context, txId);
     const consolidations = await this.getConsolidationOrderSync(context, txId);
@@ -644,3 +644,5 @@ export class DxtrOrdersGateway implements OrdersGateway {
     return { maxTxId, mappedDocketEntries };
   }
 }
+
+export default DxtrOrdersGateway;

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.ts
@@ -23,7 +23,7 @@ export type TrusteeDocument = Trustee & {
   documentType: 'TRUSTEE';
 };
 
-export type TrusteeOversightAssignmentDocument = TrusteeOversightAssignment & {
+type TrusteeOversightAssignmentDocument = TrusteeOversightAssignment & {
   documentType: 'TRUSTEE_OVERSIGHT_ASSIGNMENT';
 };
 

--- a/backend/lib/controllers/orders/orders.controller.ts
+++ b/backend/lib/controllers/orders/orders.controller.ts
@@ -20,11 +20,11 @@ import { finalizeDeferrable } from '../../deferrable/finalize-deferrable';
 
 const MODULE_NAME = 'ORDERS-CONTROLLER';
 
-export type GetOrdersResponse = CamsHttpResponseInit<Order[]>;
-export type GetSuggestedCasesResponse = CamsHttpResponseInit<CaseSummary[]>;
-export type UpdateOrderResponse = CamsHttpResponseInit;
-export type SyncOrdersResponse = CamsHttpResponseInit<SyncOrdersStatus>;
-export type ManageConsolidationResponse = CamsHttpResponseInit<ConsolidationOrder[]>;
+type GetOrdersResponse = CamsHttpResponseInit<Order[]>;
+type GetSuggestedCasesResponse = CamsHttpResponseInit<CaseSummary[]>;
+type UpdateOrderResponse = CamsHttpResponseInit;
+type SyncOrdersResponse = CamsHttpResponseInit<SyncOrdersStatus>;
+type ManageConsolidationResponse = CamsHttpResponseInit<ConsolidationOrder[]>;
 
 export class OrdersController implements CamsController, CamsTimerController {
   private readonly useCase: OrdersUseCase;

--- a/backend/lib/factory.test.ts
+++ b/backend/lib/factory.test.ts
@@ -57,8 +57,7 @@ describe('Factory function-apps', () => {
       MockOrdersGateway = (await import('./testing/mock-gateways/mock.orders.gateway'))
         .MockOrdersGateway;
 
-      DxtrOrdersGateway = (await import('./adapters/gateways/dxtr/orders.dxtr.gateway'))
-        .DxtrOrdersGateway;
+      DxtrOrdersGateway = (await import('./adapters/gateways/dxtr/orders.dxtr.gateway')).default;
 
       CaseDocketUseCase = (await import('./use-cases/case-docket/case-docket')).CaseDocketUseCase;
 

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -30,7 +30,7 @@ import {
   UserSessionCacheRepository,
   UsersRepository,
 } from './use-cases/gateways.types';
-import { DxtrOrdersGateway } from './adapters/gateways/dxtr/orders.dxtr.gateway';
+import DxtrOrdersGateway from './adapters/gateways/dxtr/orders.dxtr.gateway';
 import { OfficesGateway } from './use-cases/offices/offices.types';
 import OfficesDxtrGateway from './adapters/gateways/dxtr/offices.dxtr.gateway';
 import {

--- a/backend/lib/humble-objects/mongo-humble.ts
+++ b/backend/lib/humble-objects/mongo-humble.ts
@@ -86,7 +86,7 @@ export class DocumentClient implements Closable {
   }
 }
 
-export type Filter = {
+type Filter = {
   [key: string]: unknown;
 };
 

--- a/backend/lib/query/query-pipeline.ts
+++ b/backend/lib/query/query-pipeline.ts
@@ -39,20 +39,20 @@ function source<T = unknown>(source?: string) {
   };
 }
 
-export type First = {
+type First = {
   accumulator: 'FIRST';
   as: Field;
   field: Field;
 };
 
-export type Count = {
+type Count = {
   accumulator: 'COUNT';
   as: Field;
 };
 
 export type Accumulator = Count | First;
 
-export type Match = ConditionOrConjunction<never> & {
+type Match = ConditionOrConjunction<never> & {
   stage: 'MATCH';
 };
 
@@ -95,7 +95,7 @@ export type FieldReference<T> = Field<T> & {
   source?: string;
 };
 
-export type QueryFieldReference<T> = FieldReference<T> & ConditionFunctions<T>;
+type QueryFieldReference<T> = FieldReference<T> & ConditionFunctions<T>;
 
 export type Join = {
   stage: 'JOIN';
@@ -104,7 +104,7 @@ export type Join = {
   alias: FieldReference<never>;
 };
 
-export type AdditionalField<T = never> = {
+type AdditionalField<T = never> = {
   fieldToAdd: FieldReference<never>;
   querySource: FieldReference<never>;
   query: ConditionOrConjunction<T>;


### PR DESCRIPTION
Jira ticket: CAMS-660

# Purpose

Eliminate export keyword from exports that are not used outside of module.


# Testing/Validation

All tests are passing

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove unused exports and update DXTR orders gateway export style to use a default export.

Enhancements:
- Restrict various internal types in controllers, query pipeline, Mongo utilities, and repositories to module scope by removing unnecessary exports.
- Switch the DXTR orders gateway from a named to a default export and align its test and factory imports accordingly.