### PR TITLE
CAMS-596: Fix Cosmos DB unique index constraint violation

### DIFF
--- a/backend/lib/adapters/gateways/mongo/trustee-professional-ids.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-professional-ids.mongo.repository.test.ts
@@ -84,8 +84,30 @@ describe('TrusteeProfessionalIdsMongoRepository', () => {
     const camsTrusteeId = 'trustee-123';
     const acmsProfessionalId = 'NY-00063';
 
+    test('should throw error when acmsProfessionalId already exists', async () => {
+      const existingMapping: TrusteeProfessionalIdDocument = {
+        ...sampleProfessionalId,
+        id: 'existing-prof-id',
+        camsTrusteeId: 'different-trustee-456',
+        acmsProfessionalId,
+      };
+
+      // Mock findByAcmsProfessionalId to return existing mapping
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([existingMapping]);
+
+      await expect(
+        repository.createProfessionalId(camsTrusteeId, acmsProfessionalId, mockUser),
+      ).rejects.toThrow(
+        `ACMS Professional ID ${acmsProfessionalId} already mapped to trustee ${existingMapping.camsTrusteeId}`,
+      );
+    });
+
     test('should create a new professional ID mapping successfully', async () => {
       const mockId = 'new-prof-id';
+
+      // Mock findByAcmsProfessionalId to return empty array (no duplicates)
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]);
+
       const mockAdapter = vi
         .spyOn(MongoCollectionAdapter.prototype, 'insertOne')
         .mockResolvedValue(mockId);
@@ -114,6 +136,10 @@ describe('TrusteeProfessionalIdsMongoRepository', () => {
 
     test('should handle database errors during creation', async () => {
       const error = new Error('Database connection failed');
+
+      // Mock findByAcmsProfessionalId to return empty array (no duplicates)
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]);
+
       const mockAdapter = vi
         .spyOn(MongoCollectionAdapter.prototype, 'insertOne')
         .mockRejectedValue(error);
@@ -353,10 +379,12 @@ describe('TrusteeProfessionalIdsMongoRepository', () => {
       const trusteeId = 'harvey-barr';
 
       // Create first ACMS ID mapping
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]); // No duplicates
       vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockResolvedValue('prof-id-1');
       const result1 = await repository.createProfessionalId(trusteeId, 'NY-00063', mockUser);
 
       // Create second ACMS ID mapping
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]); // No duplicates
       vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockResolvedValue('prof-id-2');
       const result2 = await repository.createProfessionalId(trusteeId, 'UT-05321', mockUser);
 
@@ -392,6 +420,7 @@ describe('TrusteeProfessionalIdsMongoRepository', () => {
 
       // Create mappings for each CAMS trustee ID
       for (let i = 0; i < trusteeIds.length; i++) {
+        vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]); // No duplicates
         vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockResolvedValue(
           `prof-id-${i + 1}`,
         );
@@ -421,6 +450,7 @@ describe('TrusteeProfessionalIdsMongoRepository', () => {
       const acmsId = 'NY-00063';
 
       // Create a mapping
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]); // No duplicates
       vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockResolvedValue('prof-id-1');
       await repository.createProfessionalId(trusteeId, acmsId, mockUser);
 

--- a/backend/lib/adapters/gateways/mongo/trustee-professional-ids.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-professional-ids.mongo.repository.ts
@@ -9,7 +9,7 @@ import { CamsUserReference } from '@common/cams/users';
 import { Creatable } from '@common/cams/creatable';
 
 const MODULE_NAME = 'TRUSTEE-PROFESSIONAL-IDS-MONGO-REPOSITORY';
-const COLLECTION_NAME = 'trustee-professionalids';
+const COLLECTION_NAME = 'trustee-professional-ids';
 
 const { using } = QueryBuilder;
 
@@ -57,6 +57,14 @@ export class TrusteeProfessionalIdsMongoRepository
     acmsProfessionalId: string,
     user: CamsUserReference,
   ): Promise<TrusteeProfessionalId> {
+    // Check for duplicates
+    const existing = await this.findByAcmsProfessionalId(acmsProfessionalId);
+    if (existing.length > 0) {
+      throw getCamsErrorWithStack(new Error('Duplicate'), MODULE_NAME, {
+        message: `ACMS Professional ID ${acmsProfessionalId} already mapped to trustee ${existing[0].camsTrusteeId}`,
+      });
+    }
+
     const document = createAuditRecord<Creatable<TrusteeProfessionalIdDocument>>(
       {
         documentType: 'TRUSTEE_PROFESSIONAL_ID',

--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
@@ -439,10 +439,10 @@ resource archivedCasesCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbD
 
 resource trusteeProfessionalIdsCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-11-15' = {
   parent: database
-  name: 'trustee-professionalids'
+  name: 'trustee-professional-ids'
   properties: {
     resource: {
-      id: 'trustee-professionalids'
+      id: 'trustee-professional-ids'
       shardKey: {
         camsTrusteeId: 'Hash'
       }
@@ -460,9 +460,6 @@ resource trusteeProfessionalIdsCollection 'Microsoft.DocumentDB/databaseAccounts
         {
           key: {
             keys: ['acmsProfessionalId']
-          }
-          options: {
-            unique: true
           }
         }
       ]

--- a/test/bdd/package.json
+++ b/test/bdd/package.json
@@ -9,10 +9,10 @@
     "coverage": "vitest run --coverage",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "testx": "vitest run",
     "test:show-logs": "ENABLE_CONSOLE_LOGGING=true npm run test",
     "test:ui": "vitest --ui",
     "test:watch": "vitest watch",
+    "testx": "vitest run",
     "tsc": "npx tsc --noEmit"
   },
   "author": "",


### PR DESCRIPTION
# Purpose

Cosmos DB MongoDB API cannot enforce unique indexes on non-shard-key fields in sharded collections.

# Major Changes

- Remove database-level unique constraint on acmsProfessionalId field in trustee-professional-ids collection.
- Add programmatic uniqueness validation in createProfessionalId method to enforce constraint at application layer.
- Rename collection from `trustee-professionalids` to `trustee-professional-ids `for consistency with naming conventions, and fix linting error in bdd package.json.

# Testing/Validation

- Updated automated tests.
- [Deployed to validate database bicep deployment](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/23452206098).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enforce application-level uniqueness for ACMS professional IDs while aligning the trustee professional IDs collection naming with deployment configuration.

Bug Fixes:
- Prevent creation of duplicate ACMS professional ID mappings by validating existing mappings before insertion.

Enhancements:
- Rename the trustee professional IDs MongoDB collection to follow consistent hyphenated naming across code and infrastructure.

Build:
- Update Cosmos DB collection Bicep template to use the new trustee professional IDs collection name and remove the database-level unique index on acmsProfessionalId.

Tests:
- Extend repository tests to cover duplicate ACMS professional ID validation and adjust existing tests to account for the new lookup behavior.

Chores:
- Tidy BDD test package scripts ordering in package.json.

## Summary by Sourcery

Enforce application-level uniqueness for ACMS professional IDs and align the trustee professional IDs collection configuration and naming across code and infrastructure.

Bug Fixes:
- Prevent creation of duplicate ACMS professional ID mappings by validating existing mappings before insertion.

Enhancements:
- Rename the trustee professional IDs MongoDB collection to a hyphenated name consistent with deployment configuration.

Build:
- Update Cosmos DB collection Bicep template to use the new trustee professional IDs collection name and remove the database-level unique index on acmsProfessionalId.

Tests:
- Extend repository tests to cover duplicate ACMS professional ID validation and adjust existing tests to mock the new lookup behavior.

Chores:
- Reorder BDD test package scripts in package.json for consistency.