### PR TITLE
CAMS-543 - Updated logic for when the assigned staff edit button should show

### DIFF
--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
@@ -154,83 +154,92 @@ describe('CaseDetailTrusteeAndAssignedStaff', () => {
       expect(roles).toHaveLength(2);
     });
 
-    test('should show edit button when user has ManageAssignments action and case is chapter 15', () => {
-      const user: CamsUser = MockData.getCamsUser({
-        roles: [CamsRole.CaseAssignmentManager],
+    describe('Edit Button Visibility (canEditAssignedStaff)', () => {
+      // Tests for the canEditAssignedStaff helper function logic:
+      // Button should show when:
+      //   - User has ManageAssignments permission
+      //   - Case is chapter 15
+      //   - Case is NOT a consolidation member case
+      // Button should be hidden for consolidation member cases only
+
+      test('should show edit button when all conditions are met', () => {
+        const user: CamsUser = MockData.getCamsUser({
+          roles: [CamsRole.CaseAssignmentManager],
+        });
+        vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
+
+        renderWithProps();
+        const editButton = screen.getByTestId('open-modal-button');
+        expect(editButton).toBeInTheDocument();
+        expect(editButton).toBeVisible();
       });
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
 
-      renderWithProps();
-      const editButton = screen.getByTestId('open-modal-button');
-      expect(editButton).toBeInTheDocument();
-      expect(editButton).toBeVisible();
-    });
-
-    test('should not show edit button when user lacks ManageAssignments action', () => {
-      const caseDetailNoActions = {
-        ...BASE_TEST_CASE_DETAIL,
-        _actions: [],
-      };
-      renderWithProps({ caseDetail: caseDetailNoActions });
-      const editButton = screen.queryByTestId('open-modal-button');
-      expect(editButton).not.toBeInTheDocument();
-    });
-
-    test('should not show edit button for non-chapter 15 cases', () => {
-      const caseDetailChapter7 = {
-        ...BASE_TEST_CASE_DETAIL,
-        chapter: '7',
-      };
-      renderWithProps({ caseDetail: caseDetailChapter7 });
-      const editButton = screen.queryByTestId('open-modal-button');
-      expect(editButton).not.toBeInTheDocument();
-    });
-
-    test('should not show edit button when case is a consolidation member case', () => {
-      const user: CamsUser = MockData.getCamsUser({
-        roles: [CamsRole.CaseAssignmentManager],
+      test('should not show edit button when user lacks ManageAssignments action', () => {
+        const caseDetailNoActions = {
+          ...BASE_TEST_CASE_DETAIL,
+          _actions: [],
+        };
+        renderWithProps({ caseDetail: caseDetailNoActions });
+        const editButton = screen.queryByTestId('open-modal-button');
+        expect(editButton).not.toBeInTheDocument();
       });
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
 
-      const caseDetailMemberCase = {
-        ...BASE_TEST_CASE_DETAIL,
-        consolidation: [CONSOLIDATE_TO], // CONSOLIDATION_TO means this is a member case
-      };
-      renderWithProps({ caseDetail: caseDetailMemberCase });
-      const editButton = screen.queryByTestId('open-modal-button');
-      expect(editButton).not.toBeInTheDocument();
-    });
-
-    test('should show edit button when case is a consolidation lead case', () => {
-      const user: CamsUser = MockData.getCamsUser({
-        roles: [CamsRole.CaseAssignmentManager],
+      test('should not show edit button for non-chapter 15 cases', () => {
+        const caseDetailChapter7 = {
+          ...BASE_TEST_CASE_DETAIL,
+          chapter: '7',
+        };
+        renderWithProps({ caseDetail: caseDetailChapter7 });
+        const editButton = screen.queryByTestId('open-modal-button');
+        expect(editButton).not.toBeInTheDocument();
       });
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
 
-      const caseDetailLeadCase = {
-        ...BASE_TEST_CASE_DETAIL,
-        consolidation: [CONSOLIDATE_FROM], // CONSOLIDATION_FROM means this is a lead case
-      };
-      renderWithProps({ caseDetail: caseDetailLeadCase });
-      const editButton = screen.queryByTestId('open-modal-button');
-      expect(editButton).toBeInTheDocument();
-      expect(editButton).toBeVisible();
-    });
+      test('should not show edit button for consolidation member cases', () => {
+        const user: CamsUser = MockData.getCamsUser({
+          roles: [CamsRole.CaseAssignmentManager],
+        });
+        vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
 
-    test('should show edit button when case is not a consolidation case', () => {
-      const user: CamsUser = MockData.getCamsUser({
-        roles: [CamsRole.CaseAssignmentManager],
+        const caseDetailMemberCase = {
+          ...BASE_TEST_CASE_DETAIL,
+          consolidation: [CONSOLIDATE_TO], // CONSOLIDATION_TO means this is a member case
+        };
+        renderWithProps({ caseDetail: caseDetailMemberCase });
+        const editButton = screen.queryByTestId('open-modal-button');
+        expect(editButton).not.toBeInTheDocument();
       });
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
 
-      const caseDetailNonConsolidation = {
-        ...BASE_TEST_CASE_DETAIL,
-        consolidation: [], // No consolidation
-      };
-      renderWithProps({ caseDetail: caseDetailNonConsolidation });
-      const editButton = screen.queryByTestId('open-modal-button');
-      expect(editButton).toBeInTheDocument();
-      expect(editButton).toBeVisible();
+      test('should show edit button for consolidation lead cases', () => {
+        const user: CamsUser = MockData.getCamsUser({
+          roles: [CamsRole.CaseAssignmentManager],
+        });
+        vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
+
+        const caseDetailLeadCase = {
+          ...BASE_TEST_CASE_DETAIL,
+          consolidation: [CONSOLIDATE_FROM], // CONSOLIDATION_FROM means this is a lead case
+        };
+        renderWithProps({ caseDetail: caseDetailLeadCase });
+        const editButton = screen.queryByTestId('open-modal-button');
+        expect(editButton).toBeInTheDocument();
+        expect(editButton).toBeVisible();
+      });
+
+      test('should show edit button for non-consolidation cases', () => {
+        const user: CamsUser = MockData.getCamsUser({
+          roles: [CamsRole.CaseAssignmentManager],
+        });
+        vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
+
+        const caseDetailNonConsolidation = {
+          ...BASE_TEST_CASE_DETAIL,
+          consolidation: [], // Empty consolidation array
+        };
+        renderWithProps({ caseDetail: caseDetailNonConsolidation });
+        const editButton = screen.queryByTestId('open-modal-button');
+        expect(editButton).toBeInTheDocument();
+        expect(editButton).toBeVisible();
+      });
     });
 
     test('should open assignment modal when edit button is clicked', async () => {

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
@@ -21,6 +21,14 @@ export interface CaseDetailTrusteeAndAssignedStaffProps {
   onCaseAssignment: (props: AssignAttorneyModalCallbackProps) => void;
 }
 
+function canEditAssignedStaff(caseDetail: CaseDetail): boolean {
+  return (
+    Actions.contains(caseDetail, Actions.ManageAssignments) &&
+    caseDetail.chapter === '15' &&
+    !isJointAdministrationMemberCase(caseDetail.consolidation)
+  );
+}
+
 function CaseDetailTrusteeAndAssignedStaff(
   props: Readonly<CaseDetailTrusteeAndAssignedStaffProps>,
 ) {
@@ -42,21 +50,19 @@ function CaseDetailTrusteeAndAssignedStaff(
           <div className="assigned-staff-information record-detail-card">
             <h3>
               Assigned Staff{' '}
-              {Actions.contains(caseDetail, Actions.ManageAssignments) &&
-                caseDetail.chapter === '15' &&
-                !isJointAdministrationMemberCase(caseDetail.consolidation) && (
-                  <OpenModalButton
-                    uswdsStyle={UswdsButtonStyle.Unstyled}
-                    modalId={'assignmentModalId'}
-                    modalRef={assignmentModalRef}
-                    ref={openModalButtonRef}
-                    openProps={{ bCase: caseDetail, callback: handleCaseAssignment }}
-                    ariaLabel="Edit assigned staff"
-                    title="Open Staff Assignment window"
-                  >
-                    <IconLabel icon="edit" label="Edit" />
-                  </OpenModalButton>
-                )}
+              {canEditAssignedStaff(caseDetail) && (
+                <OpenModalButton
+                  uswdsStyle={UswdsButtonStyle.Unstyled}
+                  modalId={'assignmentModalId'}
+                  modalRef={assignmentModalRef}
+                  ref={openModalButtonRef}
+                  openProps={{ bCase: caseDetail, callback: handleCaseAssignment }}
+                  ariaLabel="Edit assigned staff"
+                  title="Open Staff Assignment window"
+                >
+                  <IconLabel icon="edit" label="Edit" />
+                </OpenModalButton>
+              )}
             </h3>
             {caseDetail.regionId && (
               <div


### PR DESCRIPTION
- Show if - not a consolodation case
- Show if - consolodation lead case
- Hide if - consolodation member case

Jira ticket: CAMS-543

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Adjust visibility rules for the Assigned Staff edit button based on consolidation case status.

Bug Fixes:
- Ensure the Assigned Staff edit button is hidden for consolidation member cases and shown for consolidation lead and non-consolidation cases.

Tests:
- Add unit tests covering Assigned Staff edit button visibility for consolidation lead, consolidation member, and non-consolidation cases.