### PR TITLE
Group Bicep resource updates into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,11 +54,6 @@
       "enabled": false
     },
     {
-      "description": "Disable minimumReleaseAge for Bicep resources - datasource lacks timestamp data",
-      "matchManagers": ["bicep"],
-      "minimumReleaseAge": "0 days"
-    },
-    {
       "description": "First-party GitHub Actions with digest pinning and 14-day wait",
       "matchManagers": ["github-actions"],
       "pinDigests": true,
@@ -91,6 +86,13 @@
       "description": "Create separate PRs for each major update",
       "matchUpdateTypes": ["major"],
       "groupName": null
+    },
+    {
+      "description": "Group all Bicep resource definition updates into a single PR",
+      "matchManagers": ["bicep"],
+      "groupName": "bicep resource definitions",
+      "groupSlug": "bicep-resources",
+      "minimumReleaseAge": "0 days"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
# Purpose

Separate Renovate PR's for Bicep resource definitions are very noisy.

# Major Changes

Set up a group rule.

# Testing/Validation

Config was validated. We'll have to see it work to know for sure.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Build:
- Adjust Renovate configuration to define a group rule for Bicep resource update PRs.