### PR TITLE
CAMS-706: Add search timeout alert and remove warning threshold

### DIFF
--- a/backend/lib/common-errors/gateway-timeout.ts
+++ b/backend/lib/common-errors/gateway-timeout.ts
@@ -1,0 +1,15 @@
+import { CamsError, CamsErrorOptions } from './cams-error';
+import HttpStatusCodes from '@common/api/http-status-codes';
+
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+interface GatewayTimeoutErrorOptions extends CamsErrorOptions {}
+
+export class GatewayTimeoutError extends CamsError {
+  constructor(module: string, options: GatewayTimeoutErrorOptions = {}) {
+    super(module, {
+      status: HttpStatusCodes.GATEWAY_TIMEOUT,
+      ...options,
+      message: options.message ?? 'Gateway Timeout',
+    });
+  }
+}

--- a/backend/lib/use-cases/cases/case-management.test.ts
+++ b/backend/lib/use-cases/cases/case-management.test.ts
@@ -479,6 +479,20 @@ describe('Case management tests', () => {
       );
     });
 
+    test('should pass through GatewayTimeoutError from repository', async () => {
+      const { GatewayTimeoutError } = await import('../../common-errors/gateway-timeout');
+      const error = new GatewayTimeoutError('CASES-MONGO-REPOSITORY', {
+        message: 'Query failed. Search request timed out.',
+      });
+      vi.spyOn(useCase.casesRepository, 'searchCases').mockRejectedValue(error);
+      await expect(useCase.searchCases(applicationContext, { caseNumber }, false)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Query failed. Search request timed out.',
+          status: 504,
+        }),
+      );
+    });
+
     test('should throw CamsError', async () => {
       const error = new CamsError('TEST', { message: 'test error' });
       vi.spyOn(useCase.casesRepository, 'searchCases').mockRejectedValue(error);

--- a/common/src/api/http-status-codes.ts
+++ b/common/src/api/http-status-codes.ts
@@ -8,6 +8,7 @@ const HttpStatusCodes = {
   FORBIDDEN: 403,
   NOT_FOUND: 404,
   INTERNAL_SERVER_ERROR: 500,
+  GATEWAY_TIMEOUT: 504,
 } as const;
 
 export default HttpStatusCodes;


### PR DESCRIPTION
# Purpose

We want the user to have a better experience when their broad search times out.

# Major Changes

- Return a 504 from the API when cosmos times out.
- Display a different message when the search times out.
- Remove the now-misleading SEARCH_RESULTS_WARNING_THRESHOLD message.

# Testing/Validation

Updated automated testing. We cannot trigger time outs from cosmos in our environment so we will have to see it in staging.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Handle backend search timeouts as explicit 504 errors and surface a tailored timeout message in the UI while removing the old search results warning threshold behavior.

New Features:
- Introduce a GatewayTimeoutError domain error mapped to HTTP 504 and propagate it from Mongo adapters through case search use cases.
- Distinguish search timeout failures in the UI and display a specific alert message guiding users to narrow their filters when a timeout occurs.

Bug Fixes:
- Ensure HTTP errors from the API layer carry status codes via a CamsHttpError type so the UI can react appropriately to 504 timeouts instead of treating all failures as generic errors.

Enhancements:
- Remove the search results warning threshold limit banner and always show the exact total count of results without a 10k+ cap.

Tests:
- Add unit tests to verify Mongo adapter timeout handling, propagation of GatewayTimeoutError through case management, and UI behavior for both generic and timeout-specific search errors.