### PR TITLE
CAMS-681 Refactor trustee validators to use single functions

### DIFF
--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -33,42 +33,42 @@ import { Address, ContactInformation, PhoneNumber } from '@common/cams/contact';
 const MODULE_NAME = 'TRUSTEES-USE-CASE';
 
 const addressSpec: ValidationSpec<Address> = {
-  address1: addressLine1,
-  address2: addressLine2,
-  address3: addressLine3,
-  city,
-  state,
-  zipCode,
-  countryCode,
+  address1: [addressLine1],
+  address2: [addressLine2],
+  address3: [addressLine3],
+  city: [city],
+  state: [state],
+  zipCode: [zipCode],
+  countryCode: [countryCode],
 };
 
 const phoneSpec: ValidationSpec<PhoneNumber> = {
-  number: phoneNumber,
-  extension: phoneExtension,
+  number: [phoneNumber],
+  extension: [phoneExtension],
 };
 
 const contactInformationSpec: ValidationSpec<ContactInformation> = {
   address: [V.spec(addressSpec)],
   phone: [V.optional(V.spec(phoneSpec))],
-  email: [V.optional(...email)],
-  website,
-  companyName,
+  email: [V.optional(email)],
+  website: [website],
+  companyName: [companyName],
 };
 
 const internalContactInformationSpec: ValidationSpec<ContactInformation> = {
   address: [V.optional(V.nullable(V.spec(addressSpec)))],
   phone: [V.optional(V.nullable(V.spec(phoneSpec)))],
-  email: [V.optional(V.nullable(...email))],
+  email: [V.optional(V.nullable(email))],
 };
 
 const assistantSpec: ValidationSpec<TrusteeAssistant> = {
-  name: assistantName,
-  title: [V.optional(...assistantTitle)],
+  name: [assistantName],
+  title: [V.optional(assistantTitle)],
   contact: [V.spec(contactInformationSpec)],
 };
 
 const trusteeSpec: ValidationSpec<TrusteeInput> = {
-  name: trusteeName,
+  name: [trusteeName],
   public: [V.optional(V.spec(contactInformationSpec))],
   internal: [V.optional(V.spec(internalContactInformationSpec))],
   assistant: [V.optional(V.spec(assistantSpec))],

--- a/common/src/cams/trustees-validators.ts
+++ b/common/src/cams/trustees-validators.ts
@@ -11,66 +11,74 @@ import { FIELD_VALIDATION_MESSAGES } from './validation-messages';
 import { ValidationSpec } from './validation';
 import { ZoomInfo } from './trustees';
 
-export const trusteeName = [V.minLength(1, 'Trustee name is required'), V.maxLength(50)];
+export const trusteeName = V.useValidators(
+  V.minLength(1, 'Trustee name is required'),
+  V.maxLength(50),
+);
 
-export const companyName = [V.optional(V.maxLength(50))];
+export const companyName = V.optional(V.maxLength(50));
 
-export const addressLine1 = [
+export const addressLine1 = V.useValidators(
   V.minLength(1, FIELD_VALIDATION_MESSAGES.ADDRESS_REQUIRED),
   V.maxLength(40),
-];
+);
 
-export const addressLine2 = [V.optional(V.maxLength(40))];
+export const addressLine2 = V.optional(V.maxLength(40));
 
-export const addressLine3 = [V.optional(V.maxLength(40))];
+export const addressLine3 = V.optional(V.maxLength(40));
 
-export const city = [V.minLength(1, FIELD_VALIDATION_MESSAGES.CITY_REQUIRED), V.maxLength(50)];
+export const city = V.useValidators(
+  V.minLength(1, FIELD_VALIDATION_MESSAGES.CITY_REQUIRED),
+  V.maxLength(50),
+);
 
-export const state = [V.exactLength(2, FIELD_VALIDATION_MESSAGES.STATE_REQUIRED)];
+export const state = V.exactLength(2, FIELD_VALIDATION_MESSAGES.STATE_REQUIRED);
 
-export const zipCode = [
+export const zipCode = V.useValidators(
   V.minLength(1, FIELD_VALIDATION_MESSAGES.ZIP_CODE_REQUIRED),
   V.matches(ZIP_REGEX, FIELD_VALIDATION_MESSAGES.ZIP_CODE),
-];
+);
 
-export const countryCode = [V.exactLength(2)];
+export const countryCode = V.exactLength(2);
 
-export const phoneNumber = [V.matches(PHONE_REGEX, FIELD_VALIDATION_MESSAGES.PHONE_NUMBER)];
+export const phoneNumber = V.matches(PHONE_REGEX, FIELD_VALIDATION_MESSAGES.PHONE_NUMBER);
 
-export const phoneExtension = [
-  V.optional(V.matches(EXTENSION_REGEX, FIELD_VALIDATION_MESSAGES.PHONE_EXTENSION)),
-];
+export const phoneExtension = V.optional(
+  V.matches(EXTENSION_REGEX, FIELD_VALIDATION_MESSAGES.PHONE_EXTENSION),
+);
 
-export const email = [V.matches(EMAIL_REGEX, FIELD_VALIDATION_MESSAGES.EMAIL), V.maxLength(50)];
+export const email = V.useValidators(
+  V.matches(EMAIL_REGEX, FIELD_VALIDATION_MESSAGES.EMAIL),
+  V.maxLength(50),
+);
 
-export const website = [
-  V.optional(
-    V.matches(WEBSITE_RELAXED_REGEX, FIELD_VALIDATION_MESSAGES.WEBSITE),
-    V.maxLength(255, FIELD_VALIDATION_MESSAGES.WEBSITE_MAX_LENGTH),
-  ),
-];
+export const website = V.optional(
+  V.matches(WEBSITE_RELAXED_REGEX, FIELD_VALIDATION_MESSAGES.WEBSITE),
+  V.maxLength(255, FIELD_VALIDATION_MESSAGES.WEBSITE_MAX_LENGTH),
+);
 
-export const zoomLink = [
+export const zoomLink = V.useValidators(
   V.minLength(1, FIELD_VALIDATION_MESSAGES.ZOOM_LINK),
   V.matches(WEBSITE_RELAXED_REGEX, FIELD_VALIDATION_MESSAGES.ZOOM_LINK),
   V.maxLength(255, FIELD_VALIDATION_MESSAGES.ZOOM_LINK_MAX_LENGTH),
-];
+);
 
-export const zoomPhone = [V.matches(PHONE_REGEX, FIELD_VALIDATION_MESSAGES.PHONE_NUMBER)];
+export const zoomPhone = V.matches(PHONE_REGEX, FIELD_VALIDATION_MESSAGES.PHONE_NUMBER);
 
-export const zoomMeetingId = [
-  V.matches(ZOOM_MEETING_ID_REGEX, FIELD_VALIDATION_MESSAGES.ZOOM_MEETING_ID),
-];
+export const zoomMeetingId = V.matches(
+  ZOOM_MEETING_ID_REGEX,
+  FIELD_VALIDATION_MESSAGES.ZOOM_MEETING_ID,
+);
 
-export const zoomPasscode = [V.minLength(1, FIELD_VALIDATION_MESSAGES.PASSCODE_REQUIRED)];
+export const zoomPasscode = V.minLength(1, FIELD_VALIDATION_MESSAGES.PASSCODE_REQUIRED);
 
-export const assistantName = [V.minLength(1)];
+export const assistantName = V.minLength(1);
 
-export const assistantTitle = [V.maxLength(50)];
+export const assistantTitle = V.maxLength(50);
 
 export const zoomInfoSpec: ValidationSpec<ZoomInfo> = {
-  link: zoomLink,
-  phone: zoomPhone,
-  meetingId: zoomMeetingId,
-  passcode: zoomPasscode,
+  link: [zoomLink],
+  phone: [zoomPhone],
+  meetingId: [zoomMeetingId],
+  passcode: [zoomPasscode],
 };

--- a/common/src/cams/validators.ts
+++ b/common/src/cams/validators.ts
@@ -376,6 +376,17 @@ function futureDateWithinYears(years: number, reason?: string): ValidatorFunctio
   };
 }
 
+/**
+ * Combines multiple validator functions into a single validator function.
+ * All validators are executed and their results are merged.
+ *
+ * @param {...ValidatorFunction[]} validators - Variable number of validator functions to combine
+ * @returns {ValidatorFunction} A single validator function that applies all provided validators
+ */
+function useValidators(...validators: ValidatorFunction[]): ValidatorFunction {
+  return (value: unknown): ValidatorResult => validateEach(validators, value);
+}
+
 const Validators = {
   arrayOf,
   dateAfter,
@@ -395,6 +406,7 @@ const Validators = {
   skip,
   spec,
   trimmed,
+  useValidators,
 };
 
 export default Validators;

--- a/user-interface/src/trustees/forms/trusteeForms.types.ts
+++ b/user-interface/src/trustees/forms/trusteeForms.types.ts
@@ -84,10 +84,10 @@ const completedAddressRequired: ValidatorFunction = (obj: unknown): ValidatorRes
   }
 
   const requiredFieldsSpec: Readonly<ValidationSpec<typeof form>> = {
-    address1: addressLine1,
-    city,
-    state,
-    zipCode,
+    address1: [addressLine1],
+    city: [city],
+    state: [state],
+    zipCode: [zipCode],
   };
 
   const result = validateObject(requiredFieldsSpec, form);
@@ -126,41 +126,41 @@ const phoneRequiredWithExtension: ValidatorFunction = (obj): ValidatorResult => 
 // ============================================================================
 
 export const trusteePublicSpec: Readonly<ValidationSpec<TrusteePublicFormData>> = {
-  name: trusteeName,
-  companyName,
-  address1: addressLine1,
-  address2: addressLine2,
-  city,
-  state,
-  zipCode,
-  email,
-  website,
-  phone: phoneNumber,
-  extension: phoneExtension,
+  name: [trusteeName],
+  companyName: [companyName],
+  address1: [addressLine1],
+  address2: [addressLine2],
+  city: [city],
+  state: [state],
+  zipCode: [zipCode],
+  email: [email],
+  website: [website],
+  phone: [phoneNumber],
+  extension: [phoneExtension],
 };
 
 export const trusteeInternalSpec: Readonly<ValidationSpec<TrusteeInternalFormData>> = {
   $: [completedAddressRequired, phoneRequiredWithExtension],
-  address1: [V.optional(...addressLine1)],
-  address2: addressLine2,
-  city: [V.optional(...city)],
-  state: [V.optional(...state)],
-  zipCode: [V.optional(...zipCode)],
-  email: [V.optional(...email)],
-  phone: [V.optional(...phoneNumber)],
-  extension: [V.optional(...phoneExtension)],
+  address1: [V.optional(addressLine1)],
+  address2: [addressLine2],
+  city: [V.optional(city)],
+  state: [V.optional(state)],
+  zipCode: [V.optional(zipCode)],
+  email: [V.optional(email)],
+  phone: [V.optional(phoneNumber)],
+  extension: [V.optional(phoneExtension)],
 };
 
 export const trusteeAssistantSpec: Readonly<ValidationSpec<TrusteeAssistantFormData>> = {
   $: [completedAddressRequired, phoneRequiredWithExtension],
-  name: trusteeName,
-  title: [V.optional(...assistantTitle)],
-  address1: [V.optional(...addressLine1)],
-  address2: addressLine2,
-  city: [V.optional(...city)],
-  state: [V.optional(...state)],
-  zipCode: [V.optional(...zipCode)],
-  email: [V.optional(...email)],
-  phone: [V.optional(...phoneNumber)],
-  extension: [V.optional(...phoneExtension)],
+  name: [trusteeName],
+  title: [V.optional(assistantTitle)],
+  address1: [V.optional(addressLine1)],
+  address2: [addressLine2],
+  city: [V.optional(city)],
+  state: [V.optional(state)],
+  zipCode: [V.optional(zipCode)],
+  email: [V.optional(email)],
+  phone: [V.optional(phoneNumber)],
+  extension: [V.optional(phoneExtension)],
 };


### PR DESCRIPTION
# Purpose

Improve validator composition by eliminating the need for spread operators when using validators with V.optional() and other combinators.

# Major Changes

* Added V.useValidators() helper function to combine multiple validators into single validator functions
* Refactored trustee validators (trusteeName, email, zipCode, etc.) from arrays to single functions
* Updated all usage sites to wrap validators in arrays for ValidationSpec compatibility

# Testing/Validation

All existing unit tests pass (68 tests in common workspace). Manual validation test confirms:
- Validators work correctly as single functions
- V.optional(validator) works without spread operator
- ValidationSpec works with array-wrapped validators
- TypeScript compilation succeeds

# Notes

The solution wraps multiple validators into a single function using validateEach internally. This is similar to what V.optional() and V.nullable() do, but for combining validators with AND logic instead of conditional logic.

Key insight: ValidationSpec requires arrays, but individual validators are now functions. This means usage sites need to wrap validators in arrays (e.g., `name: [trusteeName]`), but composition no longer requires spreading (e.g., `V.optional(email)` instead of `V.optional(...email)`).

Files changed:
- common/src/cams/validators.ts - Added V.useValidators() helper
- common/src/cams/trustees-validators.ts - Refactored validators to single functions
- backend/lib/use-cases/trustees/trustees.ts - Updated usage sites
- user-interface/src/trustees/forms/trusteeForms.types.ts - Updated usage sites

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application