### PR TITLE
Fix e2e environment setup

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           echo "Running Playwright Tests..."
           mkdir -p playwright/.auth
-          SLOT_NAME=${{ inputs.slotName }} DEV_TEST_USERNAME=${{secrets.OKTA_USER_NAME_USTP}} DEV_TEST_PASSWORD=${{secrets.OKTA_PASSWORD_USTP}} TARGET_HOST=https://${{ inputs.webappName }}-${{ inputs.slotName }}.azurewebsites.us CAMS_LOGIN_PROVIDER=${{ vars.CAMS_LOGIN_PROVIDER }} npx playwright test --reporter=list,html
+          SLOT_NAME=${{ inputs.slotName }} OKTA_USER_NAME=${{ secrets.OKTA_USER_NAME }} OKTA_PASSWORD=${{ secrets.OKTA_PASSWORD }} TARGET_HOST=https://${{ inputs.webappName }}-${{ inputs.slotName }}.azurewebsites.us CAMS_LOGIN_PROVIDER=${{ vars.CAMS_LOGIN_PROVIDER }} npx playwright test --reporter=list,html
 
       - name: Upload report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0


### PR DESCRIPTION
# Purpose

e2e tests were not getting logged into Okta.

# Major Changes

Replace dev mode variables with Okta variables.

# Testing/Validation

Running e2e tests - https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/20111069914.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

CI:
- Switch e2e workflow environment variables from dev test credentials to standard Okta username and password secrets for Playwright runs.