### PR TITLE
Environment-specific firewall and Node 22 update

### DIFF
--- a/.github/workflows/sub-deploy-code-slot.yml
+++ b/.github/workflows/sub-deploy-code-slot.yml
@@ -291,8 +291,14 @@ jobs:
           op: decode
           in: ${{ inputs.azResourceGrpAppEncrypted }}
 
-      - name: Enable production slot access
+      - name: Ensure correct access rules post-swap
         run: |
+          # Production slot: ensure Allow all (redundant with Bicep but ensures it's set)
           az webapp config access-restriction add --resource-group ${{ steps.rgApp.outputs.out }} --name ${{ env.webappName }} --rule-name AllowAll --action Allow --ip-address 0.0.0.0/0 --priority 100 1>/dev/null || true
           az functionapp config access-restriction add --resource-group ${{ steps.rgApp.outputs.out }} --name ${{ env.apiFunctionName }} --rule-name AllowAll --action Allow --ip-address 0.0.0.0/0 --priority 100 1>/dev/null || true
           az functionapp config access-restriction add --resource-group ${{ steps.rgApp.outputs.out }} --name ${{ inputs.dataflowsFunctionName }} --rule-name AllowAll --action Allow --ip-address 0.0.0.0/0 --priority 100 1>/dev/null || true
+
+          # Staging slot: lock down after swap (was production, now staging)
+          az webapp config access-restriction set --resource-group ${{ steps.rgApp.outputs.out }} --name ${{ env.webappName }} --slot ${{ inputs.slotName }} --default-action Deny 2>/dev/null || true
+          az functionapp config access-restriction set --resource-group ${{ steps.rgApp.outputs.out }} --name ${{ env.apiFunctionName }} --slot ${{ inputs.slotName }} --default-action Deny 2>/dev/null || true
+          az functionapp config access-restriction set --resource-group ${{ steps.rgApp.outputs.out }} --name ${{ inputs.dataflowsFunctionName }} --slot ${{ inputs.slotName }} --default-action Deny 2>/dev/null || true

--- a/ops/cloud-deployment/dataflows-resource-deploy.bicep
+++ b/ops/cloud-deployment/dataflows-resource-deploy.bicep
@@ -40,8 +40,9 @@ param functionsRuntime string
 // Provides mapping for runtime stack
 // Use the following query to check supported versions
 //  az functionapp list-runtimes --os linux --query "[].{stack:join(' ', [runtime, version]), LinuxFxVersion:linux_fx_version, SupportedFunctionsVersions:to_string(supported_functions_versions[])}" --output table
+// NOTE: Should match major version in .nvmrc (currently v22.17.1)
 var linuxFxVersionMap = {
-  node: 'NODE|20'
+  node: 'NODE|22'
 }
 
 param loginProviderConfig string
@@ -452,7 +453,7 @@ var baseApplicationSettings = concat(
         }
       ]
     : [
-        { name: 'MSSQL_PASS', value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=MSSQL-CLIENT-ID)' }
+        { name: 'MSSQL_PASS', value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=MSSQL-PASS)' }
         {
           name: 'ACMS_MSSQL_CLIENT_ID'
           value: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=ACMS-MSSQL-CLIENT-ID)'

--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -187,6 +187,7 @@ module ustpWebapp 'frontend-webapp-deploy.bicep' = {
       privateDnsZoneSubscriptionId: privateDnsZoneSubscriptionId
       oktaUrl: oktaUrl
       slotName: slotName
+      isUstpDeployment: isUstpDeployment
     }
 }
 


### PR DESCRIPTION
# Purpose

We were setting the firewall rules to deny all in Bicep and not fixing that for the production slots.

# Major Changes

Conditionally set the rule for the production slots of the webapp and api so that in Flexion environments, deployments don't cause 403 issues.

# Testing/Validation

We need to test by deploying to main.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Update app runtime and firewall configuration to support environment-specific access behavior and align Node versions with project settings.

New Features:
- Introduce environment toggle to differentiate USTP vs Flexion deployments for firewall behavior on production and staging slots.

Bug Fixes:
- Correct production slot firewall rules so Flexion environments remain publicly accessible while USTP stays locked down.
- Fix Key Vault secret reference for MSSQL password to use the correct secret name.
- Correct Veracode-related parameter description typo.

Enhancements:
- Refactor web app and function app configuration to separate shared settings from environment-specific firewall rules for production and staging slots.
- Align frontend, API, and dataflows Function Apps to use Node 22 to match the repository's .nvmrc configuration.

CI:
- Extend slot deployment workflow to re-apply open access to production and lock down the staging slot after swaps to maintain expected firewall behavior.