### PR TITLE
CAMS-727 fixing UI styling and validation logic

### DIFF
--- a/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteeAndAssignedStaff.test.tsx
@@ -161,7 +161,9 @@ describe('CaseDetailTrusteeAndAssignedStaff', () => {
         return element?.classList.contains('assignee-name') || false;
       });
       expect(assigneeNames[0]).toHaveTextContent(leadAttorney.name);
-      expect(screen.getByText('Lead Trial Attorney')).toBeInTheDocument();
+      expect(
+        screen.getByText('Lead Trial Attorney', { selector: '.assignee-role' }),
+      ).toBeInTheDocument();
     });
 
     test('should not show unassigned placeholder when leadTrialAttorney is set', () => {
@@ -183,7 +185,9 @@ describe('CaseDetailTrusteeAndAssignedStaff', () => {
       };
       renderWithProps({ caseDetail: caseDetailWithLead });
 
-      expect(screen.getByText('Lead Trial Attorney')).toBeInTheDocument();
+      expect(
+        screen.getByText('Lead Trial Attorney', { selector: '.assignee-role' }),
+      ).toBeInTheDocument();
 
       // TEST_ASSIGNMENT_1 should only appear once total (as Lead, not also as Trial Attorney)
       const assigneeNames = screen.getAllByText((_content, element) => {

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilter.types.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilter.types.ts
@@ -2,7 +2,7 @@ import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
 import { ResponseBody } from '@common/api/response';
 import { UstpOfficeDetails } from '@common/cams/offices';
-import { CamsUserReference } from '@common/cams/users';
+import { Staff } from '@common/cams/users';
 
 export const UNASSIGNED_OPTION = {
   value: 'UNASSIGNED',
@@ -15,8 +15,8 @@ interface StaffAssignmentFilterStore {
   setFilterAssigneeCallback(val: ((assignees: ComboOption[]) => void) | null): void;
   focusOnRender: boolean;
   setFocusOnRender(val: boolean): void;
-  officeAssignees: CamsUserReference[];
-  setOfficeAssignees(val: CamsUserReference[]): void;
+  officeAssignees: Staff[];
+  setOfficeAssignees(val: Staff[]): void;
   officeAssigneesError: boolean;
   setOfficeAssigneesError(val: boolean): void;
 }
@@ -30,11 +30,11 @@ type StaffAssignmentFilterViewProps = {
 };
 
 interface StaffAssignmentFilterViewModel {
-  officeAssignees: CamsUserReference[];
+  officeAssignees: Staff[];
   officeAssigneesError: boolean;
   assigneesFilterRef: React.RefObject<ComboBoxRef | null>;
 
-  assigneesToComboOptions(officeAssignees: CamsUserReference[]): ComboOption[];
+  assigneesToComboOptions(officeAssignees: Staff[]): ComboOption[];
   handleFilterAssignee(assignees: ComboOption[]): void;
 }
 
@@ -53,13 +53,13 @@ type StaffAssignmentFilterProps = {
 };
 
 interface StaffAssignmentFilterUseCase {
-  assigneesToComboOptions(officeAssignees: CamsUserReference[]): ComboOption[];
+  assigneesToComboOptions(officeAssignees: Staff[]): ComboOption[];
   fetchAssignees(): void;
   focusOnAssigneesFilter(): void;
   getOfficeAssignees(
-    apiFunction: (office: string) => Promise<ResponseBody<CamsUserReference[]>>,
+    apiFunction: (office: string) => Promise<ResponseBody<Staff[]>>,
     offices: UstpOfficeDetails[],
-  ): Promise<CamsUserReference[]>;
+  ): Promise<Staff[]>;
   handleFilterAssignee(val: ComboOption[]): void;
 }
 

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilter.types.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilter.types.ts
@@ -2,7 +2,7 @@ import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
 import { ResponseBody } from '@common/api/response';
 import { UstpOfficeDetails } from '@common/cams/offices';
-import { Staff } from '@common/cams/users';
+import { CamsUserReference, Staff } from '@common/cams/users';
 
 export const UNASSIGNED_OPTION = {
   value: 'UNASSIGNED',

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.test.ts
@@ -12,14 +12,15 @@ import { UstpOfficeDetails } from '@common/cams/offices';
 import Api2 from '@/lib/models/api2';
 import MockApi2 from '@/lib/testing/mock-api2';
 import { MockInstance } from 'vitest';
-import { CamsUserReference } from '@common/cams/users';
+import { Staff } from '@common/cams/users';
+import { CamsRole } from '@common/cams/roles';
 import { ResponseBody } from '@common/api/response';
 
 describe('staff assignment filter use case tests', () => {
   let mockFeatureFlags: FeatureFlagSet;
-  let setOfficeAssigneesSpy: MockInstance<(val: CamsUserReference[]) => void>;
+  let setOfficeAssigneesSpy: MockInstance<(val: Staff[]) => void>;
   let setOfficeAssigneesErrorSpy: MockInstance<(val: boolean) => void>;
-  const assignees = MockData.buildArray(MockData.getCamsUserReference, 5);
+  const assignees = MockData.buildArray(MockData.getStaffAssignee, 5);
   const mockStore: StaffAssignmentFilterStore = {
     officeAssignees: assignees,
     setOfficeAssignees: vi.fn(),
@@ -87,15 +88,30 @@ describe('staff assignment filter use case tests', () => {
     expect(comboOptions).toEqual(expectedComboOptions);
   });
 
+  test('assigneesToComboOptions should place lead attorneys first with "(Lead)" label', () => {
+    const lead = MockData.getStaffAssignee({
+      id: 'lead-1',
+      name: 'Zelda',
+      roles: [CamsRole.LeadTrialAttorney],
+    });
+    const nonLead = MockData.getStaffAssignee({ id: 'non-lead-1', name: 'Aaron' });
+
+    const comboOptions = useCase.assigneesToComboOptions([nonLead, lead]);
+
+    expect(comboOptions[0]).toEqual({ label: '(unassigned)', value: 'UNASSIGNED', divider: true });
+    expect(comboOptions[1]).toEqual({ label: 'Zelda (Lead)', value: 'lead-1' });
+    expect(comboOptions[2]).toEqual({ label: 'Aaron', value: 'non-lead-1' });
+  });
+
   test('getOfficeAssignees should return a unique and sorted array of assignees', async () => {
-    const user1 = MockData.getCamsUserReference({ id: 'user-1', name: 'alfred' });
-    const user2 = MockData.getCamsUserReference({ id: 'user-2', name: 'boe' });
-    const user3 = MockData.getCamsUserReference({ id: 'user-3', name: 'frankie' });
+    const user1 = MockData.getStaffAssignee({ id: 'user-1', name: 'alfred' });
+    const user2 = MockData.getStaffAssignee({ id: 'user-2', name: 'boe' });
+    const user3 = MockData.getStaffAssignee({ id: 'user-3', name: 'frankie' });
     const mockStaff = [user3, user1, user2, user2, user1];
     const expectedAssignees = [user1, user2, user3];
 
     const offices: UstpOfficeDetails[] = [MockData.getOfficeWithStaff(mockStaff)];
-    const callback = async (_officeCode: string): Promise<ResponseBody<CamsUserReference[]>> => {
+    const callback = async (_officeCode: string): Promise<ResponseBody<Staff[]>> => {
       return Promise.resolve({ data: mockStaff });
     };
 

--- a/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.ts
+++ b/user-interface/src/staff-assignment/filters/staffAssignmentFilterUseCase.ts
@@ -5,7 +5,8 @@ import {
   UNASSIGNED_OPTION,
 } from './staffAssignmentFilter.types';
 import { ResponseBody } from '@common/api/response';
-import { CamsUserReference } from '@common/cams/users';
+import { Staff } from '@common/cams/users';
+import { CamsRole } from '@common/cams/roles';
 import { UstpOfficeDetails } from '@common/cams/offices';
 import Api2 from '@/lib/models/api2';
 import LocalStorage from '@/lib/utils/local-storage';
@@ -15,16 +16,22 @@ const staffAssignmentFilterUseCase = (
   store: StaffAssignmentFilterStore,
   controls: StaffAssignmentFilterControls,
 ): StaffAssignmentFilterUseCase => {
-  const assigneesToComboOptions = (officeAssignees: CamsUserReference[]): ComboOption[] => {
-    const comboOptions: ComboOption[] = [];
+  const assigneesToComboOptions = (officeAssignees: Staff[]): ComboOption[] => {
+    const leads: ComboOption[] = [];
+    const nonLeads: ComboOption[] = [];
     officeAssignees.forEach((assignee) => {
-      comboOptions.push({
+      const isLead = assignee.roles?.includes(CamsRole.LeadTrialAttorney) ?? false;
+      const option: ComboOption = {
         value: assignee.id,
-        label: assignee.name,
-      });
+        label: isLead ? `${assignee.name} (Lead)` : assignee.name,
+      };
+      if (isLead) {
+        leads.push(option);
+      } else {
+        nonLeads.push(option);
+      }
     });
-    comboOptions.unshift(UNASSIGNED_OPTION);
-    return comboOptions;
+    return [UNASSIGNED_OPTION, ...leads, ...nonLeads];
   };
 
   const fetchAssignees = async () => {
@@ -46,10 +53,10 @@ const staffAssignmentFilterUseCase = (
   };
 
   const getOfficeAssignees = async (
-    apiFunction: (office: string) => Promise<ResponseBody<CamsUserReference[]>>,
+    apiFunction: (office: string) => Promise<ResponseBody<Staff[]>>,
     offices: UstpOfficeDetails[],
-  ): Promise<CamsUserReference[]> => {
-    const assigneeMap: Map<string, CamsUserReference> = new Map();
+  ): Promise<Staff[]> => {
+    const assigneeMap: Map<string, Staff> = new Map();
     for (const office of offices) {
       const assignees = await apiFunction(office.officeCode);
       assignees.data.forEach((assignee) => {

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModal.scss
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModal.scss
@@ -34,6 +34,14 @@
   .usa-modal__footer {
     margin-top: 0;
   }
+
+  .usa-form-group {
+    margin-top: 1rem;
+  }
+
+  .submit-cancel-button-group.usa-button-group {
+    margin-top: 1.5rem;
+  }
   .attorney-list {
     width: 100%;
     margin: 0 0 10px 0;

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModal.test.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModal.test.tsx
@@ -364,6 +364,59 @@ describe('Test Assign Attorney Modal Component', () => {
     });
   });
 
+  test('should disable submit when multiple attorneys are checked but lead attorney is cleared', async () => {
+    const modalRef = React.createRef<AssignAttorneyModalRef>();
+    renderWithProps(modalRef);
+
+    const bCase: CaseBasics = MockData.getCaseBasics({
+      override: { caseId: '081-23-00005', caseTitle: 'Test Case', dateFiled: '2024-01-01' },
+    });
+    bCase.assignments = [];
+
+    act(() => modalRef.current?.show({ bCase, callback }));
+    await userEvent.click(screen.getByTestId('open-modal-button'));
+
+    const submitButton = screen.getByTestId(`button-${modalId}-submit-button`);
+    await waitFor(() => expect(submitButton).toBeDisabled());
+
+    const sortedAttorneys = [...attorneyList].sort((a, b) => a.name.localeCompare(b.name));
+    await TestingUtilities.selectCheckbox(`attorney-${sortedAttorneys[0].id}-checkbox`);
+    await TestingUtilities.selectCheckbox(`attorney-${sortedAttorneys[1].id}-checkbox`);
+
+    await waitFor(() => expect(submitButton).toBeEnabled());
+
+    const leadSelect = screen.getByLabelText('Lead Trial Attorney');
+    await userEvent.selectOptions(leadSelect, '');
+
+    await waitFor(() => expect(submitButton).toBeDisabled());
+  });
+
+  test('should enable submit when lead attorney is selected from dropdown with multiple attorneys checked', async () => {
+    const modalRef = React.createRef<AssignAttorneyModalRef>();
+    renderWithProps(modalRef);
+
+    const bCase: CaseBasics = MockData.getCaseBasics({
+      override: { caseId: '081-23-00006', caseTitle: 'Test Case', dateFiled: '2024-01-01' },
+    });
+    bCase.assignments = [];
+
+    act(() => modalRef.current?.show({ bCase, callback }));
+    await userEvent.click(screen.getByTestId('open-modal-button'));
+
+    const submitButton = screen.getByTestId(`button-${modalId}-submit-button`);
+    const sortedAttorneys = [...attorneyList].sort((a, b) => a.name.localeCompare(b.name));
+
+    await TestingUtilities.selectCheckbox(`attorney-${sortedAttorneys[0].id}-checkbox`);
+    await TestingUtilities.selectCheckbox(`attorney-${sortedAttorneys[1].id}-checkbox`);
+
+    const leadSelect = screen.getByLabelText('Lead Trial Attorney');
+    await userEvent.selectOptions(leadSelect, '');
+    await waitFor(() => expect(submitButton).toBeDisabled());
+
+    await userEvent.selectOptions(leadSelect, sortedAttorneys[0].id);
+    await waitFor(() => expect(submitButton).toBeEnabled());
+  });
+
   test('should display error alert when call to getAttorneys throws an error', async () => {
     const error = new Error('API Rejection');
     vi.spyOn(Api2, 'getOfficeAttorneys').mockRejectedValue(error);

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModal.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModal.tsx
@@ -80,8 +80,10 @@ function AssignAttorneyModal_(
   }, [store.checkListValues]);
 
   useEffect(() => {
-    controls.modalRef.current?.buttons?.current?.disableSubmitButton(leadTrialAttorney === null);
-  }, [leadTrialAttorney]);
+    controls.modalRef.current?.buttons?.current?.disableSubmitButton(
+      leadTrialAttorney === null || store.checkListValues.length === 0,
+    );
+  }, [leadTrialAttorney, store.checkListValues]);
 
   const viewModel: AssignAttorneyModalViewModel = {
     actionButtonGroup,

--- a/user-interface/src/staff-assignment/modal/AssignAttorneyModalView.tsx
+++ b/user-interface/src/staff-assignment/modal/AssignAttorneyModalView.tsx
@@ -49,7 +49,7 @@ export function AssignAttorneyModalView(props: AssignAttorneyModalViewProps) {
           </fieldset>
           <div className="usa-form-group">
             <label className="usa-label" htmlFor="lead-trial-attorney-select">
-              Select Lead Trial Attorney
+              Lead Trial Attorney
             </label>
             <select
               className="usa-select"

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.test.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.test.ts
@@ -525,6 +525,28 @@ describe('assignAttorneyModalUseCase tests', () => {
     );
   });
 
+  test('show should deduplicate assignments with the same userId', () => {
+    const duplicateAssignment = { userId: 'att-1', name: 'Attorney One' };
+    const localSetCheckListValues = vi.fn();
+    const localUseCase = buildLocalUseCase({
+      setBCase: vi.fn(),
+      setCheckListValues: localSetCheckListValues,
+      setPreviouslySelectedList: vi.fn(),
+      setSubmissionCallback: vi.fn(),
+    });
+
+    localUseCase.show({
+      bCase: {
+        caseId: 'c1',
+        assignments: [duplicateAssignment, duplicateAssignment],
+      },
+      callback: vi.fn(),
+    } as never);
+
+    const calledWith = localSetCheckListValues.mock.calls[0][0];
+    expect(calledWith.filter((a: { id: string }) => a.id === 'att-1')).toHaveLength(1);
+  });
+
   test('show should call setSubmissionCallback when a callback is provided', () => {
     const mockCallback = vi.fn();
     const localSetSubmissionCallback = vi.fn();

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.ts
@@ -14,6 +14,9 @@ function buildInitialAttorneyChecklist(
   bCase: AssignAttorneyModalOpenProps['bCase'],
 ): AttorneyUser[] {
   const attorneys: AttorneyUser[] = [];
+  // A userId uniquely identifies a person — duplicate entries for the same userId
+  // represent the same attorney (e.g. assigned under multiple roles) and are intentionally
+  // collapsed to a single checklist entry. The first occurrence's name is used.
   const seen = new Set<string>();
   bCase.assignments?.forEach((assignment) => {
     if (!seen.has(assignment.userId)) {

--- a/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.ts
+++ b/user-interface/src/staff-assignment/modal/assignAttorneyModalUseCase.ts
@@ -1,5 +1,4 @@
 import { AttorneyUser, CamsUserReference } from '@common/cams/users';
-import { deepEqual } from '@common/object-equality';
 import Api2 from '@/lib/models/api2';
 import { ResponseBody } from '@common/api/response';
 import { CamsRole, AssignableRole } from '@common/cams/roles';
@@ -15,8 +14,12 @@ function buildInitialAttorneyChecklist(
   bCase: AssignAttorneyModalOpenProps['bCase'],
 ): AttorneyUser[] {
   const attorneys: AttorneyUser[] = [];
+  const seen = new Set<string>();
   bCase.assignments?.forEach((assignment) => {
-    attorneys.push({ id: assignment.userId, name: assignment.name } as AttorneyUser);
+    if (!seen.has(assignment.userId)) {
+      seen.add(assignment.userId);
+      attorneys.push({ id: assignment.userId, name: assignment.name } as AttorneyUser);
+    }
   });
   const lta = bCase.leadTrialAttorney;
   if (lta && !attorneys.find((a) => a.id === lta.id)) {
@@ -182,13 +185,6 @@ const assignAttorneyModalUseCase = (
           (theAttorney) => theAttorney.id !== attorney.id,
         );
       }
-      const isTheSame =
-        localCheckListValues &&
-        !!store.bCase.assignments &&
-        deepEqual(localCheckListValues, store.bCase.assignments);
-
-      controls.modalRef.current?.buttons?.current?.disableSubmitButton(isTheSame);
-
       store.setCheckListValues(localCheckListValues);
     },
 

--- a/user-interface/src/staff-assignment/row/StaffAssignmentRow.internal.test.ts
+++ b/user-interface/src/staff-assignment/row/StaffAssignmentRow.internal.test.ts
@@ -71,6 +71,28 @@ describe('StaffAssignmentRowInternal', () => {
     });
   });
 
+  test('should update leadTrialAttorney on successful assignment update', async () => {
+    const { state, actions } = Internal.useStateActions(initialState);
+
+    const leadAttorney = MockData.getAttorneyUser();
+
+    actions.updateAssignmentsCallback({
+      status: 'success',
+      apiResult: {},
+      bCase,
+      leadTrialAttorney: { id: leadAttorney.id, name: leadAttorney.name },
+      previouslySelectedList: [],
+      selectedAttorneyList: [{ id: leadAttorney.id, name: leadAttorney.name }],
+    });
+
+    await waitFor(() => {
+      expect(state.bCase.leadTrialAttorney).toEqual({
+        id: leadAttorney.id,
+        name: leadAttorney.name,
+      });
+    });
+  });
+
   test('should handle failed assignment update', async () => {
     const errorMessage = 'failed';
 

--- a/user-interface/src/staff-assignment/row/StaffAssignmentRow.internal.ts
+++ b/user-interface/src/staff-assignment/row/StaffAssignmentRow.internal.ts
@@ -62,7 +62,11 @@ function useStateActions(initialState: State): {
           role: CamsRole.TrialAttorney,
         } as CaseAssignment;
       });
-      setState({ ...state, assignments });
+      setState({
+        ...state,
+        assignments,
+        bCase: { ...state.bCase, leadTrialAttorney: props.leadTrialAttorney },
+      });
       globalAlert?.success(message);
     }
   }

--- a/user-interface/src/staff-assignment/row/StaffAssignmentRow.test.tsx
+++ b/user-interface/src/staff-assignment/row/StaffAssignmentRow.test.tsx
@@ -201,7 +201,8 @@ describe('StaffAssignmentRow tests', () => {
       expect(screen.getByTestId('staff-name-lead')).toHaveTextContent(
         `${leadTrialAttorney.name} (Lead)`,
       );
-      expect(screen.queryAllByText(leadTrialAttorney.name)).toHaveLength(1);
+      expect(screen.getByTestId('staff-name-0')).toHaveTextContent(trialAttorney.name);
+      expect(screen.getByTestId('staff-name-0')).not.toHaveTextContent(leadTrialAttorney.name);
     });
   });
 });

--- a/user-interface/src/staff-assignment/row/StaffAssignmentRow.test.tsx
+++ b/user-interface/src/staff-assignment/row/StaffAssignmentRow.test.tsx
@@ -170,4 +170,38 @@ describe('StaffAssignmentRow tests', () => {
     expect(screen.getByTestId('staff-name-0')).toBeInTheDocument();
     expect(screen.getByTestId('staff-name-0')).toHaveTextContent(assignments[0].name);
   });
+
+  test('should show "(Lead)" label next to lead trial attorney', async () => {
+    const leadTrialAttorney = MockData.getCamsUserReference();
+    const trialAttorney = MockData.getAttorneyAssignment();
+    const assignments = [trialAttorney];
+
+    renderWithProps({ bCase: { ...bCase, assignments, leadTrialAttorney } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('staff-name-lead')).toHaveTextContent(
+        `${leadTrialAttorney.name} (Lead)`,
+      );
+      expect(screen.getByTestId('staff-name-0')).not.toHaveTextContent('(Lead)');
+    });
+  });
+
+  test('should not show lead attorney twice when they also appear in assignments', async () => {
+    const leadTrialAttorney = MockData.getCamsUserReference();
+    const leadAssignment = MockData.getAttorneyAssignment({
+      userId: leadTrialAttorney.id,
+      name: leadTrialAttorney.name,
+    });
+    const trialAttorney = MockData.getAttorneyAssignment();
+    const assignments = [leadAssignment, trialAttorney];
+
+    renderWithProps({ bCase: { ...bCase, assignments, leadTrialAttorney } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('staff-name-lead')).toHaveTextContent(
+        `${leadTrialAttorney.name} (Lead)`,
+      );
+      expect(screen.queryAllByText(leadTrialAttorney.name)).toHaveLength(1);
+    });
+  });
 });

--- a/user-interface/src/staff-assignment/row/StaffAssignmentRow.tsx
+++ b/user-interface/src/staff-assignment/row/StaffAssignmentRow.tsx
@@ -70,13 +70,27 @@ export function StaffAssignmentRow(props: StaffAssignmentRowProps) {
   }
 
   function buildAssignmentList(assignments: Partial<CaseAssignment>[] | undefined) {
-    if (assignments && assignments.length > 0) {
-      return state.assignments?.map((attorney, key: number) => (
-        <span key={key} data-testid={`staff-name-${key}`}>
-          {attorney.name}
-          <br />
-        </span>
-      ));
+    const leadTrialAttorney = state.bCase.leadTrialAttorney;
+    const nonLeadAssignments = assignments?.filter((a) => a.userId !== leadTrialAttorney?.id) ?? [];
+    if (nonLeadAssignments.length > 0 || leadTrialAttorney) {
+      const items: React.ReactNode[] = [];
+      if (leadTrialAttorney) {
+        items.push(
+          <span key="lead" data-testid="staff-name-lead">
+            {leadTrialAttorney.name} (Lead)
+            <br />
+          </span>,
+        );
+      }
+      nonLeadAssignments.forEach((attorney, key: number) => {
+        items.push(
+          <span key={key} data-testid={`staff-name-${key}`}>
+            {attorney.name}
+            <br />
+          </span>,
+        );
+      });
+      return items;
     } else {
       return <span className="unassigned">(unassigned)</span>;
     }

--- a/user-interface/src/staff-assignment/row/StaffAssignmentRow.tsx
+++ b/user-interface/src/staff-assignment/row/StaffAssignmentRow.tsx
@@ -14,6 +14,7 @@ import {
 import Internal from './StaffAssignmentRow.internal';
 import { OpenModalButtonRef } from '@/lib/components/uswds/modal/modal-refs';
 import { CaseAssignment } from '@common/cams/assignments';
+import { CamsUserReference } from '@common/cams/users';
 
 export type StaffAssignmentRowOptions = {
   modalId: string;
@@ -69,31 +70,41 @@ export function StaffAssignmentRow(props: StaffAssignmentRowProps) {
     );
   }
 
-  function buildAssignmentList(assignments: Partial<CaseAssignment>[] | undefined) {
-    const leadTrialAttorney = state.bCase.leadTrialAttorney;
-    const nonLeadAssignments = assignments?.filter((a) => a.userId !== leadTrialAttorney?.id) ?? [];
-    if (nonLeadAssignments.length > 0 || leadTrialAttorney) {
-      const items: React.ReactNode[] = [];
-      if (leadTrialAttorney) {
-        items.push(
-          <span key="lead" data-testid="staff-name-lead">
-            {leadTrialAttorney.name} (Lead)
-            <br />
-          </span>,
-        );
-      }
-      nonLeadAssignments.forEach((attorney, key: number) => {
-        items.push(
-          <span key={key} data-testid={`staff-name-${key}`}>
-            {attorney.name}
-            <br />
-          </span>,
-        );
-      });
-      return items;
-    } else {
+  function buildAssignmentList(
+    assignments: Partial<CaseAssignment>[] | undefined,
+    leadTrialAttorney: CamsUserReference | undefined,
+  ) {
+    const nonLeadAssignments =
+      assignments?.filter((a) => a.userId && a.userId !== leadTrialAttorney?.id) ?? [];
+
+    if (!leadTrialAttorney && nonLeadAssignments.length === 0) {
       return <span className="unassigned">(unassigned)</span>;
     }
+
+    const displayItems: { key: React.Key; label: string; testId: string }[] = [];
+
+    if (leadTrialAttorney) {
+      displayItems.push({
+        key: 'lead',
+        label: `${leadTrialAttorney.name} (Lead)`,
+        testId: 'staff-name-lead',
+      });
+    }
+
+    nonLeadAssignments.forEach((attorney, index) => {
+      displayItems.push({
+        key: index,
+        label: attorney.name ?? '',
+        testId: `staff-name-${index}`,
+      });
+    });
+
+    return displayItems.map((item) => (
+      <span key={item.key} data-testid={item.testId}>
+        {item.label}
+        <br />
+      </span>
+    ));
   }
 
   return (
@@ -109,7 +120,9 @@ export function StaffAssignmentRow(props: StaffAssignmentRowProps) {
       <TableRowData data-testid={`attorney-list-${idx}`} className="attorney-list">
         <span className="mobile-title">Assigned Attorney:</span>
         <div className="table-flex-container">
-          <div className="attorney-list-container">{buildAssignmentList(state.assignments)}</div>
+          <div className="attorney-list-container">
+            {buildAssignmentList(state.assignments, state.bCase.leadTrialAttorney)}
+          </div>
           <div className="table-column-toolbar">
             {Actions.contains(bCase, Actions.ManageAssignments) && buildActionButton()}
           </div>


### PR DESCRIPTION
# Purpose

Updated styling and validation logic to better match requirements.

<img width="481" height="503" alt="Screenshot 2026-04-15 at 12 58 49 PM" src="https://github.com/user-attachments/assets/de2a2503-7287-4d26-bda0-cc87447785cb" />

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve staff assignment lead attorney handling, validation, and display across the assign-attorney modal, filters, and case detail views.

New Features:
- Display lead trial attorneys with a '(Lead)' label and prioritize them in staff assignment lists and filters.

Bug Fixes:
- Ensure the assign-attorney modal submit button is disabled unless at least one attorney is selected and a lead is chosen when multiple attorneys are checked.
- Prevent duplicate attorney checklist entries when the same user appears multiple times in case assignments.
- Avoid showing the lead attorney twice when they also appear in the assignments list.
- Constrain 'Lead Trial Attorney' role labels to the appropriate UI elements in case detail views.

Enhancements:
- Refine styling and spacing in the assign-attorney modal, including the lead attorney dropdown label and button group layout.
- Update staff assignment filter logic to work with the Staff type and to order assignee options with unassigned first, followed by lead and then non-lead staff.
- Expand unit test coverage for staff assignment filtering, lead attorney display, and assign-attorney modal validation and deduplication behavior.