### PR TITLE
CAMS-681 capture change history for trustee assistant

### DIFF
--- a/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tests/assistant.test.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tests/assistant.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import TrusteeDetailAuditHistory from '../TrusteeDetailAuditHistory';
+import Api2 from '@/lib/models/api2';
+import { TrusteeAssistantHistory } from '@common/cams/trustees';
+import MockData from '@common/cams/test-utilities/mock-data';
+
+const MOCK_TRUSTEE_ID = 'trustee-123';
+
+function createMockAssistantHistory(
+  override: Partial<TrusteeAssistantHistory> = {},
+): TrusteeAssistantHistory {
+  return {
+    id: 'history-1',
+    trusteeId: MOCK_TRUSTEE_ID,
+    documentType: 'AUDIT_ASSISTANT',
+    before: {
+      name: 'Jane Smith',
+      contact: MockData.getContactInformation(),
+    },
+    after: {
+      name: 'Jane M. Smith',
+      title: 'Senior Assistant',
+      contact: MockData.getContactInformation(),
+    },
+    updatedOn: '2024-01-15T10:00:00Z',
+    updatedBy: MockData.getCamsUserReference({ name: 'John Doe' }),
+    createdOn: '2024-01-15T10:00:00Z',
+    createdBy: MockData.getCamsUserReference({ name: 'John Doe' }),
+    ...override,
+  };
+}
+
+describe('TrusteeDetailAuditHistory - Assistant History', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('should render assistant change history with name', async () => {
+    const mockHistory = [createMockAssistantHistory()];
+    vi.spyOn(Api2, 'getTrusteeHistory').mockResolvedValue({ data: mockHistory });
+
+    render(<TrusteeDetailAuditHistory trusteeId={MOCK_TRUSTEE_ID} />);
+
+    await screen.findByTestId('change-type-assistant-0');
+
+    expect(screen.getByTestId('change-type-assistant-0')).toHaveTextContent('Assistant');
+    expect(screen.getByTestId('previous-assistant-0')).toHaveTextContent('Jane Smith');
+    expect(screen.getByTestId('new-assistant-0')).toHaveTextContent('Jane M. Smith');
+    expect(screen.getByTestId('new-assistant-0')).toHaveTextContent('Senior Assistant');
+  });
+
+  test('should render when assistant is newly added (before is undefined)', async () => {
+    const mockHistory = [
+      createMockAssistantHistory({
+        before: undefined,
+        after: {
+          name: 'Jane Smith',
+          title: 'Legal Assistant',
+          contact: MockData.getContactInformation(),
+        },
+      }),
+    ];
+    vi.spyOn(Api2, 'getTrusteeHistory').mockResolvedValue({ data: mockHistory });
+
+    render(<TrusteeDetailAuditHistory trusteeId={MOCK_TRUSTEE_ID} />);
+
+    await screen.findByTestId('change-type-assistant-0');
+
+    expect(screen.getByTestId('previous-assistant-0')).toBeEmptyDOMElement();
+    expect(screen.getByTestId('new-assistant-0')).toHaveTextContent('Jane Smith');
+    expect(screen.getByTestId('new-assistant-0')).toHaveTextContent('Legal Assistant');
+  });
+
+  test('should render when assistant is removed (after is undefined)', async () => {
+    const mockHistory = [
+      createMockAssistantHistory({
+        before: {
+          name: 'Jane Smith',
+          title: 'Legal Assistant',
+          contact: MockData.getContactInformation(),
+        },
+        after: undefined,
+      }),
+    ];
+    vi.spyOn(Api2, 'getTrusteeHistory').mockResolvedValue({ data: mockHistory });
+
+    render(<TrusteeDetailAuditHistory trusteeId={MOCK_TRUSTEE_ID} />);
+
+    await screen.findByTestId('change-type-assistant-0');
+
+    expect(screen.getByTestId('previous-assistant-name-0')).toHaveTextContent('Jane Smith');
+    expect(screen.getByTestId('previous-assistant-title-0')).toHaveTextContent('Legal Assistant');
+    expect(screen.getByTestId('new-assistant-0')).toBeEmptyDOMElement();
+  });
+
+  test('should render assistant without title', async () => {
+    const mockHistory = [
+      createMockAssistantHistory({
+        before: {
+          name: 'Jane Smith',
+          contact: MockData.getContactInformation(),
+        },
+        after: {
+          name: 'Jane M. Smith',
+          contact: MockData.getContactInformation(),
+        },
+      }),
+    ];
+    vi.spyOn(Api2, 'getTrusteeHistory').mockResolvedValue({ data: mockHistory });
+
+    render(<TrusteeDetailAuditHistory trusteeId={MOCK_TRUSTEE_ID} />);
+
+    await screen.findByTestId('change-type-assistant-0');
+
+    expect(screen.getByTestId('previous-assistant-name-0')).toHaveTextContent('Jane Smith');
+    expect(screen.queryByTestId('previous-assistant-title-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('new-assistant-name-0')).toHaveTextContent('Jane M. Smith');
+    expect(screen.queryByTestId('new-assistant-title-0')).not.toBeInTheDocument();
+  });
+
+  test('should render assistant contact information', async () => {
+    const mockContact = MockData.getContactInformation({
+      email: 'jane.smith@example.com',
+      phone: { number: '555-555-5555', extension: '123' },
+      address: {
+        address1: '123 Main St',
+        city: 'New York',
+        state: 'NY',
+        zipCode: '10001',
+        countryCode: 'US',
+      },
+    });
+
+    const mockHistory = [
+      createMockAssistantHistory({
+        after: {
+          name: 'Jane Smith',
+          title: 'Legal Assistant',
+          contact: mockContact,
+        },
+      }),
+    ];
+    vi.spyOn(Api2, 'getTrusteeHistory').mockResolvedValue({ data: mockHistory });
+
+    render(<TrusteeDetailAuditHistory trusteeId={MOCK_TRUSTEE_ID} />);
+
+    await screen.findByTestId('change-type-assistant-0');
+
+    const newAssistant = screen.getByTestId('new-assistant-0');
+    expect(newAssistant).toHaveTextContent('123 Main St');
+    expect(newAssistant).toHaveTextContent('New York');
+    expect(newAssistant).toHaveTextContent('555-555-5555, ext. 123');
+    expect(newAssistant).toHaveTextContent('jane.smith@example.com');
+  });
+
+  test('should render assistant history mixed with other history types', async () => {
+    const mockHistory = [
+      createMockAssistantHistory(),
+      {
+        id: 'history-2',
+        trusteeId: MOCK_TRUSTEE_ID,
+        documentType: 'AUDIT_NAME' as const,
+        before: 'John Doe',
+        after: 'John M. Doe',
+        updatedOn: '2024-01-14T10:00:00Z',
+        updatedBy: MockData.getCamsUserReference({ name: 'Admin User' }),
+        createdOn: '2024-01-14T10:00:00Z',
+        createdBy: MockData.getCamsUserReference({ name: 'Admin User' }),
+      },
+    ];
+    vi.spyOn(Api2, 'getTrusteeHistory').mockResolvedValue({ data: mockHistory });
+
+    render(<TrusteeDetailAuditHistory trusteeId={MOCK_TRUSTEE_ID} />);
+
+    await screen.findByTestId('change-type-assistant-0');
+
+    expect(screen.getByTestId('change-type-assistant-0')).toHaveTextContent('Assistant');
+    expect(screen.getByTestId('change-type-name-1')).toHaveTextContent('Name');
+  });
+});

--- a/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tests/integration.test.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tests/integration.test.tsx
@@ -1,7 +1,11 @@
 import { screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import Api2 from '@/lib/models/api2';
-import { TrusteeOversightHistory, TrusteeSoftwareHistory } from '@common/cams/trustees';
+import {
+  TrusteeOversightHistory,
+  TrusteeSoftwareHistory,
+  TrusteeAssistantHistory,
+} from '@common/cams/trustees';
 import { SYSTEM_USER_REFERENCE } from '@common/cams/auditable';
 import { CamsRole } from '@common/cams/roles';
 import MockData from '@common/cams/test-utilities/mock-data';
@@ -69,6 +73,25 @@ describe('TrusteeDetailAuditHistory - RenderTrusteeHistory Integration Tests', (
       },
     });
 
+    const mockAssistantHistory: TrusteeAssistantHistory = {
+      id: 'audit-assistant-1',
+      trusteeId: 'trustee-1',
+      documentType: 'AUDIT_ASSISTANT',
+      before: {
+        name: 'Jane Smith',
+        contact: MockData.getContactInformation(),
+      },
+      after: {
+        name: 'Jane M. Smith',
+        title: 'Senior Assistant',
+        contact: MockData.getContactInformation(),
+      },
+      updatedOn: '2024-01-10T10:00:00Z',
+      updatedBy: MockData.getCamsUserReference({ name: 'User 8' }),
+      createdOn: '2024-01-10T10:00:00Z',
+      createdBy: MockData.getCamsUserReference({ name: 'User 8' }),
+    };
+
     const allHistoryTypes = [
       mockNameHistory,
       mockPublicContactHistory,
@@ -77,6 +100,7 @@ describe('TrusteeDetailAuditHistory - RenderTrusteeHistory Integration Tests', (
       mockSoftwareHistory,
       mockOversightHistory,
       mockZoomInfoHistory,
+      mockAssistantHistory,
     ];
 
     vi.spyOn(Api2, 'getTrusteeHistory').mockResolvedValue({ data: allHistoryTypes });
@@ -96,6 +120,7 @@ describe('TrusteeDetailAuditHistory - RenderTrusteeHistory Integration Tests', (
     expect(screen.getByTestId('change-type-zoom-info-0')).toHaveTextContent(
       '341 Meeting Zoom Info',
     );
+    expect(screen.getByTestId('change-type-assistant-7')).toHaveTextContent('Assistant');
 
     expect(screen.getByTestId('previous-name-6')).toHaveTextContent('John Smith');
     expect(screen.getByTestId('previous-banks-3')).toHaveTextContent('Bank A');
@@ -104,6 +129,9 @@ describe('TrusteeDetailAuditHistory - RenderTrusteeHistory Integration Tests', (
     expect(screen.getByTestId('previous-zoom-info-0')).toHaveTextContent(
       'https://zoom.us/j/111111111',
     );
+    expect(screen.getByTestId('previous-assistant-name-7')).toHaveTextContent('Jane Smith');
+    expect(screen.getByTestId('new-assistant-name-7')).toHaveTextContent('Jane M. Smith');
+    expect(screen.getByTestId('new-assistant-title-7')).toHaveTextContent('Senior Assistant');
   });
 
   test('should handle switch case default correctly for unknown document types', async () => {

--- a/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tsx
@@ -14,6 +14,7 @@ import {
   TrusteeOversightHistory,
   TrusteeAppointmentHistory,
   TrusteeZoomInfoHistory,
+  TrusteeAssistantHistory,
   getAppointmentDetails,
   ZoomInfo,
 } from '@common/cams/trustees';
@@ -285,6 +286,53 @@ function ShowTrusteeAppointmentHistory(props: ShowTrusteeAppointmentHistoryProps
   );
 }
 
+type ShowTrusteeAssistantHistoryProps = Readonly<{ history: TrusteeAssistantHistory; idx: number }>;
+
+function ShowTrusteeAssistantHistory(props: ShowTrusteeAssistantHistoryProps) {
+  const { history, idx } = props;
+  return (
+    <tr>
+      <td data-testid={`change-type-assistant-${idx}`}>Assistant</td>
+      <td data-testid={`previous-assistant-${idx}`}>
+        {history.before && (
+          <>
+            <div className="assistant-name" data-testid={`previous-assistant-name-${idx}`}>
+              {history.before.name}
+            </div>
+            {history.before.title && (
+              <div className="assistant-title" data-testid={`previous-assistant-title-${idx}`}>
+                {history.before.title}
+              </div>
+            )}
+            <FormattedContact contact={history.before.contact} showLinks={false} />
+          </>
+        )}
+      </td>
+      <td data-testid={`new-assistant-${idx}`}>
+        {history.after && (
+          <>
+            <div className="assistant-name" data-testid={`new-assistant-name-${idx}`}>
+              {history.after.name}
+            </div>
+            {history.after.title && (
+              <div className="assistant-title" data-testid={`new-assistant-title-${idx}`}>
+                {history.after.title}
+              </div>
+            )}
+            <FormattedContact contact={history.after.contact} showLinks={false} />
+          </>
+        )}
+      </td>
+      <td data-testid={`changed-by-${idx}`}>
+        {history.updatedBy && <>{history.updatedBy.name}</>}
+      </td>
+      <td data-testid={`change-date-${idx}`}>
+        <span className="text-no-wrap">{formatDate(history.updatedOn)}</span>
+      </td>
+    </tr>
+  );
+}
+
 function RenderTrusteeHistory(props: Readonly<{ trusteeHistory: TrusteeHistory[] }>) {
   const { trusteeHistory } = props;
   return (
@@ -326,6 +374,14 @@ function RenderTrusteeHistory(props: Readonly<{ trusteeHistory: TrusteeHistory[]
             return (
               <ShowTrusteeAppointmentHistory
                 key={`${history.trusteeId}-${idx}`}
+                history={history}
+                idx={idx}
+              />
+            );
+          case 'AUDIT_ASSISTANT':
+            return (
+              <ShowTrusteeAssistantHistory
+                key={`${history.trusteeId || history.id}-${idx}`}
                 history={history}
                 idx={idx}
               />


### PR DESCRIPTION
# Purpose

Add History for update of Trustee information.  

# Major Changes

Since backend was already handling trustee assistant history, it needed to be added to the front end.

 ✅ Files Created:                                                                                             
  - assistant.test.tsx - 6 comprehensive tests                                                                  
                                                                                                                
  ✅ Files Modified:                                                                                            
  - TrusteeDetailAuditHistory.tsx - Added ShowTrusteeAssistantHistory component                                 
  - integration.test.tsx - Added assistant to all history types test                                            
                
                                                                                                                
  ✅ Feature Complete:                                                                                          
  - Backend history capture: Already implemented ✓                                                              
  - Frontend display component: Implemented with TDD ✓                                                          
  - All tests passing ✓                                                                                         
  - Changes committed and pushed ✓                                                                              
                                                                                                                
 

# Testing/Validation

                                                                                                              
  ✅ Test Results:                                                                                              
  - Common: 481 tests pass                                                                                      
  - Backend: 37 trustee tests pass                                                                              
  - Frontend: 1878 tests pass (64 TrusteeDetailAuditHistory tests including 6 new assistant tests)
 
# Notes

CAMS-685 must be merged before this one.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Capture and display trustee assistant details and audit history, including optional assistant titles and validation, across backend and frontend.

New Features:
- Add frontend rendering of trustee assistant audit history entries alongside existing trustee history types.
- Extend trustee assistant profile and form views to support an optional assistant title field.

Enhancements:
- Enforce validation for trustee assistant titles, including a 50-character maximum, in shared validators, backend use case logic, and UI forms.

Tests:
- Add focused unit and integration tests for trustee assistant audit history rendering, assistant profile display states, and assistant form behavior, including title validation and submission.