### PR TITLE
CAMS-717 Fix stale filter interactions in data verification e2e tests

### DIFF
--- a/test/e2e/playwright/consolidation-orders.spec.ts
+++ b/test/e2e/playwright/consolidation-orders.spec.ts
@@ -22,6 +22,12 @@ test.describe('Consolidation Orders', () => {
       timeout: 30000,
     });
     await expect(page.getByTestId('header-data-verification-link')).toBeVisible();
+
+    // Select pending status filter to make orders visible in the accordion
+    await page.locator('#task-status-filter .input-container').click();
+    await page.locator('[id="option-pending"]').click();
+    await page.keyboard.press('Escape');
+
     await expect(page.getByTestId('accordion-group')).toBeVisible();
 
     await officesRequestPromise;
@@ -45,7 +51,6 @@ test.describe('Consolidation Orders', () => {
     ) as ConsolidationOrder;
 
     expect(pendingConsolidationOrder).not.toBeFalsy();
-    await page.getByTestId('order-status-filter-transfer').click();
     await page.getByTestId(`accordion-button-order-list-${pendingConsolidationOrder.id}`).click();
 
     // select substantive consolidation type
@@ -104,18 +109,6 @@ test.describe('Consolidation Orders', () => {
     ) as ConsolidationOrder;
 
     expect(pendingConsolidationOrder).not.toBeFalsy();
-
-    // Action update filter
-    await page.getByTestId('order-status-filter-transfer').click();
-
-    // Assert state of all filters
-    await expect(page.getByTestId('order-status-filter-pending').locator('svg')).toBeVisible();
-    await expect(page.getByTestId('order-status-filter-approved').locator('svg')).not.toBeVisible();
-    await expect(page.getByTestId('order-status-filter-rejected').locator('svg')).not.toBeVisible();
-    await expect(page.getByTestId('order-status-filter-transfer').locator('svg')).not.toBeVisible();
-    await expect(
-      page.getByTestId('order-status-filter-consolidation').locator('svg'),
-    ).toBeVisible();
 
     // Action open accordion
     await page.getByTestId(`accordion-button-order-list-${pendingConsolidationOrder.id}`).click();

--- a/test/e2e/playwright/transfer-orders.spec.ts
+++ b/test/e2e/playwright/transfer-orders.spec.ts
@@ -29,6 +29,12 @@ test.describe('Transfer Orders', () => {
       predicate: (e) => e.url().includes('api/courts'),
     });
     await expect(page.getByTestId('header-data-verification-link')).toBeVisible();
+
+    // Select pending status filter to make orders visible in the accordion
+    await page.locator('#task-status-filter .input-container').click();
+    await page.locator('[id="option-pending"]').click();
+    await page.keyboard.press('Escape');
+
     await expect(page.getByTestId('accordion-group')).toBeVisible();
 
     const orderResponse = await orderResponsePromise;
@@ -58,7 +64,7 @@ test.describe('Transfer Orders', () => {
     // Wait for the transfer orders.
     const request = await ordersRequestPromise;
     const response = await request.response();
-    const ordersResponse = (await response.json()).data;
+    const ordersResponse = (await response.json()).data as Order[];
     const pendingTransfers = ordersResponse.filter(
       (o) => o.orderType === 'transfer' && o.status === 'pending',
     );


### PR DESCRIPTION
# Bug

The data verification e2e tests (`consolidation-orders.spec.ts` and `transfer-orders.spec.ts`) were failing because the `accordion-group` element was not found in the DOM. The filter UI was redesigned from toggle buttons to ComboBox components, and the accordion group now only renders when at least one filter is selected. The tests also referenced stale test IDs (`order-status-filter-transfer`, `order-status-filter-pending`, etc.) that no longer exist.

# Purpose

Restore passing e2e tests for data verification by updating test interactions to match the current filter UI.

# Major Changes

- Added pending status filter selection in `beforeEach` for both consolidation and transfer order specs so the accordion group renders before assertions
- Removed stale toggle-button test ID references (`order-status-filter-*`)
- Removed stale filter state assertions that relied on the old UI
- Fixed implicit `any` type on filter callback in `transfer-orders.spec.ts`

# Testing/Validation

Tests updated to reflect the current UI. The pending status filter is selected via the ComboBox (`#task-status-filter`) using the same interaction pattern established in the accessibility test suite.

# Notes

The `noFiltersSelected` guard was introduced in a recent commit — when no filters are selected, all items are hidden and `visibleItemCount` stays 0, so `AccordionGroup` never renders. The fix selects the pending status filter in `beforeEach` to satisfy this condition before checking for the accordion.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Update data verification end-to-end tests to align with the redesigned filter UI so the accordion renders and tests pass again.

Bug Fixes:
- Ensure consolidation and transfer order e2e tests select a pending status filter so the accordion group renders before assertions.
- Remove stale filter test IDs and obsolete filter state assertions that referenced the old toggle-based UI.

Enhancements:
- Type the transfer order API response as an Order[] in the e2e test to avoid implicit any and improve type safety.

Tests:
- Adjust consolidation and transfer order e2e flows to interact with the task status ComboBox filter instead of removed toggle buttons.