### PR TITLE
Fix duplicate build artifact naming issue

### DIFF
--- a/.github/workflows/sub-build.yml
+++ b/.github/workflows/sub-build.yml
@@ -50,7 +50,6 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     with:
       nodeVersion: ${{ vars.NODE_VERSION }}
-      isDeployment: true
       camsServerHostname: ${{ inputs.apiFunctionName }}.azurewebsites.us
       camsStagingHostname: ${{ inputs.apiFunctionName }}-${{ inputs.slotName }}.azurewebsites.us
       camsServerPort: ${{ vars.CAMS_SERVER_PORT }}


### PR DESCRIPTION
Fix duplicate build artifact naming issue

## Summary by Sourcery

CI:
- Remove the isDeployment flag from the sub-build workflow job configuration to avoid misclassifying or duplicating deployment-related behavior.