### PR TITLE
CAMS-546 - Update wording on the session timeout modal

### DIFF
--- a/user-interface/src/lib/components/cams/SessionTimeoutManager/SessionTimeoutManager.test.tsx
+++ b/user-interface/src/lib/components/cams/SessionTimeoutManager/SessionTimeoutManager.test.tsx
@@ -220,6 +220,6 @@ describe('SessionTimeoutManager', () => {
     });
 
     // Check that the modal content includes the timing information
-    expect(screen.getByText(/Your session will expire in/i)).toBeInTheDocument();
+    expect(screen.getByText(/You will be logged out in/i)).toBeInTheDocument();
   });
 });

--- a/user-interface/src/lib/components/cams/SessionTimeoutWarningModal/SessionTimeoutWarningModal.tsx
+++ b/user-interface/src/lib/components/cams/SessionTimeoutWarningModal/SessionTimeoutWarningModal.tsx
@@ -52,13 +52,13 @@ function SessionTimeoutWarningModal_(
     <Modal
       ref={modalRef}
       modalId={modalId}
-      heading="Session Expiring Soon"
+      heading="You Will Be Logged Out Soon"
       content={
         <p>
-          Your session will expire in{' '}
+          You will be logged out in{' '}
           {timerKey > 0 && <CountdownTimer key={timerKey} timeInMs={warningSeconds * 1000} />}{' '}
           seconds due to inactivity. Click &quot;Stay Logged In&quot; to continue working, or
-          &quot;Log Out Now&quot; to end your session.
+          &quot;Log Out Now&quot; to be logged out.
         </p>
       }
       forceAction={true}


### PR DESCRIPTION
Jira ticket: CAMS-546

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Update the session timeout warning modal messaging to clarify that the user will be logged out soon and align automated tests with the new wording.

Enhancements:
- Revise session timeout modal heading and body text to clearly communicate that the user will be logged out soon rather than that the session will expire.

Tests:
- Update session timeout manager tests to assert against the new modal wording.