### PR TITLE
Fix missing imports in date helper test

### DIFF
--- a/common/src/date-helper.test.ts
+++ b/common/src/date-helper.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { vi, describe, test, expect } from 'vitest';
 import DateHelper from './date-helper';
 
 const {


### PR DESCRIPTION
Fix missing imports in date helper test

## Summary by Sourcery

Fix missing Vitest imports in date helper tests to ensure the test suite runs correctly.

Bug Fixes:
- Resolve missing Vitest globals in date-helper tests by importing describe, test, and expect.

Tests:
- Restore proper Vitest imports in date-helper test file so the tests execute without reference errors.