### PR TITLE
CAMS-595: Fix styling of lists in Notes content

### DIFF
--- a/user-interface/src/lib/components/cams/Notes/Notes.scss
+++ b/user-interface/src/lib/components/cams/Notes/Notes.scss
@@ -106,6 +106,28 @@
       .note-item-content {
         margin-top: 1.25rem;
         margin-bottom: 1.5rem;
+
+        // The note content renders inside an <ol> (the notes list), so the browser
+        // offsets list nesting by one level: content level 1 renders as level 2
+        // (circle), level 2 as level 3 (square), etc. Re-anchor all three levels
+        // back to their expected styles using the top-level list as the root.
+        :not(li) > ul {
+          list-style-type: disc;
+          padding-left: 1.5rem;
+        }
+
+        :not(li) > ul ul {
+          list-style-type: circle;
+        }
+
+        :not(li) > ul ul ul {
+          list-style-type: square;
+        }
+
+        :not(li) > ol {
+          list-style-type: decimal;
+          padding-left: 1.5rem;
+        }
       }
 
       .note-item-content:has(+ .usa-alert-container) {


### PR DESCRIPTION
# Purpose

Since displaying notes we are using a list, any nested lists in the content of the Note is considering the first item of the list as the second (and for the rest). We update the styling in the content to assure Lists are displaying the correct styling.

Before: 
<img width="1018" height="938" alt="image" src="https://github.com/user-attachments/assets/aacf77f2-727e-4dd3-9ce2-5e0d57f60798" />

After:
<img width="462" height="400" alt="image" src="https://github.com/user-attachments/assets/6012f946-9f06-403d-960e-d4e41c792dc3" />


# Major Changes

Update styling to force correct bullet icon.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Bug Fixes:
- Correct nested unordered and ordered list markers in Notes content so list levels display with the expected disc, circle, square, and decimal styles.