### PR TITLE
Fix api healthcheck

### DIFF
--- a/ops/cloud-deployment/lib/keyvault/keyvault.bicep
+++ b/ops/cloud-deployment/lib/keyvault/keyvault.bicep
@@ -52,15 +52,15 @@ var roleIdMapping = {
 
 param tags object = {}
 
-@description('Controls whether the key vault is accessible from the public internet. Defaults to Disabled for security.')
+@description('Controls whether the key vault is accessible from the public internet.')
 @allowed([
   'Enabled'
   'Disabled'
 ])
-param publicNetworkAccess string = 'Disabled'
+param publicNetworkAccess string = 'Enabled'
 
 param networkAcls object = {
-  defaultAction: 'Deny'
+  defaultAction: 'Allow'
   bypass: 'AzureServices'
 }
 

--- a/ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep
+++ b/ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep
@@ -55,7 +55,7 @@ var keyvaultPrivateDnsZoneName = 'privatelink.vaultcore.usgovcloudapi.net'
 
 @description('Application Configuration network access control settings')
 param kvNetworkAcls object = {
-  defaultAction: 'Deny'
+  defaultAction: 'Allow'
   bypass: 'AzureServices'
   ipRules: []
   virtualNetworkRules: []


### PR DESCRIPTION
# Purpose

Key Vault networking setup was blocking access to the api.

# Major Changes

Revert back to allowing access from all networks (note that we still have RBAC in place via Role Assignments).

# Testing/Validation

Deployed to branch environment and Staging which is where I was seeing the issue.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Relax Key Vault network restrictions to restore API access blocked by prior configuration changes.

Deployment:
- Configure Key Vault public network access to be enabled by default instead of disabled.
- Update Key Vault network ACLs to allow traffic by default while still bypassing for Azure services.