### PR TITLE
Use TypeScript for index loader and transpile with esbuild

### DIFF
--- a/backend/function-apps/api/esbuild.config.mjs
+++ b/backend/function-apps/api/esbuild.config.mjs
@@ -1,10 +1,12 @@
 import * as esbuild from 'esbuild';
 import { COMMON_BUILD_OPTIONS, findFunctionEntryPoints } from '../../esbuild-shared.mjs';
 
-const entryPoints = findFunctionEntryPoints();
+const functionEntryPoints = findFunctionEntryPoints();
+// Add index.ts as an entry point to load all functions
+const entryPoints = [...functionEntryPoints, './index.ts'];
 
 // eslint-disable-next-line no-undef
-console.log(`Found ${entryPoints.length} Azure Functions to bundle`);
+console.log(`Found ${functionEntryPoints.length} Azure Functions to bundle (+ index.ts loader)`);
 
 esbuild
   .build({

--- a/backend/function-apps/api/index.ts
+++ b/backend/function-apps/api/index.ts
@@ -1,0 +1,25 @@
+// Entry point for Azure Functions v4 - loads all function registrations
+// Each import executes the app.http() registration at module load time
+
+import './admin/privileged-identity-admin.function';
+import './case-assignments/case.assignment.function';
+import './case-associated/case-associated.function';
+import './case-docket/case-docket.function';
+import './case-history/case-history.function';
+import './case-notes/case.notes.function';
+import './case-summary/case-summary.function';
+import './cases/cases.function';
+import './consolidations/consolidations.function';
+import './courts/courts.function';
+import './healthcheck/healthcheck.function';
+import './lists/lists.function';
+import './me/me.function';
+import './oauth2/mock-oauth2.function';
+import './offices/offices.function';
+import './orders/orders.function';
+import './orders-suggestions/orders-suggestions.function';
+import './staff/staff.function';
+import './trustee-appointments/trustee-appointments.function';
+import './trustee-assignments/trustee-assignments.function';
+import './trustee-history/trustee-history.function';
+import './trustees/trustees.function';

--- a/backend/function-apps/api/package.json
+++ b/backend/function-apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "CC0 v1.0",
   "description": "",
-  "main": "dist/*/*.function.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "node esbuild.config.mjs",
     "clean": "rm -rf ./dist *.zip",


### PR DESCRIPTION
Changes:
- Create index.ts that imports all 22 function modules
- Update esbuild config to include index.ts as entry point
- Update package.json main field to "dist/index.js"
- Remove manual index.js inclusion from pack.sh (now in dist/)

## Summary by Sourcery

Add a TypeScript index loader for all Azure Functions and configure the build to produce a single main entry file.

New Features:
- Introduce a TypeScript index.ts file that loads all function modules as a single entry point.

Enhancements:
- Update esbuild configuration to bundle the new index loader alongside existing function entry points.
- Point the package.json main field to the built dist/index.js entry file instead of individual function bundles.

Build:
- Extend the esbuild entryPoints to include index.ts and adjust build logging to reflect the additional loader entry.