### PR TITLE
Remove unnecessary type exports (knip)

### DIFF
--- a/backend/lib/adapters/gateways/ats/cleansing/ats-tsv-test-utils.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-tsv-test-utils.ts
@@ -14,11 +14,11 @@ import { TrusteeOverride, CleansingResult } from './ats-cleansing-types';
 import { ApplicationContext } from '../../../types/basic';
 
 // Test-only type that includes DIVISION from TSV export (not used in production)
-export type TsvAtsAppointmentRecord = AtsAppointmentRecord & {
+type TsvAtsAppointmentRecord = AtsAppointmentRecord & {
   DIVISION?: string;
 };
 
-export type TsvRow = {
+type TsvRow = {
   trusteeid: string;
   status: string;
   district: string;

--- a/backend/lib/adapters/services/observability.ts
+++ b/backend/lib/adapters/services/observability.ts
@@ -27,7 +27,7 @@ export function scrubErrorForTelemetry(error: string): string {
  * @param logger - Optional logger for diagnostics
  * @returns TelemetryClient instance or null if initialization fails
  */
-export function getOrInitializeAppInsightsClient(logger?: LoggerImpl): TelemetryClient | null {
+function getOrInitializeAppInsightsClient(logger?: LoggerImpl): TelemetryClient | null {
   const MODULE_NAME = 'APP-INSIGHTS-OBSERVABILITY';
 
   try {


### PR DESCRIPTION
# Purpose

Address knip errors by removing unnecessary type exports

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove unnecessary exported types and functions that are only used internally or in tests.

Enhancements:
- Restrict test-only helper types in ATS TSV cleansing utilities to internal module scope.
- Limit the Application Insights initialization helper in the observability service to internal usage instead of exporting it.