### PR TITLE
Pin protobufjs to 7.5.5 to fix critical CVE

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9345,9 +9345,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14751,9 +14751,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "overrides": {
     "dompurify": "3.4.0",
+    "protobufjs": "7.5.5",
     "semver": "7.7.4",
     "@babel/runtime": "7.29.2",
     "node-forge": "1.4.0",


### PR DESCRIPTION
# Purpose

Pin protobufjs to 7.5.5 to fix critical CVE

# Major Changes

Adds npm overrides in root and backend package.json to pin protobufjs to 7.5.5, patching SNYK-JS-PROTOBUFJS-16094665 (Arbitrary Code Injection, Critical). Also manually updates both lock files since npm install does not re-resolve already- satisfied transitive ranges.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Pin the protobufjs dependency to a safe version across the project to address a critical security vulnerability and update lockfiles accordingly.

Build:
- Add an npm override to force protobufjs version 7.5.5 at the root level and in the backend package configuration.

Chores:
- Regenerate and update root and backend package-lock files to reflect the pinned protobufjs version.