### PR TITLE
CAMS-723 Fix deployment slot SQL health check failure

### DIFF
--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -74,7 +74,6 @@ param idKeyvaultAppConfiguration string
 
 param cosmosDatabaseName string
 param e2eDatabaseName string
-param e2eSqlDatabaseName string
 
 @description('boolean to determine creation and configuration of Application Insights for the Azure Function')
 param deployAppInsights bool = false
@@ -268,7 +267,7 @@ resource apiSlotAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
       INFO_SHA: gitSha
       MyTaskHub: slotName
       COSMOS_DATABASE_NAME: e2eDatabaseName
-      MSSQL_DATABASE_DXTR: e2eSqlDatabaseName
+      MSSQL_DATABASE_DXTR: '@Microsoft.KeyVault(VaultName=${kvAppConfigName};SecretName=MSSQL-DATABASE-DXTR)'
       AzureWebJobsStorage: apiFunctionSlotStorageAccount.outputs.connectionString
       AzureWebJobsDataflowsStorage: dataflowsSlotStorageConnectionString
     }

--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -262,7 +262,6 @@ module ustpApiFunction 'backend-api-deploy.bicep' = {
       loginProvider: loginProvider
       cosmosDatabaseName: cosmosDatabaseName
       e2eDatabaseName: e2eDatabaseName
-      e2eSqlDatabaseName: e2eSqlDatabaseName
       kvAppConfigName: kvAppConfigName
       isUstpDeployment: isUstpDeployment
       mssqlRequestTimeout: mssqlRequestTimeout


### PR DESCRIPTION
## Summary

- The deployment slot's `MSSQL_DATABASE_DXTR` was set to `e2eSqlDatabaseName` (`CAMS_E2E`) by the CAMS-723 E2E work
- `CAMS_E2E` does not exist as a SQL database on the DXTR server, so the pre-swap health check returned `sqlDbReadStatus: false` on every main branch deployment since `0a283ddeb`
- Restores the deployment slot to use the Key Vault reference (`MSSQL-DATABASE-DXTR`) — the same real DXTR database the production slot uses — matching pre-`0a283ddeb` behavior

## Root Cause

`0a283ddeb` ("CAMS-723 Fix gaps in E2E db deployment") refactored `backend-api-deploy.bicep` and explicitly set the API deployment slot's `MSSQL_DATABASE_DXTR` to the E2E SQL database name. Previously the slot inherited the Key Vault reference from base settings and connected to the real DXTR database. Subsequent fixes (`f1843d43e`, `2e55d0a78`) only addressed the production slot and left the deployment slot broken.

## Test plan

- [ ] CI run on this branch passes health check (`sqlDbReadStatus: true`)
- [ ] `curl https://ustp-cams-node-api-development.azurewebsites.us/api/healthcheck` returns HTTP 200 with `sqlDbReadStatus: true`
- [ ] Slot swap completes successfully

Jira ticket: CAMS-723

## Summary by Sourcery

Restore the backend API deployment slot SQL database configuration to use the production DXTR Key Vault secret instead of the E2E database and remove the unused E2E SQL database parameter wiring.

Bug Fixes:
- Fix deployment slot health check failures by pointing MSSQL_DATABASE_DXTR to the real DXTR database via Key Vault rather than the non-existent E2E database.

Enhancements:
- Simplify deployment templates by removing the unused e2eSqlDatabaseName parameter from backend-api-deploy and its invocation in main.bicep.