### PR TITLE
CAMS-702 Standardized "no information added" messaging on the Trustee Detail Profile screen

### DIFF
--- a/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
@@ -299,7 +299,7 @@ describe('TrusteeDetailScreen', () => {
     expect(screen.getByTestId('zoom-info-card')).toBeInTheDocument();
     expect(screen.getByTestId('zoom-info-heading')).toBeInTheDocument();
     expect(screen.getByTestId('zoom-info-empty-message')).toHaveTextContent(
-      'No information has been entered.',
+      'No information added.',
     );
   });
 

--- a/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.test.tsx
+++ b/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.test.tsx
@@ -29,11 +29,11 @@ describe('MeetingOfCreditorsInfoCard', () => {
     expect(screen.getByTestId('zoom-info-heading')).toHaveTextContent('341 Meeting');
   });
 
-  test('should render "No information has been entered" when zoomInfo is undefined', () => {
+  test('should render "No information added" when zoomInfo is undefined', () => {
     render(<MeetingOfCreditorsInfoCard zoomInfo={undefined} onEdit={mockOnEdit} />);
 
     expect(screen.getByTestId('zoom-info-empty-message')).toHaveTextContent(
-      'No information has been entered.',
+      'No information added.',
     );
   });
 

--- a/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.tsx
+++ b/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.tsx
@@ -35,9 +35,7 @@ export default function MeetingOfCreditorsInfoCard({
           </Button>
         </h3>
       </div>
-      {!zoomInfo && (
-        <div data-testid="zoom-info-empty-message">No information has been entered.</div>
-      )}
+      {!zoomInfo && <div data-testid="zoom-info-empty-message">No information added.</div>}
       {zoomInfo && (
         <div data-testid="zoom-info-content">
           <div className="zoom-link">

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.test.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.test.tsx
@@ -315,7 +315,7 @@ describe('TrusteeDetailProfile', () => {
     expect(screen.getByTestId('trustee-bank-0')).toHaveTextContent('Bank: Single Trust Bank');
   });
 
-  test('should render "No information has been entered" when banks array is undefined', () => {
+  test('should render "No information added" when banks array is undefined', () => {
     const trusteeWithoutBanks = {
       ...mockTrustee,
       banks: undefined,
@@ -323,13 +323,11 @@ describe('TrusteeDetailProfile', () => {
 
     renderWithProps({ trustee: trusteeWithoutBanks });
 
-    expect(screen.getByTestId('no-other-information')).toHaveTextContent(
-      'No information has been entered.',
-    );
+    expect(screen.getByTestId('no-other-information')).toHaveTextContent('No information added.');
     expect(screen.queryByTestId('trustee-bank-0')).not.toBeInTheDocument();
   });
 
-  test('should render "No information has been entered" when banks array is empty', () => {
+  test('should render "No information added" when banks array is empty', () => {
     const trusteeWithEmptyBanks = {
       ...mockTrustee,
       banks: [],
@@ -337,9 +335,7 @@ describe('TrusteeDetailProfile', () => {
 
     renderWithProps({ trustee: trusteeWithEmptyBanks });
 
-    expect(screen.getByTestId('no-other-information')).toHaveTextContent(
-      'No information has been entered.',
-    );
+    expect(screen.getByTestId('no-other-information')).toHaveTextContent('No information added.');
     expect(screen.queryByTestId('trustee-bank-0')).not.toBeInTheDocument();
   });
 

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.tsx
@@ -75,7 +75,7 @@ export default function TrusteeDetailProfile({
               </div>
             )}
             {!trustee.software && (!trustee.banks || trustee.banks.length === 0) && (
-              <div data-testid="no-other-information">No information has been entered.</div>
+              <div data-testid="no-other-information">No information added.</div>
             )}
           </div>
         </div>


### PR DESCRIPTION
Jira ticket: CAMS-702


# Purpose

Messaging for no information added on the trustee detail profile screen was inconsistent between the various sections.

# Major Changes

Changed all "no info" messages to "No information added."

# Testing/Validation

updated

## Summary by Sourcery

Standardize the empty-state messaging on trustee-related UI panels.

Enhancements:
- Update trustee profile and meeting of creditors panels to use the unified "No information added." empty-state message across banks and Zoom info sections.

Tests:
- Adjust trustee detail profile, meeting of creditors info card, and trustee detail screen tests to assert the new standardized empty-state message.