### PR TITLE
CAMS-701 Fixed width of trustee assistant form state field

### DIFF
--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.scss
@@ -3,7 +3,6 @@
     .form-column {
       .field-group {
         .usa-form-group.assistant-state-input {
-          max-width: 186px;
           width: 100%;
         }
 


### PR DESCRIPTION
Jira ticket: CAMS-701


# Purpose

Width of state field is too small and content wraps

# Major Changes

Removed max-width in scss

# Testing/Validation

N/A

## Summary by Sourcery

Bug Fixes:
- Prevent the trustee assistant state field content from wrapping by allowing the field to use full available width.