### PR TITLE
CAMS-725 Frontend success metrics for trustee case detail panel

### DIFF
--- a/backend/function-apps/dataflows/migrations/backfill-case-appointment-dates.ts
+++ b/backend/function-apps/dataflows/migrations/backfill-case-appointment-dates.ts
@@ -4,7 +4,6 @@ import ApplicationContextCreator from '../../azure/application-context-creator';
 import {
   buildFunctionName,
   buildQueueName,
-  buildStartQueueHttpTrigger,
   CursorMessage,
   StartMessage,
 } from '../dataflows-common';
@@ -49,7 +48,6 @@ const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
 const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
 const HANDLE_ERROR = buildFunctionName(MODULE_NAME, 'handleError');
 const HANDLE_RETRY = buildFunctionName(MODULE_NAME, 'handleRetry');
-const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 
 // Error objects don't serialize reliably over storage queues; use lastErrorMessage instead.
 type BackfillRetryMessage = BackfillAppointment & {
@@ -251,13 +249,6 @@ function setup() {
     queueName: RETRY.queueName,
     handler: handleRetry,
     extraOutputs: [DLQ, HARD_STOP],
-  });
-
-  app.http(HTTP_TRIGGER, {
-    route: 'backfill-case-appointment-dates',
-    methods: ['POST'],
-    extraOutputs: [START],
-    handler: buildStartQueueHttpTrigger(MODULE_NAME, START),
   });
 }
 

--- a/ops/cloud-deployment/frontend-webapp-deploy.bicep
+++ b/ops/cloud-deployment/frontend-webapp-deploy.bicep
@@ -193,6 +193,15 @@ module searchWorkbooks 'lib/workbooks/search-workbooks.bicep' = if (createApplic
   }
 }
 
+module frontendWorkbooks 'lib/workbooks/frontend-workbooks.bicep' = if (createApplicationInsights) {
+  name: '${webappName}-frontend-workbooks-module'
+  params: {
+    location: location
+    appInsightsResourceId: webappInsights.outputs.id
+    tags: tags
+  }
+}
+
 var applicationSettings = concat(
   [
     {

--- a/ops/cloud-deployment/lib/workbooks/dataflow-workbooks.bicep
+++ b/ops/cloud-deployment/lib/workbooks/dataflow-workbooks.bicep
@@ -60,17 +60,3 @@ resource trusteeDueDateMetricsWorkbook 'Microsoft.Insights/workbooks@2023-06-01'
     serializedData: loadTextContent('trustee-due-date-metrics.json')
   }
 }
-
-resource trusteeCaseDetailInfoEngagementWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
-  name: guid('trustee-case-detail-info-engagement-workbook', resourceGroup().id)
-  location: location
-  tags: tags
-  kind: 'shared'
-  properties: {
-    displayName: 'Trustee Case Detail Info Engagement'
-    description: 'Track adoption of the trustee case detail panel: panel views, profile navigations, Zoom link clicks, and copy Zoom info clicks.'
-    category: 'workbook'
-    sourceId: appInsightsResourceId
-    serializedData: loadTextContent('trustee-case-detail-info-engagement.json')
-  }
-}

--- a/ops/cloud-deployment/lib/workbooks/dataflow-workbooks.bicep
+++ b/ops/cloud-deployment/lib/workbooks/dataflow-workbooks.bicep
@@ -60,3 +60,17 @@ resource trusteeDueDateMetricsWorkbook 'Microsoft.Insights/workbooks@2023-06-01'
     serializedData: loadTextContent('trustee-due-date-metrics.json')
   }
 }
+
+resource trusteeCaseDetailInfoEngagementWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('trustee-case-detail-info-engagement-workbook', resourceGroup().id)
+  location: location
+  tags: tags
+  kind: 'shared'
+  properties: {
+    displayName: 'Trustee Case Detail Info Engagement'
+    description: 'Track adoption of the trustee case detail panel: panel views, profile navigations, Zoom link clicks, and copy Zoom info clicks.'
+    category: 'workbook'
+    sourceId: appInsightsResourceId
+    serializedData: loadTextContent('trustee-case-detail-info-engagement.json')
+  }
+}

--- a/ops/cloud-deployment/lib/workbooks/frontend-workbooks.bicep
+++ b/ops/cloud-deployment/lib/workbooks/frontend-workbooks.bicep
@@ -1,0 +1,20 @@
+param location string = resourceGroup().location
+
+@description('Resource ID of the Application Insights instance for the webapp.')
+param appInsightsResourceId string
+
+param tags object = {}
+
+resource trusteeCaseDetailInfoEngagementWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('trustee-case-detail-info-engagement-workbook', resourceGroup().id)
+  location: location
+  tags: tags
+  kind: 'shared'
+  properties: {
+    displayName: 'Trustee Case Detail Info Engagement'
+    description: 'Track adoption of the trustee case detail panel: panel views, profile navigations, Zoom link clicks, and copy Zoom info clicks.'
+    category: 'workbook'
+    sourceId: appInsightsResourceId
+    serializedData: loadTextContent('trustee-case-detail-info-engagement.json')
+  }
+}

--- a/ops/cloud-deployment/lib/workbooks/trustee-case-detail-info-engagement.json
+++ b/ops/cloud-deployment/lib/workbooks/trustee-case-detail-info-engagement.json
@@ -1,0 +1,222 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# Trustee Case Detail Info Engagement\n\n\n"
+      },
+      "name": "header"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 604800000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                },
+                {
+                  "durationMs": 5184000000
+                },
+                {
+                  "durationMs": 7776000000
+                }
+              ]
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            }
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components"
+      },
+      "name": "parameters - 2"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Trustee Panel Views Per Day\nNumber of times the trustee case detail panel was viewed with a trustee present"
+      },
+      "name": "panel-views-title"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where name == \"Trustee Info Viewed\"\n| where timestamp {TimeRange}\n| summarize Count = count() by Day = startofday(timestamp)\n| order by Day asc\n",
+        "size": 0,
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "chartSettings": {
+          "xAxis": "Day",
+          "showDataPoints": true,
+          "xSettings": {
+            "numberFormatSettings": {
+              "unit": 27,
+              "options": {
+                "style": "decimal",
+                "useGrouping": true
+              }
+            }
+          }
+        }
+      },
+      "name": "panel-views"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Trustee Profile Navigations Per Day\nNumber of clicks on the trustee profile link"
+      },
+      "name": "profile-navigations-title"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where name == \"Trustee Profile Navigated\"\n| where timestamp {TimeRange}\n| summarize Count = count() by Day = startofday(timestamp)\n| order by Day asc\n",
+        "size": 0,
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "chartSettings": {
+          "xAxis": "Day",
+          "showDataPoints": true,
+          "xSettings": {
+            "numberFormatSettings": {
+              "unit": 27,
+              "options": {
+                "style": "decimal",
+                "useGrouping": true
+              }
+            }
+          }
+        }
+      },
+      "name": "profile-navigations"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Zoom Link Clicks Per Day\nNumber of times the Zoom meeting link was clicked"
+      },
+      "name": "zoom-clicks-title"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where name == \"Zoom Link Clicked\"\n| where timestamp {TimeRange}\n| summarize Count = count() by Day = startofday(timestamp)\n| order by Day asc\n",
+        "size": 0,
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "chartSettings": {
+          "xAxis": "Day",
+          "showDataPoints": true,
+          "xSettings": {
+            "numberFormatSettings": {
+              "unit": 27,
+              "options": {
+                "style": "decimal",
+                "useGrouping": true
+              }
+            }
+          }
+        }
+      },
+      "name": "zoom-clicks"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Copy Zoom Info Clicks Per Day\nNumber of times the copy Zoom info button was clicked"
+      },
+      "name": "copy-zoom-title"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where name == \"Zoom Info Copied\"\n| where timestamp {TimeRange}\n| summarize Count = count() by Day = startofday(timestamp)\n| order by Day asc\n",
+        "size": 0,
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "chartSettings": {
+          "xAxis": "Day",
+          "showDataPoints": true,
+          "xSettings": {
+            "numberFormatSettings": {
+              "unit": 27,
+              "options": {
+                "style": "decimal",
+                "useGrouping": true
+              }
+            }
+          }
+        }
+      },
+      "name": "copy-zoom"
+    }
+  ],
+  "fallbackResourceIds": [
+    "/subscriptions/729f9083-9edf-4269-919f-3f05f7a0ab20/resourceGroups/rg-cams-app-dev-1fee48/providers/Microsoft.Insights/components/appi-ustp-cams-dev-1fee48-dataflows"
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/ops/cloud-deployment/lib/workbooks/trustee-case-detail-info-engagement.json
+++ b/ops/cloud-deployment/lib/workbooks/trustee-case-detail-info-engagement.json
@@ -216,7 +216,7 @@
     }
   ],
   "fallbackResourceIds": [
-    "/subscriptions/729f9083-9edf-4269-919f-3f05f7a0ab20/resourceGroups/rg-cams-app-dev-1fee48/providers/Microsoft.Insights/components/appi-ustp-cams-dev-1fee48-dataflows"
+    "/subscriptions/729f9083-9edf-4269-919f-3f05f7a0ab20/resourceGroups/rg-cams-app-dev-f64e59/providers/Microsoft.Insights/components/appi-ustp-cams-dev-f64e59-webapp"
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
@@ -2,7 +2,7 @@
 
 .case-detail-trustee-panel {
   h3 {
-    padding-bottom: 1.5rem;
+    padding-bottom: 1.25rem;
   }
 
   .appointed-date {
@@ -23,6 +23,9 @@
   .usa-card__body {
     .case-trustee-card-header {
       @include trustee-card-header;
+    }
+    .case-trustee-card-name {
+      margin-bottom: 0.4rem;
     }
   }
 }

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.test.tsx
@@ -18,6 +18,13 @@ vi.mock('./useCaseAppointment', () => ({
 import { useTrustee } from './useTrustee';
 import { useCaseAppointment } from './useCaseAppointment';
 
+const mockTrackEvent = vi.fn();
+vi.mock('@/lib/hooks/UseApplicationInsights', () => ({
+  getAppInsights: () => ({
+    appInsights: { trackEvent: mockTrackEvent },
+  }),
+}));
+
 const mockUseTrustee = vi.mocked(useTrustee);
 const mockUseCaseAppointment = vi.mocked(useCaseAppointment);
 
@@ -274,6 +281,33 @@ describe('CaseDetailTrusteePanel', () => {
     expect(screen.getByTestId('case-detail-trustee-panel-appointed-date')).toHaveTextContent(
       'Appointed: 04/07/2026',
     );
+  });
+
+  test('fires "Trustee Info Viewed" telemetry event when trustee loads', () => {
+    const trustee = MockData.getTrustee();
+    mockUseCaseAppointment.mockReturnValue({
+      appointedDate: null,
+      trusteeId: trustee.trusteeId,
+      loading: false,
+    });
+    mockUseTrustee.mockReturnValue({ trustee, loading: false });
+
+    renderPanel();
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'Trustee Info Viewed' });
+  });
+
+  test('does not fire "Trustee Info Viewed" telemetry when trustee is null', () => {
+    mockUseCaseAppointment.mockReturnValue({
+      appointedDate: null,
+      trusteeId: null,
+      loading: false,
+    });
+    mockUseTrustee.mockReturnValue({ trustee: null, loading: false });
+
+    renderPanel();
+
+    expect(mockTrackEvent).not.toHaveBeenCalledWith({ name: 'Trustee Info Viewed' });
   });
 
   test('does not render appointed date when appointedDate is null', () => {

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.test.tsx
@@ -307,7 +307,7 @@ describe('CaseDetailTrusteePanel', () => {
 
     renderPanel();
 
-    expect(mockTrackEvent).not.toHaveBeenCalledWith({ name: 'Trustee Info Viewed' });
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 
   test('does not render appointed date when appointedDate is null', () => {

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.tsx
@@ -1,7 +1,9 @@
 import './CaseDetailTrusteePanel.scss';
+import { useEffect } from 'react';
 import { CaseDetail } from '@common/cams/cases';
 import { useTrustee } from './useTrustee';
 import { useCaseAppointment } from './useCaseAppointment';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 import { TrusteeName } from './TrusteeName';
 import FormattedContact from '@/lib/components/cams/FormattedContact';
 import ContactInformationCard from '@/trustees/panels/ContactInformationCard';
@@ -33,6 +35,12 @@ export default function CaseDetailTrusteePanel({
     loading: appointmentLoading,
   } = useCaseAppointment(caseDetail.caseId);
   const { trustee, loading: trusteeLoading } = useTrustee(trusteeId ?? undefined);
+
+  useEffect(() => {
+    if (trustee) {
+      getAppInsights().appInsights.trackEvent({ name: 'Trustee Info Viewed' });
+    }
+  }, [trustee]);
 
   if (appointmentLoading || trusteeLoading) {
     return (

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.tsx
@@ -81,7 +81,7 @@ export default function CaseDetailTrusteePanel({
           <div className="usa-card__container">
             <div className="usa-card__body">
               <h4>Public Contact Info</h4>
-              <div data-testid="case-trustee-card-name">
+              <div data-testid="case-trustee-card-name" className="case-trustee-card-name">
                 <TrusteeName trusteeName={trustee.name} trusteeId={trusteeId} openNewTab />
               </div>
               <div data-testid="case-trustee-public-contact">

--- a/user-interface/src/case-detail/panels/TrusteeName.test.tsx
+++ b/user-interface/src/case-detail/panels/TrusteeName.test.tsx
@@ -1,9 +1,17 @@
 import { BrowserRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TrusteeName } from './TrusteeName';
 import { CamsRole } from '@common/cams/roles';
 import LocalStorage from '@/lib/utils/local-storage';
 import MockData from '@common/cams/test-utilities/mock-data';
+
+const mockTrackEvent = vi.fn();
+vi.mock('@/lib/hooks/UseApplicationInsights', () => ({
+  getAppInsights: () => ({
+    appInsights: { trackEvent: mockTrackEvent },
+  }),
+}));
 
 const TRUSTEE_NAME = 'John Doe';
 const TRUSTEE_ID = 'trustee-123';
@@ -12,6 +20,7 @@ describe('TrusteeName', () => {
   let user: ReturnType<typeof MockData.getCamsUser>;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     user = MockData.getCamsUser({ roles: [CamsRole.TrusteeAdmin] });
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(MockData.getCamsSession({ user }));
   });
@@ -43,6 +52,35 @@ describe('TrusteeName', () => {
 
     expect(screen.queryByTestId('case-detail-trustee-link')).not.toBeInTheDocument();
     expect(screen.getByText(TRUSTEE_NAME)).toBeInTheDocument();
+  });
+
+  describe('telemetry', () => {
+    test('fires "Trustee Profile Navigated" when the link is clicked', async () => {
+      render(
+        <BrowserRouter>
+          <TrusteeName trusteeName={TRUSTEE_NAME} trusteeId={TRUSTEE_ID} />
+        </BrowserRouter>,
+      );
+
+      await userEvent.click(screen.getByTestId('case-detail-trustee-link'));
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'Trustee Profile Navigated' });
+    });
+
+    test('does not fire "Trustee Profile Navigated" when name renders as plain text', async () => {
+      const noAccessUser = MockData.getCamsUser({ roles: [] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(
+        MockData.getCamsSession({ user: noAccessUser }),
+      );
+
+      render(
+        <BrowserRouter>
+          <TrusteeName trusteeName={TRUSTEE_NAME} trusteeId={TRUSTEE_ID} />
+        </BrowserRouter>,
+      );
+
+      expect(mockTrackEvent).not.toHaveBeenCalledWith({ name: 'Trustee Profile Navigated' });
+    });
   });
 
   describe('openNewTab', () => {

--- a/user-interface/src/case-detail/panels/TrusteeName.test.tsx
+++ b/user-interface/src/case-detail/panels/TrusteeName.test.tsx
@@ -79,7 +79,7 @@ describe('TrusteeName', () => {
         </BrowserRouter>,
       );
 
-      expect(mockTrackEvent).not.toHaveBeenCalledWith({ name: 'Trustee Profile Navigated' });
+      expect(mockTrackEvent).not.toHaveBeenCalled();
     });
   });
 

--- a/user-interface/src/case-detail/panels/TrusteeName.tsx
+++ b/user-interface/src/case-detail/panels/TrusteeName.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { CamsRole } from '@common/cams/roles';
 import LocalStorage from '@/lib/utils/local-storage';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 interface TrusteeNameProps {
   trusteeName: string;
@@ -33,6 +34,7 @@ export function TrusteeName({ trusteeName, trusteeId, openNewTab = false }: Trus
       aria-label={`View trustee profile for ${trusteeName}${openNewTab ? ' (opens in new tab)' : ''}`}
       target={openNewTab ? '_blank' : undefined}
       rel={openNewTab ? 'noopener noreferrer' : undefined}
+      onClick={() => getAppInsights().appInsights.trackEvent({ name: 'Trustee Profile Navigated' })}
     >
       {linkContent}
     </Link>

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.test.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import CommsLink from './CommsLink';
 import { ContactInformation } from '@common/cams/contact';
+import TestingUtilities from '@/lib/testing/testing-utilities';
 
 // Mock the IconLabel component to simplify testing
 import * as IconLabelModule from '@/lib/components/cams/IconLabel/IconLabel';
@@ -556,6 +557,22 @@ describe('CommsLink Component', () => {
       const iconLabel = screen.getByTestId('icon-label');
       expect(iconLabel).toHaveTextContent('Custom Website');
       expect(iconLabel.getAttribute('data-icon')).toBe('custom-icon');
+    });
+  });
+
+  describe('onClick prop', () => {
+    test('calls onClick when website link is clicked', async () => {
+      const userEvent = TestingUtilities.setupUserEvent();
+      const onClick = vi.fn();
+      render(
+        <CommsLink
+          contact={{ website: 'https://example.com' } as Omit<ContactInformation, 'address'>}
+          mode="website"
+          onClick={onClick}
+        />,
+      );
+      await userEvent.click(screen.getByRole('link'));
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
@@ -13,6 +13,7 @@ type CommsLinkProps = {
   emailSubject?: string;
   hideIcon?: boolean;
   name?: string;
+  onClick?: () => void;
 };
 
 const NON_DIGITS = /\D/g;
@@ -32,7 +33,7 @@ function toTelephoneUri(number: string, extension?: string) {
 }
 
 function CommsLink(props: Readonly<CommsLinkProps>) {
-  const { contact, mode, label, icon, emailSubject, hideIcon, name } = props;
+  const { contact, mode, label, icon, emailSubject, hideIcon, name, onClick } = props;
   const { email, website, phone } = contact;
   const { number, extension } = phone ?? {};
 
@@ -100,6 +101,7 @@ function CommsLink(props: Readonly<CommsLinkProps>) {
         target={target}
         rel="noopener noreferrer"
         aria-label={ariaLabel}
+        onClick={onClick}
       >
         {linkContent}
       </a>

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import './CommsLink.scss';
 import { ContactInformation } from '@common/cams/contact';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
@@ -13,7 +14,7 @@ type CommsLinkProps = {
   emailSubject?: string;
   hideIcon?: boolean;
   name?: string;
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 };
 
 const NON_DIGITS = /\D/g;

--- a/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.test.tsx
+++ b/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.test.tsx
@@ -6,6 +6,13 @@ import TestingUtilities, { CamsUserEvent } from '@/lib/testing/testing-utilities
 import MockData from '@common/cams/test-utilities/mock-data';
 import { mockClipboardWrite, mockClipboardUndefined } from '@/lib/testing/mock-clipboard';
 
+const mockTrackEvent = vi.fn();
+vi.mock('@/lib/hooks/UseApplicationInsights', () => ({
+  getAppInsights: () => ({
+    appInsights: { trackEvent: mockTrackEvent },
+  }),
+}));
+
 describe('MeetingOfCreditorsInfoCard', () => {
   let userEvent: CamsUserEvent;
   const mockOnEdit = vi.fn();
@@ -14,6 +21,24 @@ describe('MeetingOfCreditorsInfoCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     userEvent = TestingUtilities.setupUserEvent();
+  });
+
+  test('fires "Zoom Link Clicked" telemetry when Zoom link is clicked', async () => {
+    render(<MeetingOfCreditorsInfoCard zoomInfo={mockZoomInfo} />);
+
+    const zoomLink = screen.getByTestId('zoom-link').querySelector('a')!;
+    await userEvent.click(zoomLink);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'Zoom Link Clicked' });
+  });
+
+  test('fires "Zoom Info Copied" telemetry when copy button is clicked', async () => {
+    mockClipboardWrite();
+    render(<MeetingOfCreditorsInfoCard zoomInfo={mockZoomInfo} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy Meeting of Creditors info' }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'Zoom Info Copied' });
   });
 
   const mockZoomInfo: ZoomInfo = {

--- a/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.tsx
+++ b/user-interface/src/trustees/panels/MeetingOfCreditorsInfoCard.tsx
@@ -7,6 +7,7 @@ import { copyHTMLToClipboard } from '@/lib/utils/clipBoard';
 import Icon from '@/lib/components/uswds/Icon';
 import { formatPhoneNumber } from '@common/phone-helper';
 import CommsLink from '@/lib/components/cams/CommsLink/CommsLink';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 interface ZoomInfoCardProps {
   zoomInfo?: ZoomInfo;
@@ -44,6 +45,9 @@ export default function MeetingOfCreditorsInfoCard({
                     contact={{ website: zoomInfo.link }}
                     mode="website"
                     label="Zoom Link"
+                    onClick={() =>
+                      getAppInsights().appInsights.trackEvent({ name: 'Zoom Link Clicked' })
+                    }
                   />
                 </div>
                 <div className="zoom-phone" data-testid="zoom-phone">
@@ -72,7 +76,10 @@ export default function MeetingOfCreditorsInfoCard({
                   uswdsStyle={UswdsButtonStyle.Outline}
                   aria-label="Copy Meeting of Creditors info"
                   title="Copy Meeting of Creditors info"
-                  onClick={() => copyHTMLToClipboard('#meeting-of-creditors-info-copy')}
+                  onClick={() => {
+                    getAppInsights().appInsights.trackEvent({ name: 'Zoom Info Copied' });
+                    copyHTMLToClipboard('#meeting-of-creditors-info-copy');
+                  }}
                 >
                   <Icon name="content_copy" />
                   Copy Zoom Info


### PR DESCRIPTION
## Summary

- Instruments the trustee case detail panel with Application Insights `trackEvent` calls for four interactions: panel views, profile navigations, Zoom link clicks, and copy Zoom info clicks
- Adds an optional `onClick` prop to `CommsLink` so callers can track link interactions without wrapping the component
- Adds an Azure Monitor workbook (`Trustee Case Detail Info Engagement`) with one bar chart per metric, defaulting to a 7-day time range
- Removes the HTTP trigger from the backfill migration — the start queue will be triggered directly via storage queue
- Minor spacing adjustments to the trustee panel heading and trustee name card

## Test plan

- [ ] Verify `trackEvent` is called with `"Trustee Info Viewed"` when the trustee panel loads with a trustee present
- [ ] Verify `trackEvent` is called with `"Trustee Profile Navigated"` when the trustee name link is clicked
- [ ] Verify `trackEvent` is called with `"Zoom Link Clicked"` when the Zoom link is clicked
- [ ] Verify `trackEvent` is called with `"Zoom Info Copied"` when the copy Zoom info button is clicked
- [ ] Confirm all new unit tests pass (`npm test` in `user-interface`)
- [ ] Deploy workbook via Bicep and confirm it appears in Azure Monitor with correct charts
- [ ] Confirm the backfill migration can still be triggered via the storage queue

## Summary by Sourcery

Instrument trustee case detail UI interactions with telemetry and add corresponding monitoring while simplifying the related backfill migration trigger.

New Features:
- Add Application Insights tracking for trustee info panel views, trustee profile navigations, Zoom link clicks, and Zoom info copy actions.
- Expose an optional onClick handler on the CommsLink component to allow callers to track link interactions.
- Introduce an Azure Monitor workbook to visualize trustee case detail info engagement metrics over time.

Enhancements:
- Adjust spacing in the trustee case detail panel header and trustee name card for improved layout.

Deployment:
- Provision a new shared Azure Monitor workbook resource for trustee case detail info engagement in the deployment templates.

Tests:
- Add unit tests covering new telemetry events in trustee-related components and the CommsLink onClick behavior.

Chores:
- Remove the unused HTTP trigger from the backfill-case-appointment-dates migration so it is initiated solely via the storage queue.