### PR TITLE
Add .beads/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ dev-tools/.venv/
 vitest.config.d.ts
 vitest.config.js
 vitest.config.js.map
+
+# Beads issue tracker (local-only; issues are stored in the remote Dolt repo)
+.beads/


### PR DESCRIPTION
# Purpose

Prevent the Beads issue tracker's local directory from being accidentally committed to this repository.

# Major Changes

* Added `.beads/` to `.gitignore`

# Testing/Validation

Manual verification: `.beads/` is now ignored by git.

# Notes

The `.beads/` directory is created locally by the Beads issue tracker to store its embedded Dolt database and runtime state. Issues themselves are stored in the shared remote Dolt repo (`git+https://github.com/flexion/flexion-doj-cams-issues.git`), making the local `.beads/` directory entirely machine-specific scaffolding that has no business being committed here.

The `.beads/.gitignore` already excludes the Dolt database itself, but the parent `.gitignore` had no entry for the directory, so `config.yaml`, `metadata.json`, `hooks/`, and `README.md` were showing up as staged files.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Build:
- Add the .beads/ directory to the top-level .gitignore so its contents are not tracked.