### PR TITLE
Add additional logging to E2E database load

### DIFF
--- a/test/e2e/scripts/load-cosmos-data.ts
+++ b/test/e2e/scripts/load-cosmos-data.ts
@@ -15,6 +15,10 @@ if (!adminKey) {
 
 (async () => {
   try {
+    console.log(
+      `Seeding E2E database from endpoint '${endpoint}'.`,
+      `Admin key exists? ${adminKey !== undefined}`,
+    );
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
@@ -26,7 +30,7 @@ if (!adminKey) {
     }
     console.log('E2E CosmosDB seeded successfully.');
   } catch (err) {
-    console.error('Error seeding E2E CosmosDB:', err);
+    console.error('Error seeding E2E CosmosDB:', err.message);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
## Summary by Sourcery

Improve observability of the E2E CosmosDB seeding script used in test runs.

Tests:
- Log the target endpoint and presence of an admin key when seeding the E2E CosmosDB test database.
- Log only the error message instead of the full error object when seeding the E2E CosmosDB database fails.