### PR TITLE
Fix slot deployment SHA validation failures

### DIFF
--- a/.github/workflows/reusable-endpoint-test.yml
+++ b/.github/workflows/reusable-endpoint-test.yml
@@ -64,7 +64,8 @@ jobs:
           --apiFunctionName ${{ inputs.apiFunctionName }} \
           --webappName ${{ inputs.webappName }} \
           --gitSha ${{ github.sha }} \
-          --slotName ${{ inputs.slotName }}
+          --slotName ${{ inputs.slotName }} \
+          --resourceGroup ${{ steps.rgApp.outputs.out }}
 
       - name: Disable GHA runner access
         if: always()

--- a/.github/workflows/sub-build.yml
+++ b/.github/workflows/sub-build.yml
@@ -50,6 +50,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     with:
       nodeVersion: ${{ vars.NODE_VERSION }}
+      isDeployment: true
       camsServerHostname: ${{ inputs.apiFunctionName }}.azurewebsites.us
       camsStagingHostname: ${{ inputs.apiFunctionName }}-${{ inputs.slotName }}.azurewebsites.us
       camsServerPort: ${{ vars.CAMS_SERVER_PORT }}


### PR DESCRIPTION
Resolves issue where endpoint tests were failing with SHA mismatches after
  slot deployments.

  Root cause: Frontend build artifacts were not being created because
  isDeployment flag was missing, causing deployments to reuse old artifacts
  from previous workflow runs.

  Changes:
  - Add isDeployment: true flag to frontend build in sub-build.yml to ensure artifacts are packaged and uploaded
  - Change webapp slot deployment to synchronous mode (--async false) to ensure deployment completes before health checks run
  - Add missing --resourceGroup parameter to endpoint-test.sh invocation

## Summary by Sourcery

Ensure endpoint tests use artifacts from the current frontend deployment and have the required context for validating slot deployments.

CI:
- Pass the resource group name into the endpoint test workflow when invoking endpoint-test.sh so validation has full deployment context.
- Mark the frontend sub-build workflow run as a deployment to force packaging and uploading of fresh build artifacts for slot deployments.