### PR TITLE
Fix webapp SHA check race condition in endpoint-test.sh

### DIFF
--- a/ops/scripts/pipeline/endpoint-test.sh
+++ b/ops/scripts/pipeline/endpoint-test.sh
@@ -180,9 +180,13 @@ if [[ "${expected_git_sha}" != '' ]]; then
   echo "Expect sha ${expected_git_sha}"
   retry=0
   currentGitSha=""
-  while [ "${expected_git_sha}" != "${currentGitSha}" ] && [ ${retry} -le 2 ]; do
+  shaCheck="PENDING"
+  # Retry until both API and webapp SHA checks pass (or max retries reached)
+  while [ ${retry} -le 2 ]; do
     retry=$((retry+1))
     echo "Retry attempt: $retry"
+
+    # Check API SHA
     curl "${targetApiURL}" -s | tee api_response.json || true
     echo "api_response.json contents:"
     cat api_response.json
@@ -194,14 +198,8 @@ except Exception as e:
     print('')" || true)
     echo "Current sha ${currentGitSha}"
     echo "Comparing expected_git_sha: $expected_git_sha with currentGitSha: $currentGitSha"
-    if [[ "${expected_git_sha}" == "${currentGitSha}" ]]; then
-      apiStatusCode=$("${apiCmd[@]}" || true)
-    else
-      apiStatusCode=0 # if version does not match set to a non 200 status code
-      sleep 60
-    fi
 
-    # Check front end SHA meta tag
+    # Check webapp SHA
     shaCheck="OK"
     webStatusCheck=$("${webCmd[@]}" || true)
     echo "webStatusCheck: $webStatusCheck"
@@ -212,6 +210,28 @@ except Exception as e:
         echo "Expected SHA not found in webapp HTML."
         shaCheck="FAILED"
         curl "$targetWebAppURL" -s | grep -i meta || true
+      fi
+    fi
+
+    # Exit loop if both checks pass
+    if [[ "${expected_git_sha}" == "${currentGitSha}" && "$shaCheck" == "OK" ]]; then
+      echo "Both API and webapp SHA checks passed"
+      apiStatusCode=$("${apiCmd[@]}" || true)
+      break
+    fi
+
+    # If not the last retry, sleep and try again
+    if [ ${retry} -le 2 ]; then
+      echo "SHA check incomplete (API: ${currentGitSha}, webapp: ${shaCheck}). Retrying in 60s..."
+      apiStatusCode=0 # Set to non-200 to indicate failure
+      sleep 60
+    else
+      echo "Max retries reached. Final state - API SHA: ${currentGitSha}, webapp SHA check: ${shaCheck}"
+      # Set final status codes
+      if [[ "${expected_git_sha}" == "${currentGitSha}" ]]; then
+        apiStatusCode=$("${apiCmd[@]}" || true)
+      else
+        apiStatusCode=0
       fi
     fi
   done


### PR DESCRIPTION
The webapp SHA verification was failing intermittently because it only ran once when the API SHA matched, with no retry opportunity. This caused deployments to fail even when the correct SHA was present.

Changes:
- Modified retry loop to check both API and webapp SHA on each iteration
- Loop now exits only when BOTH checks pass (not just API)
- Added proper sleep/retry logic when either check fails
- Improved logging to show which check is incomplete

The script now allows up to 3 attempts with 60s delays for both the API and webapp to synchronize, preventing false failures from timing issues or instance synchronization lag.

Jira ticket: CAMS-723

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve endpoint-test deployment script SHA verification to handle race conditions between API and webapp versions.

Bug Fixes:
- Ensure the endpoint-test script retries both API and webapp SHA checks up to three times before failing to avoid intermittent false negatives.
- Only mark the SHA verification as successful when both API and webapp SHAs match the expected value.
- Provide clearer logging when API or webapp SHA checks are incomplete or when maximum retries are reached.