### PR TITLE
Fix Azure Functions 404 errors by using single bundle approach

### DIFF
--- a/backend/function-apps/api/esbuild.config.mjs
+++ b/backend/function-apps/api/esbuild.config.mjs
@@ -1,17 +1,13 @@
 import * as esbuild from 'esbuild';
-import { COMMON_BUILD_OPTIONS, findFunctionEntryPoints } from '../../esbuild-shared.mjs';
+import { COMMON_BUILD_OPTIONS } from '../../esbuild-shared.mjs';
 
-const entryPoints = findFunctionEntryPoints();
-
-// eslint-disable-next-line no-undef
-console.log(`Found ${entryPoints.length} Azure Functions to bundle`);
-
+// Build a single bundle that imports all functions
+// This ensures all app.http() registration code executes at startup
 esbuild
   .build({
     ...COMMON_BUILD_OPTIONS,
-    entryPoints,
-    outdir: 'dist',
-    outbase: '.',
+    entryPoints: ['./index.ts'],
+    outfile: 'dist/index.js',
   })
   .catch((err) => {
     // eslint-disable-next-line no-undef

--- a/backend/function-apps/api/index.ts
+++ b/backend/function-apps/api/index.ts
@@ -1,0 +1,23 @@
+// This file imports all Azure Functions to ensure their registration code executes
+// Each function file calls app.http() or app.timer() at module load time
+
+import './admin/privileged-identity-admin.function';
+import './case-assignments/case.assignment.function';
+import './case-associated/case-associated.function';
+import './case-docket/case-docket.function';
+import './case-history/case-history.function';
+import './case-notes/case.notes.function';
+import './case-summary/case-summary.function';
+import './cases/cases.function';
+import './consolidations/consolidations.function';
+import './courts/courts.function';
+import './healthcheck/healthcheck.function';
+import './lists/lists.function';
+import './offices/offices.function';
+import './orders/orders.function';
+import './orders-suggestions/orders-suggestions.function';
+import './staff/staff.function';
+import './trustee-appointments/trustee-appointments.function';
+import './trustee-assignments/trustee-assignments.function';
+import './trustee-history/trustee-history.function';
+import './trustees/trustees.function';

--- a/backend/function-apps/api/package.json
+++ b/backend/function-apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "CC0 v1.0",
   "description": "",
-  "main": "dist/*/*.function.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "node esbuild.config.mjs",
     "clean": "rm -rf ./dist *.zip",


### PR DESCRIPTION
Switch from multiple function bundles to a single bundle to ensure all
  Azure Functions v4 app.http() registrations execute at startup.

  Changes:
  - Add index.ts that imports all function modules
  - Update esbuild config to bundle from single entry point
  - Update package.json main field to point to dist/index.js

  This fixes 404 errors that occurred after esbuild migration because the
  Azure Functions runtime was not loading all function files, preventing
  their registration code from executing.

## Summary by Sourcery

Switch the Azure Functions API app to a single bundled entry point so all HTTP functions are loaded and registered correctly at startup.

Bug Fixes:
- Resolve Azure Functions v4 404 responses caused by some HTTP functions not being registered after the esbuild bundling change.

Enhancements:
- Introduce a central index.ts entry that imports all function modules for bundling.
- Update the esbuild configuration and package.json main field to build and run from the new single entry bundle.