### PR TITLE
CAMS-719 Refine inactive trustee verification UI per QA feedback 

### DIFF
--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.test.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.test.tsx
@@ -596,24 +596,24 @@ describe('TrusteeMatchVerificationAccordion', () => {
       ],
     };
 
+    test('should render "Inactive trustee" as task type label for inactive match', () => {
+      renderWithProps({ order: inactiveOrder });
+
+      const heading = screen.getByTestId(`accordion-heading-${inactiveOrder.id}`);
+      expect(heading.textContent).toContain('Inactive trustee');
+      expect(heading.textContent).not.toContain('Trustee Mismatch');
+    });
+
     test('should render distinct problem statement for inactive match', () => {
       renderWithProps({ order: inactiveOrder });
 
       const content = screen.getByTestId(`accordion-content-${inactiveOrder.id}`);
       expect(content.textContent).toContain(
-        'Matched trustee has an inactive appointment status for case',
+        'Trustee is inactive in CAMS but was appointed to case',
       );
       expect(content.textContent).not.toContain(
         'Trustee sent from the court does not match a CAMS Trustee',
       );
-    });
-
-    test('should render warning alert banner with formatted inactive status', () => {
-      renderWithProps({ order: inactiveOrder });
-
-      const alert = screen.getByTestId(`alert-inactive-status-warning-${inactiveOrder.id}`);
-      expect(alert).toBeInTheDocument();
-      expect(alert.textContent).toContain('Voluntarily Suspended');
     });
 
     test('should still render original problem statement for other mismatch types', () => {
@@ -625,30 +625,17 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(content.textContent).toContain(
         'Trustee sent from the court does not match a CAMS Trustee',
       );
-      expect(content.textContent).not.toContain('inactive appointment status');
+      expect(content.textContent).not.toContain('inactive');
     });
 
-    test('should not render warning alert for non-inactive mismatch types', () => {
+    test('should render "Trustee Mismatch" as task type label for non-inactive mismatch types', () => {
       renderWithProps({
         order: { ...sampleOrderWithCandidates, mismatchReason: 'HIGH_CONFIDENCE_MATCH' },
       });
 
-      expect(
-        screen.queryByTestId(`alert-inactive-status-warning-${sampleOrder.id}`),
-      ).not.toBeInTheDocument();
-    });
-
-    test('should not render warning alert when inactiveAppointmentStatus is undefined', () => {
-      const { inactiveAppointmentStatus: _omit, ...orderWithoutStatus } = inactiveOrder;
-      renderWithProps({ order: orderWithoutStatus as TrusteeMatchVerification });
-
-      const content = screen.getByTestId(`accordion-content-${inactiveOrder.id}`);
-      expect(content.textContent).toContain(
-        'Matched trustee has an inactive appointment status for case',
-      );
-      expect(
-        screen.queryByTestId(`alert-inactive-status-warning-${inactiveOrder.id}`),
-      ).not.toBeInTheDocument();
+      const heading = screen.getByTestId(`accordion-heading-${sampleOrder.id}`);
+      expect(heading.textContent).toContain('Trustee Mismatch');
+      expect(heading.textContent).not.toContain('Inactive trustee');
     });
   });
 });

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -10,7 +10,7 @@ import { CourtDivisionDetails } from '@common/cams/courts';
 import { formatDate } from '@/lib/utils/datetime';
 import { formatAppointmentStatus } from '@common/cams/trustee-appointments';
 import { formatChapterType } from '@common/cams/trustees';
-import Alert, { AlertDetails, UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import { AlertDetails, UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { TrusteeAppointmentSyncErrorCode } from '@common/cams/dataflow-events';
 import { getCaseNumber, getCaseIdParts } from '@common/cams/cases';
 import Api2 from '@/lib/models/api2';
@@ -63,6 +63,10 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
   const { divisionCode } = getCaseIdParts(order.caseId);
   const courtDetails = courts.find((c) => c.courtDivisionCode === divisionCode);
   const courtName = courtDetails?.courtName ?? order.courtId;
+
+  const isInactiveStatus =
+    order.mismatchReason === TrusteeAppointmentSyncErrorCode.PerfectMatchInactiveStatus;
+  const taskTypeLabel = isInactiveStatus ? 'Inactive trustee' : orderType.get(order.orderType);
 
   const { legacy } = order.dxtrTrustee;
   const addressLines = [
@@ -297,9 +301,9 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
           >
             <span
               className="event-type-label"
-              aria-label={`${fieldHeaders[2]} - ${orderType.get(order.orderType)}.`}
+              aria-label={`${fieldHeaders[2]} - ${taskTypeLabel}.`}
             >
-              {orderType.get(order.orderType)}
+              {taskTypeLabel}
             </span>
           </div>
           <div
@@ -327,24 +331,10 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
             </p>
           ) : (
             <>
-              {order.mismatchReason ===
-              TrusteeAppointmentSyncErrorCode.PerfectMatchInactiveStatus ? (
-                <>
-                  <p className="problem-statement">
-                    Matched trustee has an inactive appointment status for case: {caseLink}
-                  </p>
-                  {order.inactiveAppointmentStatus && (
-                    <Alert
-                      id={`inactive-status-warning-${order.id}`}
-                      type={UswdsAlertStyle.Warning}
-                      title="Inactive Appointment Status"
-                      message={`The matched trustee's appointment status is ${formatAppointmentStatus(order.inactiveAppointmentStatus)}. Review the appointment details before confirming.`}
-                      show={true}
-                      inline={true}
-                      role="status"
-                    />
-                  )}
-                </>
+              {isInactiveStatus ? (
+                <p className="problem-statement">
+                  Trustee is inactive in CAMS but was appointed to case: {caseLink}
+                </p>
               ) : (
                 <p className="problem-statement">
                   Trustee sent from the court does not match a CAMS Trustee for case: {caseLink}


### PR DESCRIPTION
# Purpose

  QA feedback indicated the inactive trustee verification task needed clearer labeling and a simpler layout. The task type was showing as "Trustee Mismatch"
  (same as other verification types), the problem statement was vague, and the warning alert banner was redundant since the inactive status is already visible in
   the Trustee Appointment column.

  # Major Changes

  - Changed the task type label from "Trustee Mismatch" to "Inactive trustee" for `PERFECT_MATCH_INACTIVE_STATUS` verifications
  - Updated problem statement from "Matched trustee has an inactive appointment status for case" to "Trustee is inactive in CAMS but was appointed to case"
  - Removed the warning alert banner (`Alert` component) since the appointment status is already displayed in the Trustee Appointment column

  # Testing/Validation

  - Verify that inactive trustee verifications display "Inactive trustee" as the task type label in the accordion heading
  - Verify that non-inactive verifications (e.g., HIGH_CONFIDENCE_MATCH) still display "Trustee Mismatch"
  - Verify the problem statement reads "Trustee is inactive in CAMS but was appointed to case: [case link]"
  - Verify no warning alert banner appears for inactive status verifications
  - Verify no regressions in other verification types

  # Notes

  Jira: CAMS-719

  # Definition of Done:

  - [x] Code refactored for clarity: Developers can understand the work simply by reviewing the code
  - [x] Dependency rule followed: More important code doesn't directly depend on less important code
  - [x] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
  - [x] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Refine the inactive trustee verification UI to use a clearer task type label and simplified messaging.

Enhancements:
- Display 'Inactive trustee' as the task type label for perfect-match inactive status verifications while keeping 'Trustee Mismatch' for other mismatch types.
- Simplify the inactive trustee problem statement copy to better describe the CAMS inactivity versus case appointment scenario.
- Remove the inactive status warning alert banner in favor of relying on the trustee appointment column and updated problem statement.

Tests:
- Update trustee verification accordion tests to cover the new task type labels, revised inactive problem statement, and removal of the warning alert banner.