### PR TITLE
Use root package.json overrides for backend pack

### DIFF
--- a/backend/Dockerfile.build
+++ b/backend/Dockerfile.build
@@ -6,13 +6,23 @@ FROM node:22.22.2-slim
 ARG FUNCTION_APP
 WORKDIR /build
 
-# Copy package files for the specific function app (build context is workspace root)
+# Copy root package.json (for overrides) and the function app's package.json
+COPY package.json ./root-package.json
 COPY backend/function-apps/${FUNCTION_APP}/package.json .
 
 # IMPORTANT: Always use root package-lock.json for consistency
 # Individual function apps do NOT have their own package-lock.json files
 # This ensures identical dependency resolution across all environments
 COPY package-lock.json .
+
+# Merge root overrides into the function app package.json so npm ci applies them
+# npm only reads overrides from the root package.json it operates on
+RUN node -e " \
+  const root = JSON.parse(require('fs').readFileSync('root-package.json', 'utf8')); \
+  const app = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); \
+  if (root.overrides) app.overrides = root.overrides; \
+  require('fs').writeFileSync('package.json', JSON.stringify(app, null, 2)); \
+" && rm root-package.json
 
 # Install dependencies (will build native modules for Linux)
 # Use npm ci for reproducible, lockfile-driven installs

--- a/backend/pack.sh
+++ b/backend/pack.sh
@@ -63,6 +63,15 @@ if [[ "$OSTYPE" == linux* ]]; then
   cp "$FUNCTION_APP_PATH/package.json" "$BUILD_TEMP/"
   cp package-lock.json "$BUILD_TEMP/"
 
+  # Merge root overrides into function app package.json so npm ci applies them
+  # npm only reads overrides from the root package.json it operates on
+  node -e "
+    const root = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
+    const app = JSON.parse(require('fs').readFileSync('$BUILD_TEMP/package.json', 'utf8'));
+    if (root.overrides) app.overrides = root.overrides;
+    require('fs').writeFileSync('$BUILD_TEMP/package.json', JSON.stringify(app, null, 2));
+  "
+
   # Run npm ci in temp directory with root lockfile
   cd "$BUILD_TEMP" || exit
   npm ci --production --ignore-scripts=false --workspaces=false


### PR DESCRIPTION
# Purpose

Sometimes overridden packages cause problems with the backend pack scripts.

# Major Changes

Bring in the root package.json and replace the versions in the workspace package.json.

# Testing/Validation

Tested locally and in GHA with multiple overrides.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhancements:
- Merge overrides from the repository root package.json into the backend function app package.json before running npm ci to ensure consistent dependency overrides in backend builds.