### PR TITLE
Properly set up allow rules

### DIFF
--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -283,6 +283,7 @@ var baseApiFunctionAppConfigProperties = {
 
   var slotFunctionAppConfigProperties = union(baseApiFunctionAppConfigProperties, {
     ipSecurityRestrictions: stagingIpSecurityRestrictionsRules
+    ipSecurityRestrictionsDefaultAction: 'Deny'
     appSettings: concat(baseApiFunctionAppConfigProperties.appSettings, [
       {
         name: 'INFO_SHA'

--- a/ops/cloud-deployment/frontend-webapp-deploy.bicep
+++ b/ops/cloud-deployment/frontend-webapp-deploy.bicep
@@ -311,6 +311,7 @@ var stagingWebappConfigProperties = union(
   baseWebappConfigProperties,
   {
     ipSecurityRestrictions: stagingIpSecurityRestrictionsRules
+    ipSecurityRestrictionsDefaultAction: 'Deny'
   },
   isPremiumPlanType ? { minTlsCipherSuite: preferredMinTLSCipherSuite } : {}
 )


### PR DESCRIPTION
# Purpose

The Bicep setup contained conflicting firewall rules.

# Major Changes

Resolve the conflict by only setting the rules up once.

# Testing/Validation

Ran the deployment and validated that the production slots we expect to be accessible are until the point of failure of the e2e job (being addressed on another branch).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Align firewall defaults and production slot IP security rules between USTP and non-USTP deployments for backend API and frontend web app.

Bug Fixes:
- Correct production slot firewall behavior so USTP deployments deny-by-default with optional Veracode allow rule, while non-USTP deployments remain publicly accessible.

Enhancements:
- Simplify and centralize IP security restriction configuration by relying on environment-specific defaults instead of redundant catch-all rules in production slots.

Deployment:
- Adjust Bicep templates for backend API and frontend web app to set ipSecurityRestrictionsDefaultAction based on deployment type and avoid conflicting firewall rules.