### PR TITLE
CAMS-696 Fix link wrapping in trustee cards

### DIFF
--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.scss
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.scss
@@ -1,4 +1,7 @@
 .comms-link {
+  // Allow long URLs/emails to wrap even without natural break points
+  overflow-wrap: anywhere;
+
   span.cams-icon-label {
     text-decoration: inherit;
   }

--- a/user-interface/src/trustees/panels/TrusteeAssistantCard.tsx
+++ b/user-interface/src/trustees/panels/TrusteeAssistantCard.tsx
@@ -18,6 +18,7 @@ export default function TrusteeAssistantCard({
   onAdd,
 }: Readonly<TrusteeAssistantCardProps>) {
   const isEmpty = !assistant;
+  const isNameOnly = assistant && !assistant.title && !assistant.contact;
   const buttonId = isEmpty ? 'edit-assistant-empty' : `edit-assistant-${index}`;
   const handleClick = isEmpty ? onAdd : onEdit;
   const buttonLabel = isEmpty ? 'Add assistant' : `Edit assistant ${assistant?.name ?? ''}`;
@@ -42,7 +43,12 @@ export default function TrusteeAssistantCard({
               </Button>
             </div>
             {isEmpty && <div data-testid="no-assistant-information">No information added.</div>}
-            {!isEmpty && (
+            {!isEmpty && isNameOnly && (
+              <div data-testid={`assistant-name-only-${index}`}>
+                No additional information added.
+              </div>
+            )}
+            {!isEmpty && !isNameOnly && (
               <>
                 {assistant.title && (
                   <div className="assistant-title" data-testid={`assistant-title-${index}`}>

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.scss
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.scss
@@ -23,17 +23,9 @@
       }
 
       #add-another-assistant-button {
-        color: #005ea2;
-        text-decoration: none;
-        font-weight: normal;
         display: flex;
         align-items: center;
         gap: 0;
-
-        &:hover {
-          color: #1a4480;
-          text-decoration: underline;
-        }
 
         .add-icon {
           width: 1.5rem;


### PR DESCRIPTION
# Bug

Long URLs, email addresses, and other links without natural line breaks (hyphens, spaces, etc.) were overflowing the boundaries of trustee cards instead of wrapping to the next line. This made the cards look broken and caused content to be cut off or extend beyond the card's fixed width.

# Purpose

Ensure all links in trustee cards wrap properly within card boundaries, regardless of the length or character composition of the URL or email address.

# Major Changes

- Added `overflow-wrap: anywhere` CSS property to the `.comms-link` class to allow long URLs/emails to wrap at any character when necessary
- Added name-only state handling to TrusteeAssistantCard to show appropriate message when only assistant name is provided
- Removed redundant custom styling from add-another-assistant button (now inherits from USWDS button styles)

# Testing/Validation

Manual testing recommended:
- [ ] Create or view trustee cards with very long URLs (e.g., `https://verylongdomainnamewithoutanyhyphensorbreaks.com/path`)
- [ ] Verify long email addresses wrap properly within cards
- [ ] Test on various screen sizes to ensure wrapping works at all card widths
- [ ] Verify assistant cards display "No additional information added" when only name field is populated
- [ ] Confirm add-another-assistant button styling appears consistent with other USWDS buttons

# Notes

The `overflow-wrap: anywhere` CSS property allows the browser to break long strings at any character position to prevent overflow. This is applied to the CommsLink component, which renders all phone, email, and website links across trustee cards (ContactInformationCard, TrusteeAssistantCard, etc.), so the fix applies universally to all cards displaying contact information.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve trustee assistant cards and link rendering to handle long contact details and clarify assistant information states.

New Features:
- Display a name-only state message for trustee assistant cards when only the assistant name is provided.

Bug Fixes:
- Ensure long URLs and email addresses in communication links wrap within trustee cards instead of overflowing.

Enhancements:
- Align the add-another-assistant button styling with standard USWDS button styles by removing redundant custom CSS.