### PR TITLE
Add PR validation workflow for pre-merge e2e testing

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,125 @@
+name: Pull Request Validation
+
+on:
+  pull_request:
+    branches:
+      - main-copy-for-testing  # Testing branch (change to 'main' after validation)
+    types:
+      - ready_for_review  # When PR moved from draft to ready
+      - labeled           # When any label is added
+      - synchronize       # When new commits pushed (gated by label check)
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '**/*.md'
+
+concurrency:
+  group: pr-e2e-staging-slot
+  cancel-in-progress: false  # Queue PRs, don't cancel
+
+jobs:
+  # Fast checks run on every trigger
+  setup:
+    name: Setup
+    uses: ./.github/workflows/reusable-build-info.yml
+    secrets: inherit # pragma: allowlist secret
+    with:
+      environment: 'Develop'  # Always use Develop for PRs
+
+  accessibility-test:
+    uses: ./.github/workflows/reusable-accessibility.yml
+    with:
+      path: user-interface
+      node-version: ${{ vars.NODE_VERSION }}
+
+  unit-test-frontend:
+    uses: ./.github/workflows/reusable-unit-test.yml
+    with:
+      path: user-interface
+      node-version: ${{ vars.NODE_VERSION }}
+
+  unit-test-backend:
+    uses: ./.github/workflows/reusable-unit-test.yml
+    with:
+      path: backend
+      node-version: ${{ vars.NODE_VERSION }}
+
+  unit-test-common:
+    uses: ./.github/workflows/reusable-unit-test.yml
+    with:
+      path: common
+      node-version: ${{ vars.NODE_VERSION }}
+
+  knip:
+    uses: ./.github/workflows/reusable-knip.yml
+    with:
+      node-version: ${{ vars.NODE_VERSION }}
+
+  security-scan:
+    name: Security
+    uses: ./.github/workflows/sub-security-scan.yml
+    secrets: inherit # pragma: allowlist secret
+
+  build:
+    name: Build
+    needs: [setup]
+    uses: ./.github/workflows/sub-build.yml
+    secrets: inherit # pragma: allowlist secret
+    with:
+      nodeVersion: ${{ vars.NODE_VERSION }}
+      camsServerPort: ${{ vars.CAMS_SERVER_PORT }}
+      camsServerProtocol: ${{ vars.CAMS_SERVER_PROTOCOL }}
+      camsBasePath: ${{ vars.CAMS_BASE_PATH }}
+      webappName: ${{ needs.setup.outputs.webappName }}
+      apiFunctionName: ${{ needs.setup.outputs.apiFunctionName }}
+      dataflowsFunctionName: ${{ needs.setup.outputs.dataflowsFunctionName }}
+      environment: ${{ needs.setup.outputs.ghaEnvironment }}
+      launchDarklyEnvironment: ${{ vars.CAMS_LAUNCH_DARKLY_ENV }}
+      azResourceGrpAppEncrypted: ${{ needs.setup.outputs.azResourceGrpAppEncrypted }}
+      slotName: ${{ needs.setup.outputs.slotName }}
+
+  # E2E deployment and tests only run when explicitly requested
+  deploy-pr-code:
+    name: Deploy PR to Staging Slot
+    needs:
+      [
+        setup,
+        build,
+        accessibility-test,
+        unit-test-frontend,
+        unit-test-backend,
+        unit-test-common,
+        security-scan,
+        knip,
+      ]
+    # Only deploy if: (1) PR has run-e2e-tests label, OR (2) event is ready_for_review
+    if: |
+      github.event.action == 'ready_for_review' ||
+      contains(github.event.pull_request.labels.*.name, 'run-e2e-tests')
+    uses: ./.github/workflows/sub-deploy-code-slot.yml
+    with:
+      ghaEnvironment: ${{ needs.setup.outputs.ghaEnvironment }}
+      azResourceGrpAppEncrypted: ${{ needs.setup.outputs.azResourceGrpAppEncrypted }}
+      stackName: ${{ needs.setup.outputs.stackName }}
+      apiFunctionName: ${{ needs.setup.outputs.apiFunctionName }}
+      dataflowsFunctionName: ${{ needs.setup.outputs.dataflowsFunctionName }}
+      webappName: ${{ needs.setup.outputs.webappName }}
+      environmentHash: ${{ needs.setup.outputs.environmentHash }}
+      slotName: ${{ needs.setup.outputs.slotName }}
+      initialDeployment: 'false'  # Never initial deployment for PRs
+    secrets: inherit # pragma: allowlist secret
+
+  execute-pr-e2e:
+    name: E2E Tests
+    needs: [setup, deploy-pr-code]
+    uses: ./.github/workflows/reusable-e2e.yml
+    with:
+      apiFunctionName: ${{ needs.setup.outputs.apiFunctionName }}
+      dataflowsFunctionName: ${{ needs.setup.outputs.dataflowsFunctionName }}
+      slotName: ${{ needs.setup.outputs.slotName }}
+      webappName: ${{ needs.setup.outputs.webappName }}
+      stackName: ${{ needs.setup.outputs.stackName }}
+      azResourceGrpAppEncrypted: ${{ needs.setup.outputs.azResourceGrpAppEncrypted }}
+      ghaEnvironment: ${{ needs.setup.outputs.ghaEnvironment }}
+      branchHashId: ${{ needs.setup.outputs.environmentHash }}
+    secrets: inherit # pragma: allowlist secret

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -1,8 +1,8 @@
 # GitHub Actions Workflow Analysis
 
 ## Summary
-- **Total Workflows**: 23
-- **Main Workflows**: 9
+- **Total Workflows**: 24
+- **Main Workflows**: 10
 - **Reusable Workflows**: 14
 
 ## Legend
@@ -72,6 +72,179 @@ flowchart LR
     class azure_remove_branch_yml_list job
     class azure_remove_branch_yml_check job
     class azure_remove_branch_yml_clean_up job
+```
+
+### Pull_request Triggered Workflows
+
+Workflows triggered by `pull_request`:
+- **Pull Request Validation** (`pr-validation.yml`)
+
+```mermaid
+flowchart LR
+    trigger_pull_request(["pull_request"])
+    pr_validation_yml["Pull Request Validation"]
+    pr_validation_yml_setup["Setup"]
+    reusable_build_info_yml["reusable-build-info.yml"]
+    reusable_build_info_yml_build_info["Run Info"]
+    pr_validation_yml_accessibility_test["accessibility-test"]
+    reusable_accessibility_yml["reusable-accessibility.yml"]
+    reusable_accessibility_yml_playwright_accessibility_test["playwright-accessibility-test"]
+    pr_validation_yml_unit_test_frontend["unit-test-frontend"]
+    reusable_unit_test_yml["reusable-unit-test.yml"]
+    reusable_unit_test_yml_unit_test["Unit test ${{ inputs.path }}"]
+    pr_validation_yml_unit_test_backend["unit-test-backend"]
+    pr_validation_yml_unit_test_common["unit-test-common"]
+    pr_validation_yml_knip["knip"]
+    reusable_knip_yml["reusable-knip.yml"]
+    reusable_knip_yml_knip["Knip"]
+    pr_validation_yml_security_scan["Security"]
+    sub_security_scan_yml["Security"]
+    sub_security_scan_yml_sca_scan["SCA Scan"]
+    sub_security_scan_yml_sast_scan["SAST Scan"]
+    pr_validation_yml_build["Build"]
+    sub_build_yml["sub-build.yml"]
+    sub_build_yml_see_slot_name["see-slot-name"]
+    sub_build_yml_build_frontend_predeployment["Build Frontend Predeployment"]
+    reusable_build_frontend_yml["reusable-build-frontend.yml"]
+    reusable_build_frontend_yml_build_frontend["build-frontend"]
+    sub_build_yml_backend["backend"]
+    pr_validation_yml_deploy_pr_code["Deploy PR to Staging Slot"]
+    sub_deploy_code_slot_yml["sub-deploy-code-slot.yml"]
+    sub_deploy_code_slot_yml_deploy_code["Slot Code Deployment"]
+    sub_deploy_code_yml["sub-deploy-code.yml"]
+    sub_deploy_code_yml_deploy_webapp["deploy-webapp"]
+    sub_deploy_code_yml_deploy_api["deploy-api"]
+    sub_deploy_code_yml_deploy_dataflows_app["deploy-dataflows-app"]
+    sub_deploy_code_yml_endpoint_test_application["endpoint-test-application"]
+    reusable_endpoint_test_yml["reusable-endpoint-test.yml"]
+    reusable_endpoint_test_yml_endpoint_test_application["endpoint-test-application"]
+    sub_deploy_code_yml_enable_access["enable-access"]
+    sub_deploy_code_slot_yml_deploy_webapp_slot["deploy-webapp-slot"]
+    sub_deploy_code_slot_yml_deploy_api_slot["deploy-api-slot"]
+    sub_deploy_code_slot_yml_deploy_dataflows_slot["deploy-dataflows-slot"]
+    sub_deploy_code_slot_yml_endpoint_test_application_slot["endpoint-test-application-slot"]
+    sub_deploy_code_slot_yml_execute_e2e_test["execute-e2e-test"]
+    reusable_e2e_yml["reusable-e2e.yml"]
+    reusable_e2e_yml_playwright_e2e_test["playwright-e2e-test"]
+    sub_deploy_code_slot_yml_swap_webapp_deployment_slot["swap-webapp-deployment-slot"]
+    sub_deploy_code_slot_yml_swap_nodeapi_deployment_slot["swap-nodeapi-deployment-slot"]
+    sub_deploy_code_slot_yml_swap_dataflows_app_deployment_slot["swap-dataflows-app-deployment-slot"]
+    sub_deploy_code_slot_yml_endpoint_test_application_post_swap["endpoint-test-application-post-swap"]
+    sub_deploy_code_slot_yml_enable_access["enable-access"]
+    pr_validation_yml_execute_pr_e2e["E2E Tests"]
+
+    trigger_pull_request --> pr_validation_yml
+    pr_validation_yml --> pr_validation_yml_setup
+    reusable_build_info_yml --> reusable_build_info_yml_build_info
+    pr_validation_yml_setup --> reusable_build_info_yml
+    pr_validation_yml --> pr_validation_yml_accessibility_test
+    reusable_accessibility_yml --> reusable_accessibility_yml_playwright_accessibility_test
+    pr_validation_yml_accessibility_test --> reusable_accessibility_yml
+    pr_validation_yml --> pr_validation_yml_unit_test_frontend
+    reusable_unit_test_yml --> reusable_unit_test_yml_unit_test
+    pr_validation_yml_unit_test_frontend --> reusable_unit_test_yml
+    pr_validation_yml --> pr_validation_yml_unit_test_backend
+    pr_validation_yml_unit_test_backend --> reusable_unit_test_yml
+    pr_validation_yml --> pr_validation_yml_unit_test_common
+    pr_validation_yml_unit_test_common --> reusable_unit_test_yml
+    pr_validation_yml --> pr_validation_yml_knip
+    reusable_knip_yml --> reusable_knip_yml_knip
+    pr_validation_yml_knip --> reusable_knip_yml
+    pr_validation_yml --> pr_validation_yml_security_scan
+    sub_security_scan_yml --> sub_security_scan_yml_sca_scan
+    sub_security_scan_yml --> sub_security_scan_yml_sast_scan
+    pr_validation_yml_security_scan --> sub_security_scan_yml
+    pr_validation_yml --> pr_validation_yml_build
+    sub_build_yml --> sub_build_yml_see_slot_name
+    sub_build_yml --> sub_build_yml_build_frontend_predeployment
+    reusable_build_frontend_yml --> reusable_build_frontend_yml_build_frontend
+    sub_build_yml_build_frontend_predeployment --> reusable_build_frontend_yml
+    sub_build_yml --> sub_build_yml_backend
+    pr_validation_yml_build --> sub_build_yml
+    pr_validation_yml --> pr_validation_yml_deploy_pr_code
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_deploy_code
+    sub_deploy_code_yml --> sub_deploy_code_yml_deploy_webapp
+    sub_deploy_code_yml --> sub_deploy_code_yml_deploy_api
+    sub_deploy_code_yml --> sub_deploy_code_yml_deploy_dataflows_app
+    sub_deploy_code_yml --> sub_deploy_code_yml_endpoint_test_application
+    reusable_endpoint_test_yml --> reusable_endpoint_test_yml_endpoint_test_application
+    sub_deploy_code_yml_endpoint_test_application --> reusable_endpoint_test_yml
+    sub_deploy_code_yml --> sub_deploy_code_yml_enable_access
+    sub_deploy_code_slot_yml_deploy_code --> sub_deploy_code_yml
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_deploy_webapp_slot
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_deploy_api_slot
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_deploy_dataflows_slot
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_endpoint_test_application_slot
+    sub_deploy_code_slot_yml_endpoint_test_application_slot --> reusable_endpoint_test_yml
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_execute_e2e_test
+    reusable_e2e_yml --> reusable_e2e_yml_playwright_e2e_test
+    sub_deploy_code_slot_yml_execute_e2e_test --> reusable_e2e_yml
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_swap_webapp_deployment_slot
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_swap_nodeapi_deployment_slot
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_swap_dataflows_app_deployment_slot
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_endpoint_test_application_post_swap
+    sub_deploy_code_slot_yml_endpoint_test_application_post_swap --> reusable_endpoint_test_yml
+    sub_deploy_code_slot_yml --> sub_deploy_code_slot_yml_enable_access
+    pr_validation_yml_deploy_pr_code --> sub_deploy_code_slot_yml
+    pr_validation_yml --> pr_validation_yml_execute_pr_e2e
+    pr_validation_yml_execute_pr_e2e --> reusable_e2e_yml
+
+    classDef reusable fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#000000
+    classDef mainWorkflow fill:#f3e5f5,stroke:#4a148c,stroke-width:2px,color:#000000
+    classDef trigger fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000000
+    classDef job fill:#f1f8e9,stroke:#33691e,stroke-width:1px,color:#000000
+
+    class trigger_pull_request trigger
+    class pr_validation_yml mainWorkflow
+    class pr_validation_yml_setup job
+    class reusable_build_info_yml reusable
+    class reusable_build_info_yml_build_info job
+    class pr_validation_yml_accessibility_test job
+    class reusable_accessibility_yml reusable
+    class reusable_accessibility_yml_playwright_accessibility_test job
+    class pr_validation_yml_unit_test_frontend job
+    class reusable_unit_test_yml reusable
+    class reusable_unit_test_yml_unit_test job
+    class pr_validation_yml_unit_test_backend job
+    class pr_validation_yml_unit_test_common job
+    class pr_validation_yml_knip job
+    class reusable_knip_yml reusable
+    class reusable_knip_yml_knip job
+    class pr_validation_yml_security_scan job
+    class sub_security_scan_yml mainWorkflow
+    class sub_security_scan_yml_sca_scan job
+    class sub_security_scan_yml_sast_scan job
+    class pr_validation_yml_build job
+    class sub_build_yml reusable
+    class sub_build_yml_see_slot_name job
+    class sub_build_yml_build_frontend_predeployment job
+    class reusable_build_frontend_yml reusable
+    class reusable_build_frontend_yml_build_frontend job
+    class sub_build_yml_backend job
+    class pr_validation_yml_deploy_pr_code job
+    class sub_deploy_code_slot_yml reusable
+    class sub_deploy_code_slot_yml_deploy_code job
+    class sub_deploy_code_yml reusable
+    class sub_deploy_code_yml_deploy_webapp job
+    class sub_deploy_code_yml_deploy_api job
+    class sub_deploy_code_yml_deploy_dataflows_app job
+    class sub_deploy_code_yml_endpoint_test_application job
+    class reusable_endpoint_test_yml reusable
+    class reusable_endpoint_test_yml_endpoint_test_application job
+    class sub_deploy_code_yml_enable_access job
+    class sub_deploy_code_slot_yml_deploy_webapp_slot job
+    class sub_deploy_code_slot_yml_deploy_api_slot job
+    class sub_deploy_code_slot_yml_deploy_dataflows_slot job
+    class sub_deploy_code_slot_yml_endpoint_test_application_slot job
+    class sub_deploy_code_slot_yml_execute_e2e_test job
+    class reusable_e2e_yml reusable
+    class reusable_e2e_yml_playwright_e2e_test job
+    class sub_deploy_code_slot_yml_swap_webapp_deployment_slot job
+    class sub_deploy_code_slot_yml_swap_nodeapi_deployment_slot job
+    class sub_deploy_code_slot_yml_swap_dataflows_app_deployment_slot job
+    class sub_deploy_code_slot_yml_endpoint_test_application_post_swap job
+    class sub_deploy_code_slot_yml_enable_access job
+    class pr_validation_yml_execute_pr_e2e job
 ```
 
 ### Push Triggered Workflows
@@ -1180,6 +1353,8 @@ flowchart LR
     update_dependencies_yml["NPM Package Updates"]
     trigger_delete(["delete"])
     azure_remove_branch_yml["Clean up Flexion Azure Resources"]
+    trigger_pull_request(["pull_request"])
+    pr_validation_yml["Pull Request Validation"]
     trigger_push(["push"])
     continuous_deployment_yml["Continuous Deployment"]
     trigger_schedule(["schedule"])
@@ -1197,6 +1372,7 @@ flowchart LR
     trigger_workflow_dispatch --> dast_scan_yml
     trigger_workflow_dispatch --> update_dependencies_yml
     trigger_delete --> azure_remove_branch_yml
+    trigger_pull_request --> pr_validation_yml
     trigger_push --> continuous_deployment_yml
     trigger_schedule --> build_azure_cli_image_yml
     trigger_schedule --> dast_scan_yml
@@ -1208,6 +1384,7 @@ flowchart LR
     class trigger_workflow_call trigger
     class trigger_workflow_dispatch trigger
     class trigger_delete trigger
+    class trigger_pull_request trigger
     class trigger_push trigger
     class trigger_schedule trigger
     class trigger_workflow_run trigger
@@ -1215,6 +1392,7 @@ flowchart LR
     class deploy_security_scan_storage_yml mainWorkflow
     class e2e_test_yml mainWorkflow
     class azure_remove_branch_yml mainWorkflow
+    class pr_validation_yml mainWorkflow
     class continuous_deployment_yml mainWorkflow
     class build_azure_cli_image_yml mainWorkflow
     class dast_scan_yml mainWorkflow
@@ -1237,6 +1415,9 @@ flowchart LR
 - **Clean up Flexion Azure Resources** (`azure-remove-branch.yml`)
   - Triggers: delete, workflow_dispatch
   - Jobs: 3
+- **Pull Request Validation** (`pr-validation.yml`)
+  - Triggers: pull_request
+  - Jobs: 10
 - **Continuous Deployment** (`continuous-deployment.yml`)
   - Triggers: push, workflow_dispatch
   - Jobs: 10


### PR DESCRIPTION
# Purpose

We have had failing e2e tests go unnoticed multiple times recently.

# Major Changes

Implements CAMS-723 Phase 0: Bootstrap the pr-validation.yml workflow.

This workflow enables pre-merge e2e testing for PRs. Label-based triggering allows developers to control when expensive e2e tests run.

- Initially targets main-copy-for-testing for safe testing
- Triggers on ready_for_review, labeled, and synchronize events
- E2E tests only run when run-e2e-tests label present or PR marked ready
- Concurrency control ensures sequential e2e test execution
- Uses existing staging slot infrastructure

# Testing/Validation

New workflows need to go to main to be discoverable so it will be tested after that.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add a pull request validation workflow that runs tests and optional e2e checks on PRs using the existing staging slot infrastructure.

New Features:
- Introduce a pull_request-triggered validation workflow that runs accessibility, unit, security, and build checks for changes targeting the main testing branch.
- Enable optional PR e2e testing and staging-slot deployment based on labels or readiness state with queued execution via concurrency control.

Documentation:
- Update the GitHub Actions workflow diagram and documentation to include the new pull request validation workflow and its triggers.