### PR TITLE
CAMS-595: Update Playwirght selectors

### DIFF
--- a/test/e2e/playwright/case-notes.spec.ts
+++ b/test/e2e/playwright/case-notes.spec.ts
@@ -12,7 +12,7 @@ test.describe('Case Notes', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`/case-detail/${DataGenerationUtils.KNOWN_GOOD_TRANSFER_TO_CASE_ID}/notes`);
 
-    addCaseNoteButton = page.getByTestId('open-modal-button_case-note-add-button');
+    addCaseNoteButton = page.getByTestId('open-modal-button_note-add-button');
     await expect(addCaseNoteButton).toBeVisible();
     noteNotesAlert = page.getByTestId('alert-message');
     await expect(noteNotesAlert).toBeVisible();
@@ -32,59 +32,53 @@ test.describe('Case Notes', () => {
     let caseNoteHeader;
 
     //Open Add Note modal to create a new note and submit
-    await page.locator('[data-testid="open-modal-button_case-note-add-button"]').click();
-    await expect(page.locator('[data-testid="modal-content-case-note-modal"]')).toBeVisible();
+    await page.locator('[data-testid="open-modal-button_note-add-button"]').click();
+    await expect(page.locator('[data-testid="modal-content-note-modal"]')).toBeVisible();
 
-    await page.locator('[data-testid="case-note-title-input"]').fill(testNoteTitle);
+    await page.locator('[data-testid="note-title-input"]').fill(testNoteTitle);
     await page.locator('[data-testid="editor-content"] > div').fill(testNoteContent);
-    await expect(
-      page.locator('[data-testid="button-case-note-modal-submit-button"]'),
-    ).toBeVisible();
-    await page.locator('[data-testid="button-case-note-modal-submit-button"]').click();
-    await expect(page.locator('[data-testid="modal-content-case-note-modal"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="button-note-modal-submit-button"]')).toBeVisible();
+    await page.locator('[data-testid="button-note-modal-submit-button"]').click();
+    await expect(page.locator('[data-testid="modal-content-note-modal"]')).not.toBeVisible();
 
     //Ensure Newly created Note is there
-    caseNoteHeader = page.getByTestId('case-note-0-header');
+    caseNoteHeader = page.getByTestId('note-item-0-header');
     await expect(caseNoteHeader).toBeVisible();
     await expect(caseNoteHeader).toHaveText(testNoteTitle);
 
     //Edit newly created Case Note and ensure previous values are populated on first load
     await expect(
-      page.locator('[data-testid="open-modal-button_case-note-edit-button_0"]'),
+      page.locator('[data-testid="open-modal-button_note-item-edit-button_0"]'),
     ).toBeVisible();
-    await page.locator('[data-testid="open-modal-button_case-note-edit-button_0"]').click();
+    await page.locator('[data-testid="open-modal-button_note-item-edit-button_0"]').click();
 
-    await expect(page.locator('[data-testid="case-note-title-input"]')).toBeVisible();
+    await expect(page.locator('[data-testid="note-title-input"]')).toBeVisible();
     await expect(page.locator('[data-testid="editor-content"] > div')).toBeVisible();
 
-    await page.locator('[data-testid="case-note-title-input"]').clear();
-    await page.locator('[data-testid="case-note-title-input"]').fill(noteTitleEdit);
+    await page.locator('[data-testid="note-title-input"]').clear();
+    await page.locator('[data-testid="note-title-input"]').fill(noteTitleEdit);
     await page.locator('[data-testid="editor-content"] > div').clear();
     await page.locator('[data-testid="editor-content"] > div').fill(noteContentEdit);
 
-    await expect(
-      page.locator('[data-testid="button-case-note-modal-submit-button"]'),
-    ).toBeEnabled();
-    await page.locator('[data-testid="button-case-note-modal-submit-button"]').click();
-    await expect(
-      page.locator('[data-testid="button-case-note-modal-submit-button"]'),
-    ).toBeDisabled();
-    await expect(page.locator('[data-testid="modal-content-case-note-modal"]')).not.toBeVisible();
-    caseNoteHeader = page.getByTestId('case-note-0-header');
+    await expect(page.locator('[data-testid="button-note-modal-submit-button"]')).toBeEnabled();
+    await page.locator('[data-testid="button-note-modal-submit-button"]').click();
+    await expect(page.locator('[data-testid="button-note-modal-submit-button"]')).toBeDisabled();
+    await expect(page.locator('[data-testid="modal-content-note-modal"]')).not.toBeVisible();
+    caseNoteHeader = page.getByTestId('note-item-0-header');
     await expect(caseNoteHeader).toBeVisible();
     await expect(caseNoteHeader).toHaveText(noteTitleEdit);
 
     //Remove Newly created note edit
     await expect(
-      page.locator('[data-testid="open-modal-button_case-note-remove-button_0"]'),
+      page.locator('[data-testid="open-modal-button_note-item-remove-button_0"]'),
     ).toBeVisible();
-    await page.locator('[data-testid="open-modal-button_case-note-remove-button_0"]').click();
+    await page.locator('[data-testid="open-modal-button_note-item-remove-button_0"]').click();
     await expect(
-      page.locator('[data-testid="button-remove-note-modal-submit-button"]'),
+      page.locator('[data-testid="button-note-remove-modal-submit-button"]'),
     ).toBeVisible();
-    await page.locator('[data-testid="button-remove-note-modal-submit-button"]').click();
+    await page.locator('[data-testid="button-note-remove-modal-submit-button"]').click();
 
-    await expect(page.locator('[data-testid="searchable-case-notes"]')).not.toBeVisible();
-    await expect(page.locator('[data-testid="empty-notes-test-id"]')).toBeVisible();
+    await expect(page.locator('[data-testid="searchable-notes"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="empty-notes"]')).toBeVisible();
   });
 });


### PR DESCRIPTION
Update Playwright test selectors for case notes now that its using the

shared component;

Jira ticket: CAMS-595

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Tests:
- Adjust Playwright selectors for creating, editing, and deleting case notes to use the updated shared notes component test IDs.