### PR TITLE
Add additional SHA check and explicit slot restart

### DIFF
--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -69,6 +69,13 @@ jobs:
           op: decode
           in: ${{ inputs.azResourceGrpAppEncrypted }}
 
+      - name: Verify downloaded artifact
+        run: |
+          echo "Verifying artifact contents..."
+          ls -lh ./${{ inputs.webappName }}.zip
+          unzip -l ./${{ inputs.webappName }}.zip | head -20
+          unzip -p ./${{ inputs.webappName }}.zip index.html | grep -i "meta name=\"info-sha\"" || echo "SHA meta tag not found"
+
       - name: Deploy to Azure WebApp Slot
         id: deploy-webapp-slot-step
         run: |

--- a/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
+++ b/ops/scripts/pipeline/slots/az-app-slot-deploy.sh
@@ -99,6 +99,10 @@ while [ $attempt -le $max_attempts ]; do
 
     if az webapp deploy --resource-group "${app_rg}" --src-path "${artifact_path}" --name "${app_name}" --slot "${slot_name}" --type zip --async false --track-status true --clean true; then
         echo "Deployment succeeded on attempt ${attempt}"
+        echo "Restarting webapp slot to clear cache..."
+        az webapp restart --resource-group "${app_rg}" --name "${app_name}" --slot "${slot_name}"
+        echo "Waiting for restart to complete..."
+        sleep 15
         break
     else
         exit_code=$?


### PR DESCRIPTION
Add additional SHA check and explicit slot restart

## Summary by Sourcery

Add artifact content verification to the deployment workflow and restart the Azure WebApp slot after successful deployments to ensure fresh content is served.

CI:
- Add a workflow step to inspect the downloaded artifact and check for an info-sha meta tag in index.html before deployment.

Deployment:
- Restart the Azure WebApp slot after a successful zip deployment and wait briefly to ensure the restart completes.