### PR TITLE
CAMS-660 Removed export keyword from common where not used

### DIFF
--- a/common/src/api/common.ts
+++ b/common/src/api/common.ts
@@ -1,6 +1,3 @@
-import { UUID } from 'crypto';
-
-export type Key = string | number | UUID;
 export type UriString = string;
 
 export type NullableOptionalFields<T> = {

--- a/common/src/api/response.ts
+++ b/common/src/api/response.ts
@@ -1,7 +1,7 @@
 import { UriString } from './common';
 import { Pagination } from './pagination';
 
-export type ResponseMetaData = {
+type ResponseMetaData = {
   self: UriString;
 };
 

--- a/common/src/cams/cases.ts
+++ b/common/src/cams/cases.ts
@@ -6,7 +6,7 @@ import { CamsUserReference } from './users';
 
 export const VALID_CASEID_PATTERN = RegExp(/^[\dA-Z]{3}-\d{2}-\d{5}$/);
 
-export type FlatOfficeDetail = {
+type FlatOfficeDetail = {
   officeName: string;
   officeCode: string;
   courtId: string;

--- a/common/src/cams/offices.ts
+++ b/common/src/cams/offices.ts
@@ -23,13 +23,13 @@ export type UstpDivision = {
   courtOffice: CourtOffice;
 };
 
-export type Court = {
+type Court = {
   courtId: string; // DXTR AO_CS_DIV.COURT_ID
   courtName?: string; // DXTR AO_COURT.COURT_NAME
   state?: string;
 };
 
-export type CourtOffice = {
+type CourtOffice = {
   courtOfficeCode: string; // DXTR AO_OFFICE.OFFICE_CODE
   courtOfficeName: string; // DXTR AO_OFFICE.OFFICE_DISPLAY_NAME
 };

--- a/common/src/cams/orders.ts
+++ b/common/src/cams/orders.ts
@@ -150,7 +150,7 @@ export type TransferOrderActionRejection = {
   reason?: string;
 };
 
-export type TransferOrderActionApproval = {
+type TransferOrderActionApproval = {
   id: string;
   caseId: string;
   orderType: 'transfer';
@@ -159,21 +159,6 @@ export type TransferOrderActionApproval = {
 };
 
 export type TransferOrderAction = TransferOrderActionRejection | TransferOrderActionApproval;
-
-export type OrderActionRejection<T = TransferOrder> = {
-  id: string;
-  status: 'rejected';
-  reason?: string;
-  order: T;
-};
-
-export type OrderActionApproval<T = TransferOrder> = {
-  id: string;
-  status: 'approved';
-  order: T;
-};
-
-export type OrderAction<T> = OrderActionRejection<T> | OrderActionApproval<T>;
 
 export type OrderSync = {
   consolidations: ConsolidationOrder[];

--- a/common/src/cams/parties.ts
+++ b/common/src/cams/parties.ts
@@ -10,7 +10,7 @@ export type LegacyAddress = {
   cityStateZipCountry?: string;
 };
 
-export type TaxIds = {
+type TaxIds = {
   taxId?: string;
   ssn?: string;
 };

--- a/common/src/cams/trustees.ts
+++ b/common/src/cams/trustees.ts
@@ -7,7 +7,7 @@ import { OversightRole } from './roles';
 import { NullableOptionalFields } from '../api/common';
 
 // Chapter types supported for trustee assignments
-export type ChapterType = '7-panel' | '7-non-panel' | '11' | '11-subchapter-v' | '12' | '13';
+type ChapterType = '7-panel' | '7-non-panel' | '11' | '11-subchapter-v' | '12' | '13';
 
 export function formatChapterType(chapter: string): string {
   const chapterLabels: Record<ChapterType, string> = {
@@ -23,20 +23,19 @@ export function formatChapterType(chapter: string): string {
 }
 
 export const TRUSTEE_STATUS_VALUES = ['active', 'not active', 'suspended'] as const;
-export type TrusteeStatus = (typeof TRUSTEE_STATUS_VALUES)[number];
 
-export type TrusteeCore = {
+type TrusteeCore = {
   name: string;
   public: ContactInformation;
   internal?: Partial<ContactInformation>;
 };
 
-export type TrusteeOptionalFields = {
+type TrusteeOptionalFields = {
   banks?: string[];
   software?: string;
 };
 
-export type TrusteeData = TrusteeCore & TrusteeOptionalFields;
+type TrusteeData = TrusteeCore & TrusteeOptionalFields;
 
 export type Trustee = TrusteeData &
   Auditable &

--- a/common/src/queue/dataflow-types.ts
+++ b/common/src/queue/dataflow-types.ts
@@ -7,8 +7,3 @@ export type CaseSyncEvent = {
   error?: unknown;
   retryCount?: number;
 };
-
-export type CaseSyncResults = {
-  events: CaseSyncEvent[];
-  lastTxId?: string;
-};


### PR DESCRIPTION
Jira ticket: CAMS-660

# Purpose

There were a lot of unused exports in common. 

# Major Changes

Removed export keywords or removed type completely if it is totally unused.

# Testing/Validation

All tests are passing.


# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Clean up unused and over-exposed type exports in the common package to reduce surface area and dead code.

Enhancements:
- Demote several shared types (e.g., chapter, court, office, response metadata, tax IDs) from exported to internal where they are only used within their defining modules.
- Remove unused generic order action and case sync result types from common where they are no longer referenced.
- Simplify the common API module by removing an unused union key type.