### PR TITLE
CAMS-416 Integrate Key Vault setup into main.bicep deployment

### DIFF
--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -179,6 +179,23 @@ module network './lib//network/ustp-cams-network.bicep' = {
   }
 }
 
+module kvSetup './ustp-cams-kv-app-config-setup.bicep' = {
+  name: '${stackName}-kv-setup-module'
+  params: {
+    stackName: stackName
+    location: location
+    deployDns: deployDns
+    kvResourceGroup: kvAppConfigResourceGroupName
+    kvName: kvAppConfigName
+    networkResourceGroup: networkResourceGroupName
+    virtualNetworkName: virtualNetworkName
+    privateEndpointSubnetId: network.outputs.privateEndpointSubnetId
+    privateDnsZoneResourceGroup: privateDnsZoneResourceGroup
+    privateDnsZoneSubscriptionId: privateDnsZoneSubscriptionId
+    managedIdentityName: idKeyvaultAppConfiguration
+  }
+}
+
 module ustpWebapp 'frontend-webapp-deploy.bicep' = {
     name: '${stackName}-webapp-module'
     scope: resourceGroup(appResourceGroup)
@@ -211,6 +228,7 @@ module ustpWebapp 'frontend-webapp-deploy.bicep' = {
 module ustpApiFunction 'backend-api-deploy.bicep' = {
     name: '${stackName}-function-module'
     scope: resourceGroup(appResourceGroup)
+    dependsOn: [kvSetup]
     params: {
       deployAppInsights: deployAppInsights
       analyticsWorkspaceId: deployAppInsights ? analyticsWorkspaceId : ''
@@ -255,6 +273,7 @@ module ustpApiFunction 'backend-api-deploy.bicep' = {
 module ustpDataflowsFunction 'dataflows-resource-deploy.bicep' = {
   name: '${stackName}-dataflows-module'
   scope: resourceGroup(appResourceGroup)
+  dependsOn: [kvSetup]
   params: {
     deployAppInsights: deployAppInsights
     analyticsWorkspaceId: deployAppInsights ? analyticsWorkspaceId : ''

--- a/ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep
+++ b/ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep
@@ -1,5 +1,8 @@
 /*
-  Example to execute deployment template:
+  This template is invoked automatically by main.bicep as part of the standard deployment workflow.
+  It no longer needs to be run separately before deploying a new environment.
+
+  For standalone/manual execution:
   az deployment group create -w \
     -g bankruptcy-oversight-support-systems
     --template-file ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep \
@@ -7,14 +10,15 @@
                  virtualNetworkName=vnet-test \
                  kvResourceGroup=bankruptcy-oversight-support-systems \
                  networkResourceGroup=bankruptcy-oversight-support-systems \
-                 privateEndpointSubnetName=snet-pep-kv-test \
-                 privateEndpointSubnetPrefix=10.20.20.0/28
+                 privateEndpointSubnetId=<subnet-resource-id>
 
-  What needs to happen
-  1. Provision managed identity.
-  2. Provision keyvault and update keyvault access to allow managed identity with "Key Vault Secrets User" to secrets.
-  3. Deploy private DNS zone (privatelink.vaultcore.usgovcloudapi.net) and ensure virtual network of the service using keyvault is linked.
-  4. Setup private endpoint resources in target subnet. Subnet should be in same virtual network as service using keyvault.
+  What this template provisions:
+  1. Managed identity with "Key Vault Secrets User" access to the vault.
+  2. Key Vault with network ACLs (public access disabled).
+  3. Private DNS zone (privatelink.vaultcore.usgovcloudapi.net) linked to the virtual network.
+  4. Private endpoint for the vault in the designated private endpoint subnet.
+
+  Note: Key Vault secrets are provisioned manually and are not part of this template.
 */
 
 @description('Application name will be use to name keyvault prepended by kv-')


### PR DESCRIPTION
# Purpose

Key Vault, its managed identity, private DNS zone, and private endpoint were previously set up as a manual prerequisite step before deploying a new environment. This eliminates that manual step by integrating the KV setup into the automated deployment.

# Major Changes

- Added `kvSetup` module to `main.bicep` that calls `ustp-cams-kv-app-config-setup.bicep`, wired entirely from parameters already present in `main.bicep` — no new parameters required
- Added `dependsOn: [kvSetup]` to the API function and dataflows function modules to ensure the vault and managed identity are provisioned before the apps are configured
- Updated the header comment in `ustp-cams-kv-app-config-setup.bicep` to reflect that it is now invoked automatically by `main.bicep`

# Testing/Validation

Changes were validated by reviewing the existing parameter surface of both `main.bicep` and `ustp-cams-kv-app-config-setup.bicep` to confirm all required inputs are already available. Deployment is idempotent — if a Key Vault already exists in an environment, Azure will reconcile desired state rather than create a duplicate.

This will require some manual testing in a new environment to ensure that KV is set up properly.

# Notes

All parameters needed by `ustp-cams-kv-app-config-setup.bicep` were already present in `main.bicep`, so no changes to `azure-deploy.sh` or any GitHub Actions workflow files were necessary. The `ustp-cams-kv-app-config-setup.bicep` file is preserved for standalone/manual use if ever needed.

Secret population into the vault remains a manual step and is intentionally out of scope.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Integrate automated Key Vault infrastructure provisioning into the main environment deployment template and ensure dependent app modules wait for vault setup to complete.

Enhancements:
- Add a Key Vault setup module to main.bicep, wiring it into existing parameters and network outputs to provision the vault, managed identity, DNS zone, and private endpoint as part of standard deployments.
- Set explicit dependencies so backend API and dataflows function deployments wait for Key Vault setup to finish before app configuration runs.

Documentation:
- Clarify the Key Vault setup template header comment to describe its automatic invocation from main.bicep, its provisioning responsibilities, and its continued support for optional standalone/manual execution.