### PR TITLE
Ignore private repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,11 @@ backend/dev-users.json
 .gitmodules
 .ustp-cams-fdp
 
+# Other USTP Repos
+.cams-gists
+.ado-mirror
+.threat-model
+
 # Python (docs tooling and caches)
 dev-tools/.venv-docs/
 dev-tools/.venv/


### PR DESCRIPTION
# Purpose

We want to be able to work on all repos from the same workspace, but not include references to private repositories.

# Major Changes

Add directory names for private repositories to the `.gitignore`.

# Testing/Validation

Directories are not tracked.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhancements:
- Add ignore patterns for private repository directories to support using a shared workspace without tracking private code.