### PR TITLE
CAMS-595 Use divs with list roles to imporove content style

### DIFF
--- a/user-interface/src/lib/components/cams/NoteItem/NoteItem.tsx
+++ b/user-interface/src/lib/components/cams/NoteItem/NoteItem.tsx
@@ -55,7 +55,7 @@ export function NoteItem({
   getDraftAlertMessage,
 }: NoteItemProps) {
   return (
-    <li className={`note-item grid-container`} data-testid={`note-item-${index}`}>
+    <div role="listitem" className={`note-item grid-container`} data-testid={`note-item-${index}`}>
       <div className="grid-row">
         <div className="grid-col-10">
           <div className="text-wrapper">
@@ -138,6 +138,6 @@ export function NoteItem({
           className="note-item-draft-alert"
         />
       )}
-    </li>
+    </div>
   );
 }

--- a/user-interface/src/lib/components/cams/Notes/Notes.scss
+++ b/user-interface/src/lib/components/cams/Notes/Notes.scss
@@ -106,28 +106,6 @@
       .note-item-content {
         margin-top: 1.25rem;
         margin-bottom: 1.5rem;
-
-        // The note content renders inside an <ol> (the notes list), so the browser
-        // offsets list nesting by one level: content level 1 renders as level 2
-        // (circle), level 2 as level 3 (square), etc. Re-anchor all three levels
-        // back to their expected styles using the top-level list as the root.
-        :not(li) > ul {
-          list-style-type: disc;
-          padding-left: 1.5rem;
-        }
-
-        :not(li) > ul ul {
-          list-style-type: circle;
-        }
-
-        :not(li) > ul ul ul {
-          list-style-type: square;
-        }
-
-        :not(li) > ol {
-          list-style-type: decimal;
-          padding-left: 1.5rem;
-        }
       }
 
       .note-item-content:has(+ .usa-alert-container) {

--- a/user-interface/src/lib/components/cams/Notes/Notes.tsx
+++ b/user-interface/src/lib/components/cams/Notes/Notes.tsx
@@ -343,9 +343,14 @@ function Notes_(props: NotesProps, ref: React.Ref<NotesRef>) {
               </div>
             )}
             {notes && notes.length > 0 && (
-              <ol className="search-notes" id="searchable-notes" data-testid="searchable-notes">
+              <div
+                role="list"
+                className="search-notes"
+                id="searchable-notes"
+                data-testid="searchable-notes"
+              >
                 {renderNotes()}
-              </ol>
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION

# Purpose

Previous styling fix was a hack and didn't fully solve the issue.

# Major Changes

Implement a better fix that properly handles the look and feel of lists within the notes.  This fix should also be handled properly by screen readers.

We changed the \<ol>\<li> of the entire notes list so that it wouldn't affect the level for the list items inside of each note.  Instead of puting the entire notes list in an \<ol>\<li>, we instead put the notes list inside of \<div role="list">\<div role="listitem">

As a result, the notes list is still semantically a list, it looks like a list of notes, the screen reader reads it as a list of notes, it smells like a list, feels like a list, it _is_ a list.  !BUT! the \<ul>\<li> WithIn the individual notes, now acts like it's not inside of another list.  This is good.  We don't want the lists inside of the note to think it's inside of another list.

All this talk about lists might be dizzying and confusing.  It's confusing to even talk about.

I'm exhausted now.



# Testing/Validation

Lists are passing.


# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
