### PR TITLE
Fix GPG decryption error by pinning cloudposse action

### DIFF
--- a/.github/workflows/reusable-build-info.yml
+++ b/.github/workflows/reusable-build-info.yml
@@ -119,28 +119,28 @@ jobs:
           echo "dataflowsFunctionName=${dataflowsFunctionName}" >> $GITHUB_OUTPUT
           echo "slotName=${{ vars.SLOT_NAME }}" >> $GITHUB_OUTPUT
 
-      - uses: cloudposse/github-action-secret-outputs@main
+      - uses: cloudposse/github-action-secret-outputs@67ae2f7ee1890986ba0012bacd079a5a36ecb449 # main
         id: rgApp
         with:
           secret: ${{ secrets.PGP_SIGNING_PASSPHRASE }}
           op: encode
           in: ${{ steps.build-info.outputs.azResourceGrpApp }}
 
-      - uses: cloudposse/github-action-secret-outputs@main
+      - uses: cloudposse/github-action-secret-outputs@67ae2f7ee1890986ba0012bacd079a5a36ecb449 # main
         id: rgNetwork
         with:
           secret: ${{ secrets.PGP_SIGNING_PASSPHRASE }}
           op: encode
           in: ${{ steps.build-info.outputs.azResourceGrpNetwork }}
 
-      - uses: cloudposse/github-action-secret-outputs@main
+      - uses: cloudposse/github-action-secret-outputs@67ae2f7ee1890986ba0012bacd079a5a36ecb449 # main
         id: rgAppDecode
         with:
           secret: ${{ secrets.PGP_SIGNING_PASSPHRASE }}
           op: decode
           in: ${{ steps.rgApp.outputs.out }}
 
-      - uses: cloudposse/github-action-secret-outputs@main
+      - uses: cloudposse/github-action-secret-outputs@67ae2f7ee1890986ba0012bacd079a5a36ecb449 # main
         id: rgNetworkDecode
         with:
           secret: ${{ secrets.PGP_SIGNING_PASSPHRASE }}


### PR DESCRIPTION
# Purpose

Fix GitHub Actions GPG decryption failure: `gpg: decrypt_message failed: Unknown system error`

This error was preventing the E2E workflow from decoding encrypted resource group names passed from `reusable-build-info.yml`.

## Root Cause

Version mismatch in the `cloudposse/github-action-secret-outputs` action:
- `reusable-build-info.yml` used `@main` to **encode** secrets
- `reusable-e2e.yml` and other workflows used pinned version `@67ae2f7` to **decode** secrets
- The incompatible GPG versions caused decryption to fail

## Timeline of the Issue

1. **March 31, 2026** - Commit `32d824523` (PR #2107)
   - ✅ Originally pinned to `67ae2f7` and merged to main

2. **April 7, 2026** - Commit `071ef2968` ("CAMS-723 - Pre-merge e2e")
   - ❌ Accidentally reverted back to `@main` (likely from merge conflict or branch based on old code)
   - **This introduced the GPG decryption bug**

3. **April 8, 2026** - Commit `7e1b31b23` (Renovate bot)
   - 🤖 Renovate detected the issue and created PR to re-pin to `67ae2f7`
   - ⚠️ Never merged - still sitting on `origin/renovate/cloudposse-github-action-secret-outputs-.x`

4. **April 13, 2026** - This fix
   - ✅ Re-pinned all 4 instances in `reusable-build-info.yml` to `67ae2f7`

# Major Changes

- Pinned `cloudposse/github-action-secret-outputs` to `@67ae2f7ee1890986ba0012bacd079a5a36ecb449` in `reusable-build-info.yml`
- Changed all 4 instances:
  - `rgApp` (encode)
  - `rgNetwork` (encode)
  - `rgAppDecode` (decode)
  - `rgNetworkDecode` (decode)
- Now matches the version used in all other workflows (`reusable-e2e.yml`, `reusable-deploy.yml`, etc.)

# Testing/Validation

- [x] Workflow file passes YAML linting
- [ ] GitHub Actions workflow runs successfully without GPG errors
- [ ] E2E tests can decode encrypted resource group names
- [ ] Build info job completes without errors

# Notes

- The Renovate bot's fix attempt (commit `7e1b31b23`) on April 8 was correct but never merged
- All other workflows were already using the pinned version, so this was the only file out of sync
- Future: Consider using Renovate's auto-merge for pinned action updates to prevent version drift

Jira ticket: CAMS-723