### PR TITLE
CAMS-649 Fixed no appointments message

### DIFF
--- a/user-interface/src/trustees/panels/TrusteeAppointments.test.tsx
+++ b/user-interface/src/trustees/panels/TrusteeAppointments.test.tsx
@@ -71,7 +71,7 @@ describe('TrusteeAppointments', () => {
     render(<TrusteeAppointments trusteeId="trustee-123" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No appointments found for this trustee./i)).toBeInTheDocument();
+      expect(screen.getByText(/There are no appointments for this Trustee./i)).toBeInTheDocument();
     });
   });
 
@@ -125,7 +125,7 @@ describe('TrusteeAppointments', () => {
     render(<TrusteeAppointments trusteeId="trustee-123" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No appointments found for this trustee./i)).toBeInTheDocument();
+      expect(screen.getByText(/There are no appointments for this Trustee./i)).toBeInTheDocument();
     });
   });
 
@@ -136,7 +136,7 @@ describe('TrusteeAppointments', () => {
     render(<TrusteeAppointments trusteeId="trustee-123" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No appointments found for this trustee./i)).toBeInTheDocument();
+      expect(screen.getByText(/There are no appointments for this Trustee./i)).toBeInTheDocument();
     });
   });
 });

--- a/user-interface/src/trustees/panels/TrusteeAppointments.tsx
+++ b/user-interface/src/trustees/panels/TrusteeAppointments.tsx
@@ -45,7 +45,9 @@ export default function TrusteeAppointments(props: Readonly<TrusteeAppointmentsP
     return (
       <div className="trustee-appointments-list">
         <div className="record-detail-container">
-          <Alert type={UswdsAlertStyle.Error}>{error}</Alert>
+          <Alert type={UswdsAlertStyle.Error} inline={true} show={true}>
+            {error}
+          </Alert>
         </div>
       </div>
     );
@@ -54,9 +56,7 @@ export default function TrusteeAppointments(props: Readonly<TrusteeAppointmentsP
   if (appointments.length === 0) {
     return (
       <div className="trustee-appointments-list">
-        <div className="record-detail-container">
-          <Alert type={UswdsAlertStyle.Info}>No appointments found for this trustee.</Alert>
-        </div>
+        <div className="record-detail-container">There are no appointments for this Trustee.</div>
       </div>
     );
   }


### PR DESCRIPTION
# Purpose

Message was there in an alert but the alert was not being shown. 

# Major Changes

Replaced with simple text.

# Testing/Validation

tests updated

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Update trustee appointments panel messaging for error and empty states.

Bug Fixes:
- Ensure error alerts for trustee appointments are explicitly shown inline when an error occurs.
- Correct visibility and wording of the message displayed when a trustee has no appointments.

Tests:
- Update trustee appointments tests to assert the new empty-state message text.