### PR TITLE
CAMS-546 refactor out the initializeInactiveLogout logout logic since it was redundant with the new timeout dialog

### DIFF
--- a/common/src/cams/validators.test.ts
+++ b/common/src/cams/validators.test.ts
@@ -1110,14 +1110,14 @@ describe('validators', () => {
         min: '2024-01-01',
         max: '2024-12-31',
         value: '2023-12-31',
-        expected: { reasons: ['Date is before minimum allowed date'] },
+        expected: { reasons: ['Must be on or after 01/01/2024.'] },
       },
       {
         description: 'should return invalid for date after maximum',
         min: '2024-01-01',
         max: '2024-12-31',
         value: '2025-01-01',
-        expected: { reasons: ['Date is after maximum allowed date'] },
+        expected: { reasons: ['Must be on or before 12/31/2024.'] },
       },
       {
         description: 'should return valid when no min specified',
@@ -1143,25 +1143,9 @@ describe('validators', () => {
         value: '2024-06-15',
         expected: VALID,
       },
-      {
-        description: 'should use custom reason when date is before minimum',
-        min: '2024-01-01',
-        max: '2024-12-31',
-        reason: 'Date is not within allowed range. Enter a valid date.',
-        value: '2023-12-31',
-        expected: { reasons: ['Date is not within allowed range. Enter a valid date.'] },
-      },
-      {
-        description: 'should use custom reason when date is after maximum',
-        min: '2024-01-01',
-        max: '2024-12-31',
-        reason: 'Date is not within allowed range. Enter a valid date.',
-        value: '2025-01-01',
-        expected: { reasons: ['Date is not within allowed range. Enter a valid date.'] },
-      },
     ];
     test.each(testCases)('$description', (testCase) => {
-      const validator = Validators.dateMinMax(testCase.min, testCase.max, testCase.reason);
+      const validator = Validators.dateMinMax(testCase.min, testCase.max);
       expect(validator(testCase.value)).toEqual(testCase.expected);
     });
   });

--- a/common/src/cams/validators.ts
+++ b/common/src/cams/validators.ts
@@ -7,6 +7,7 @@ import {
   validateObject,
   VALID,
 } from './validation';
+import DateHelper from '../date-helper';
 
 /********************************************************************************
  * Common Validator Functions
@@ -275,13 +276,13 @@ function isValidDate(value: unknown): ValidatorResult {
 /**
  * Creates a validator function that checks if a date is within a specified range.
  * Validates that the date is after the minimum date and before the maximum date if provided.
+ * Returns specific error messages with formatted dates (MM/DD/YYYY).
  *
  * @param {string} [min] - The minimum allowed date in YYYY-MM-DD format
  * @param {string} [max] - The maximum allowed date in YYYY-MM-DD format
- * @param {string} [reason] - Optional custom error message to use for range violations
  * @returns {ValidatorFunction} A validator function that checks date range
  */
-function dateMinMax(min?: string, max?: string, reason?: string): ValidatorFunction {
+function dateMinMax(min?: string, max?: string): ValidatorFunction {
   return (value: unknown): ValidatorResult => {
     const dateCheck = isValidDate(value);
     if (!dateCheck.valid) {
@@ -293,14 +294,16 @@ function dateMinMax(min?: string, max?: string, reason?: string): ValidatorFunct
     if (min) {
       const minDate = new Date(min);
       if (date < minDate) {
-        return { reasons: [reason ?? 'Date is before minimum allowed date'] };
+        const formattedMin = DateHelper.formatDate(min);
+        return { reasons: [`Must be on or after ${formattedMin}.`] };
       }
     }
 
     if (max) {
       const maxDate = new Date(max);
       if (date > maxDate) {
-        return { reasons: [reason ?? 'Date is after maximum allowed date'] };
+        const formattedMax = DateHelper.formatDate(max);
+        return { reasons: [`Must be on or before ${formattedMax}.`] };
       }
     }
 

--- a/common/src/date-helper.test.ts
+++ b/common/src/date-helper.test.ts
@@ -1,8 +1,14 @@
 import { vi } from 'vitest';
 import DateHelper from './date-helper';
 
-const { getTodaysIsoDate, isValidDateString, nowInSeconds, sortDates, sortDatesReverse } =
-  DateHelper;
+const {
+  formatDate,
+  getTodaysIsoDate,
+  isValidDateString,
+  nowInSeconds,
+  sortDates,
+  sortDatesReverse,
+} = DateHelper;
 
 describe('date helper tests', () => {
   test('should sort dates newest first', () => {
@@ -70,5 +76,21 @@ describe('date helper tests', () => {
       // Restore the original Date.now function
       Date.now = originalDateNow;
     }
+  });
+
+  describe('formatDate', () => {
+    test('should format valid ISO date string to MM/DD/YYYY', () => {
+      expect(formatDate('2024-01-15')).toBe('01/15/2024');
+      expect(formatDate('1979-10-01')).toBe('10/01/1979');
+      expect(formatDate('2025-12-31')).toBe('12/31/2025');
+    });
+
+    test('should return input as-is for invalid date strings', () => {
+      expect(formatDate('')).toBe('');
+      expect(formatDate('bogus')).toBe('bogus');
+      expect(formatDate('01/15/2024')).toBe('01/15/2024');
+      expect(formatDate('2024-1-1')).toBe('2024-1-1');
+      expect(formatDate('not-a-date')).toBe('not-a-date');
+    });
   });
 });

--- a/common/src/date-helper.ts
+++ b/common/src/date-helper.ts
@@ -1,3 +1,7 @@
+// Global date constraints for date pickers
+// October 1, 1979 - the inception of the USTP trustee program pilot for the U.S. Bankruptcy Code
+export const DEFAULT_MIN_DATE = '1979-10-01';
+
 function sortDates(dateA: Date | string, dateB: Date | string): number {
   //Sort DESC
   if (dateA > dateB) {
@@ -32,7 +36,16 @@ function nowInSeconds() {
   return Math.floor(Date.now() / 1000);
 }
 
+function formatDate(isoDate: string): string {
+  if (!isValidDateString(isoDate)) {
+    return isoDate;
+  }
+  const [year, month, day] = isoDate.split('-');
+  return `${month}/${day}/${year}`;
+}
+
 const DateHelper = {
+  formatDate,
   getIsoDate,
   getTodaysIsoDate,
   isValidDateString,

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
@@ -306,8 +306,8 @@ export function PrivilegedIdentity() {
                 id="privileged-expiration-date"
                 label="Expires on"
                 disabled={true}
-                minDate={getTodaysIsoDate()}
-                maxDate={getMaxDate()}
+                min={getTodaysIsoDate()}
+                max={getMaxDate()}
                 onChange={handleExpirationUpdate}
                 ref={datePickerRef}
               ></DatePicker>

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -6,7 +6,6 @@ import Icon from '@/lib/components/uswds/Icon';
 import Input from '@/lib/components/uswds/Input';
 import { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import DateRangePicker from '@/lib/components/uswds/DateRangePicker';
-import { ValidatorFunction } from 'common/src/cams/validation';
 import {
   ComboBoxRef,
   DateRange,
@@ -18,6 +17,7 @@ import { CaseDetail, CaseDocket, CaseDocketEntry, CaseNote } from '@common/cams/
 import CaseDetailAssociatedCases from './panels/CaseDetailAssociatedCases';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import { EventCaseReference } from '@common/cams/events';
+import { DEFAULT_MIN_DATE } from '@common/date-helper';
 import './CaseDetailScreen.scss';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { AssignAttorneyModalCallbackProps } from '@/staff-assignment/modal/assignAttorneyModal.types';
@@ -283,13 +283,6 @@ export default function CaseDetailScreen(props: Readonly<CaseDetailProps>) {
 
   const globalAlert = useGlobalAlert();
 
-  const minDateValidator: ValidatorFunction = (value: unknown) => {
-    if (typeof value !== 'string') return { reasons: ['Must be a string'] };
-    const date = new Date(value);
-    const minDate = new Date('1978-12-31');
-    return date <= minDate ? { reasons: ['Must be later than 1978.'] } : { valid: true as const };
-  };
-
   async function fetchCaseBasicInfo() {
     setIsLoading(true);
     Api2.getCaseDetail(caseId!)
@@ -413,11 +406,15 @@ export default function CaseDetailScreen(props: Readonly<CaseDetailProps>) {
   }
 
   function handleStartDateChange(ev: React.ChangeEvent<HTMLInputElement>) {
-    setSelectedDateRange({ ...selectedDateRange, start: ev.target.value });
+    const start = ev.target.dataset.start || ev.target.value;
+    const end = ev.target.dataset.end;
+    setSelectedDateRange({ start, end });
   }
 
   function handleEndDateChange(ev: React.ChangeEvent<HTMLInputElement>) {
-    setSelectedDateRange({ ...selectedDateRange, end: ev.target.value });
+    const start = ev.target.dataset.start;
+    const end = ev.target.dataset.end || ev.target.value;
+    setSelectedDateRange({ start, end });
   }
 
   function handleCaseAssignment(assignment: AssignAttorneyModalCallbackProps) {
@@ -620,10 +617,8 @@ export default function CaseDetailScreen(props: Readonly<CaseDetailProps>) {
                         endDateLabel="Docket Date Range End"
                         onStartDateChange={handleStartDateChange}
                         onEndDateChange={handleEndDateChange}
+                        min={DEFAULT_MIN_DATE}
                         ref={dateRangeRef}
-                        futureDateWarningThresholdYears={100}
-                        startDateValidators={[minDateValidator]}
-                        endDateValidators={[minDateValidator]}
                       ></DateRangePicker>
                     </div>
                     <div className="in-docket-search form-field" data-testid="docket-number-search">

--- a/user-interface/src/case-detail/CaseDetailScreenSortAndFilter.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreenSortAndFilter.test.tsx
@@ -585,10 +585,15 @@ describe('Case Detail sort, search, and filter tests', () => {
       });
 
       const startDateText = screen.getByTestId('docket-date-range-date-start');
+      const endDateText = screen.getByTestId('docket-date-range-date-end');
+
+      fireEvent.change(endDateText, { target: { value: '2023-08-31' } });
       fireEvent.change(startDateText, { target: { value: '2023-07-01' } });
 
-      const docketListAfter = screen.getByTestId('searchable-docket');
-      expect(docketListAfter.children.length).toEqual(2);
+      await waitFor(() => {
+        const docketListAfter = screen.getByTestId('searchable-docket');
+        expect(docketListAfter.children.length).toEqual(2);
+      });
     });
 
     test('should list proper dockets when end date changes', async () => {
@@ -625,11 +630,16 @@ describe('Case Detail sort, search, and filter tests', () => {
         const endDateText = screen.getByTestId('docket-date-range-date-end');
         expect(endDateText).toBeInTheDocument();
       });
+      const startDateText = screen.getByTestId('docket-date-range-date-start');
       const endDateText = screen.getByTestId('docket-date-range-date-end');
+
+      fireEvent.change(startDateText, { target: { value: '2023-05-01' } });
       fireEvent.change(endDateText, { target: { value: '2023-07-01' } });
 
-      const docketListAfter = screen.getByTestId('searchable-docket');
-      expect(docketListAfter.children.length).toEqual(2);
+      await waitFor(() => {
+        const docketListAfter = screen.getByTestId('searchable-docket');
+        expect(docketListAfter.children.length).toEqual(2);
+      });
     });
   });
 

--- a/user-interface/src/lib/components/uswds/DatePicker.scss
+++ b/user-interface/src/lib/components/uswds/DatePicker.scss
@@ -3,14 +3,5 @@
   .date-error {
     padding: 0.5rem 0;
     font-size: 1rem;
-    // TODO: fix color imports from USWDS
-    color: #8b0a03;
-  }
-
-  .date-warning {
-    padding: 0.5rem 0;
-    font-size: 1rem;
-    // TODO: fix color imports from USWDS
-    color: #936f38;
   }
 }

--- a/user-interface/src/lib/components/uswds/DatePicker.test.tsx
+++ b/user-interface/src/lib/components/uswds/DatePicker.test.tsx
@@ -21,14 +21,6 @@ function getInput(id: string) {
   return screen.getByTestId(id) as HTMLInputElement;
 }
 
-function getWarningElement() {
-  return document.querySelector('.date-warning');
-}
-
-function getWarningText() {
-  return (document.querySelector('.date-warning') as HTMLElement | null)?.textContent ?? '';
-}
-
 function renderWithProps(props?: Partial<DatePickerProps>): InputRef {
   const ref = React.createRef<InputRef>();
   const defaultProps: DatePickerProps = { id: DEFAULT_ID, onChange: mockOnChange };
@@ -154,14 +146,14 @@ describe('DatePicker additional coverage tests', () => {
     expect(label).toHaveTextContent(labelText);
   });
 
-  test('should handle minDate and maxDate attributes', () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate });
+  test('should handle min and max attributes', () => {
+    const min = '2024-01-01';
+    const max = '2024-12-31';
+    renderWithProps({ min, max });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
-    expect(inputEl).toHaveAttribute('min', minDate);
-    expect(inputEl).toHaveAttribute('max', maxDate);
+    expect(inputEl).toHaveAttribute('min', min);
+    expect(inputEl).toHaveAttribute('max', max);
   });
 
   test('should handle required prop', () => {
@@ -188,9 +180,9 @@ describe('DatePicker additional coverage tests', () => {
   });
 
   test('should show error message when date is invalid', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+    const min = '2024-01-01';
+    const max = '2024-12-31';
+    renderWithProps({ min, max, onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -198,9 +190,7 @@ describe('DatePicker additional coverage tests', () => {
 
     await waitFor(() => {
       const errorElement = document.querySelector('.date-error');
-      expect(errorElement).toHaveTextContent(
-        'Date is not within allowed range. Enter a valid date.',
-      );
+      expect(errorElement).toHaveTextContent('Must be on or after 01/01/2024.');
     });
   });
 
@@ -214,9 +204,9 @@ describe('DatePicker additional coverage tests', () => {
     expect(inputEl).toHaveValue(initialValue);
   });
 
-  test('should reset to minDate when no initial value and minDate exists', async () => {
-    const minDate = '2024-01-01';
-    const view = renderWithProps({ minDate, onChange: mockOnChange });
+  test('should reset to min when no initial value and min exists', async () => {
+    const min = '2024-01-01';
+    const view = renderWithProps({ min, onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -242,9 +232,9 @@ describe('DatePicker additional coverage tests', () => {
   });
 
   test('should handle change event with valid date within range', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+    const min = '2024-01-01';
+    const max = '2024-12-31';
+    renderWithProps({ min, max, onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -263,9 +253,7 @@ describe('DatePicker additional coverage tests', () => {
   });
 
   test('should apply error styling when error exists', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+    renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -276,10 +264,8 @@ describe('DatePicker additional coverage tests', () => {
     });
   });
 
-  test('should set error message when date is above maxDate threshold', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+  test('should set error message when date is above max threshold', async () => {
+    renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -287,9 +273,7 @@ describe('DatePicker additional coverage tests', () => {
 
     await waitFor(() => {
       const errorElement = document.querySelector('.date-error');
-      expect(errorElement).toHaveTextContent(
-        'Date is not within allowed range. Enter a valid date.',
-      );
+      expect(errorElement).toHaveTextContent('Must be on or before 12/31/2024.');
     });
   });
 
@@ -304,9 +288,7 @@ describe('DatePicker additional coverage tests', () => {
   });
 
   test('should set aria-invalid when there is an error', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+    renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -334,7 +316,7 @@ describe('DatePicker additional coverage tests', () => {
     expect(errorDiv).toHaveTextContent(customError);
   });
 
-  test('should reset to clearDateValue when no initial value and no minDate', async () => {
+  test('should reset to default min when no initial value provided', async () => {
     const view = renderWithProps({ onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
@@ -344,7 +326,7 @@ describe('DatePicker additional coverage tests', () => {
     act(() => view.resetValue());
 
     await waitFor(() => {
-      expect(inputEl).toHaveValue('');
+      expect(inputEl).toHaveValue('1979-10-01');
     });
   });
 
@@ -353,8 +335,8 @@ describe('DatePicker additional coverage tests', () => {
     const mockChangeSpy = vi.fn();
     renderWithProps({
       value: initialValue,
-      minDate: '2024-01-01',
-      maxDate: '2024-12-31',
+      min: '2024-01-01',
+      max: '2024-12-31',
       onChange: mockChangeSpy,
     });
 
@@ -408,10 +390,8 @@ describe('DatePicker additional coverage tests', () => {
     act(() => expect(ref.current?.getValue()).toBe(''));
   });
 
-  test('should clear errors and warnings when field becomes empty', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+  test('should clear errors when field becomes empty', async () => {
+    renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -419,7 +399,7 @@ describe('DatePicker additional coverage tests', () => {
 
     await waitForValidation();
 
-    expect(getErrorText()).toContain('Date is not within allowed range');
+    expect(getErrorText()).toContain('Must be on or after');
 
     fireEvent.change(inputEl, { target: { value: '' } });
 
@@ -430,10 +410,8 @@ describe('DatePicker additional coverage tests', () => {
     expect(getErrorText()).toBe('');
   });
 
-  test('should clear errors and warnings when date is incomplete', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+  test('should clear errors when date is incomplete', async () => {
+    renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -441,7 +419,7 @@ describe('DatePicker additional coverage tests', () => {
 
     await waitForValidation();
 
-    expect(getErrorText()).toContain('Date is not within allowed range');
+    expect(getErrorText()).toContain('Must be on or after');
 
     fireEvent.change(inputEl, { target: { value: '2024-06' } });
 
@@ -452,10 +430,8 @@ describe('DatePicker additional coverage tests', () => {
     expect(getErrorText()).toBe('');
   });
 
-  test('should clear errors and warnings for invalid dates', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+  test('should clear errors for invalid dates', async () => {
+    renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
     const inputEl = screen.getByTestId(DEFAULT_ID);
 
@@ -466,7 +442,7 @@ describe('DatePicker additional coverage tests', () => {
     });
 
     let errorElement = document.querySelector('.date-error');
-    expect(errorElement?.textContent).toContain('Date is not within allowed range');
+    expect(errorElement?.textContent).toContain('Must be on or after');
 
     fireEvent.change(inputEl, { target: { value: '2024-02-31' } });
 
@@ -478,90 +454,16 @@ describe('DatePicker additional coverage tests', () => {
     expect(errorElement?.textContent).toBe('');
   });
 
-  test('should clear warning message when clearValue() is called', async () => {
-    const ref = React.createRef<InputRef>();
-    const today = new Date();
-    const farFutureDate = new Date(today.getFullYear() + 150, today.getMonth(), today.getDate());
-    const farFutureDateString = farFutureDate.toISOString().split('T')[0];
-
-    render(
-      <DatePicker
-        id="test-clear-warning"
-        ref={ref}
-        futureDateWarningThresholdYears={100}
-        onChange={mockOnChange}
-      />,
-    );
-
-    const inputEl = screen.getByTestId('test-clear-warning');
-
-    fireEvent.change(inputEl, { target: { value: farFutureDateString } });
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 600));
-    });
-
-    let warningElement = document.querySelector('.date-warning');
-    expect(warningElement).toBeInTheDocument();
-    expect(warningElement?.textContent).toContain('more than 100 years in the future');
-
-    act(() => ref.current?.clearValue());
-
-    await waitFor(() => {
-      warningElement = document.querySelector('.date-warning');
-      expect(warningElement).toBeNull();
-    });
-  });
-
-  test('should clear warning message when resetValue() is called', async () => {
-    const ref = React.createRef<InputRef>();
-    const today = new Date();
-    const farFutureDate = new Date(today.getFullYear() + 150, today.getMonth(), today.getDate());
-    const farFutureDateString = farFutureDate.toISOString().split('T')[0];
-
-    render(
-      <DatePicker
-        id="test-reset-warning"
-        ref={ref}
-        value="2024-01-01"
-        futureDateWarningThresholdYears={100}
-        onChange={mockOnChange}
-      />,
-    );
-
-    const inputEl = screen.getByTestId('test-reset-warning');
-
-    fireEvent.change(inputEl, { target: { value: farFutureDateString } });
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 600));
-    });
-
-    let warningElement = document.querySelector('.date-warning');
-    expect(warningElement).toBeInTheDocument();
-    expect(warningElement?.textContent).toContain('more than 100 years in the future');
-
-    act(() => ref.current?.resetValue());
-
-    await waitFor(() => {
-      warningElement = document.querySelector('.date-warning');
-      expect(warningElement).toBeNull();
-      expect(inputEl).toHaveValue('2024-01-01');
-    });
-  });
-
   test('should clear error message when resetValue() is called', async () => {
     const ref = React.createRef<InputRef>();
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
 
     render(
       <DatePicker
         id="test-reset-error"
         ref={ref}
         value="2024-06-15"
-        minDate={minDate}
-        maxDate={maxDate}
+        min="2024-01-01"
+        max="2024-12-31"
         onChange={mockOnChange}
       />,
     );
@@ -575,7 +477,7 @@ describe('DatePicker additional coverage tests', () => {
     });
 
     let errorElement = document.querySelector('.date-error');
-    expect(errorElement?.textContent).toContain('Date is not within allowed range');
+    expect(errorElement?.textContent).toContain('Must be on or before');
 
     act(() => ref.current?.resetValue());
 
@@ -600,9 +502,7 @@ describe('DatePicker edge case coverage', () => {
       ['truly invalid date like month 13', '2024-13-01'],
       ['invalid day like day 32', '2024-12-32'],
     ])('should not show error for %s', async (_label, value) => {
-      const minDate = '2024-01-01';
-      const maxDate = '2024-12-31';
-      renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+      renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
       fireEvent.change(getInput(DEFAULT_ID), { target: { value } });
 
@@ -617,15 +517,13 @@ describe('DatePicker edge case coverage', () => {
     ])(
       'should clear error when entering %s after error exists',
       async (_label, followUpValue, delay) => {
-        const minDate = '2024-01-01';
-        const maxDate = '2024-12-31';
-        renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+        renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
         const input = getInput(DEFAULT_ID);
         fireEvent.change(input, { target: { value: '2023-12-15' } });
 
         await waitFor(() => {
-          expect(getErrorText()).toContain('Date is not within allowed range');
+          expect(getErrorText()).toContain('Must be on or after');
         });
 
         fireEvent.change(input, { target: { value: followUpValue } });
@@ -636,107 +534,8 @@ describe('DatePicker edge case coverage', () => {
     );
   });
 
-  describe('future date warning behavior', () => {
-    test.each([
-      {
-        label: 'no warning when prop not set',
-        threshold: undefined,
-        date: '2250-06-15',
-        expectWarning: false,
-        expectedSnippet: '',
-      },
-      {
-        label: 'warning when over 100 years in future',
-        threshold: 100,
-        date: '2250-06-15',
-        expectWarning: true,
-        expectedSnippet: 'more than 100 years in the future',
-      },
-      {
-        label: 'custom threshold of 50 years',
-        threshold: 50,
-        date: '2100-06-15',
-        expectWarning: true,
-        expectedSnippet: 'more than 50 years in the future',
-      },
-    ])('$label', async ({ threshold, date, expectWarning, expectedSnippet }) => {
-      renderWithProps({
-        minDate: '2024-01-01',
-        maxDate: '9999-12-31',
-        futureDateWarningThresholdYears: threshold,
-      });
-
-      fireEvent.change(getInput(DEFAULT_ID), { target: { value: date } });
-
-      await waitForValidation();
-
-      const warningText = getWarningText();
-      if (expectWarning) {
-        expect(warningText).toContain(expectedSnippet);
-      } else {
-        expect(warningText).toBe('');
-      }
-    });
-
-    test('should not show warning for dates exactly at threshold', async () => {
-      renderWithProps({ onChange: mockOnChange, futureDateWarningThresholdYears: 100 });
-
-      const inputEl = getInput(DEFAULT_ID);
-
-      const now = new Date();
-      const hundredYearsFromNow = new Date(now.getFullYear() + 100, now.getMonth(), now.getDate());
-      const dateString = hundredYearsFromNow.toISOString().split('T')[0];
-
-      fireEvent.change(inputEl, { target: { value: dateString } });
-
-      await waitForValidation();
-
-      expect(getWarningElement()).not.toBeInTheDocument();
-    });
-
-    test('should not show warning when there is an error', async () => {
-      renderWithProps({
-        minDate: '2024-01-01',
-        maxDate: '2024-12-31',
-        futureDateWarningThresholdYears: 100,
-      });
-
-      fireEvent.change(getInput(DEFAULT_ID), { target: { value: '2025-06-15' } });
-
-      await waitForValidation();
-
-      expect(getErrorText()).toContain('Date is not within allowed range');
-
-      expect(getWarningElement()).not.toBeInTheDocument();
-    });
-
-    test('should clear warning when date is changed to within threshold', async () => {
-      renderWithProps({
-        minDate: '2024-01-01',
-        maxDate: '9999-12-31',
-        futureDateWarningThresholdYears: 100,
-      });
-
-      const inputEl = getInput(DEFAULT_ID);
-
-      fireEvent.change(inputEl, { target: { value: '2250-06-15' } });
-
-      await waitForValidation();
-
-      expect(getWarningText()).toContain('more than 100 years in the future');
-
-      fireEvent.change(inputEl, { target: { value: '2030-06-15' } });
-
-      await waitForValidation();
-
-      expect(getWarningText()).toBe('');
-    });
-  });
-
-  test('should allow dates with years before 1900 when within minDate/maxDate range', async () => {
-    const minDate = '1800-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+  test('should allow dates with years before 1900 when within min/max range', async () => {
+    renderWithProps({ min: '1800-01-01', max: '2024-12-31', onChange: mockOnChange });
 
     fireEvent.change(getInput(DEFAULT_ID), { target: { value: '1850-06-15' } });
 
@@ -746,16 +545,14 @@ describe('DatePicker edge case coverage', () => {
   });
 
   test('should clear error when entering valid date after error', async () => {
-    const minDate = '2024-01-01';
-    const maxDate = '2024-12-31';
-    renderWithProps({ minDate, maxDate, onChange: mockOnChange });
+    renderWithProps({ min: '2024-01-01', max: '2024-12-31', onChange: mockOnChange });
 
     const inputEl = getInput(DEFAULT_ID);
 
     fireEvent.change(inputEl, { target: { value: '2023-12-15' } });
 
     await waitFor(() => {
-      expect(getErrorText()).toContain('Date is not within allowed range');
+      expect(getErrorText()).toContain('Must be on or after');
     });
 
     fireEvent.change(inputEl, { target: { value: '2024-06-15' } });
@@ -776,17 +573,18 @@ describe('DatePicker edge case coverage', () => {
     expect(onBlurSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('should have default max attribute to prevent year overflow', () => {
+  test('should have default max attribute set to today', () => {
     renderWithProps({ onChange: mockOnChange });
 
     const inputEl = getInput(DEFAULT_ID);
 
-    expect(inputEl).toHaveAttribute('max', '9999-12-31');
+    const today = new Date().toISOString().split('T')[0];
+    expect(inputEl).toHaveAttribute('max', today);
   });
 
-  test('should respect custom maxDate over default max', () => {
+  test('should respect custom max over default max', () => {
     const customMax = '2025-12-31';
-    renderWithProps({ maxDate: customMax, onChange: mockOnChange });
+    renderWithProps({ max: customMax, onChange: mockOnChange });
 
     const inputEl = getInput(DEFAULT_ID);
 
@@ -794,65 +592,135 @@ describe('DatePicker edge case coverage', () => {
   });
 
   test('should run multiple custom validators and concatenate error messages', async () => {
-    const minDateValidator = vi.fn((value: unknown) => {
+    const blackoutDateValidator = vi.fn((value: unknown) => {
       if (typeof value !== 'string') return { reasons: ['Must be a string'] };
-      const date = new Date(value);
-      const minDate = new Date('1978-01-01');
-      return date < minDate
-        ? { reasons: ['Date must be on or after 01/01/1978.'] }
+      const blackoutDates = ['2024-12-25', '2024-07-04'];
+      return blackoutDates.includes(value)
+        ? { reasons: ['Date is not available.'] }
         : { valid: true as const };
     });
 
-    const maxDateValidator = vi.fn((value: unknown) => {
+    const specialFormatValidator = vi.fn((value: unknown) => {
       if (typeof value !== 'string') return { reasons: ['Must be a string'] };
-      const date = new Date(value);
-      const maxDate = new Date('2030-12-31');
-      return date > maxDate
-        ? { reasons: ['Date must be on or before 12/31/2030.'] }
+      // Example: reject dates on the 13th
+      return value.endsWith('-13')
+        ? { reasons: ['Date cannot be on the 13th.'] }
         : { valid: true as const };
     });
 
-    renderWithProps({ validators: [minDateValidator, maxDateValidator], onChange: mockOnChange });
+    renderWithProps({
+      validators: [blackoutDateValidator, specialFormatValidator],
+      onChange: mockOnChange,
+    });
 
     const inputEl = getInput(DEFAULT_ID);
 
-    fireEvent.change(inputEl, { target: { value: '2031-01-01' } });
+    fireEvent.change(inputEl, { target: { value: '2024-12-25' } });
     fireEvent.blur(inputEl);
 
     await waitFor(() => {
-      expect(getErrorText()).toBe('Date must be on or before 12/31/2030.');
+      expect(getErrorText()).toBe('Date is not available.');
     });
 
-    expect(minDateValidator).toHaveBeenCalledWith('2031-01-01');
-    expect(maxDateValidator).toHaveBeenCalledWith('2031-01-01');
+    expect(blackoutDateValidator).toHaveBeenCalledWith('2024-12-25');
+    expect(specialFormatValidator).toHaveBeenCalledWith('2024-12-25');
   });
 
   test('should clear custom validator errors on valid input', async () => {
-    const minDateValidator = (value: unknown) => {
+    const blackoutDateValidator = (value: unknown) => {
       if (typeof value !== 'string') return { reasons: ['Must be a string'] };
-      const date = new Date(value);
-      const minDate = new Date('1978-01-01');
-      return date < minDate
-        ? { reasons: ['Date must be on or after 01/01/1978.'] }
+      const blackoutDates = ['2024-12-25', '2024-07-04'];
+      return blackoutDates.includes(value)
+        ? { reasons: ['Date is not available.'] }
         : { valid: true as const };
     };
 
-    renderWithProps({ validators: [minDateValidator], onChange: mockOnChange });
+    renderWithProps({ validators: [blackoutDateValidator], onChange: mockOnChange });
 
     const inputEl = getInput(DEFAULT_ID);
 
-    fireEvent.change(inputEl, { target: { value: '1977-12-31' } });
+    fireEvent.change(inputEl, { target: { value: '2024-12-25' } });
     fireEvent.blur(inputEl);
 
     await waitFor(() => {
-      expect(getErrorText()).toBe('Date must be on or after 01/01/1978.');
+      expect(getErrorText()).toBe('Date is not available.');
     });
 
-    fireEvent.change(inputEl, { target: { value: '2024-01-15' } });
+    fireEvent.change(inputEl, { target: { value: '2024-12-26' } });
     fireEvent.blur(inputEl);
 
     await waitFor(() => {
       expect(getErrorText()).toBe('');
+    });
+  });
+
+  test('should show badInput error message on blur when input has invalid format', async () => {
+    const ref = React.createRef<InputRef>();
+    render(
+      <React.StrictMode>
+        <BrowserRouter>
+          <DatePicker id={DEFAULT_ID} onChange={mockOnChange} ref={ref} />
+        </BrowserRouter>
+      </React.StrictMode>,
+    );
+
+    const inputEl = getInput(DEFAULT_ID) as HTMLInputElement;
+
+    Object.defineProperty(inputEl, 'validity', {
+      writable: true,
+      value: {
+        badInput: true,
+        customError: false,
+        patternMismatch: false,
+        rangeOverflow: false,
+        rangeUnderflow: false,
+        stepMismatch: false,
+        tooLong: false,
+        tooShort: false,
+        typeMismatch: false,
+        valid: false,
+        valueMissing: false,
+      },
+    });
+
+    fireEvent.blur(inputEl);
+
+    await waitFor(() => {
+      expect(getErrorText()).toContain('Must be a valid date mm/dd/yyyy.');
+    });
+  });
+
+  test('should handle resetValue when value prop exists', async () => {
+    const initialValue = '2024-05-10';
+    const view = renderWithProps({ value: initialValue });
+
+    const datePicker = screen.getByTestId(DEFAULT_ID);
+
+    act(() => view.setValue('2024-12-25'));
+    await waitFor(() => {
+      expect(datePicker.attributes.getNamedItem('value')?.value).toEqual('2024-12-25');
+    });
+
+    act(() => view.resetValue());
+    await waitFor(() => {
+      expect(datePicker.attributes.getNamedItem('value')?.value).toEqual(initialValue);
+    });
+  });
+
+  test('should handle resetValue when min prop exists but no value prop', async () => {
+    const minDate = '2020-01-01';
+    const view = renderWithProps({ min: minDate });
+
+    const datePicker = screen.getByTestId(DEFAULT_ID);
+
+    act(() => view.setValue('2024-12-25'));
+    await waitFor(() => {
+      expect(datePicker.attributes.getNamedItem('value')?.value).toEqual('2024-12-25');
+    });
+
+    act(() => view.resetValue());
+    await waitFor(() => {
+      expect(datePicker.attributes.getNamedItem('value')?.value).toEqual(minDate);
     });
   });
 });

--- a/user-interface/src/lib/components/uswds/DatePicker.tsx
+++ b/user-interface/src/lib/components/uswds/DatePicker.tsx
@@ -11,11 +11,10 @@ import React, {
 } from 'react';
 import Validators from 'common/src/cams/validators';
 import { ValidatorFunction } from 'common/src/cams/validation';
+import DateHelper, { DEFAULT_MIN_DATE } from 'common/src/date-helper';
 
 export type DatePickerProps = JSX.IntrinsicElements['input'] & {
   id: string;
-  minDate?: string;
-  maxDate?: string;
   onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   label?: string;
@@ -24,24 +23,67 @@ export type DatePickerProps = JSX.IntrinsicElements['input'] & {
   value?: string;
   required?: boolean;
   customErrorMessage?: string;
-  futureDateWarningThresholdYears?: number;
   validators?: ValidatorFunction[];
 };
 
 function DatePicker_(props: DatePickerProps, ref: React.Ref<InputRef>) {
-  const { id, label, minDate, maxDate } = props;
+  const { id, label } = props;
 
   const inputRef = useRef<HTMLInputElement>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const validationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [warningMessage, setWarningMessage] = useState<string>('');
 
   // Use custom error message from parent if provided
   const displayErrorMessage = props.customErrorMessage || errorMessage;
   const [isDisabled, setIsDisabled] = useState<boolean>(!!props.disabled);
   const [dateValue, setDateValue] = useState<string | null>(props.value ?? null);
+
+  // Helper functions to compute min/max with defaults
+  const getMin = () => (typeof props.min === 'string' ? props.min : undefined) ?? DEFAULT_MIN_DATE;
+  const getMax = () =>
+    (typeof props.max === 'string' ? props.max : undefined) ?? DateHelper.getTodaysIsoDate();
+
+  // Centralized validation helper
+  function validateDateValue(value: string | null): string[] {
+    if (!value) return [];
+
+    const errors: string[] = [];
+
+    const isCompleteDate = /^\d{4}-\d{2}-\d{2}$/.test(value);
+    if (!isCompleteDate) return errors;
+
+    const date = new Date(value);
+    if (isNaN(date.getTime())) return errors;
+
+    // Min/max validation
+    const minMaxValidator = Validators.dateMinMax(getMin(), getMax());
+    const minMaxResult = minMaxValidator(value);
+    if (!minMaxResult.valid && minMaxResult.reasons) {
+      errors.push(...minMaxResult.reasons);
+    }
+
+    // Custom validators
+    if (props.validators) {
+      props.validators.forEach((validator) => {
+        const result = validator(value);
+        if (!result.valid && result.reasons) {
+          errors.push(...result.reasons);
+        }
+      });
+    }
+
+    return [...new Set(errors)];
+  }
+
+  // Reset value helper
+  function getResetValue(): string | null {
+    if (props.value) return props.value;
+
+    const min = getMin();
+    return min || null;
+  }
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -54,6 +96,12 @@ function DatePicker_(props: DatePickerProps, ref: React.Ref<InputRef>) {
       }
     };
   }, []);
+
+  // Re-validate when min/max constraints change
+  useEffect(() => {
+    const errors = validateDateValue(dateValue);
+    setErrorMessage(errors.join(' '));
+  }, [props.min, props.max, dateValue]);
 
   function setClassName() {
     return `usa-input ${props.className} ${displayErrorMessage.length ? 'usa-input--error' : ''}`;
@@ -74,27 +122,20 @@ function DatePicker_(props: DatePickerProps, ref: React.Ref<InputRef>) {
 
   function clearValue() {
     setErrorMessage('');
-    setWarningMessage('');
     clearDateValue();
   }
 
   function resetValue() {
     setErrorMessage('');
-    setWarningMessage('');
-    if (props.value) {
-      setDateValue(props.value);
-    } else if (props.minDate) {
-      setDateValue(props.minDate);
-    } else {
-      clearDateValue();
-    }
+    const resetTo = getResetValue();
+    setDateValue(resetTo);
   }
 
   function setValue(value: string) {
     if (value.length > 0) {
       setDateValue(value);
     } else {
-      resetValue();
+      clearDateValue();
     }
   }
 
@@ -109,8 +150,6 @@ function DatePicker_(props: DatePickerProps, ref: React.Ref<InputRef>) {
   function handleChange(ev: React.ChangeEvent<HTMLInputElement>) {
     const rawValue = ev.target.value;
 
-    // Always update the internal state to match what the user typed
-    // This is required for controlled inputs to work properly
     setDateValue(rawValue || null);
 
     if (props.onChange) {
@@ -123,57 +162,13 @@ function DatePicker_(props: DatePickerProps, ref: React.Ref<InputRef>) {
 
     if (!rawValue) {
       setErrorMessage('');
-      setWarningMessage('');
-      return;
-    }
-
-    const isCompleteDate = /^\d{4}-\d{2}-\d{2}$/.test(rawValue);
-    if (!isCompleteDate) {
-      setErrorMessage('');
-      setWarningMessage('');
-      return;
-    }
-
-    const value = new Date(rawValue);
-
-    if (isNaN(value.getTime())) {
-      setErrorMessage('');
-      setWarningMessage('');
       return;
     }
 
     // Debounce validation to avoid showing errors while user is typing
     validationTimeoutRef.current = setTimeout(() => {
-      const minMaxValidator = Validators.dateMinMax(
-        props.minDate,
-        props.maxDate,
-        'Date is not within allowed range. Enter a valid date.',
-      );
-      const minMaxResult = minMaxValidator(rawValue);
-
-      if (!minMaxResult.valid && minMaxResult.reasons) {
-        setErrorMessage(minMaxResult.reasons.join(' '));
-        setWarningMessage('');
-      } else {
-        setErrorMessage('');
-
-        if (props.futureDateWarningThresholdYears) {
-          const futureValidator = Validators.futureDateWithinYears(
-            props.futureDateWarningThresholdYears,
-          );
-          const futureResult = futureValidator(rawValue);
-
-          if (!futureResult.valid && futureResult.reasons) {
-            setWarningMessage(
-              `This date is more than ${props.futureDateWarningThresholdYears} years in the future. Please verify.`,
-            );
-          } else {
-            setWarningMessage('');
-          }
-        } else {
-          setWarningMessage('');
-        }
-      }
+      const errors = validateDateValue(rawValue);
+      setErrorMessage(errors.join(' '));
     }, 500);
   }
 
@@ -187,16 +182,11 @@ function DatePicker_(props: DatePickerProps, ref: React.Ref<InputRef>) {
     const invalidDateMessage = 'Must be a valid date mm/dd/yyyy.';
     if (inputRef.current && inputRef.current.validity.badInput) {
       errors.push(invalidDateMessage);
-    } else if (props.validators && dateValue) {
-      props.validators.forEach((validator) => {
-        const result = validator(dateValue);
-        if (!result.valid && result.reasons) {
-          errors.push(...result.reasons);
-        }
-      });
+    } else {
+      errors.push(...validateDateValue(dateValue));
     }
 
-    setErrorMessage(errors.join(' '));
+    setErrorMessage([...new Set(errors)].join(' '));
 
     if (props.onBlur) {
       props.onBlur(ev);
@@ -250,22 +240,17 @@ function DatePicker_(props: DatePickerProps, ref: React.Ref<InputRef>) {
           onChange={handleChange}
           onBlur={handleBlur}
           data-testid={id}
-          min={minDate}
-          max={maxDate || '9999-12-31'}
+          min={getMin()}
+          max={getMax()}
           value={dateValue ?? ''}
           disabled={isDisabled}
           required={props.required}
           ref={inputRef}
         />
       </div>
-      <div id={`${id}-error`} className="date-error" aria-live="polite">
+      <div id={`${id}-error`} className="date-error usa-input__error-message" aria-live="polite">
         {displayErrorMessage}
       </div>
-      {warningMessage && !displayErrorMessage && (
-        <div id={`${id}-warning`} className="date-warning" aria-live="polite">
-          {warningMessage}
-        </div>
-      )}
     </div>
   );
 }

--- a/user-interface/src/lib/components/uswds/forms.scss
+++ b/user-interface/src/lib/components/uswds/forms.scss
@@ -1,4 +1,5 @@
 $secondary-dark: #B50909;
+$secondary-darker: #8B0A03;
 $warning-light: #FFFFCA;
 $warning-text: #990000;
 
@@ -82,7 +83,7 @@ button.unstyled-button {
 
 .usa-input__error-message {
   padding: 0.25rem 0;
-  color: $warning-text;
+  color: $secondary-dark;
 }
 
 .usa-radio__input + label {


### PR DESCRIPTION
- Refactored out the `initializeInactiveLogout` function as it was conflicting with the new session timeout modal logic
- Moved `SessionTimerController` into its own file, replacing what we had in `inactive-logout.ts`
- Changed `HEARTBEAT` from 5 minutes to 1 minute

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Centralize session timeout and inactivity handling in a new session timer module and align Okta heartbeat/logout behavior with the new timeout dialog.

New Features:
- Introduce a shared session timer module to manage inactivity timeouts, warning and logout events across the app.

Bug Fixes:
- Ensure Okta heartbeat uses the new 1-minute interval and respects user activity when renewing tokens or triggering session timeout warnings.

Enhancements:
- Refactor Okta session management to use the new session timer APIs instead of the legacy inactive logout logic.
- Move SessionTimerController logic out of the Okta library into a reusable timer abstraction.
- Reset last interaction when OktaProvider initializes to properly seed inactivity tracking.
- Wire SessionTimeoutManager to the new session timer events and logout helpers instead of the removed inactive-logout module.

Tests:
- Update and extend Okta and session timeout tests to cover the new heartbeat behavior, logout timer clearing, and integration with SessionTimeoutManager and OktaProvider.