### PR TITLE
Fix broken import from common

### DIFF
--- a/backend/function-apps/dataflows/import/sync-cases.ts
+++ b/backend/function-apps/dataflows/import/sync-cases.ts
@@ -12,7 +12,7 @@ import SyncCases from '../../../lib/use-cases/dataflows/sync-cases';
 import CasesRuntimeState from '../../../lib/use-cases/dataflows/cases-runtime-state';
 import ExportAndLoadCase from '../../../lib/use-cases/dataflows/export-and-load-case';
 import { buildQueueError } from '../../../lib/use-cases/dataflows/queue-types';
-import { CaseSyncEvent } from 'common';
+import { CaseSyncEvent } from '@common/queue/dataflow-types';
 
 const MODULE_NAME = 'SYNC-CASES';
 const PAGE_SIZE = 100;


### PR DESCRIPTION
Fix broken import from common

## Summary by Sourcery

Bug Fixes:
- Correct the CaseSyncEvent import to reference the shared queue dataflow types package instead of the generic common module.