### PR TITLE
CAMS-647 - Revert invalid securestring type and remove unnecessary dependsOn

### DIFF
--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -102,10 +102,10 @@ param maxObjectKeyCount string
 param gitSha string
 
 @secure()
-param dataflowsStorageConnectionString securestring
+param dataflowsStorageConnectionString string
 
 @secure()
-param dataflowsSlotStorageConnectionString securestring
+param dataflowsSlotStorageConnectionString string
 
 var createApplicationInsights = deployAppInsights && !empty(analyticsWorkspaceId)
 

--- a/ops/cloud-deployment/dataflows-resource-deploy.bicep
+++ b/ops/cloud-deployment/dataflows-resource-deploy.bicep
@@ -597,5 +597,5 @@ module dataflowWorkbooks 'lib/workbooks/dataflow-workbooks.bicep' = if (createAp
   }
 }
 
-output dataflowsStorageConnectionString securestring = 'DefaultEndpointsProtocol=https;AccountName=${dataflowsFunctionStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${dataflowsFunctionStorageAccount.listKeys().keys[0].value}'
-output dataflowsSlotStorageConnectionString securestring = 'DefaultEndpointsProtocol=https;AccountName=${dataflowsFunctionSlotStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${dataflowsFunctionSlotStorageAccount.listKeys().keys[0].value}'
+output dataflowsStorageConnectionString string = 'DefaultEndpointsProtocol=https;AccountName=${dataflowsFunctionStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${dataflowsFunctionStorageAccount.listKeys().keys[0].value}'
+output dataflowsSlotStorageConnectionString string = 'DefaultEndpointsProtocol=https;AccountName=${dataflowsFunctionSlotStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${dataflowsFunctionSlotStorageAccount.listKeys().keys[0].value}'

--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -228,9 +228,6 @@ module ustpApiFunction 'backend-api-deploy.bicep' = {
       dataflowsStorageConnectionString: ustpDataflowsFunction.outputs.dataflowsStorageConnectionString
       dataflowsSlotStorageConnectionString: ustpDataflowsFunction.outputs.dataflowsSlotStorageConnectionString
     }
-    dependsOn: [
-      ustpDataflowsFunction
-    ]
 }
 
 module ustpDataflowsFunction 'dataflows-resource-deploy.bicep' = {


### PR DESCRIPTION
# Purpose

Fix broken CI pipeline due to buggy bicep scripts

# Major Changes

  Changes:
  - Reverted outputs to string type in dataflows-resource-deploy.bicep
  - Reverted parameters to string type (kept @secure() decorator) in backend-api-deploy.bicep
  - Removed explicit dependsOn from main.bicep (implicit dependency exists via outputs reference)

## Summary by Sourcery

Fix CI deployment failures by correcting Bicep parameter/output types and simplifying module dependencies.

Bug Fixes:
- Align dataflows storage connection string parameters and outputs to use plain string types compatible with the current deployment tooling while retaining security attributes where needed.
- Remove a redundant explicit module dependency in the main Bicep template that is already satisfied via output references.