### PR TITLE
CAMS-730 Harden sub-security-scan.yml to use least privilege

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -68,8 +68,6 @@ jobs:
     name: Security
     uses: ./.github/workflows/sub-security-scan.yml
     secrets:
-      SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }} # pragma: allowlist secret
-      SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }} # pragma: allowlist secret
       AZ_SECURITY_SCAN_CLIENT_ID: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }} # pragma: allowlist secret
       AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }} # pragma: allowlist secret
       AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }} # pragma: allowlist secret

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -68,9 +68,6 @@ jobs:
     name: Security
     uses: ./.github/workflows/sub-security-scan.yml
     secrets:
-      SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }} # pragma: allowlist secret
-      SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }} # pragma: allowlist secret
-      AZ_SECURITY_SCAN_STORAGE_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }} # pragma: allowlist secret
       AZ_SECURITY_SCAN_CLIENT_ID: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }} # pragma: allowlist secret
       AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }} # pragma: allowlist secret
       AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }} # pragma: allowlist secret

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -68,6 +68,8 @@ jobs:
     name: Security
     uses: ./.github/workflows/sub-security-scan.yml
     secrets:
+      SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }} # pragma: allowlist secret
+      SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }} # pragma: allowlist secret
       AZ_SECURITY_SCAN_CLIENT_ID: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }} # pragma: allowlist secret
       AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }} # pragma: allowlist secret
       AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }} # pragma: allowlist secret

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -3,10 +3,6 @@ name: Security
 on:
   workflow_call:
     secrets:
-      SNYK_OAUTH_CLIENT_ID:
-        required: true
-      SNYK_OAUTH_CLIENT_SECRET:
-        required: true
       AZ_SECURITY_SCAN_CLIENT_ID:
         required: true
       AZ_TENANT_ID:
@@ -33,17 +29,11 @@ jobs:
           subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
 
-      - name: Seed Snyk secrets into Key Vault
-        run: |
-          az keyvault secret set --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-ID --value "$SNYK_OAUTH_CLIENT_ID" --output none
-          az keyvault secret set --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-SECRET --value "$SNYK_OAUTH_CLIENT_SECRET" --output none
-        env:
-          SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }}
-          SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }}
-
       - name: Fetch secrets from Key Vault
         run: |
           echo "AZ_SECURITY_SCAN_STORAGE_NAME=$(az keyvault secret show --vault-name kv-ustp-cams --name AZ-SECURITY-SCAN-STORAGE-NAME --query value -o tsv)" >> "$GITHUB_ENV"
+          echo "SNYK_OAUTH_CLIENT_ID=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-ID --query value -o tsv)" >> "$GITHUB_ENV"
+          echo "SNYK_OAUTH_CLIENT_SECRET=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-SECRET --query value -o tsv)" >> "$GITHUB_ENV"
 
       - name: Setup Snyk CLI
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1
@@ -54,8 +44,6 @@ jobs:
         run: snyk auth --auth-type=oauth --client-secret="$SNYK_OAUTH_CLIENT_SECRET" --client-id="$SNYK_OAUTH_CLIENT_ID"
         env:
           SNYK_API: https://api.snykgov.io
-          SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }}
-          SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }}
 
       - name: Run Snyk SCA scan
         run: snyk test --all-projects --exclude=function-apps --severity-threshold=medium --policy-path=. --sarif-file-output=snyk-sca.sarif
@@ -121,6 +109,8 @@ jobs:
       - name: Fetch secrets from Key Vault
         run: |
           echo "AZ_SECURITY_SCAN_STORAGE_NAME=$(az keyvault secret show --vault-name kv-ustp-cams --name AZ-SECURITY-SCAN-STORAGE-NAME --query value -o tsv)" >> "$GITHUB_ENV"
+          echo "SNYK_OAUTH_CLIENT_ID=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-ID --query value -o tsv)" >> "$GITHUB_ENV"
+          echo "SNYK_OAUTH_CLIENT_SECRET=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-SECRET --query value -o tsv)" >> "$GITHUB_ENV"
 
       - name: Setup Snyk CLI
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1
@@ -131,8 +121,6 @@ jobs:
         run: snyk auth --auth-type=oauth --client-secret="$SNYK_OAUTH_CLIENT_SECRET" --client-id="$SNYK_OAUTH_CLIENT_ID"
         env:
           SNYK_API: https://api.snykgov.io
-          SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }}
-          SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }}
 
       - name: Run Snyk Code (SAST) scan
         id: snyk-scan

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -33,6 +33,14 @@ jobs:
           subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
 
+      - name: Seed Snyk secrets into Key Vault
+        run: |
+          az keyvault secret set --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-ID --value "$SNYK_OAUTH_CLIENT_ID" --output none
+          az keyvault secret set --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-SECRET --value "$SNYK_OAUTH_CLIENT_SECRET" --output none
+        env:
+          SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }}
+          SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }}
+
       - name: Fetch secrets from Key Vault
         run: |
           echo "AZ_SECURITY_SCAN_STORAGE_NAME=$(az keyvault secret show --vault-name kv-ustp-cams --name AZ-SECURITY-SCAN-STORAGE-NAME --query value -o tsv)" >> "$GITHUB_ENV"

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -3,12 +3,6 @@ name: Security
 on:
   workflow_call:
     secrets:
-      SNYK_OAUTH_CLIENT_ID:
-        required: true
-      SNYK_OAUTH_CLIENT_SECRET:
-        required: true
-      AZ_SECURITY_SCAN_STORAGE_NAME:
-        required: true
       AZ_SECURITY_SCAN_CLIENT_ID:
         required: true
       AZ_TENANT_ID:
@@ -28,6 +22,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZ_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+          environment: ${{ vars.AZURE_ENVIRONMENT }}
+
+      - name: Fetch secrets from Key Vault
+        run: |
+          echo "SNYK_OAUTH_CLIENT_ID=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-ID --query value -o tsv)" >> "$GITHUB_ENV"
+          echo "SNYK_OAUTH_CLIENT_SECRET=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-SECRET --query value -o tsv)" >> "$GITHUB_ENV"
+          echo "AZ_SECURITY_SCAN_STORAGE_NAME=$(az keyvault secret show --vault-name kv-ustp-cams --name AZ-SECURITY-SCAN-STORAGE-NAME --query value -o tsv)" >> "$GITHUB_ENV"
+
       - name: Setup Snyk CLI
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1
         with:
@@ -37,8 +44,6 @@ jobs:
         run: snyk auth --auth-type=oauth --client-secret="$SNYK_OAUTH_CLIENT_SECRET" --client-id="$SNYK_OAUTH_CLIENT_ID"
         env:
           SNYK_API: https://api.snykgov.io
-          SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }}
-          SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }}
 
       - name: Run Snyk SCA scan
         run: snyk test --all-projects --exclude=function-apps --severity-threshold=medium --policy-path=. --sarif-file-output=snyk-sca.sarif
@@ -51,28 +56,18 @@ jobs:
         env:
           SNYK_API: https://api.snykgov.io
 
-      - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
-        if: always()
-        with:
-          client-id: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZ_TENANT_ID }}
-          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
-          environment: ${{ vars.AZURE_ENVIRONMENT }}
-
       - name: Upload raw SARIF to Azure Storage
         if: always()
         run: |
           if [ -f snyk-sca.sarif ]; then
             az storage blob upload \
-              --account-name "$ACCOUNT_NAME" \
+              --account-name "$AZ_SECURITY_SCAN_STORAGE_NAME" \
               --auth-mode login \
               -f snyk-sca.sarif \
               -c security-scan-results \
               -n "snyk-sca-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.ref_name }}.sarif" \
               --overwrite
           fi
-        env:
-          ACCOUNT_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }}
 
       - name: Sanitize SARIF for GitHub upload
         if: always()
@@ -104,6 +99,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZ_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+          environment: ${{ vars.AZURE_ENVIRONMENT }}
+
+      - name: Fetch secrets from Key Vault
+        run: |
+          echo "SNYK_OAUTH_CLIENT_ID=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-ID --query value -o tsv)" >> "$GITHUB_ENV"
+          echo "SNYK_OAUTH_CLIENT_SECRET=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-SECRET --query value -o tsv)" >> "$GITHUB_ENV"
+          echo "AZ_SECURITY_SCAN_STORAGE_NAME=$(az keyvault secret show --vault-name kv-ustp-cams --name AZ-SECURITY-SCAN-STORAGE-NAME --query value -o tsv)" >> "$GITHUB_ENV"
+
       - name: Setup Snyk CLI
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1
         with:
@@ -113,8 +121,6 @@ jobs:
         run: snyk auth --auth-type=oauth --client-secret="$SNYK_OAUTH_CLIENT_SECRET" --client-id="$SNYK_OAUTH_CLIENT_ID"
         env:
           SNYK_API: https://api.snykgov.io
-          SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }}
-          SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }}
 
       - name: Run Snyk Code (SAST) scan
         id: snyk-scan
@@ -123,35 +129,25 @@ jobs:
         env:
           SNYK_API: https://api.snykgov.io
 
-      - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
-        if: always()
-        with:
-          client-id: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZ_TENANT_ID }}
-          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
-          environment: ${{ vars.AZURE_ENVIRONMENT }}
-
       - name: Upload raw SARIF to Azure Storage
         if: always()
         run: |
           if [ -f snyk-code.sarif ]; then
             az storage blob upload \
-              --account-name "$ACCOUNT_NAME" \
+              --account-name "$AZ_SECURITY_SCAN_STORAGE_NAME" \
               --auth-mode login \
               -f snyk-code.sarif \
               -c security-scan-results \
               -n "snyk-code-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.ref_name }}.sarif" \
               --overwrite
           fi
-        env:
-          ACCOUNT_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }}
 
       - name: Download SAST baseline
         id: baseline
         if: always()
         run: |
           if az storage blob download \
-            --account-name "$ACCOUNT_NAME" \
+            --account-name "$AZ_SECURITY_SCAN_STORAGE_NAME" \
             --auth-mode login \
             -c snyk-baseline \
             -n snyk-code-baseline.txt \
@@ -161,8 +157,6 @@ jobs:
             echo "::warning::No SAST baseline found. All findings will be treated as new."
             echo "baseline_found=false" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          ACCOUNT_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }}
 
       - name: Compare against baseline
         id: baseline-compare

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -3,6 +3,10 @@ name: Security
 on:
   workflow_call:
     secrets:
+      SNYK_OAUTH_CLIENT_ID:
+        required: true
+      SNYK_OAUTH_CLIENT_SECRET:
+        required: true
       AZ_SECURITY_SCAN_CLIENT_ID:
         required: true
       AZ_TENANT_ID:
@@ -31,8 +35,6 @@ jobs:
 
       - name: Fetch secrets from Key Vault
         run: |
-          echo "SNYK_OAUTH_CLIENT_ID=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-ID --query value -o tsv)" >> "$GITHUB_ENV"
-          echo "SNYK_OAUTH_CLIENT_SECRET=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-SECRET --query value -o tsv)" >> "$GITHUB_ENV"
           echo "AZ_SECURITY_SCAN_STORAGE_NAME=$(az keyvault secret show --vault-name kv-ustp-cams --name AZ-SECURITY-SCAN-STORAGE-NAME --query value -o tsv)" >> "$GITHUB_ENV"
 
       - name: Setup Snyk CLI
@@ -44,6 +46,8 @@ jobs:
         run: snyk auth --auth-type=oauth --client-secret="$SNYK_OAUTH_CLIENT_SECRET" --client-id="$SNYK_OAUTH_CLIENT_ID"
         env:
           SNYK_API: https://api.snykgov.io
+          SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }}
+          SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }}
 
       - name: Run Snyk SCA scan
         run: snyk test --all-projects --exclude=function-apps --severity-threshold=medium --policy-path=. --sarif-file-output=snyk-sca.sarif
@@ -108,8 +112,6 @@ jobs:
 
       - name: Fetch secrets from Key Vault
         run: |
-          echo "SNYK_OAUTH_CLIENT_ID=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-ID --query value -o tsv)" >> "$GITHUB_ENV"
-          echo "SNYK_OAUTH_CLIENT_SECRET=$(az keyvault secret show --vault-name kv-ustp-cams --name SNYK-OAUTH-CLIENT-SECRET --query value -o tsv)" >> "$GITHUB_ENV"
           echo "AZ_SECURITY_SCAN_STORAGE_NAME=$(az keyvault secret show --vault-name kv-ustp-cams --name AZ-SECURITY-SCAN-STORAGE-NAME --query value -o tsv)" >> "$GITHUB_ENV"
 
       - name: Setup Snyk CLI
@@ -121,6 +123,8 @@ jobs:
         run: snyk auth --auth-type=oauth --client-secret="$SNYK_OAUTH_CLIENT_SECRET" --client-id="$SNYK_OAUTH_CLIENT_ID"
         env:
           SNYK_API: https://api.snykgov.io
+          SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }}
+          SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }}
 
       - name: Run Snyk Code (SAST) scan
         id: snyk-scan

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -318,6 +318,8 @@ flowchart LR
         Secrets_AZ_SECURITY_SCAN_CLIENT_ID["AZ_SECURITY_SCAN_CLIENT_ID"]
         Secrets_AZ_SUBSCRIPTION_ID["AZ_SUBSCRIPTION_ID"]
         Secrets_AZ_TENANT_ID["AZ_TENANT_ID"]
+        Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
+        Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
@@ -347,7 +349,7 @@ flowchart LR
             typecheck_vars["NODE_VERSION"]
         end
         subgraph security_scan_subgraph["Security"]
-            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID"]
+            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
         end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
@@ -363,6 +365,8 @@ flowchart LR
         Secrets --> Secrets_AZ_SECURITY_SCAN_CLIENT_ID
         Secrets --> Secrets_AZ_SUBSCRIPTION_ID
         Secrets --> Secrets_AZ_TENANT_ID
+        Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
+        Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
         Variables --> Variables_CAMS_LAUNCH_DARKLY_ENV
         Variables --> Variables_CAMS_SERVER_PORT
@@ -371,6 +375,8 @@ flowchart LR
     Secrets_AZ_SECURITY_SCAN_CLIENT_ID -.-> security_scan_subgraph
     Secrets_AZ_SUBSCRIPTION_ID -.-> security_scan_subgraph
     Secrets_AZ_TENANT_ID -.-> security_scan_subgraph
+    Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
+    Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
     Variables_CAMS_LAUNCH_DARKLY_ENV -.-> build_subgraph
     Variables_CAMS_SERVER_PORT -.-> build_subgraph
@@ -869,6 +875,8 @@ flowchart LR
         Secrets_AZ_SECURITY_SCAN_CLIENT_ID["AZ_SECURITY_SCAN_CLIENT_ID"]
         Secrets_AZ_SUBSCRIPTION_ID["AZ_SUBSCRIPTION_ID"]
         Secrets_AZ_TENANT_ID["AZ_TENANT_ID"]
+        Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
+        Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
@@ -898,7 +906,7 @@ flowchart LR
             typecheck_vars["NODE_VERSION"]
         end
         subgraph security_scan_subgraph["Security"]
-            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID"]
+            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
         end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
@@ -914,6 +922,8 @@ flowchart LR
         Secrets --> Secrets_AZ_SECURITY_SCAN_CLIENT_ID
         Secrets --> Secrets_AZ_SUBSCRIPTION_ID
         Secrets --> Secrets_AZ_TENANT_ID
+        Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
+        Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
         Variables --> Variables_CAMS_LAUNCH_DARKLY_ENV
         Variables --> Variables_CAMS_SERVER_PORT
@@ -922,6 +932,8 @@ flowchart LR
     Secrets_AZ_SECURITY_SCAN_CLIENT_ID -.-> security_scan_subgraph
     Secrets_AZ_SUBSCRIPTION_ID -.-> security_scan_subgraph
     Secrets_AZ_TENANT_ID -.-> security_scan_subgraph
+    Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
+    Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
     Variables_CAMS_LAUNCH_DARKLY_ENV -.-> build_subgraph
     Variables_CAMS_SERVER_PORT -.-> build_subgraph

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -316,11 +316,8 @@ flowchart LR
     subgraph "External Inputs"
         Secrets["Secrets"]
         Secrets_AZ_SECURITY_SCAN_CLIENT_ID["AZ_SECURITY_SCAN_CLIENT_ID"]
-        Secrets_AZ_SECURITY_SCAN_STORAGE_NAME["AZ_SECURITY_SCAN_STORAGE_NAME"]
         Secrets_AZ_SUBSCRIPTION_ID["AZ_SUBSCRIPTION_ID"]
         Secrets_AZ_TENANT_ID["AZ_TENANT_ID"]
-        Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
-        Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
@@ -350,7 +347,7 @@ flowchart LR
             typecheck_vars["NODE_VERSION"]
         end
         subgraph security_scan_subgraph["Security"]
-            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SECURITY_SCAN_STORAGE_NAME<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
+            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID"]
         end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
@@ -364,22 +361,16 @@ flowchart LR
     end
 
         Secrets --> Secrets_AZ_SECURITY_SCAN_CLIENT_ID
-        Secrets --> Secrets_AZ_SECURITY_SCAN_STORAGE_NAME
         Secrets --> Secrets_AZ_SUBSCRIPTION_ID
         Secrets --> Secrets_AZ_TENANT_ID
-        Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
-        Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
         Variables --> Variables_CAMS_LAUNCH_DARKLY_ENV
         Variables --> Variables_CAMS_SERVER_PORT
         Variables --> Variables_CAMS_SERVER_PROTOCOL
         Variables --> Variables_NODE_VERSION
     Secrets_AZ_SECURITY_SCAN_CLIENT_ID -.-> security_scan_subgraph
-    Secrets_AZ_SECURITY_SCAN_STORAGE_NAME -.-> security_scan_subgraph
     Secrets_AZ_SUBSCRIPTION_ID -.-> security_scan_subgraph
     Secrets_AZ_TENANT_ID -.-> security_scan_subgraph
-    Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
-    Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
     Variables_CAMS_LAUNCH_DARKLY_ENV -.-> build_subgraph
     Variables_CAMS_SERVER_PORT -.-> build_subgraph
@@ -876,11 +867,8 @@ flowchart LR
     subgraph "External Inputs"
         Secrets["Secrets"]
         Secrets_AZ_SECURITY_SCAN_CLIENT_ID["AZ_SECURITY_SCAN_CLIENT_ID"]
-        Secrets_AZ_SECURITY_SCAN_STORAGE_NAME["AZ_SECURITY_SCAN_STORAGE_NAME"]
         Secrets_AZ_SUBSCRIPTION_ID["AZ_SUBSCRIPTION_ID"]
         Secrets_AZ_TENANT_ID["AZ_TENANT_ID"]
-        Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
-        Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
@@ -910,7 +898,7 @@ flowchart LR
             typecheck_vars["NODE_VERSION"]
         end
         subgraph security_scan_subgraph["Security"]
-            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SECURITY_SCAN_STORAGE_NAME<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
+            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID"]
         end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
@@ -924,22 +912,16 @@ flowchart LR
     end
 
         Secrets --> Secrets_AZ_SECURITY_SCAN_CLIENT_ID
-        Secrets --> Secrets_AZ_SECURITY_SCAN_STORAGE_NAME
         Secrets --> Secrets_AZ_SUBSCRIPTION_ID
         Secrets --> Secrets_AZ_TENANT_ID
-        Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
-        Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
         Variables --> Variables_CAMS_LAUNCH_DARKLY_ENV
         Variables --> Variables_CAMS_SERVER_PORT
         Variables --> Variables_CAMS_SERVER_PROTOCOL
         Variables --> Variables_NODE_VERSION
     Secrets_AZ_SECURITY_SCAN_CLIENT_ID -.-> security_scan_subgraph
-    Secrets_AZ_SECURITY_SCAN_STORAGE_NAME -.-> security_scan_subgraph
     Secrets_AZ_SUBSCRIPTION_ID -.-> security_scan_subgraph
     Secrets_AZ_TENANT_ID -.-> security_scan_subgraph
-    Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
-    Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
     Variables_CAMS_LAUNCH_DARKLY_ENV -.-> build_subgraph
     Variables_CAMS_SERVER_PORT -.-> build_subgraph

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -1,8 +1,8 @@
 # GitHub Actions Workflow Analysis
 
 ## Summary
-- **Total Workflows**: 27
-- **Main Workflows**: 11
+- **Total Workflows**: 28
+- **Main Workflows**: 12
 - **Reusable Workflows**: 16
 
 ## Legend
@@ -101,11 +101,15 @@ flowchart LR
 ### Push Triggered Workflows
 
 Workflows triggered by `push`:
+- **Deploy GitHub Pages** (`deploy-pages.yml`)
 - **Continuous Deployment** (`continuous-deployment.yml`)
 
 ```mermaid
 flowchart LR
     trigger_push(["push"])
+    deploy_pages_yml["Deploy GitHub Pages"]
+    deploy_pages_yml_build["build"]
+    deploy_pages_yml_deploy["deploy"]
     continuous_deployment_yml["Continuous Deployment"]
     continuous_deployment_yml_setup["Setup"]
     reusable_build_info_yml["reusable-build-info.yml"]
@@ -169,6 +173,9 @@ flowchart LR
     sub_deploy_code_slot_yml_endpoint_test_application_post_swap["endpoint-test-application-post-swap"]
     sub_deploy_code_slot_yml_enable_access["enable-access"]
 
+    trigger_push --> deploy_pages_yml
+    deploy_pages_yml --> deploy_pages_yml_build
+    deploy_pages_yml --> deploy_pages_yml_deploy
     trigger_push --> continuous_deployment_yml
     continuous_deployment_yml --> continuous_deployment_yml_setup
     reusable_build_info_yml --> reusable_build_info_yml_build_info
@@ -243,6 +250,9 @@ flowchart LR
     classDef job fill:#f1f8e9,stroke:#33691e,stroke-width:1px,color:#000000
 
     class trigger_push trigger
+    class deploy_pages_yml mainWorkflow
+    class deploy_pages_yml_build job
+    class deploy_pages_yml_deploy job
     class continuous_deployment_yml mainWorkflow
     class continuous_deployment_yml_setup job
     class reusable_build_info_yml reusable
@@ -1135,6 +1145,32 @@ flowchart LR
     class reusable_dast_yml_zap_dast_scan job
 ```
 
+#### Deploy GitHub Pages
+
+Manual execution of `deploy-pages.yml`
+
+```mermaid
+flowchart LR
+    trigger_workflow_dispatch(["workflow_dispatch"])
+    deploy_pages_yml["Deploy GitHub Pages"]
+    deploy_pages_yml_build["build"]
+    deploy_pages_yml_deploy["deploy"]
+
+    trigger_workflow_dispatch --> deploy_pages_yml
+    deploy_pages_yml --> deploy_pages_yml_build
+    deploy_pages_yml --> deploy_pages_yml_deploy
+
+    classDef reusable fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#000000
+    classDef mainWorkflow fill:#f3e5f5,stroke:#4a148c,stroke-width:2px,color:#000000
+    classDef trigger fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000000
+    classDef job fill:#f1f8e9,stroke:#33691e,stroke-width:1px,color:#000000
+
+    class trigger_workflow_dispatch trigger
+    class deploy_pages_yml mainWorkflow
+    class deploy_pages_yml_build job
+    class deploy_pages_yml_deploy job
+```
+
 #### Deploy Security Scan Storage
 
 Manual execution of `deploy-security-scan-storage.yml`
@@ -1318,6 +1354,7 @@ flowchart LR
 flowchart LR
     trigger_workflow_dispatch(["workflow_dispatch"])
     deploy_security_scan_storage_yml["Deploy Security Scan Storage"]
+    deploy_pages_yml["Deploy GitHub Pages"]
     e2e_test_yml["Stand Alone E2E Test Runs"]
     azure_remove_branch_yml["Clean up Flexion Azure Resources"]
     prune_e2e_image_cache_yml["Prune E2E Image Cache"]
@@ -1327,6 +1364,9 @@ flowchart LR
     build_azure_cli_image_yml["Build Custom Azure CLI Runner Image"]
     dast_scan_yml["Stand Alone DAST Scan"]
     update_dependencies_yml["NPM Package Updates"]
+    trigger_push(["push"])
+    deploy_pages_yml["Deploy GitHub Pages"]
+    continuous_deployment_yml["Continuous Deployment"]
     trigger_delete(["delete"])
     azure_remove_branch_yml["Clean up Flexion Azure Resources"]
     trigger_schedule(["schedule"])
@@ -1336,12 +1376,11 @@ flowchart LR
     dast_scan_yml["Stand Alone DAST Scan"]
     trigger_pull_request(["pull_request"])
     pr_validation_yml["Pull Request E2E Validation"]
-    trigger_push(["push"])
-    continuous_deployment_yml["Continuous Deployment"]
     trigger_workflow_run(["workflow_run"])
     slack_notification_yml["slack-notification"]
 
     trigger_workflow_dispatch --> deploy_security_scan_storage_yml
+    trigger_workflow_dispatch --> deploy_pages_yml
     trigger_workflow_dispatch --> e2e_test_yml
     trigger_workflow_dispatch --> azure_remove_branch_yml
     trigger_workflow_dispatch --> prune_e2e_image_cache_yml
@@ -1351,25 +1390,27 @@ flowchart LR
     trigger_workflow_dispatch --> build_azure_cli_image_yml
     trigger_workflow_dispatch --> dast_scan_yml
     trigger_workflow_dispatch --> update_dependencies_yml
+    trigger_push --> deploy_pages_yml
+    trigger_push --> continuous_deployment_yml
     trigger_delete --> azure_remove_branch_yml
     trigger_schedule --> prune_e2e_image_cache_yml
     trigger_schedule --> refresh_e2e_base_images_yml
     trigger_schedule --> build_azure_cli_image_yml
     trigger_schedule --> dast_scan_yml
     trigger_pull_request --> pr_validation_yml
-    trigger_push --> continuous_deployment_yml
     trigger_workflow_run --> slack_notification_yml
 
     classDef mainWorkflow fill:#f3e5f5,stroke:#4a148c,stroke-width:2px,color:#000000
     classDef trigger fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000000
 
     class trigger_workflow_dispatch trigger
+    class trigger_push trigger
     class trigger_delete trigger
     class trigger_schedule trigger
     class trigger_pull_request trigger
-    class trigger_push trigger
     class trigger_workflow_run trigger
     class deploy_security_scan_storage_yml mainWorkflow
+    class deploy_pages_yml mainWorkflow
     class e2e_test_yml mainWorkflow
     class azure_remove_branch_yml mainWorkflow
     class prune_e2e_image_cache_yml mainWorkflow
@@ -1388,6 +1429,9 @@ flowchart LR
 - **Deploy Security Scan Storage** (`deploy-security-scan-storage.yml`)
   - Triggers: workflow_dispatch
   - Jobs: 1
+- **Deploy GitHub Pages** (`deploy-pages.yml`)
+  - Triggers: push, workflow_dispatch
+  - Jobs: 2
 - **Stand Alone E2E Test Runs** (`e2e-test.yml`)
   - Triggers: workflow_dispatch
   - Jobs: 2

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -328,8 +328,6 @@ flowchart LR
         Secrets_AZ_SECURITY_SCAN_CLIENT_ID["AZ_SECURITY_SCAN_CLIENT_ID"]
         Secrets_AZ_SUBSCRIPTION_ID["AZ_SUBSCRIPTION_ID"]
         Secrets_AZ_TENANT_ID["AZ_TENANT_ID"]
-        Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
-        Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
@@ -359,7 +357,7 @@ flowchart LR
             typecheck_vars["NODE_VERSION"]
         end
         subgraph security_scan_subgraph["Security"]
-            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
+            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID"]
         end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
@@ -375,8 +373,6 @@ flowchart LR
         Secrets --> Secrets_AZ_SECURITY_SCAN_CLIENT_ID
         Secrets --> Secrets_AZ_SUBSCRIPTION_ID
         Secrets --> Secrets_AZ_TENANT_ID
-        Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
-        Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
         Variables --> Variables_CAMS_LAUNCH_DARKLY_ENV
         Variables --> Variables_CAMS_SERVER_PORT
@@ -385,8 +381,6 @@ flowchart LR
     Secrets_AZ_SECURITY_SCAN_CLIENT_ID -.-> security_scan_subgraph
     Secrets_AZ_SUBSCRIPTION_ID -.-> security_scan_subgraph
     Secrets_AZ_TENANT_ID -.-> security_scan_subgraph
-    Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
-    Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
     Variables_CAMS_LAUNCH_DARKLY_ENV -.-> build_subgraph
     Variables_CAMS_SERVER_PORT -.-> build_subgraph
@@ -885,8 +879,6 @@ flowchart LR
         Secrets_AZ_SECURITY_SCAN_CLIENT_ID["AZ_SECURITY_SCAN_CLIENT_ID"]
         Secrets_AZ_SUBSCRIPTION_ID["AZ_SUBSCRIPTION_ID"]
         Secrets_AZ_TENANT_ID["AZ_TENANT_ID"]
-        Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
-        Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
@@ -916,7 +908,7 @@ flowchart LR
             typecheck_vars["NODE_VERSION"]
         end
         subgraph security_scan_subgraph["Security"]
-            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
+            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID"]
         end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
@@ -932,8 +924,6 @@ flowchart LR
         Secrets --> Secrets_AZ_SECURITY_SCAN_CLIENT_ID
         Secrets --> Secrets_AZ_SUBSCRIPTION_ID
         Secrets --> Secrets_AZ_TENANT_ID
-        Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
-        Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
         Variables --> Variables_CAMS_LAUNCH_DARKLY_ENV
         Variables --> Variables_CAMS_SERVER_PORT
@@ -942,8 +932,6 @@ flowchart LR
     Secrets_AZ_SECURITY_SCAN_CLIENT_ID -.-> security_scan_subgraph
     Secrets_AZ_SUBSCRIPTION_ID -.-> security_scan_subgraph
     Secrets_AZ_TENANT_ID -.-> security_scan_subgraph
-    Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
-    Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
     Variables_CAMS_LAUNCH_DARKLY_ENV -.-> build_subgraph
     Variables_CAMS_SERVER_PORT -.-> build_subgraph

--- a/ops/cloud-deployment/lib/keyvault/keyvault-secret-role-assignment.bicep
+++ b/ops/cloud-deployment/lib/keyvault/keyvault-secret-role-assignment.bicep
@@ -1,0 +1,29 @@
+@description('Name of the key vault containing the secret.')
+param keyVaultName string
+
+@description('Name of the secret to scope the role assignment to.')
+param secretName string
+
+@description('Principal ID of the managed identity or service principal to grant access.')
+param objectId string
+
+var keyVaultSecretsUserId = '4633458b-17de-408a-b874-0445c86b69e6'
+
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource secret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+  parent: kv
+  name: secretName
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVaultSecretsUserId, objectId, secret.id)
+  scope: secret
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserId)
+    principalId: objectId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/ops/cloud-deployment/lib/keyvault/keyvault.bicep
+++ b/ops/cloud-deployment/lib/keyvault/keyvault.bicep
@@ -23,36 +23,6 @@ param enabledForTemplateDeployment bool = false
 @description('Specifies the Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. Get it by using Get-AzSubscription cmdlet.')
 param tenantId string = subscription().tenantId
 
-@description('Specifies the object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. Get it by using Get-AzADUser or Get-AzADServicePrincipal cmdlets.')
-param objectId string
-
-@description('Specifies the role the user will get with the secret in the vault. Valid values are: Key Vault Administrator, Key Vault Certificates Officer, Key Vault Crypto Officer, Key Vault Crypto Service Encryption User, Key Vault Crypto User, Key Vault Reader, Key Vault Secrets Officer, Key Vault Secrets User.')
-@allowed([
-  'Key Vault Administrator'
-  'Key Vault Certificates Officer'
-  'Key Vault Crypto Officer'
-  'Key Vault Crypto Service Encryption User'
-  'Key Vault Crypto User'
-  'Key Vault Reader'
-  'Key Vault Secrets Officer'
-  'Key Vault Secrets User'
-])
-param roleName string = 'Key Vault Secrets User'
-
-var roleIdMapping = {
-  'Key Vault Administrator': '00482a5a-887f-4fb3-b363-3b7fe8e74483'
-  'Key Vault Certificates Officer': 'a4417e6f-fecd-4de8-b567-7b0420556985'
-  'Key Vault Crypto Officer': '14b46e9e-c2b7-41b4-b07b-48a6ebf60603'
-  'Key Vault Crypto Service Encryption User': 'e147488a-f6f5-4113-8e2d-b22465e65bf6'
-  'Key Vault Crypto User': '12338af0-0e69-4776-bea7-57ae8d297424'
-  'Key Vault Reader': '21090545-7ca7-4776-b22c-e363652d74d2'
-  'Key Vault Secrets Officer': 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7'
-  'Key Vault Secrets User': '4633458b-17de-408a-b874-0445c86b69e6'
-}
-
-@description('Controls whether the role assignment granting the objectId access to the vault is created.')
-param makeRoleAssignment bool = true
-
 param tags object = {}
 
 // 'Disabled' was attempted and reverted (c7006f8ff) — private endpoint constraints block portal and pipeline access. RBAC (enableRbacAuthorization) is enforced as the primary access control.
@@ -85,16 +55,6 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
     }
     publicNetworkAccess: publicNetworkAccess
     networkAcls: networkAcls
-  }
-}
-
-resource kvRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (makeRoleAssignment) {
-  name: guid(roleIdMapping[roleName], objectId, kv.id)
-  scope: kv
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleIdMapping[roleName])
-    principalId: objectId
-    principalType: 'ServicePrincipal'
   }
 }
 

--- a/ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep
+++ b/ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep
@@ -13,7 +13,7 @@
                  privateEndpointSubnetId=<subnet-resource-id>
 
   What this template provisions:
-  1. Managed identity with "Key Vault Secrets User" access to the vault.
+  1. Managed identity with Key Vault Secrets User access scoped to individual secrets.
   2. Key Vault with network ACLs (public access disabled).
   3. Private DNS zone (privatelink.vaultcore.usgovcloudapi.net) linked to the virtual network.
   4. Private endpoint for the vault in the designated private endpoint subnet.
@@ -28,6 +28,7 @@ param deployedAt string = utcNow()
 
 param deployDns bool = true
 
+@description('When false, no role assignments are created (used for USTP deployments where the ADO service principal lacks role assignment permissions).')
 param makeRoleAssignment bool = true
 
 param location string = resourceGroup().location
@@ -63,7 +64,7 @@ param kvNetworkAcls object = {
   virtualNetworkRules: []
 }
 
-@description('Managed identity with Secrets User role to Keyvault')
+@description('Managed identity with Secrets User role to individual secrets in the Keyvault')
 param managedIdentityName string = 'id-kv-app-config-${uniqueString(stackName)}'
 
 var tags = {
@@ -71,6 +72,32 @@ var tags = {
   component: 'security'
   'deployed-at': deployedAt
 }
+
+// All secrets consumed by the API and Dataflows function apps via @Microsoft.KeyVault() references.
+// Both apps have identical secret needs so they share one managed identity.
+// Auth-method-specific secrets (MSSQL-USER/PASS vs MSSQL-CLIENT-ID) are both included here
+// because the vault holds all secrets regardless of which auth method is active.
+var functionAppSecrets = [
+  'ADMIN-KEY'
+  'MONGO-CONNECTION-STRING'
+  'MSSQL-HOST'
+  'MSSQL-DATABASE-DXTR'
+  'MSSQL-ENCRYPT'
+  'MSSQL-TRUST-UNSIGNED-CERT'
+  'MSSQL-USER'
+  'MSSQL-PASS'
+  'MSSQL-CLIENT-ID'
+  'ACMS-MSSQL-HOST'
+  'ACMS-MSSQL-DATABASE'
+  'ACMS-MSSQL-ENCRYPT'
+  'ACMS-MSSQL-TRUST-UNSIGNED-CERT'
+  'ACMS-MSSQL-USER'
+  'ACMS-MSSQL-PASS'
+  'ACMS-MSSQL-CLIENT-ID'
+  'FEATURE-FLAG-SDK-KEY'
+  'CAMS-USER-GROUP-GATEWAY-CONFIG'
+  'OKTA-API-KEY'
+]
 
 module appConfigIdentity './lib/identity/managed-identity.bicep' = {
   name: '${stackName}-id-app-config-module'
@@ -88,13 +115,23 @@ module appConfigKeyvault './lib/keyvault/keyvault.bicep' = {
   params: {
     location: location
     keyVaultName: kvName
-    objectId: appConfigIdentity.outputs.principalId
-    roleName: 'Key Vault Secrets User'
-    makeRoleAssignment: makeRoleAssignment
     networkAcls: kvNetworkAcls
     tags: tags
   }
 }
+
+module appConfigSecretRoleAssignments './lib/keyvault/keyvault-secret-role-assignment.bicep' = [
+  for secretName in functionAppSecrets: if (makeRoleAssignment) {
+    name: '${stackName}-kv-secret-role-${secretName}'
+    scope: resourceGroup(kvResourceGroup)
+    params: {
+      keyVaultName: kvName
+      secretName: secretName
+      objectId: appConfigIdentity.outputs.principalId
+    }
+    dependsOn: [appConfigKeyvault]
+  }
+]
 
 resource ustpVirtualNetwork 'Microsoft.Network/virtualNetworks@2022-11-01' existing = {
   name: virtualNetworkName

--- a/ops/scripts/utility/setup-security-scan-federated-credential.sh
+++ b/ops/scripts/utility/setup-security-scan-federated-credential.sh
@@ -11,9 +11,8 @@
 #   repo:ORG/REPO:workflow:CALLER-WORKFLOW-NAME:environment:security-scan
 #
 # Prerequisites:
-#   - az CLI logged in as an Entra ID admin (can create app registrations and role assignments)
+#   - az CLI logged in as an Entra ID admin (can create app registrations)
 #   - The security scan storage account already exists
-#   - Both Key Vaults (kv-ustp-cams, kv-ustp-cams-dev) already exist
 #
 # This script is idempotent — re-running it will update existing resources in place
 # rather than creating duplicates.
@@ -25,8 +24,6 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 STORAGE_ACCOUNT_NAME="${AZ_SECURITY_SCAN_STORAGE_NAME:?Set AZ_SECURITY_SCAN_STORAGE_NAME}"
 RESOURCE_GROUP="${AZ_SECURITY_SCAN_RG:?Set AZ_SECURITY_SCAN_RG}"
-KV_RESOURCE_GROUP="${AZ_KV_RG:?Set AZ_KV_RG}"
-KV_NAMES=("kv-ustp-cams" "kv-ustp-cams-dev")
 GITHUB_ORG="US-Trustee-Program"
 GITHUB_REPO="Bankruptcy-Oversight-Support-Systems"
 GITHUB_WORKFLOW="Continuous Deployment"
@@ -115,27 +112,6 @@ if [[ -z "$EXISTING_ROLE" ]]; then
 else
   echo "    Role already assigned — skipping."
 fi
-
-echo "==> Checking Key Vault Secrets Officer role assignments..."
-for KV_NAME in "${KV_NAMES[@]}"; do
-  KV_SCOPE="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${KV_RESOURCE_GROUP}/providers/Microsoft.KeyVault/vaults/${KV_NAME}"
-  EXISTING_KV_ROLE=$(az role assignment list \
-    --assignee "$SP_ID" \
-    --role "Key Vault Secrets Officer" \
-    --scope "$KV_SCOPE" \
-    --query "[0].id" -o tsv 2>/dev/null || true)
-
-  if [[ -z "$EXISTING_KV_ROLE" ]]; then
-    az role assignment create \
-      --assignee-object-id "$SP_ID" \
-      --assignee-principal-type ServicePrincipal \
-      --role "Key Vault Secrets Officer" \
-      --scope "$KV_SCOPE"
-    echo "    Key Vault Secrets Officer assigned on $KV_NAME."
-  else
-    echo "    Key Vault Secrets Officer already assigned on $KV_NAME — skipping."
-  fi
-done
 
 echo ""
 echo "==> Done."

--- a/ops/scripts/utility/setup-security-scan-federated-credential.sh
+++ b/ops/scripts/utility/setup-security-scan-federated-credential.sh
@@ -11,8 +11,9 @@
 #   repo:ORG/REPO:workflow:CALLER-WORKFLOW-NAME:environment:security-scan
 #
 # Prerequisites:
-#   - az CLI logged in as an Entra ID admin (can create app registrations)
+#   - az CLI logged in as an Entra ID admin (can create app registrations and role assignments)
 #   - The security scan storage account already exists
+#   - Both Key Vaults (kv-ustp-cams, kv-ustp-cams-dev) already exist
 #
 # This script is idempotent — re-running it will update existing resources in place
 # rather than creating duplicates.
@@ -24,6 +25,8 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 STORAGE_ACCOUNT_NAME="${AZ_SECURITY_SCAN_STORAGE_NAME:?Set AZ_SECURITY_SCAN_STORAGE_NAME}"
 RESOURCE_GROUP="${AZ_SECURITY_SCAN_RG:?Set AZ_SECURITY_SCAN_RG}"
+KV_RESOURCE_GROUP="${AZ_KV_RG:?Set AZ_KV_RG}"
+KV_NAMES=("kv-ustp-cams" "kv-ustp-cams-dev")
 GITHUB_ORG="US-Trustee-Program"
 GITHUB_REPO="Bankruptcy-Oversight-Support-Systems"
 GITHUB_WORKFLOW="Continuous Deployment"
@@ -112,6 +115,27 @@ if [[ -z "$EXISTING_ROLE" ]]; then
 else
   echo "    Role already assigned — skipping."
 fi
+
+echo "==> Checking Key Vault Secrets Officer role assignments..."
+for KV_NAME in "${KV_NAMES[@]}"; do
+  KV_SCOPE="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${KV_RESOURCE_GROUP}/providers/Microsoft.KeyVault/vaults/${KV_NAME}"
+  EXISTING_KV_ROLE=$(az role assignment list \
+    --assignee "$SP_ID" \
+    --role "Key Vault Secrets Officer" \
+    --scope "$KV_SCOPE" \
+    --query "[0].id" -o tsv 2>/dev/null || true)
+
+  if [[ -z "$EXISTING_KV_ROLE" ]]; then
+    az role assignment create \
+      --assignee-object-id "$SP_ID" \
+      --assignee-principal-type ServicePrincipal \
+      --role "Key Vault Secrets Officer" \
+      --scope "$KV_SCOPE"
+    echo "    Key Vault Secrets Officer assigned on $KV_NAME."
+  else
+    echo "    Key Vault Secrets Officer already assigned on $KV_NAME — skipping."
+  fi
+done
 
 echo ""
 echo "==> Done."


### PR DESCRIPTION
# Purpose

Reduce the blast radius of a compromised security scan workflow by eliminating long-lived Azure credentials and replacing broad secret inheritance with explicit, minimal secret declarations.

# Major Changes

- Replaced `secrets: inherit` in `continuous-deployment.yml` with explicit secret pass-through listing only the 4 secrets the workflow actually needs
- Added `workflow_call.secrets:` block to `sub-security-scan.yml` declaring only required secrets
- Added `permissions:` blocks to both scan jobs (`contents: read`, `security-events: write` for sca-scan, `id-token: write` for OIDC)
- Migrated `azure/login` from long-lived `AZURE_CREDENTIALS` to OIDC Workload Identity Federation using scoped app registration
- Switched Azure Storage commands from account-key auth to `--auth-mode login`, eliminating the need to fetch storage keys (and the `AZ_SECURITY_SCAN_RG` secret entirely)
- Added runbook script (`ops/scripts/utility/setup-security-scan-federated-credential.sh`) for creating the Azure federated credential and Storage Blob Data Contributor role assignment scoped to the security scan storage account

# Testing/Validation

Workflow syntax validated by pre-commit hook. Azure federated credential and role assignment created via the runbook and verified in Azure portal. GitHub Actions repository variables (`AZ_SECURITY_SCAN_CLIENT_ID`, `AZ_TENANT_ID`, `AZ_SUBSCRIPTION_ID`) set for the OIDC login.

# Notes

The `AZURE_CREDENTIALS` secret declaration is retained in the workflow with `required: false` to avoid breaking callers during transition, but is no longer referenced by any step. It can be removed entirely in a follow-up once confirmed clean.

`AZ_SECURITY_SCAN_RG` is no longer passed to or used by this workflow — `--auth-mode login` resolves the storage endpoint from the account name alone without needing the resource group.

This change applies to the Flexion environment only; USTP infrastructure is unaffected.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Harden the security scan workflow by switching to OIDC-based Azure auth and least-privilege secret usage, and update documentation to reflect the workflow’s reusable status and new inputs.

Enhancements:
- Limit sub-security-scan workflow inputs to explicitly declared secrets and remove reliance on broad secrets inheritance.
- Migrate Azure login in security scan jobs from long-lived AZURE_CREDENTIALS to OIDC Workload Identity Federation using repository variables for identity.
- Use Azure CLI login-based authentication for storage operations instead of account keys, removing the need for the security scan resource group secret.
- Tighten GitHub Actions job permissions for the security scan jobs to only those required for contents, security events, and id-token.
- Add a runbook script to provision the federated credential and scoped role assignment for the security scan storage account.

Documentation:
- Update the workflow diagram documentation to classify sub-security-scan.yml as a reusable workflow and to document its new secrets inputs and relationships.