### PR TITLE
Skipped failing e2e test.

### DIFF
--- a/test/e2e/playwright/trustees.spec.ts
+++ b/test/e2e/playwright/trustees.spec.ts
@@ -115,7 +115,7 @@ test.describe('Trustees', () => {
     await expect(zipInput).toHaveValue('12345');
   });
 
-  test('should assign an auditor to a trustee', async ({ page }) => {
+  test.skip('should assign an auditor to a trustee', async ({ page }) => {
     // Navigate to the first trustee's detail page
     const trusteesTable = page.getByTestId('trustees-table');
     await expect(trusteesTable).toBeVisible(timeoutOption);


### PR DESCRIPTION
Disable trustee assignee E2E test for now because E2E uses mocked users and the current production sanity checks with a call to Okta that we don't currently mock so the test fails.

## Summary by Sourcery

Tests:
- Mark the trustee auditor assignment Playwright E2E test as skipped while Okta-related sanity checks remain unmocked.