### PR TITLE
e2e firewall merge to main troubleshooting

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -64,6 +64,13 @@ jobs:
           --stack-name ${{ inputs.stackName }} \
           --server-name ${{ secrets.AZ_SQL_SERVER_NAME }}
 
+          if [[ "${{ inputs.ghaEnvironment }}" == "Main-Gov" ]]; then
+            ./ops/scripts/pipeline/add-cosmos-firewall-rule.sh \
+            -g ${{ secrets.AZURE_RG }} \
+            --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \
+            --stack-name ${{ inputs.stackName }}
+          fi
+
       - name: Install Application Node Dependencies
         run: npm ci
 
@@ -140,3 +147,11 @@ jobs:
           --stack-name ${{ inputs.stackName }} \
           --server-name ${{ secrets.AZ_SQL_SERVER_NAME }} \
           --delete
+
+          if [[ "${{ inputs.ghaEnvironment }}" == "Main-Gov" ]]; then
+            ./ops/scripts/pipeline/add-cosmos-firewall-rule.sh \
+            -g ${{ secrets.AZURE_RG }} \
+            --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \
+            --stack-name ${{ inputs.stackName }} \
+            --delete
+          fi

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -67,8 +67,7 @@ jobs:
           if [[ "${{ inputs.ghaEnvironment }}" == "Main-Gov" ]]; then
             ./ops/scripts/pipeline/add-cosmos-firewall-rule.sh \
             -g ${{ secrets.AZURE_RG }} \
-            --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \
-            --stack-name ${{ inputs.stackName }}
+            --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }}
           fi
 
       - name: Install Application Node Dependencies
@@ -152,6 +151,5 @@ jobs:
             ./ops/scripts/pipeline/add-cosmos-firewall-rule.sh \
             -g ${{ secrets.AZURE_RG }} \
             --account-name ${{ secrets.AZ_COSMOS_MONGO_ACCOUNT_NAME }} \
-            --stack-name ${{ inputs.stackName }} \
             --delete
           fi

--- a/ops/scripts/pipeline/add-cosmos-firewall-rule.sh
+++ b/ops/scripts/pipeline/add-cosmos-firewall-rule.sh
@@ -4,18 +4,20 @@
 # Prerequisite:
 #   - curl
 #   - Azure CLI
-# Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str> --stack-name <stack_name:str> [--delete]
+# Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str> [--delete]
 
 set -euo pipefail # ensure job step fails in CI pipeline when error occurs
 
+db_rg=
+cosmos_account=
 delete=
 while [[ $# -gt 0 ]]; do
     case $1 in
     -h | --help)
         printf ""
-        printf "Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str> --stack-name <stack_name:str> [--delete]"
+        printf "Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str> [--delete]"
         printf ""
-        shift
+        exit 0
         ;;
     -g | --resource-group)
         db_rg="${2}"
@@ -24,11 +26,6 @@ while [[ $# -gt 0 ]]; do
 
     --account-name)
         cosmos_account="${2}"
-        shift 2
-        ;;
-
-    --stack-name)
-        stack_name="${2}"
         shift 2
         ;;
 
@@ -43,12 +40,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "${db_rg}" || -z "${cosmos_account}" || -z "${stack_name}" ]]; then
-    printf "Error: Missing parameters. Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str> --stack-name <stack_name:str>"
+if [[ -z "${db_rg}" || -z "${cosmos_account}" ]]; then
+    printf "Error: Missing parameters. Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str>"
     exit 1
 fi
 
 agentIp=$(curl -s --retry 3 --retry-delay 30 --retry-all-errors https://api.ipify.org)
+
+if [[ -z "${agentIp}" ]]; then
+    printf "Error: Unable to determine GHA runner IP address."
+    exit 1
+fi
 
 existingIps=$(az cosmosdb show -n "${cosmos_account}" -g "${db_rg}" --query "ipRules[].ipAddressOrRange" -o tsv 2>/dev/null | tr '\n' ',' | sed 's/,$//')
 

--- a/ops/scripts/pipeline/add-cosmos-firewall-rule.sh
+++ b/ops/scripts/pipeline/add-cosmos-firewall-rule.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Description: Helper script to add/remove GHA runner IP in Cosmos DB firewall rules
+# Prerequisite:
+#   - curl
+#   - Azure CLI
+# Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str> --stack-name <stack_name:str> [--delete]
+
+set -euo pipefail # ensure job step fails in CI pipeline when error occurs
+
+delete=
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -h | --help)
+        printf ""
+        printf "Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str> --stack-name <stack_name:str> [--delete]"
+        printf ""
+        shift
+        ;;
+    -g | --resource-group)
+        db_rg="${2}"
+        shift 2
+        ;;
+
+    --account-name)
+        cosmos_account="${2}"
+        shift 2
+        ;;
+
+    --stack-name)
+        stack_name="${2}"
+        shift 2
+        ;;
+
+    --delete)
+        delete=true
+        shift
+        ;;
+
+    *)
+        exit 2 # error on unknown flag/switch
+        ;;
+    esac
+done
+
+if [[ -z "${db_rg}" || -z "${cosmos_account}" || -z "${stack_name}" ]]; then
+    printf "Error: Missing parameters. Usage: add-cosmos-firewall-rule.sh -g <resource_group:str> --account-name <cosmos_account:str> --stack-name <stack_name:str>"
+    exit 1
+fi
+
+agentIp=$(curl -s --retry 3 --retry-delay 30 --retry-all-errors https://api.ipify.org)
+
+existingIps=$(az cosmosdb show -n "${cosmos_account}" -g "${db_rg}" --query "ipRules[].ipAddressOrRange" -o tsv 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+
+if [[ -n "${delete}" ]]; then
+    echo "Removing GHA runner IP (${agentIp}) from Cosmos DB firewall..."
+    newIps=$(echo "${existingIps}" | tr ',' '\n' | grep -v "^${agentIp}$" | tr '\n' ',' | sed 's/,$//' || true)
+    az cosmosdb update -n "${cosmos_account}" -g "${db_rg}" --ip-range-filter "${newIps}" 1>/dev/null
+    echo "IP removed..."
+else
+    echo "Adding GHA runner IP (${agentIp}) to Cosmos DB firewall..."
+    if [[ -n "${existingIps}" ]]; then
+        newIps="${existingIps},${agentIp}"
+    else
+        newIps="${agentIp}"
+    fi
+    az cosmosdb update -n "${cosmos_account}" -g "${db_rg}" --ip-range-filter "${newIps}" 1>/dev/null
+    echo "IP added. Waiting for firewall rule to propagate..."
+    sleep 60
+fi


### PR DESCRIPTION
# Purpose

Add firewall rule to CI merge to main build to troubleshoot mongoDB firewall issues.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add a helper script and CI wiring to manage Cosmos DB firewall rules for GitHub Actions runners in the Main-Gov environment.

Build:
- Update reusable e2e GitHub Actions workflow to add and later remove Cosmos DB firewall rules during Main-Gov runs using a helper script.

Deployment:
- Introduce a pipeline script to add or delete the GitHub Actions runner IP from Cosmos DB firewall rules for troubleshooting connectivity issues.