### PR TITLE
CAMS-703: Display Zoom phone number

### DIFF
--- a/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.tsx
+++ b/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.tsx
@@ -55,11 +55,10 @@ export default function MeetingOfCreditorsInfoCard({
             <a
               href={`tel:${zoomInfo.phone}`}
               className="usa-link comms-link"
-              aria-label={`Phone: ${zoomInfo.phone}`}
+              aria-label={`Phone: ${formatPhoneNumber(zoomInfo.phone)}`}
             >
               <IconLabel icon="phone" label={formatPhoneNumber(zoomInfo.phone)} location="left" />
             </a>
-            <span className="usa-sr-only">{`: ${zoomInfo.phone}`}</span>
           </div>
           <div className="zoom-meeting-id" data-testid="zoom-meeting-id">
             Meeting ID: {formatMeetingId(zoomInfo.meetingId)}


### PR DESCRIPTION
Co-authored-by: Kelly D <41132296+diabagatekelly@users.noreply.github.com>

# Purpose

Display zoom meeting phone number instead of the word 'phone'.

# Major Changes

Update Icon label to display the properly formatted phone number

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

New Features:
- Show a formatted Zoom phone number as the label for the phone contact link on the Meeting of Creditors info card.