### PR TITLE
CAMS-596 Fix bug caused by static db connection held by abstract mssql client

### DIFF
--- a/backend/lib/adapters/gateways/abstract-mssql-client.test.ts
+++ b/backend/lib/adapters/gateways/abstract-mssql-client.test.ts
@@ -52,12 +52,15 @@ vi.mock('mssql', async (importOriginal) => {
   };
 });
 
+class TestDbClient extends AbstractMssqlClient {
+  constructor(_context: ApplicationContext, config: IDbConfig, childModuleName: string) {
+    super(config, childModuleName);
+  }
+}
+
 describe('Abstract MS-SQL client', () => {
   test('should get appropriate results', async () => {
-    const applicationContext = await createMockApplicationContext();
-    // setup test
-    // execute method under test
-    const context = applicationContext;
+    const context = await createMockApplicationContext();
     const query = 'SELECT * FROM foo WHERE data = @param1 AND name=@param2';
     const input = [
       {
@@ -72,16 +75,38 @@ describe('Abstract MS-SQL client', () => {
       },
     ] as unknown as DbTableFieldSpec[];
 
-    // execute method under test
-    class TestDbClient extends AbstractMssqlClient {
-      constructor(_context: ApplicationContext, config: IDbConfig, childModuleName: string) {
-        super(config, childModuleName);
-      }
-    }
     const client = new TestDbClient(context, context.config.dxtrDbConfig, 'TEST_MODULE');
     const queryResult: QueryResults = await client.executeQuery<string>(context, query, input);
 
-    // assert
     expect(queryResult).toEqual({ results: 'test string', message: '', success: true });
+  });
+
+  test('should use separate connection pools for clients with different database configs', async () => {
+    const { ConnectionPool } = await import('mssql');
+    const mockConnectionPool = vi.mocked(ConnectionPool);
+    mockConnectionPool.mockClear();
+
+    const context = await createMockApplicationContext();
+    const configA: IDbConfig = { ...context.config.dxtrDbConfig, database: 'DATABASE_A' };
+    const configB: IDbConfig = { ...context.config.dxtrDbConfig, database: 'DATABASE_B' };
+
+    new TestDbClient(context, configA, 'CLIENT_A');
+    new TestDbClient(context, configB, 'CLIENT_B');
+
+    expect(mockConnectionPool).toHaveBeenCalledTimes(2);
+  });
+
+  test('should reuse the same connection pool for clients with the same database config', async () => {
+    const { ConnectionPool } = await import('mssql');
+    const mockConnectionPool = vi.mocked(ConnectionPool);
+    mockConnectionPool.mockClear();
+
+    const context = await createMockApplicationContext();
+    const config: IDbConfig = { ...context.config.dxtrDbConfig, database: 'SHARED_DATABASE' };
+
+    new TestDbClient(context, config, 'CLIENT_1');
+    new TestDbClient(context, config, 'CLIENT_2');
+
+    expect(mockConnectionPool).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/lib/adapters/gateways/abstract-mssql-client.ts
+++ b/backend/lib/adapters/gateways/abstract-mssql-client.ts
@@ -5,14 +5,17 @@ import { ApplicationContext } from '../types/basic';
 import { getCamsError } from '../../common-errors/error-utilities';
 
 export abstract class AbstractMssqlClient {
-  private static connectionPool: ConnectionPool;
+  private static connectionPools: Map<string, ConnectionPool> = new Map();
   private readonly moduleName: string;
+  private readonly poolKey: string;
 
   protected constructor(dbConfig: IDbConfig, childModuleName: string) {
     this.moduleName = `ABSTRACT-MSSQL-CLIENT (${childModuleName})`;
-    if (!AbstractMssqlClient.connectionPool) {
-      AbstractMssqlClient.connectionPool = new ConnectionPool(dbConfig as config);
-      deferClose(AbstractMssqlClient.connectionPool);
+    this.poolKey = `${dbConfig.server}:${dbConfig.port}:${dbConfig.database}`;
+    if (!AbstractMssqlClient.connectionPools.has(this.poolKey)) {
+      const pool = new ConnectionPool(dbConfig as config);
+      AbstractMssqlClient.connectionPools.set(this.poolKey, pool);
+      deferClose(pool);
     }
   }
 
@@ -21,11 +24,12 @@ export abstract class AbstractMssqlClient {
     query: string,
     input?: DbTableFieldSpec[],
   ): Promise<QueryResults> {
+    const connectionPool = AbstractMssqlClient.connectionPools.get(this.poolKey);
     try {
-      if (!AbstractMssqlClient.connectionPool.connected) {
-        await AbstractMssqlClient.connectionPool.connect();
+      if (!connectionPool.connected) {
+        await connectionPool.connect();
       }
-      const request = AbstractMssqlClient.connectionPool.request();
+      const request = connectionPool.request();
 
       if (typeof input != 'undefined') {
         input.forEach((item) => {


### PR DESCRIPTION
# Purpose

Fix bug caused by static db connection held by abstract mssql client

# Major Changes

* Added a map to the abstract sql client that holds connections for specific "server + port + dbname" tuples.

# Testing/Validation

* Unit tests written to confirm function of the map.

## Summary by Sourcery

Switch the abstract MSSQL client to manage separate connection pools per database configuration instead of a single static pool, and add tests to verify the new behavior.

Bug Fixes:
- Fix incorrect sharing of a single static database connection pool across clients using different MSSQL database configurations.

Enhancements:
- Introduce keyed connection pool management in the abstract MSSQL client using a map keyed by server, port, and database name.

Tests:
- Add unit tests to ensure separate pools are created for different database configs and reused for identical configs in the abstract MSSQL client.