### PR TITLE
Disable minimumReleaseAge for Bicep resources

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,11 @@
       "enabled": false
     },
     {
+      "description": "Disable minimumReleaseAge for Bicep resources - datasource lacks timestamp data",
+      "matchManagers": ["bicep"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "description": "First-party GitHub Actions with digest pinning and 14-day wait",
       "matchManagers": ["github-actions"],
       "pinDigests": true,


### PR DESCRIPTION
# Purpose

We want to keep our ARM resource definitions up-to-date.

# Major Changes

Disable minimum age requirements for Bicep resource definitions only.

# Testing/Validation

Validated the config and performed a dry-run to ensure that it behaves as we want.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Build:
- Update Renovate configuration to exempt Bicep resources from minimumReleaseAge restrictions.