### PR TITLE
Fix MockData regression in MockApi2 getTrusteeAppointments

### DIFF
--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -2504,7 +2504,20 @@ async function getTrusteeHistory(_ignore: string): Promise<ResponseBody<TrusteeH
 
 async function getTrusteeAppointments(trusteeId: string) {
   return {
-    data: [MockData.getTrusteeAppointment({ trusteeId })],
+    data: [
+      {
+        id: 'appointment-1',
+        trusteeId,
+        chapter: '7-panel' as const,
+        courtId: '0208',
+        divisionCode: '081',
+        appointedDate: '2023-01-01T00:00:00Z',
+        status: 'active' as const,
+        effectiveDate: '2023-01-01T00:00:00Z',
+        updatedOn: '2023-01-01T00:00:00Z',
+        updatedBy: { id: 'user-1', name: 'Mock User' },
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
# Purpose

Fix the build 

# Major Changes

Fix MockData regression in MockApi2 getTrusteeAppointments

  Replace MockData.getTrusteeAppointment() call with object literal in
  getTrusteeAppointments function. This was reintroduced in a merge after
  the original work to remove MockData dependencies from MockApi2.

# Testing/Validation

Build builds and tests are passing

## Summary by Sourcery

Bug Fixes:
- Fix build regression caused by reintroducing a MockData.getTrusteeAppointment call in MockApi2.getTrusteeAppointments.