### PR TITLE
CAMS-727 - Added select option for Lead Trial Attorney

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+AGENTS.md
+
 # IDEs
 
 ## Keep the environment config out of the repo

--- a/backend/lib/use-cases/case-assignment/case-assignment.test.ts
+++ b/backend/lib/use-cases/case-assignment/case-assignment.test.ts
@@ -431,6 +431,23 @@ describe('Case assignment tests', () => {
       expect(createAssignment).not.toHaveBeenCalled();
     });
 
+    test('should throw when more than one LeadTrialAttorney is assigned', async () => {
+      vi.spyOn(CaseManagement.prototype, 'getCaseSummary').mockResolvedValue(
+        MockData.getCaseDetail({
+          override: { courtDivisionCode: getCourtDivisionCodes(user)[0] },
+        }),
+      );
+      const assignmentUseCase = new CaseAssignmentUseCase(applicationContext);
+      await expect(
+        assignmentUseCase.createTrialAttorneyAssignments(
+          applicationContext,
+          caseId,
+          [attorneyJaneSmith, attorneyJoeNobel],
+          CamsRole.LeadTrialAttorney,
+        ),
+      ).rejects.toThrow('Only one Lead Trial Attorney may be assigned to a case.');
+    });
+
     test('should use TrialAttorney as assignableRole when role is LeadTrialAttorney', async () => {
       const searchSpy = vi
         .spyOn(MockMongoRepository.prototype, 'search')

--- a/backend/lib/use-cases/case-assignment/case-assignment.test.ts
+++ b/backend/lib/use-cases/case-assignment/case-assignment.test.ts
@@ -431,6 +431,110 @@ describe('Case assignment tests', () => {
       expect(createAssignment).not.toHaveBeenCalled();
     });
 
+    test('should use TrialAttorney as assignableRole when role is LeadTrialAttorney', async () => {
+      const searchSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'search')
+        .mockImplementation((predicate: OfficeUserRolesPredicate) => {
+          if (predicate.userId === attorneyJaneSmith.id) {
+            return Promise.resolve([officeStaffJaneSmith]);
+          }
+          return Promise.resolve([]);
+        });
+      vi.spyOn(CaseManagement.prototype, 'getCaseSummary').mockResolvedValue(
+        MockData.getCaseDetail({
+          override: { courtDivisionCode: getCourtDivisionCodes(user)[0] },
+        }),
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'create').mockImplementation(
+        (consolidationOrder: ConsolidationOrder) =>
+          Promise.resolve(MockData.getConsolidationOrder({ override: { ...consolidationOrder } })),
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createCaseHistory').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'getConsolidation').mockResolvedValue([]);
+
+      const assignmentUseCase = new CaseAssignmentUseCase(applicationContext);
+      await assignmentUseCase.createTrialAttorneyAssignments(
+        applicationContext,
+        caseId,
+        [attorneyJaneSmith],
+        CamsRole.LeadTrialAttorney,
+      );
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ role: CamsRole.TrialAttorney }),
+      );
+    });
+
+    test('should not remove TrialAttorney assignments when assigning a LeadTrialAttorney', async () => {
+      const trialAttorneyRecord = {
+        caseId,
+        userId: attorneyJoeNobel.id,
+        name: attorneyJoeNobel.name,
+        role: CamsRole.TrialAttorney,
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'getAssignmentsForCases').mockResolvedValue(
+        new Map([[caseId, [trialAttorneyRecord]]]),
+      );
+      const updateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'update')
+        .mockResolvedValue(randomId);
+      vi.spyOn(MockMongoRepository.prototype, 'create').mockImplementation(
+        (consolidationOrder: ConsolidationOrder) =>
+          Promise.resolve(MockData.getConsolidationOrder({ override: { ...consolidationOrder } })),
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createCaseHistory').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'getConsolidation').mockResolvedValue([]);
+      vi.spyOn(CaseManagement.prototype, 'getCaseSummary').mockResolvedValue(
+        MockData.getCaseDetail({
+          override: { courtDivisionCode: getCourtDivisionCodes(user)[0] },
+        }),
+      );
+
+      const assignmentUseCase = new CaseAssignmentUseCase(applicationContext);
+      await assignmentUseCase.createTrialAttorneyAssignments(
+        applicationContext,
+        caseId,
+        [attorneyJaneSmith],
+        CamsRole.LeadTrialAttorney,
+      );
+
+      expect(updateSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ role: CamsRole.TrialAttorney }),
+      );
+    });
+
+    test('should create assignment with LeadTrialAttorney role when role is LeadTrialAttorney', async () => {
+      vi.spyOn(CaseManagement.prototype, 'getCaseSummary').mockResolvedValue(
+        MockData.getCaseDetail({
+          override: { courtDivisionCode: getCourtDivisionCodes(user)[0] },
+        }),
+      );
+      const createSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'create')
+        .mockImplementation((consolidationOrder: ConsolidationOrder) =>
+          Promise.resolve(MockData.getConsolidationOrder({ override: { ...consolidationOrder } })),
+        );
+      vi.spyOn(MockMongoRepository.prototype, 'createCaseHistory').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'getConsolidation').mockResolvedValue([]);
+
+      const assignmentUseCase = new CaseAssignmentUseCase(applicationContext);
+      await assignmentUseCase.createTrialAttorneyAssignments(
+        applicationContext,
+        caseId,
+        [attorneyJaneSmith],
+        CamsRole.LeadTrialAttorney,
+      );
+
+      expect(createSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          caseId,
+          userId: attorneyJaneSmith.id,
+          name: attorneyJaneSmith.name,
+          role: CamsRole.LeadTrialAttorney,
+        }),
+      );
+    });
+
     test('should not do anything if user does have the CaseAssignmentManager role but not for the correct division', async () => {
       const assignmentUseCase = new CaseAssignmentUseCase(applicationContext);
       vi.spyOn(CaseManagement.prototype, 'getCaseSummary').mockResolvedValue(

--- a/backend/lib/use-cases/case-assignment/case-assignment.ts
+++ b/backend/lib/use-cases/case-assignment/case-assignment.ts
@@ -79,15 +79,19 @@ export class CaseAssignmentUseCase {
     const { officeCode } = divisionCodeMap.get(bCase.caseId.substring(0, 3));
 
     const officesRepo = factory.getOfficesRepository(context);
+    const assignableRole = role === CamsRole.LeadTrialAttorney ? CamsRole.TrialAttorney : role;
     const calls = [];
     const validatedAssignments: CamsUserReference[] = [];
     newAssignees.forEach((assignee) => {
       calls.push(
         officesRepo
-          .search({ officeCode, userId: assignee.id, role })
+          .search({ officeCode, userId: assignee.id, role: assignableRole })
           .then((response) => {
             return response.find((staff) => {
-              if (staff.roles.includes(role as CamsRoleType) && staff.name === assignee.name) {
+              if (
+                staff.roles.includes(assignableRole as CamsRoleType) &&
+                staff.name === assignee.name
+              ) {
                 return true;
               }
             });
@@ -143,7 +147,9 @@ export class CaseAssignmentUseCase {
     const existingAssignmentRecordsMap = await assignmentRepo.getAssignmentsForCases([
       bCase.caseId,
     ]);
-    const existingAssignmentRecords = existingAssignmentRecordsMap.get(bCase.caseId) ?? [];
+    const existingAssignmentRecords = (existingAssignmentRecordsMap.get(bCase.caseId) ?? []).filter(
+      (a) => a.role === role,
+    );
     for (const existingAssignment of existingAssignmentRecords) {
       const stillAssigned = listOfAssignments.find((newAssignment) => {
         return (

--- a/backend/lib/use-cases/case-assignment/case-assignment.ts
+++ b/backend/lib/use-cases/case-assignment/case-assignment.ts
@@ -47,6 +47,11 @@ export class CaseAssignmentUseCase {
         message: 'User does not have appropriate access to create assignments for this office.',
       });
     }
+    if (role === CamsRole.LeadTrialAttorney && newAssignees.length > 1) {
+      throw new AssignmentError(MODULE_NAME, {
+        message: 'Only one Lead Trial Attorney may be assigned to a case.',
+      });
+    }
     await this.assignTrialAttorneys(context, caseId, newAssignees, role);
 
     // Reassign all member cases if this is a joint administration lead case.

--- a/backend/lib/use-cases/cases/case-management.test.ts
+++ b/backend/lib/use-cases/cases/case-management.test.ts
@@ -271,6 +271,47 @@ describe('Case management tests', () => {
       expect(actual).toEqual(expected);
     });
 
+    test('should split mixed assignments into TrialAttorney and leadTrialAttorney in getCaseDetail', async () => {
+      const leadAttorney = { id: '003', name: 'Lead Attorney' };
+      const leadAssignment: CaseAssignment = {
+        documentType: 'ASSIGNMENT',
+        id: '3',
+        caseId: caseIdWithAssignments,
+        userId: leadAttorney.id,
+        name: leadAttorney.name,
+        role: CamsRole.LeadTrialAttorney,
+        assignedOn: currentDate,
+        updatedOn: currentDate,
+        updatedBy: MockData.getCamsUserReference(),
+      };
+      const mixedMap = new Map([[caseIdWithAssignments, [...assignments, leadAssignment]]]);
+      const bCase = MockData.getCaseDetail({ override: { caseId: caseIdWithAssignments } });
+
+      vi.spyOn(CaseAssignmentUseCase.prototype, 'findAssignmentsByCaseId').mockResolvedValue(
+        mixedMap,
+      );
+      vi.spyOn(useCase.casesGateway, 'getCaseDetail').mockResolvedValue(bCase);
+
+      const actual = await useCase.getCaseDetail(applicationContext, caseIdWithAssignments);
+
+      expect(actual.assignments).toEqual(assignments);
+      expect(actual.leadTrialAttorney).toEqual({ id: leadAttorney.id, name: leadAttorney.name });
+    });
+
+    test('should set leadTrialAttorney to undefined when no LeadTrialAttorney assignments exist', async () => {
+      const bCase = MockData.getCaseDetail({ override: { caseId: caseIdWithAssignments } });
+
+      vi.spyOn(CaseAssignmentUseCase.prototype, 'findAssignmentsByCaseId').mockResolvedValue(
+        assignmentMap,
+      );
+      vi.spyOn(useCase.casesGateway, 'getCaseDetail').mockResolvedValue(bCase);
+
+      const actual = await useCase.getCaseDetail(applicationContext, caseIdWithAssignments);
+
+      expect(actual.assignments).toEqual(assignments);
+      expect(actual.leadTrialAttorney).toBeUndefined();
+    });
+
     test('should throw an AssignmentError when CaseAssignmentUseCase.findAssignmentsByCaseId throws an error', async () => {
       const bCase = MockData.getCaseDetail({ override: { caseId: 'ThrowError' } });
 
@@ -439,6 +480,39 @@ describe('Case management tests', () => {
       const expectedCases = args.includeCaseAssignments ? casesWithAssignments : cases;
       expect(actual).toEqual({ metadata: { total: cases.length }, data: expectedCases });
       expect(!!assignmentsSpy.mock.calls.length).toEqual(args.includeCaseAssignments);
+    });
+
+    test('should split assignments into TrialAttorney and leadTrialAttorney in searchCases', async () => {
+      const caseId = MockData.randomCaseId();
+      const leadAttorney = MockData.getCamsUserReference();
+      const trialAttorneyAssignment = MockData.getAttorneyAssignment({ caseId });
+      const leadAssignment: CaseAssignment = {
+        ...trialAttorneyAssignment,
+        id: 'lead-id',
+        userId: leadAttorney.id,
+        name: leadAttorney.name,
+        role: CamsRole.LeadTrialAttorney,
+      };
+      const mixedMap = new Map([[caseId, [trialAttorneyAssignment, leadAssignment]]]);
+
+      vi.spyOn(useCase.casesRepository, 'searchCases').mockResolvedValue({
+        metadata: { total: 1 },
+        data: [MockData.getSyncedCase({ override: { caseId } })],
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'getAssignmentsForCases').mockResolvedValue(mixedMap);
+
+      const actual = await useCase.searchCases(
+        applicationContext,
+        { caseNumber: '00-00000' },
+        true,
+      );
+
+      const resultCase = actual.data[0];
+      expect(resultCase.assignments).toEqual([trialAttorneyAssignment]);
+      expect(resultCase.leadTrialAttorney).toEqual({
+        id: leadAttorney.id,
+        name: leadAttorney.name,
+      });
     });
 
     test('should return cases and actions for the user', async () => {

--- a/backend/lib/use-cases/cases/case-management.ts
+++ b/backend/lib/use-cases/cases/case-management.ts
@@ -196,10 +196,13 @@ export default class CaseManagement {
       if (includeAssignments) {
         const assignmentsMap = await this.assignmentRepository.getAssignmentsForCases(caseIds);
         for (const caseId of caseIds) {
-          const assignments = assignmentsMap.get(caseId) ?? [];
+          const allAssignments = assignmentsMap.get(caseId) ?? [];
           const caseWithAssignments = {
             ...casesMap.get(caseId),
-            assignments,
+            assignments: allAssignments.filter((a) => a.role === CamsRole.TrialAttorney),
+            leadTrialAttorney: allAssignments
+              .filter((a) => a.role === CamsRole.LeadTrialAttorney)
+              .map((a) => ({ id: a.userId, name: a.name }))[0],
           };
           casesMap.set(caseId, caseWithAssignments);
         }
@@ -279,7 +282,12 @@ export default class CaseManagement {
       }
 
       if (assignments.status === 'fulfilled') {
-        caseDetails.assignments = assignments.value;
+        caseDetails.assignments = assignments.value.filter(
+          (a) => a.role === CamsRole.TrialAttorney,
+        );
+        caseDetails.leadTrialAttorney = assignments.value
+          .filter((a) => a.role === CamsRole.LeadTrialAttorney)
+          .map((a) => ({ id: a.userId, name: a.name }))[0];
       } else {
         context.logger.debug(
           MODULE_NAME,
@@ -328,7 +336,7 @@ export default class CaseManagement {
     const caseAssignment = new CaseAssignmentUseCase(context);
     try {
       const assignmentsMap = await caseAssignment.findAssignmentsByCaseId([bCase.caseId]);
-      return assignmentsMap.get(bCase.caseId);
+      return assignmentsMap.get(bCase.caseId) ?? [];
     } catch (e) {
       throw new AssignmentError(MODULE_NAME, {
         message:

--- a/common/src/cams/assignments.ts
+++ b/common/src/cams/assignments.ts
@@ -1,5 +1,5 @@
 import { CamsUserReference } from './users';
-import { CamsRole } from './roles';
+import { AssignableRoleType } from './roles';
 import { Auditable } from './auditable';
 
 export type CaseAssignment = Auditable & {
@@ -16,5 +16,5 @@ export type CaseAssignment = Auditable & {
 export type StaffAssignmentAction = {
   caseId: string;
   attorneyList: CamsUserReference[];
-  role: typeof CamsRole.TrialAttorney;
+  role: AssignableRoleType;
 };

--- a/common/src/cams/cases.ts
+++ b/common/src/cams/cases.ts
@@ -38,6 +38,7 @@ export type CaseBasics = FlatOfficeDetail & {
   debtorTypeCode?: string;
   debtorTypeLabel?: string;
   assignments?: CaseAssignment[];
+  leadTrialAttorney?: CamsUserReference;
 };
 
 export type CaseSummary = CaseBasics & {
@@ -68,6 +69,7 @@ export function getCaseBasics<T extends CaseBasics>(bCase: T): CaseBasics {
     debtorTypeCode,
     debtorTypeLabel,
     assignments,
+    leadTrialAttorney,
   } = bCase;
   const result: CaseBasics = {
     officeName,
@@ -92,6 +94,7 @@ export function getCaseBasics<T extends CaseBasics>(bCase: T): CaseBasics {
   if (debtorTypeCode !== undefined) result.debtorTypeCode = debtorTypeCode;
   if (debtorTypeLabel !== undefined) result.debtorTypeLabel = debtorTypeLabel;
   if (assignments !== undefined) result.assignments = assignments;
+  if (leadTrialAttorney !== undefined) result.leadTrialAttorney = leadTrialAttorney;
   return result;
 }
 

--- a/common/src/cams/roles.ts
+++ b/common/src/cams/roles.ts
@@ -3,6 +3,7 @@ export const CamsRole = {
   SuperUser: 'SuperUser',
   CaseAssignmentManager: 'CaseAssignmentManager',
   TrialAttorney: 'TrialAttorney',
+  LeadTrialAttorney: 'LeadTrialAttorney',
   DataVerifier: 'DataVerifier',
   TrusteeAdmin: 'TrusteeAdmin',
   Auditor: 'Auditor',
@@ -17,6 +18,7 @@ export type CamsRoleType = (typeof CamsRole)[keyof typeof CamsRole];
 
 export const AssignableRole = {
   TrialAttorney: CamsRole.TrialAttorney,
+  LeadTrialAttorney: CamsRole.LeadTrialAttorney,
 } as const;
 
 export type AssignableRoleType = (typeof AssignableRole)[keyof typeof AssignableRole];

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -349,6 +349,7 @@ export default function CaseDetailScreen(props: Readonly<CaseDetailProps>) {
     const updatedCaseBasicInfo: CaseDetail = {
       ...caseBasicInfo!,
       assignments,
+      leadTrialAttorney: assignment.leadTrialAttorney,
     };
 
     setCaseBasicInfo(updatedCaseBasicInfo);

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
@@ -549,7 +549,12 @@ describe('CaseDetailTrusteeAndAssignedStaff', () => {
       vi.spyOn(Api2, 'postStaffAssignments').mockResolvedValue(apiResult);
 
       const onCaseAssignment = vi.fn();
-      renderWithProps({ onCaseAssignment });
+      // Use a case with no existing assignments so selecting 1 attorney auto-selects them as lead,
+      // satisfying the LeadTrialAttorney requirement before submitting.
+      renderWithProps({
+        onCaseAssignment,
+        caseDetail: { ...BASE_TEST_CASE_DETAIL, assignments: [] },
+      });
 
       const assignedStaffEditButton = screen.getByTestId('open-modal-button');
       await userEvent.click(assignedStaffEditButton);

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
@@ -142,6 +142,58 @@ describe('CaseDetailTrusteeAndAssignedStaff', () => {
       expect(placeholder).toBeInTheDocument();
     });
 
+    test('should display leadTrialAttorney with Lead Trial Attorney role label', () => {
+      const leadAttorney = { id: 'lead-1', name: 'Lead Attorney Name' };
+      const caseDetailWithLead = {
+        ...BASE_TEST_CASE_DETAIL,
+        assignments: [],
+        leadTrialAttorney: leadAttorney,
+      };
+      renderWithProps({ caseDetail: caseDetailWithLead });
+
+      const assigneeNames = screen.getAllByText((_content, element) => {
+        return element?.classList.contains('assignee-name') || false;
+      });
+      expect(assigneeNames[0]).toHaveTextContent(leadAttorney.name);
+      expect(screen.getByText('Lead Trial Attorney')).toBeInTheDocument();
+    });
+
+    test('should not show unassigned placeholder when leadTrialAttorney is set', () => {
+      const leadAttorney = { id: 'lead-1', name: 'Lead Attorney' };
+      const caseDetailWithLead = {
+        ...BASE_TEST_CASE_DETAIL,
+        assignments: [],
+        leadTrialAttorney: leadAttorney,
+      };
+      renderWithProps({ caseDetail: caseDetailWithLead });
+
+      expect(screen.queryByText('(unassigned)')).not.toBeInTheDocument();
+    });
+
+    test('should not render lead trial attorney in the trial attorney list (deduplication)', () => {
+      const caseDetailWithLead = {
+        ...BASE_TEST_CASE_DETAIL,
+        leadTrialAttorney: { id: TEST_ASSIGNMENT_1.userId, name: TEST_TRIAL_ATTORNEY_1.name },
+      };
+      renderWithProps({ caseDetail: caseDetailWithLead });
+
+      expect(screen.getByText('Lead Trial Attorney')).toBeInTheDocument();
+
+      // TEST_ASSIGNMENT_1 should only appear once total (as Lead, not also as Trial Attorney)
+      const assigneeNames = screen.getAllByText((_content, element) => {
+        return element?.classList.contains('assignee-name') || false;
+      });
+      const leadCount = assigneeNames.filter((el) =>
+        el.textContent?.includes(TEST_TRIAL_ATTORNEY_1.name),
+      );
+      expect(leadCount).toHaveLength(1);
+
+      // Only TEST_ASSIGNMENT_2 should appear as Trial Attorney
+      expect(screen.getByText('Trial Attorney')).toBeInTheDocument();
+      const trialRoles = screen.getAllByText('Trial Attorney');
+      expect(trialRoles).toHaveLength(1);
+    });
+
     test('should render list of assigned staff with names and roles', () => {
       renderWithProps();
 

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx
@@ -10,7 +10,7 @@ import OpenModalButton from '@/lib/components/uswds/modal/OpenModalButton';
 import { useRef } from 'react';
 import { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import Actions from '@common/cams/actions';
-import { AttorneyUser } from '@common/cams/users';
+import { CaseAssignment } from '@common/cams/assignments';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
 import { OpenModalButtonRef } from '@/lib/components/uswds/modal/modal-refs';
 import { getCaseNumber } from '@common/cams/cases';
@@ -79,25 +79,30 @@ function CaseDetailTrusteeAndAssignedStaff(
               </div>
             )}
             <div className="assigned-staff-list">
-              {(typeof caseDetail.assignments === 'undefined' ||
-                caseDetail.assignments.length === 0) && (
-                <span className="unassigned-placeholder">(unassigned)</span>
+              {(!caseDetail.assignments || caseDetail.assignments.length === 0) &&
+                !caseDetail.leadTrialAttorney && (
+                  <span className="unassigned-placeholder">(unassigned)</span>
+                )}
+              {caseDetail.leadTrialAttorney && (
+                <ul className="usa-list usa-list--unstyled">
+                  <li className="individual-assignee">
+                    <span className="assignee-name">{caseDetail.leadTrialAttorney.name}</span>
+                    <span className="vertical-divider"> | </span>
+                    <span className="assignee-role">Lead Trial Attorney</span>
+                  </li>
+                </ul>
               )}
               {caseDetail.assignments && caseDetail.assignments.length > 0 && (
                 <ul className="usa-list usa-list--unstyled">
-                  {caseDetail.assignments &&
-                    caseDetail.assignments.length > 0 &&
-                    (caseDetail.assignments as Array<AttorneyUser>)?.map(
-                      (staff: AttorneyUser, idx: number) => {
-                        return (
-                          <li key={idx} className="individual-assignee">
-                            <span className="assignee-name">{staff.name}</span>
-                            <span className="vertical-divider"> | </span>
-                            <span className="assignee-role">Trial Attorney</span>
-                          </li>
-                        );
-                      },
-                    )}
+                  {(caseDetail.assignments as Array<CaseAssignment>)
+                    .filter((staff) => caseDetail.leadTrialAttorney?.id !== staff.userId)
+                    .map((staff: CaseAssignment, idx: number) => (
+                      <li key={idx} className="individual-assignee">
+                        <span className="assignee-name">{staff.name}</span>
+                        <span className="vertical-divider"> | </span>
+                        <span className="assignee-role">Trial Attorney</span>
+                      </li>
+                    ))}
                 </ul>
               )}
             </div>

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModal.test.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModal.test.tsx
@@ -290,6 +290,80 @@ describe('Test Assign Attorney Modal Component', () => {
     });
   });
 
+  test('should enable submit button when exactly one attorney is checked (auto-select as lead)', async () => {
+    const modalRef = React.createRef<AssignAttorneyModalRef>();
+    renderWithProps(modalRef);
+
+    const bCase: CaseBasics = MockData.getCaseBasics({
+      override: { caseId: '081-23-00002', caseTitle: 'Test Case', dateFiled: '2024-01-01' },
+    });
+    bCase.assignments = [];
+
+    act(() => modalRef.current?.show({ bCase, callback }));
+
+    await userEvent.click(screen.getByTestId('open-modal-button'));
+    const submitButton = screen.getByTestId(`button-${modalId}-submit-button`);
+
+    await waitFor(() => expect(submitButton).toBeDisabled());
+
+    const sortedAttorneys = [...attorneyList].sort((a, b) => a.name.localeCompare(b.name));
+    await TestingUtilities.selectCheckbox(`attorney-${sortedAttorneys[0].id}-checkbox`);
+
+    await waitFor(() => expect(submitButton).toBeEnabled());
+  });
+
+  test('should post LeadTrialAttorney assignment when submitting', async () => {
+    const postSpy = vi.spyOn(Api2, 'postStaffAssignments').mockResolvedValue({ data: undefined });
+    const modalRef = React.createRef<AssignAttorneyModalRef>();
+    renderWithProps(modalRef);
+
+    const bCase: CaseBasics = MockData.getCaseBasics({
+      override: { caseId: '081-23-00003', caseTitle: 'Test Case', dateFiled: '2024-01-01' },
+    });
+    bCase.assignments = [];
+
+    act(() => modalRef.current?.show({ bCase, callback }));
+    await userEvent.click(screen.getByTestId('open-modal-button'));
+
+    await waitFor(() => expect(screen.getByTestId(`modal-${modalId}`)).toHaveClass('is-visible'));
+
+    const sortedAttorneys = [...attorneyList].sort((a, b) => a.name.localeCompare(b.name));
+    await TestingUtilities.selectCheckbox(`attorney-${sortedAttorneys[0].id}-checkbox`);
+
+    const submitButton = screen.getByTestId(`button-${modalId}-submit-button`);
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ role: 'LeadTrialAttorney' }));
+    });
+  });
+
+  test('should pre-check and enable submit when bCase has leadTrialAttorney', async () => {
+    const modalRef = React.createRef<AssignAttorneyModalRef>();
+    renderWithProps(modalRef);
+
+    const sortedAttorneys = [...attorneyList].sort((a, b) => a.name.localeCompare(b.name));
+    const preSelectedAttorney = sortedAttorneys[0];
+
+    const bCase: CaseBasics = MockData.getCaseBasics({
+      override: { caseId: '081-23-00004', caseTitle: 'Test Case', dateFiled: '2024-01-01' },
+    });
+    bCase.assignments = [];
+    bCase.leadTrialAttorney = { id: preSelectedAttorney.id, name: preSelectedAttorney.name };
+
+    act(() => modalRef.current?.show({ bCase, callback }));
+    await userEvent.click(screen.getByTestId('open-modal-button'));
+
+    const submitButton = screen.getByTestId(`button-${modalId}-submit-button`);
+    await waitFor(() => expect(submitButton).toBeEnabled());
+
+    await waitFor(() => {
+      const checkbox = screen.getByTestId(`checkbox-attorney-${preSelectedAttorney.id}-checkbox`);
+      expect(checkbox).toBeChecked();
+    });
+  });
+
   test('should display error alert when call to getAttorneys throws an error', async () => {
     const error = new Error('API Rejection');
     vi.spyOn(Api2, 'getOfficeAttorneys').mockRejectedValue(error);

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModal.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModal.tsx
@@ -38,7 +38,10 @@ function AssignAttorneyModal_(
     modalRef: ref as React.RefObject<ModalRefType | null>,
     submitButton: {
       label: 'Assign',
-      onClick: () => useCase.submitValues(props.assignmentChangeCallback, leadTrialAttorney!),
+      onClick: () => {
+        if (!leadTrialAttorney) return;
+        useCase.submitValues(props.assignmentChangeCallback, leadTrialAttorney);
+      },
       disabled: true,
       closeOnClick: false,
     },

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModal.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModal.tsx
@@ -22,6 +22,7 @@ function AssignAttorneyModal_(
   const controls = useAssignAttorneyModalControlsReact();
   const store = useAssignAttorneyModalStoreReact();
   const useCase = assignAttorneyModalUseCase(store, controls);
+  const [leadTrialAttorney, setLeadTrialAttorney] = useState<CamsUserReference | null>(null);
 
   const modalHeading = (
     <>
@@ -37,7 +38,7 @@ function AssignAttorneyModal_(
     modalRef: ref as React.RefObject<ModalRefType | null>,
     submitButton: {
       label: 'Assign',
-      onClick: () => useCase.submitValues(props.assignmentChangeCallback),
+      onClick: () => useCase.submitValues(props.assignmentChangeCallback, leadTrialAttorney!),
       disabled: true,
       closeOnClick: false,
     },
@@ -55,6 +56,7 @@ function AssignAttorneyModal_(
 
   useEffect(() => {
     useCase.fetchAttorneys();
+    setLeadTrialAttorney(store.bCase?.leadTrialAttorney ?? null);
   }, [store.bCase]);
 
   useEffect(() => {
@@ -62,6 +64,21 @@ function AssignAttorneyModal_(
       globalAlert?.error(store.globalAlertError);
     }
   }, [store.globalAlertError]);
+
+  useEffect(() => {
+    const checked = store.checkListValues;
+    if (checked.length === 1) {
+      setLeadTrialAttorney({ id: checked[0].id, name: checked[0].name });
+    } else {
+      setLeadTrialAttorney((prev) =>
+        prev && !checked.find((a) => a.id === prev.id) ? null : prev,
+      );
+    }
+  }, [store.checkListValues]);
+
+  useEffect(() => {
+    controls.modalRef.current?.buttons?.current?.disableSubmitButton(leadTrialAttorney === null);
+  }, [leadTrialAttorney]);
 
   const viewModel: AssignAttorneyModalViewModel = {
     actionButtonGroup,
@@ -79,6 +96,9 @@ function AssignAttorneyModal_(
     sortAttorneys: useCase.sortAttorneys,
     tableContainerRef: controls.tableContainerRef,
     updateCheckList: useCase.updateCheckList,
+    checkedAttorneys: store.checkListValues,
+    leadTrialAttorney,
+    updateLeadTrialAttorney: setLeadTrialAttorney,
   };
 
   return <AssignAttorneyModalView viewModel={viewModel} />;

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModalView.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModalView.tsx
@@ -47,6 +47,31 @@ export function AssignAttorneyModalView(props: AssignAttorneyModalViewProps) {
                   })}
             </div>
           </fieldset>
+          <div className="usa-form-group">
+            <label className="usa-label" htmlFor="lead-trial-attorney-select">
+              Select Lead Trial Attorney
+            </label>
+            <select
+              className="usa-select"
+              id="lead-trial-attorney-select"
+              value={viewModel.leadTrialAttorney?.id ?? ''}
+              onChange={(e) => {
+                const selected = viewModel.checkedAttorneys.find((a) => a.id === e.target.value);
+                viewModel.updateLeadTrialAttorney(
+                  selected ? { id: selected.id, name: selected.name } : null,
+                );
+              }}
+            >
+              <option value="">- Select -</option>
+              {[...viewModel.checkedAttorneys]
+                .sort((a, b) => viewModel.sortAttorneys(a as AttorneyUser, b as AttorneyUser))
+                .map((attorney) => (
+                  <option key={attorney.id} value={attorney.id}>
+                    {attorney.name}
+                  </option>
+                ))}
+            </select>
+          </div>
           {viewModel.alertMessage && (
             <Alert {...viewModel.alertMessage} show={true} inline={true} />
           )}

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModal.types.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModal.types.ts
@@ -49,6 +49,9 @@ export interface AssignAttorneyModalViewModel {
   sortAttorneys(a: AttorneyUser, b: AttorneyUser): number;
   tableContainerRef: RefObject<HTMLDivElement | null>;
   updateCheckList(ev: React.ChangeEvent<HTMLInputElement>, attorney: AttorneyUser): void;
+  checkedAttorneys: CamsUserReference[];
+  leadTrialAttorney: CamsUserReference | null;
+  updateLeadTrialAttorney(attorney: CamsUserReference | null): void;
 }
 
 export interface AssignAttorneyModalUseCase {
@@ -61,13 +64,17 @@ export interface AssignAttorneyModalUseCase {
   onOpen(): void;
   show(showProps: AssignAttorneyModalOpenProps | undefined): void;
   sortAttorneys(a: AttorneyUser, b: AttorneyUser): number;
-  submitValues(callback: (val: CamsUserReference[]) => void): void;
+  submitValues(
+    callback: (val: CamsUserReference[]) => void,
+    leadTrialAttorney: CamsUserReference,
+  ): void;
   updateCheckList(ev: React.ChangeEvent<HTMLInputElement>, attorney: AttorneyUser): void;
 }
 
 export interface AssignAttorneyModalCallbackProps {
   bCase: CaseBasics;
   selectedAttorneyList: AttorneyUser[];
+  leadTrialAttorney: CamsUserReference;
   previouslySelectedList: AttorneyUser[];
   status: 'success' | 'error';
   apiResult: object;

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.test.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.test.ts
@@ -176,9 +176,9 @@ describe('assignAttorneyModalUseCase tests', () => {
   });
 
   test('submitValues should throw an error when no case is supplied.', async () => {
-    await expect(useCase.submitValues(() => {})).rejects.toThrow(
-      'No bankruptcy case was supplied. Can not set attorneys without a case.',
-    );
+    await expect(
+      useCase.submitValues(() => {}, { id: 'att-1', name: 'Test Attorney' }),
+    ).rejects.toThrow('No bankruptcy case was supplied. Can not set attorneys without a case.');
   });
 
   test('updateCheckList should throw an error when no case is supplied.', async () => {
@@ -353,7 +353,10 @@ describe('assignAttorneyModalUseCase tests', () => {
       setCheckListValues: vi.fn(),
       setIsUpdatingAssignment: vi.fn(),
     });
-    await localUseCase.submitValues(mockAssignmentChangeCallback);
+    await localUseCase.submitValues(mockAssignmentChangeCallback, {
+      id: 'att-1',
+      name: 'Test Attorney',
+    });
     expect(mockSubmissionCallback).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'success' }),
     );
@@ -371,7 +374,7 @@ describe('assignAttorneyModalUseCase tests', () => {
       setCheckListValues: vi.fn(),
       setIsUpdatingAssignment: vi.fn(),
     });
-    await localUseCase.submitValues(() => {});
+    await localUseCase.submitValues(() => {}, { id: 'att-1', name: 'Test Attorney' });
     expect(mockSubmissionCallback).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'error' }),
     );
@@ -403,6 +406,90 @@ describe('assignAttorneyModalUseCase tests', () => {
     const localUseCase = assignAttorneyModalUseCase(mockStore, localControls);
     localUseCase.hide();
     expect(mockHide).toHaveBeenCalled();
+  });
+
+  test('show should pre-populate checkListValues from leadTrialAttorney when not already in assignments', () => {
+    const leadAttorney = { id: 'lead-1', name: 'Lead Attorney' };
+    const localSetCheckListValues = vi.fn();
+    const localUseCase = buildLocalUseCase({
+      setBCase: vi.fn(),
+      setCheckListValues: localSetCheckListValues,
+      setPreviouslySelectedList: vi.fn(),
+      setSubmissionCallback: vi.fn(),
+    });
+
+    localUseCase.show({
+      bCase: { caseId: 'c1', assignments: [], leadTrialAttorney: leadAttorney },
+      callback: vi.fn(),
+    } as never);
+
+    expect(localSetCheckListValues).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: leadAttorney.id, name: leadAttorney.name }),
+      ]),
+    );
+  });
+
+  test('show should not duplicate attorney who is both in assignments and leadTrialAttorney', () => {
+    const attorney = { id: 'att-1', name: 'Attorney One' };
+    const localSetCheckListValues = vi.fn();
+    const localUseCase = buildLocalUseCase({
+      setBCase: vi.fn(),
+      setCheckListValues: localSetCheckListValues,
+      setPreviouslySelectedList: vi.fn(),
+      setSubmissionCallback: vi.fn(),
+    });
+
+    localUseCase.show({
+      bCase: {
+        caseId: 'c1',
+        assignments: [{ userId: attorney.id, name: attorney.name }],
+        leadTrialAttorney: attorney,
+      },
+      callback: vi.fn(),
+    } as never);
+
+    const calledWith = localSetCheckListValues.mock.calls[0][0];
+    expect(calledWith.filter((a: { id: string }) => a.id === attorney.id)).toHaveLength(1);
+  });
+
+  test('submitValues should post to both TrialAttorney and LeadTrialAttorney roles', async () => {
+    const postSpy = vi.spyOn(Api2, 'postStaffAssignments').mockResolvedValue({} as never);
+    const leadAttorney = { id: 'lead-1', name: 'Lead Attorney' };
+    const localUseCase = buildLocalUseCase({
+      bCase: { caseId: 'c1', officeCode: 'OFF', assignments: [] },
+      checkListValues: [leadAttorney],
+      attorneyList: [leadAttorney],
+      submissionCallback: vi.fn(),
+      setCheckListValues: vi.fn(),
+      setIsUpdatingAssignment: vi.fn(),
+    });
+
+    await localUseCase.submitValues(vi.fn(), leadAttorney);
+
+    expect(postSpy).toHaveBeenCalledTimes(2);
+    expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ role: 'TrialAttorney' }));
+    expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ role: 'LeadTrialAttorney' }));
+  });
+
+  test('submitValues should include leadTrialAttorney in the success callback', async () => {
+    vi.spyOn(Api2, 'postStaffAssignments').mockResolvedValue({} as never);
+    const leadAttorney = { id: 'lead-1', name: 'Lead Attorney' };
+    const mockSubmissionCallback = vi.fn();
+    const localUseCase = buildLocalUseCase({
+      bCase: { caseId: 'c1', officeCode: 'OFF', assignments: [] },
+      checkListValues: [leadAttorney],
+      attorneyList: [leadAttorney],
+      submissionCallback: mockSubmissionCallback,
+      setCheckListValues: vi.fn(),
+      setIsUpdatingAssignment: vi.fn(),
+    });
+
+    await localUseCase.submitValues(vi.fn(), leadAttorney);
+
+    expect(mockSubmissionCallback).toHaveBeenCalledWith(
+      expect.objectContaining({ leadTrialAttorney: leadAttorney, status: 'success' }),
+    );
   });
 
   test('show should call setSubmissionCallback when a callback is provided', () => {

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.test.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.test.ts
@@ -472,6 +472,39 @@ describe('assignAttorneyModalUseCase tests', () => {
     expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ role: 'LeadTrialAttorney' }));
   });
 
+  test('submitValues should roll back TrialAttorney assignments when the LeadTrialAttorney call fails', async () => {
+    const leadAttorney = { id: 'lead-1', name: 'Lead Attorney' };
+    const previousAssignment = { userId: 'att-prev', name: 'Previous Attorney' };
+    const postSpy = vi
+      .spyOn(Api2, 'postStaffAssignments')
+      .mockResolvedValueOnce({} as never) // TrialAttorney succeeds
+      .mockRejectedValueOnce(new Error('Lead API error')) // LeadTrialAttorney fails
+      .mockResolvedValueOnce({} as never); // rollback succeeds
+    const mockSubmissionCallback = vi.fn();
+    const localUseCase = buildLocalUseCase({
+      bCase: { caseId: 'c1', officeCode: 'OFF', assignments: [previousAssignment] },
+      checkListValues: [leadAttorney],
+      attorneyList: [leadAttorney],
+      submissionCallback: mockSubmissionCallback,
+      setCheckListValues: vi.fn(),
+      setIsUpdatingAssignment: vi.fn(),
+    });
+
+    await localUseCase.submitValues(vi.fn(), leadAttorney);
+
+    expect(postSpy).toHaveBeenCalledTimes(3);
+    expect(postSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        role: 'TrialAttorney',
+        attorneyList: [{ id: previousAssignment.userId, name: previousAssignment.name }],
+      }),
+    );
+    expect(mockSubmissionCallback).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'error' }),
+    );
+  });
+
   test('submitValues should include leadTrialAttorney in the success callback', async () => {
     vi.spyOn(Api2, 'postStaffAssignments').mockResolvedValue({} as never);
     const leadAttorney = { id: 'lead-1', name: 'Lead Attorney' };

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.ts
@@ -2,7 +2,7 @@ import { AttorneyUser, CamsUserReference } from '@common/cams/users';
 import { deepEqual } from '@common/object-equality';
 import Api2 from '@/lib/models/api2';
 import { ResponseBody } from '@common/api/response';
-import { CamsRole } from '@common/cams/roles';
+import { CamsRole, AssignableRole } from '@common/cams/roles';
 import { getCamsUserReference } from '@common/cams/session';
 import {
   AssignAttorneyModalStore,
@@ -74,7 +74,10 @@ const assignAttorneyModalUseCase = (
       }
     },
 
-    submitValues: async (assignmentChangeCallback: (val: CamsUserReference[]) => void) => {
+    submitValues: async (
+      assignmentChangeCallback: (val: CamsUserReference[]) => void,
+      leadTrialAttorney: CamsUserReference,
+    ) => {
       if (!store.bCase) {
         throw Error('No bankruptcy case was supplied. Can not set attorneys without a case.');
       }
@@ -98,10 +101,16 @@ const assignAttorneyModalUseCase = (
           attorneyList: finalAttorneyList,
           role: CamsRole.TrialAttorney,
         });
+        await Api2.postStaffAssignments({
+          caseId: store.bCase?.caseId,
+          attorneyList: [leadTrialAttorney],
+          role: AssignableRole.LeadTrialAttorney,
+        });
         if (store.submissionCallback) {
           store.submissionCallback({
             bCase: store.bCase,
             selectedAttorneyList: finalAttorneyList,
+            leadTrialAttorney: leadTrialAttorney,
             previouslySelectedList: store.previouslySelectedList,
             status: 'success',
             apiResult: {},
@@ -115,6 +124,7 @@ const assignAttorneyModalUseCase = (
           store.submissionCallback({
             bCase: store.bCase,
             selectedAttorneyList: finalAttorneyList,
+            leadTrialAttorney: leadTrialAttorney,
             previouslySelectedList: store.previouslySelectedList,
             status: 'error',
             apiResult: e as Error,
@@ -184,14 +194,16 @@ const assignAttorneyModalUseCase = (
   const show = (showProps: AssignAttorneyModalOpenProps | undefined) => {
     if (showProps && showProps.bCase) {
       store.setBCase(showProps.bCase);
-      if (showProps.bCase.assignments) {
-        const attorneys: AttorneyUser[] = [];
-        showProps.bCase.assignments.forEach((assignment) => {
-          attorneys.push({ id: assignment.userId, name: assignment.name } as AttorneyUser);
-        });
-        store.setCheckListValues(attorneys);
-        store.setPreviouslySelectedList(attorneys);
+      const attorneys: AttorneyUser[] = [];
+      showProps.bCase.assignments?.forEach((assignment) => {
+        attorneys.push({ id: assignment.userId, name: assignment.name } as AttorneyUser);
+      });
+      const lta = showProps.bCase.leadTrialAttorney;
+      if (lta && !attorneys.find((a) => a.id === lta.id)) {
+        attorneys.push({ id: lta.id, name: lta.name } as AttorneyUser);
       }
+      store.setCheckListValues(attorneys);
+      store.setPreviouslySelectedList(attorneys);
       if (showProps.callback) {
         store.setSubmissionCallback(() => showProps.callback);
       }

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.ts
@@ -11,6 +11,20 @@ import {
   AssignAttorneyModalOpenProps,
 } from './assignAttorneyModal.types';
 
+function buildInitialAttorneyChecklist(
+  bCase: AssignAttorneyModalOpenProps['bCase'],
+): AttorneyUser[] {
+  const attorneys: AttorneyUser[] = [];
+  bCase.assignments?.forEach((assignment) => {
+    attorneys.push({ id: assignment.userId, name: assignment.name } as AttorneyUser);
+  });
+  const lta = bCase.leadTrialAttorney;
+  if (lta && !attorneys.find((a) => a.id === lta.id)) {
+    attorneys.push({ id: lta.id, name: lta.name } as AttorneyUser);
+  }
+  return attorneys;
+}
+
 const assignAttorneyModalUseCase = (
   store: AssignAttorneyModalStore,
   controls: AssignAttorneyModalControls,
@@ -101,11 +115,24 @@ const assignAttorneyModalUseCase = (
           attorneyList: finalAttorneyList,
           role: CamsRole.TrialAttorney,
         });
-        await Api2.postStaffAssignments({
-          caseId: store.bCase?.caseId,
-          attorneyList: [leadTrialAttorney],
-          role: AssignableRole.LeadTrialAttorney,
-        });
+        try {
+          await Api2.postStaffAssignments({
+            caseId: store.bCase?.caseId,
+            attorneyList: [leadTrialAttorney],
+            role: AssignableRole.LeadTrialAttorney,
+          });
+        } catch (leadError) {
+          const rollbackList: CamsUserReference[] = (store.bCase.assignments ?? []).map((a) => ({
+            id: a.userId,
+            name: a.name,
+          }));
+          await Api2.postStaffAssignments({
+            caseId: store.bCase.caseId,
+            attorneyList: rollbackList,
+            role: CamsRole.TrialAttorney,
+          });
+          throw leadError;
+        }
         if (store.submissionCallback) {
           store.submissionCallback({
             bCase: store.bCase,
@@ -194,14 +221,7 @@ const assignAttorneyModalUseCase = (
   const show = (showProps: AssignAttorneyModalOpenProps | undefined) => {
     if (showProps && showProps.bCase) {
       store.setBCase(showProps.bCase);
-      const attorneys: AttorneyUser[] = [];
-      showProps.bCase.assignments?.forEach((assignment) => {
-        attorneys.push({ id: assignment.userId, name: assignment.name } as AttorneyUser);
-      });
-      const lta = showProps.bCase.leadTrialAttorney;
-      if (lta && !attorneys.find((a) => a.id === lta.id)) {
-        attorneys.push({ id: lta.id, name: lta.name } as AttorneyUser);
-      }
+      const attorneys = buildInitialAttorneyChecklist(showProps.bCase);
       store.setCheckListValues(attorneys);
       store.setPreviouslySelectedList(attorneys);
       if (showProps.callback) {

--- a/user-interface/src/staff-assignment/row/StaffAssignmentRow.internal.test.ts
+++ b/user-interface/src/staff-assignment/row/StaffAssignmentRow.internal.test.ts
@@ -57,6 +57,7 @@ describe('StaffAssignmentRowInternal', () => {
       status: 'success',
       apiResult: {},
       bCase,
+      leadTrialAttorney: mappedCaseAssignments[0],
       previouslySelectedList: mappedCaseAssignments,
       selectedAttorneyList: endingAssignments.map((assignment) => {
         return { id: assignment.userId!, name: assignment.name! };
@@ -82,6 +83,7 @@ describe('StaffAssignmentRowInternal', () => {
         message: errorMessage,
       },
       bCase,
+      leadTrialAttorney: mappedCaseAssignments[0],
       previouslySelectedList: mappedCaseAssignments,
       selectedAttorneyList: mappedCaseAssignments,
     });
@@ -99,6 +101,7 @@ describe('StaffAssignmentRowInternal', () => {
       status: 'success',
       apiResult: {},
       bCase: undefined as never,
+      leadTrialAttorney: mappedCaseAssignments[0],
       previouslySelectedList: mappedCaseAssignments,
       selectedAttorneyList: mappedCaseAssignments,
     });
@@ -117,6 +120,7 @@ describe('StaffAssignmentRowInternal', () => {
       status: 'success',
       apiResult: {},
       bCase,
+      leadTrialAttorney: { id: attorney.id, name: attorney.name },
       previouslySelectedList: [],
       selectedAttorneyList: [{ id: attorney.id, name: attorney.name }],
     });
@@ -136,6 +140,7 @@ describe('StaffAssignmentRowInternal', () => {
       status: 'success',
       apiResult: {},
       bCase,
+      leadTrialAttorney: mappedCaseAssignments[0],
       previouslySelectedList: mappedCaseAssignments,
       selectedAttorneyList: [],
     });


### PR DESCRIPTION
# Purpose

Add support for designating a Lead Trial Attorney on a case, distinct from regular Trial Attorney assignments.

# Major Changes

  Common (common/)
                                                                                                                                                                                                       
  src/cams/roles.ts
  - Added LeadTrialAttorney to both CamsRole and AssignableRole enums                                                                                                                                  
                                                                                                                                                                                                       
  src/cams/cases.ts                                                                                                                                                                                    
  - Changed leadTrialAttorneys?: CamsUserReference[] → leadTrialAttorney?: CamsUserReference on CaseBasics                                                                                             
                                                                                                                                                                                                       
  src/cams/assignments.ts                                                                                                                                                                              
  - Widened StaffAssignmentAction.role to AssignableRoleType to allow LeadTrialAttorney                                                                                                                
                                                                                                                                                                                                       
  ---                                                                                                                                                                                                  
  Backend (backend/)                                                                                                                                                                                   
                                                                                                                                                                                                       
  lib/use-cases/case-assignment/case-assignment.ts                                                                                                                                                     
  - When assigning a LeadTrialAttorney, uses TrialAttorney as the "assignable role" for staff validation (they must be a trial attorney to be a lead)                                                  
  - Stores the assignment with role: LeadTrialAttorney                                                                                                                                                 
  - Filters existing assignment records by role to prevent cross-role unassignment                                                                                                                     
                                                                                                                                                                                                       
  lib/use-cases/cases/case-management.ts                                                                                                                                                               
  - getCaseDetail: splits assignments — TrialAttorney → caseDetails.assignments, first LeadTrialAttorney → caseDetails.leadTrialAttorney                                                               
  - searchCases: same split for case list results                                                                                                                                                      
  - getCaseAssignments: added ?? [] fallback so .filter() doesn't throw when a case has no assignments                                                                                                 
                                                                                                                                                                                                       
  ---                                                                                                                                                                                                  
  Frontend (user-interface/)                                                                                                                                                                           
                                                                                                                                                                                                       
  src/staff-assignment/modal/AssignAttorneyModal.tsx                                                                                                                                                   
  - Added leadTrialAttorney state (initially null)                                                                                                                                                     
  - Pre-populates from bCase.leadTrialAttorney when a case is loaded                                                                                                                                   
  - Auto-selects: if exactly 1 attorney is checked, auto-sets them as lead                                                                                                                             
  - Disables submit button when no lead is selected                                                                                                                                                    
                                                                                                                                                                                                       
  src/staff-assignment/modal/AssignAttorneyModalView.tsx                                                                                                                                               
  - Replaced the ComboBox with a native USWDS <select> scoped to only the checked attorneys                                                                                                            
                                                                                                                                                                                                       
  src/staff-assignment/modal/assignAttorneyModalUseCase.ts                                                                                                                                             
  - submitValues posts two API calls: one for TrialAttorney (full list) and one for LeadTrialAttorney (single)                                                                                         
  - show pre-populates checkboxes from both assignments and leadTrialAttorney, deduped                                                                                                                 
  - Both success and error callbacks include leadTrialAttorney                                                                                                                                         
                                                                                                                                                                                                       
  src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.tsx                                                                                                                                         
  - Displays lead trial attorney in its own <li> with "Lead Trial Attorney" role label                                                                                                                 
  - Deduplicates: lead attorney is excluded from the regular Trial Attorney list                                                                                                                       
  - (unassigned) placeholder only shows when both assignments and leadTrialAttorney are absent                                                                                                         
                                                                                                                                                                                                       
  src/case-detail/CaseDetailScreen.tsx                                                                                                                                                                 
  - Passes leadTrialAttorney through the assignment callback update 

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add explicit support for designating and handling a single Lead Trial Attorney per case across shared types, backend case assignment/case management flows, and UI assignment/case-detail screens.

New Features:
- Introduce LeadTrialAttorney as an assignable role alongside TrialAttorney and expose it on case basics and case detail views.
- Allow users to select a Lead Trial Attorney in the Assign Attorney modal, including auto-selection when a single attorney is checked.

Enhancements:
- Split mixed trial-attorney assignments into regular TrialAttorney and a distinct leadTrialAttorney field in case detail and search results.
- Ensure assigning a LeadTrialAttorney validates against trial-attorney eligibility, avoids removing regular TrialAttorney assignments, and scopes unassignment by role.
- Pre-populate and deduplicate assignment checklists and case-detail displays when a lead trial attorney is present, and hide the unassigned placeholder when any attorney is assigned as lead.

Tests:
- Extend backend and frontend tests to cover LeadTrialAttorney validation, assignment persistence, case-detail/search splitting, modal behavior, and deduplication logic.