### PR TITLE
Add MSSQL_DATABASE_DXTR as slot setting in dataflows

### DIFF
--- a/ops/cloud-deployment/dataflows-resource-deploy.bicep
+++ b/ops/cloud-deployment/dataflows-resource-deploy.bicep
@@ -244,6 +244,7 @@ resource dataflowsFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
         'AzureWebJobsDataflowsStorage'
         'MyTaskHub'
         'COSMOS_DATABASE_NAME'
+        'MSSQL_DATABASE_DXTR'
       ]
     }
   }


### PR DESCRIPTION
# Purpose

The api Function App has the `MSSQL_DATABASE_DXTR` set up as a slot setting (i.e. value does not swap) but the dataflows Function App does not.

# Major Changes

Add the variable to the list of slot settings.

# Testing/Validation

Will ensure that the value does not swap on subsequent deployments.

# Notes

This was preventing dataflows that need to read from DXTR from working properly.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Deployment:
- Mark MSSQL_DATABASE_DXTR as a slot setting for the dataflows Function App so its value is preserved across slot swaps.