### PR TITLE
CAMS-705: WIP: Use dynamic workspace name matching deployed branch

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -64,6 +64,43 @@ jobs:
             --parameters 'databaseResourceGroupName=${{ secrets.AZURE_RG }} networkResourceGroupName=${{ steps.rgNetwork.outputs.out }} webappResourceGroupName=${{ steps.rgApp.outputs.out }} analyticsResourceGroupName=${{ secrets.AZ_ANALYTICS_RG }} azSubscription=${{ secrets.AZURE_SUBSCRIPTION }} branchName=${{ github.ref_name }} branchHashId=${{ inputs.environmentHash }} isBranchDeployment=${{ inputs.deployBranch }}' \
             -l ${{ secrets.AZ_LOCATION }}
 
+      - name: Get or create Log Analytics workspace for branch
+        id: analyticsWorkspace
+        if: inputs.deployBicep == 'true'
+        run: |
+          if [[ "${{ inputs.deployBranch }}" == "true" ]]; then
+            # Branch deployment - use branch-specific workspace
+            WORKSPACE_NAME="law-${{ inputs.stackName }}"
+            echo "Branch deployment - using workspace: ${WORKSPACE_NAME}"
+
+            # Check if workspace exists
+            WORKSPACE_ID=$(az monitor log-analytics workspace show \
+              -g ${{ secrets.AZ_ANALYTICS_RG }} \
+              -n "${WORKSPACE_NAME}" \
+              --query "id" -o tsv 2>/dev/null || echo "")
+
+            if [[ -z "${WORKSPACE_ID}" ]]; then
+              # Create the workspace if it doesn't exist
+              echo "Creating Log Analytics workspace: ${WORKSPACE_NAME}"
+              az deployment group create \
+                -g ${{ secrets.AZ_ANALYTICS_RG }} \
+                -f ./ops/cloud-deployment/lib/analytics/log-analytics-workspace.bicep \
+                -p workspaceName="${WORKSPACE_NAME}" \
+                   location=${{ secrets.AZ_LOCATION }} \
+                   tags='{"isBranchDeployment":"true","branchHashId":"${{ inputs.environmentHash }}"}'
+
+              WORKSPACE_ID=$(az monitor log-analytics workspace show \
+                -g ${{ secrets.AZ_ANALYTICS_RG }} \
+                -n "${WORKSPACE_NAME}" \
+                --query "id" -o tsv)
+            fi
+            echo "analyticsWorkspaceId=${WORKSPACE_ID}" >> $GITHUB_OUTPUT
+          else
+            # Main deployment - use shared workspace from secret
+            echo "Main deployment - using shared workspace"
+            echo "analyticsWorkspaceId=${{ secrets.AZ_ANALYTICS_WORKSPACE_ID }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Deploy Azure resources
         id: azure-deploy
         if: inputs.deployBicep == 'true'
@@ -85,7 +122,7 @@ jobs:
             --ustpIssueCollectorHash ${{ secrets.USTP_ISSUE_COLLECTOR_HASH }} \
             --createAlerts ${{ inputs.ghaEnvironment == 'Main-Gov' }} \
             --deployAppInsights true \
-            --analyticsWorkspaceId ${{ secrets.AZ_ANALYTICS_WORKSPACE_ID }} \
+            --analyticsWorkspaceId ${{ steps.analyticsWorkspace.outputs.analyticsWorkspaceId }} \
             --webappPlanType ${{ vars.AZ_PLAN_TYPE }} \
             --loginProvider ${{ vars.CAMS_LOGIN_PROVIDER }} \
             --loginProviderConfig '${{ vars.CAMS_LOGIN_PROVIDER_CONFIG }}' \


### PR DESCRIPTION
# Problem

Branch deployments were not receiving Application Insights telemetry in their workbooks. Investigation revealed a workspace mismatch: App Insights resources were being linked to the shared law-cams-branches workspace (via the hardcoded AZ_ANALYTICS_WORKSPACE_ID secret), while branch-specific workbooks query their own workspace (e.g.,                 law-ustp-cams-dev-f64e59).                                                                                                                                                       
                                                                                                                                                                                   
This caused:                                                                                                                                                                     
  - Zero telemetry visible in branch deployment workbooks                                                                                                                          
  - All branch telemetry silently flowing to the shared workspace instead  

# Solution

Modified .github/workflows/reusable-deploy.yml to dynamically determine the correct Log Analytics workspace based on deployment type:                                            
                                                                                                                                                                                   
  - Branch deployments (deployBranch == 'true'): Look up or create a branch-specific workspace named law-{stackName} (e.g., law-ustp-cams-dev-f64e59)                              
  - Main deployments: Continue using the shared workspace from AZ_ANALYTICS_WORKSPACE_ID secret                                                                                    
                                                                                                                                                                                   
  Added a new workflow step "Get or create Log Analytics workspace for branch" that:                                                                                               
  1. Checks if a branch-specific workspace exists                                                                                                                                  
  2. Creates it using the existing log-analytics-workspace.bicep template if not                                                                                                   
  3. Outputs the workspace ID for use by the Bicep deployment                                                                                                                      
                                                                                                                                                                                   
  The --analyticsWorkspaceId parameter now uses the step output instead of the hardcoded secret.

# Testing/Validation

1. Deploy a new branch with deployBranch: true                                                                                                                                   
  2. Verify the Log Analytics workspace law-{stackName} is created in AZ_ANALYTICS_RG                                                                                              
  3. Verify App Insights resources (appi-{stackName}-webapp, appi-{stackName}-node-api, appi-{stackName}-dataflows) are linked to the branch workspace                             
  4. Navigate the deployed app and confirm telemetry appears in the branch-specific workbook                                                                                       
  5. Verify main branch deployments still use the shared workspace 

# Other Changes

- Existing branch deployments will need their App Insights resources manually re-linked to the correct workspace (via Azure Portal → App Insights → Properties → Change          
  workspace), or redeployed                                                                                                                                                        
  - The reusable-infrastructure-deploy.yml still uses the shared workspace for Cosmos diagnostics — this is intentional since Cosmos is shared infrastructure  

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Dynamically select the correct Log Analytics workspace for deployments so that branch environments use their own workspace while main deployments continue using the shared workspace.

Enhancements:
- Add a workflow step to discover or create a branch-specific Log Analytics workspace based on the stack name when deploying branch environments.
- Update the Bicep deployment to consume the workspace ID produced by the workflow step instead of a hardcoded shared workspace secret.