### PR TITLE
CAMS-717 Fix e2e filter interaction for all-selected default

### DIFF
--- a/test/e2e/playwright/consolidation-orders.spec.ts
+++ b/test/e2e/playwright/consolidation-orders.spec.ts
@@ -23,11 +23,7 @@ test.describe('Consolidation Orders', () => {
     });
     await expect(page.getByTestId('header-data-verification-link')).toBeVisible();
 
-    // Select pending status filter to make orders visible in the accordion
-    await page.locator('#task-status-filter .input-container').click();
-    await page.locator('[id="option-pending"]').click();
-    await page.keyboard.press('Escape');
-
+    // All status filters are selected by default, so pending orders are already visible
     await expect(page.getByTestId('accordion-group')).toBeVisible();
 
     await officesRequestPromise;

--- a/test/e2e/playwright/transfer-orders.spec.ts
+++ b/test/e2e/playwright/transfer-orders.spec.ts
@@ -30,11 +30,7 @@ test.describe('Transfer Orders', () => {
     });
     await expect(page.getByTestId('header-data-verification-link')).toBeVisible();
 
-    // Select pending status filter to make orders visible in the accordion
-    await page.locator('#task-status-filter .input-container').click();
-    await page.locator('[id="option-pending"]').click();
-    await page.keyboard.press('Escape');
-
+    // All status filters are selected by default, so pending orders are already visible
     await expect(page.getByTestId('accordion-group')).toBeVisible();
 
     const orderResponse = await orderResponsePromise;


### PR DESCRIPTION
# Bug

The consolidation and transfer order Playwright e2e tests were failing because the `beforeEach` hook toggled the "Pending Review" status filter, which previously *selected* it (when the default was no filters) but now *deselects* it (after the default was changed to all options selected). This left pending orders hidden, causing every test interaction with pending accordions to fail.

# Purpose

Restore the e2e tests for consolidation and transfer orders so they pass against the updated Data Verification screen, which now defaults all status filters to selected.

# Major Changes

* Removed the 3-line status filter toggle (`click input-container` → `click option-pending` → `Escape`) from the `beforeEach` in both `consolidation-orders.spec.ts` and `transfer-orders.spec.ts`
* Updated the comment to reflect that pending orders are already visible with the new default

# Testing/Validation

Change is limited to e2e test setup. The tests themselves are unchanged — only the unnecessary filter interaction in `beforeEach` was removed. Pending orders are already visible when all status filters are selected by default, so no filter manipulation is needed before interacting with pending accordions.

# Notes

The root cause: `b67410e` defaulted all Data Verification filters to selected so orders are visible on first load, and `f42b742` updated the unit tests accordingly — but the two Playwright e2e specs were not updated at the same time.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Update order e2e specs to align with the default of all status filters being selected, ensuring pending orders are visible without extra setup.

Tests:
- Remove redundant status filter toggling in consolidation and transfer order Playwright specs now that all statuses are selected by default.
- Clarify e2e test setup comments to reflect that pending orders are visible without manipulating filters.