### PR TITLE
CAMS-596 - Fix SQL script to import professionalIds from ACMS

### DIFF
--- a/backend/lib/adapters/gateways/acms/acms.gateway.ts
+++ b/backend/lib/adapters/gateways/acms/acms.gateway.ts
@@ -259,7 +259,7 @@ export class AcmsGatewayImpl extends AbstractMssqlClient implements AcmsGateway 
     const query = `
       SELECT
         CONCAT(ACMS.GROUP_DESIGNATOR, '-', RIGHT(CONCAT('0000', ACMS.UST_PROF_CODE), 5)) AS acmsProfessionalId
-      FROM CMMPR ACMS
+      FROM [dbo].[CMMPR] AS ACMS
       WHERE ACMS.PROF_FIRST_NAME = @firstName
         AND ACMS.PROF_LAST_NAME = @lastName
         AND ACMS.PROF_STATE = @state


### PR DESCRIPTION
# Purpose

Specify the DBO so the SQL statement doesn't fail in the migration.

# Major Changes

* Hardened the SQL statement

## Summary by Sourcery

Bug Fixes:
- Specify the dbo schema for the CMMPR table in the ACMS professional ID query to avoid SQL execution errors during migrations.