### PR TITLE
Fix missing MSSQL_DATABASE_DXTR

### DIFF
--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -297,6 +297,7 @@ resource apiMainAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
       INFO_SHA: 'ProductionSlot'
       MyTaskHub: 'main'
       COSMOS_DATABASE_NAME: cosmosDatabaseName
+      MSSQL_DATABASE_DXTR: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=MSSQL-DATABASE-DXTR)'
       AzureWebJobsStorage: apiFunctionStorageAccount.outputs.connectionString
       AzureWebJobsDataflowsStorage: dataflowsStorageConnectionString
     }


### PR DESCRIPTION
# Purpose

Fix broken main deployment

# Major Changes

Add MSSQL_DATABASE_DXTR that was omitted from the last fix to the CI pipeline.

## Summary by Sourcery

Add the missing MSSQL database application setting to the backend API deployment configuration so main deployment succeeds.

Build:
- Configure backend API app settings to include MSSQL_DATABASE_DXTR sourced from Key Vault for main deployment.

CI:
- Align deployment configuration with CI expectations by adding the MSSQL_DATABASE_DXTR setting required for successful main deployment.