### PR TITLE
CAMS-732: Add feature flag to conditionally hide trustee assigned staff

### DIFF
--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -19,4 +19,5 @@ export const testFeatureFlags: FeatureFlagSet = {
   'show-debtor-name-column': true,
   'display-chpt7-panel-upcoming-key-dates': true,
   'trustee-verification-enabled': true,
+  'trustee-assigned-staff-enabled': true,
 };

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -15,6 +15,7 @@ export const SHOW_DEBTOR_NAME_COLUMN = 'show-debtor-name-column';
 export const DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES = 'display-chpt7-panel-upcoming-key-dates';
 export const TRUSTEE_VERIFICATION_ENABLED = 'trustee-verification-enabled';
 export const VIEW_TRUSTEE_ON_CASE = 'view-trustee-on-case';
+export const TRUSTEE_ASSIGNED_STAFF_ENABLED = 'trustee-assigned-staff-enabled';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();

--- a/user-interface/src/trustees/TrusteeDetailNavigation.test.tsx
+++ b/user-interface/src/trustees/TrusteeDetailNavigation.test.tsx
@@ -6,8 +6,11 @@ import TrusteeDetailNavigation, {
   TrusteeDetailNavigationProps,
   mapTrusteeDetailNavState,
 } from './TrusteeDetailNavigation';
-import * as featureFlagsHook from '@/lib/hooks/UseFeatureFlags';
-import { TRUSTEE_ASSIGNED_STAFF_ENABLED } from '@/lib/hooks/UseFeatureFlags';
+import useFeatureFlags from '@/lib/hooks/UseFeatureFlags';
+import { testFeatureFlags } from '@common/feature-flags';
+
+vi.mock('@/lib/hooks/UseFeatureFlags');
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
 
 vi.mock('@/lib/utils/navigation', () => ({
   setCurrentNav: vi.fn((activeNav, currentNav) => (activeNav === currentNav ? 'usa-current' : '')),
@@ -23,13 +26,7 @@ vi.mock('@/lib/utils/navigation', () => ({
 
 describe('TrusteeDetailNavigation', () => {
   beforeEach(() => {
-    vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-      [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
-    });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
+    mockUseFeatureFlags.mockReturnValue(testFeatureFlags);
   });
 
   function renderWithRouter(props: TrusteeDetailNavigationProps) {
@@ -175,56 +172,45 @@ describe('TrusteeDetailNavigation', () => {
     });
   });
 
-  describe('Feature Flag: TRUSTEE_ASSIGNED_STAFF_ENABLED', () => {
-    test('should show Assigned Staff nav link when flag is enabled', () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
-      });
-
+  describe('trustee-assigned-staff-enabled flag is enabled', () => {
+    test('should show Assigned Staff nav link', () => {
       renderWithRouter(defaultProps);
 
       expect(screen.getByTestId('trustee-assigned-staff-nav-link')).toBeInTheDocument();
       expect(screen.getByText('Assigned Staff')).toBeInTheDocument();
     });
 
-    test('should hide Assigned Staff nav link when flag is disabled', () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: false,
-      });
+    test('should render 5 nav items', () => {
+      renderWithRouter(defaultProps);
 
+      const listItems = screen.getAllByRole('listitem');
+      expect(listItems).toHaveLength(5);
+    });
+  });
+
+  describe('trustee-assigned-staff-enabled flag is disabled', () => {
+    beforeEach(() => {
+      mockUseFeatureFlags.mockReturnValue({
+        ...testFeatureFlags,
+        'trustee-assigned-staff-enabled': false,
+      });
+    });
+
+    test('should not show Assigned Staff nav link', () => {
       renderWithRouter(defaultProps);
 
       expect(screen.queryByTestId('trustee-assigned-staff-nav-link')).not.toBeInTheDocument();
       expect(screen.queryByText('Assigned Staff')).not.toBeInTheDocument();
     });
 
-    test('should render 5 nav items when flag is enabled', () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
-      });
-
-      renderWithRouter(defaultProps);
-
-      const listItems = screen.getAllByRole('listitem');
-      expect(listItems).toHaveLength(5);
-    });
-
-    test('should render 4 nav items when flag is disabled', () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: false,
-      });
-
+    test('should render 4 nav items', () => {
       renderWithRouter(defaultProps);
 
       const listItems = screen.getAllByRole('listitem');
       expect(listItems).toHaveLength(4);
     });
 
-    test('should still show all other nav links when Assigned Staff is hidden', () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: false,
-      });
-
+    test('should still show all other nav links', () => {
       renderWithRouter(defaultProps);
 
       expect(screen.getByTestId('trustee-profile-nav-link')).toBeInTheDocument();

--- a/user-interface/src/trustees/TrusteeDetailNavigation.test.tsx
+++ b/user-interface/src/trustees/TrusteeDetailNavigation.test.tsx
@@ -6,6 +6,8 @@ import TrusteeDetailNavigation, {
   TrusteeDetailNavigationProps,
   mapTrusteeDetailNavState,
 } from './TrusteeDetailNavigation';
+import * as featureFlagsHook from '@/lib/hooks/UseFeatureFlags';
+import { TRUSTEE_ASSIGNED_STAFF_ENABLED } from '@/lib/hooks/UseFeatureFlags';
 
 vi.mock('@/lib/utils/navigation', () => ({
   setCurrentNav: vi.fn((activeNav, currentNav) => (activeNav === currentNav ? 'usa-current' : '')),
@@ -20,6 +22,16 @@ vi.mock('@/lib/utils/navigation', () => ({
 }));
 
 describe('TrusteeDetailNavigation', () => {
+  beforeEach(() => {
+    vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+      [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   function renderWithRouter(props: TrusteeDetailNavigationProps) {
     return render(
       <BrowserRouter>
@@ -160,6 +172,65 @@ describe('TrusteeDetailNavigation', () => {
     const links = screen.getAllByRole('link');
     links.forEach((link) => {
       expect(link).toHaveClass('usa-sidenav__link');
+    });
+  });
+
+  describe('Feature Flag: TRUSTEE_ASSIGNED_STAFF_ENABLED', () => {
+    test('should show Assigned Staff nav link when flag is enabled', () => {
+      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
+      });
+
+      renderWithRouter(defaultProps);
+
+      expect(screen.getByTestId('trustee-assigned-staff-nav-link')).toBeInTheDocument();
+      expect(screen.getByText('Assigned Staff')).toBeInTheDocument();
+    });
+
+    test('should hide Assigned Staff nav link when flag is disabled', () => {
+      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: false,
+      });
+
+      renderWithRouter(defaultProps);
+
+      expect(screen.queryByTestId('trustee-assigned-staff-nav-link')).not.toBeInTheDocument();
+      expect(screen.queryByText('Assigned Staff')).not.toBeInTheDocument();
+    });
+
+    test('should render 5 nav items when flag is enabled', () => {
+      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
+      });
+
+      renderWithRouter(defaultProps);
+
+      const listItems = screen.getAllByRole('listitem');
+      expect(listItems).toHaveLength(5);
+    });
+
+    test('should render 4 nav items when flag is disabled', () => {
+      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: false,
+      });
+
+      renderWithRouter(defaultProps);
+
+      const listItems = screen.getAllByRole('listitem');
+      expect(listItems).toHaveLength(4);
+    });
+
+    test('should still show all other nav links when Assigned Staff is hidden', () => {
+      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: false,
+      });
+
+      renderWithRouter(defaultProps);
+
+      expect(screen.getByTestId('trustee-profile-nav-link')).toBeInTheDocument();
+      expect(screen.getByTestId('trustee-appointments-nav-link')).toBeInTheDocument();
+      expect(screen.getByTestId('trustee-notes-nav-link')).toBeInTheDocument();
+      expect(screen.getByTestId('trustee-audit-history-nav-link')).toBeInTheDocument();
     });
   });
 });

--- a/user-interface/src/trustees/TrusteeDetailNavigation.tsx
+++ b/user-interface/src/trustees/TrusteeDetailNavigation.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { setCurrentNav, createNavStateMapper } from '@/lib/utils/navigation';
+import useFeatureFlags, { TRUSTEE_ASSIGNED_STAFF_ENABLED } from '@/lib/hooks/UseFeatureFlags';
 
 export enum TrusteeNavState {
   TRUSTEE_PROFILE,
@@ -32,6 +33,8 @@ export default function TrusteeDetailNavigation({
   className,
 }: TrusteeDetailNavigationProps) {
   const [activeNav, setActiveNav] = useState<TrusteeNavState>(initiallySelectedNavLink);
+  const flags = useFeatureFlags();
+  const showAssignedStaff = !!flags[TRUSTEE_ASSIGNED_STAFF_ENABLED];
 
   return (
     <>
@@ -63,17 +66,19 @@ export default function TrusteeDetailNavigation({
               Appointments
             </NavLink>
           </li>
-          <li className="usa-sidenav__item">
-            <NavLink
-              to={`/trustees/${trusteeId}/assigned-staff`}
-              data-testid="trustee-assigned-staff-nav-link"
-              className={`usa-sidenav__link ${setCurrentNav(activeNav, TrusteeNavState.ASSIGNED_STAFF)}`}
-              onClick={() => setActiveNav(TrusteeNavState.ASSIGNED_STAFF)}
-              title="View staff assigned to the current trustee"
-            >
-              Assigned Staff
-            </NavLink>
-          </li>
+          {showAssignedStaff && (
+            <li className="usa-sidenav__item">
+              <NavLink
+                to={`/trustees/${trusteeId}/assigned-staff`}
+                data-testid="trustee-assigned-staff-nav-link"
+                className={`usa-sidenav__link ${setCurrentNav(activeNav, TrusteeNavState.ASSIGNED_STAFF)}`}
+                onClick={() => setActiveNav(TrusteeNavState.ASSIGNED_STAFF)}
+                title="View staff assigned to the current trustee"
+              >
+                Assigned Staff
+              </NavLink>
+            </li>
+          )}
           <li className="usa-sidenav__item">
             <NavLink
               to={`/trustees/${trusteeId}/notes`}

--- a/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
@@ -8,7 +8,10 @@ import MockData from '@common/cams/test-utilities/mock-data';
 import TestingUtilities from '@/lib/testing/testing-utilities';
 import Api2 from '@/lib/models/api2';
 import * as featureFlagsHook from '@/lib/hooks/UseFeatureFlags';
-import { DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES } from '@/lib/hooks/UseFeatureFlags';
+import {
+  DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES,
+  TRUSTEE_ASSIGNED_STAFF_ENABLED,
+} from '@/lib/hooks/UseFeatureFlags';
 
 const mockOnEditPublicProfile = vi.fn();
 const mockOnEditInternalProfile = vi.fn();
@@ -86,6 +89,7 @@ describe('TrusteeDetailScreen', () => {
     vi.spyOn(Api2, 'getTrusteeNotes').mockResolvedValue({ data: [] });
     vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
       [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
+      [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
     });
   });
 
@@ -556,6 +560,39 @@ describe('TrusteeDetailScreen', () => {
       });
 
       renderWithRouter(['/trustees/123/appointments/appt-1/upcoming-key-dates/edit']);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/my-cases');
+      });
+    });
+  });
+
+  describe('assigned-staff route', () => {
+    beforeEach(() => {
+      vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
+    });
+
+    test('should render TrusteeAssignedStaff when TRUSTEE_ASSIGNED_STAFF_ENABLED flag is enabled', async () => {
+      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+        [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
+        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
+      });
+
+      renderWithRouter(['/trustees/123/assigned-staff']);
+
+      await waitFor(() => {
+        expect(document.querySelector('.trustee-assigned-staff-container')).toBeInTheDocument();
+      });
+    });
+
+    test('should redirect home when TRUSTEE_ASSIGNED_STAFF_ENABLED flag is disabled', async () => {
+      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+        [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
+        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: false,
+      });
+
+      renderWithRouter(['/trustees/123/assigned-staff']);
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/my-cases');

--- a/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
@@ -7,11 +7,11 @@ import { ContactInformation } from '@common/cams/contact';
 import MockData from '@common/cams/test-utilities/mock-data';
 import TestingUtilities from '@/lib/testing/testing-utilities';
 import Api2 from '@/lib/models/api2';
-import * as featureFlagsHook from '@/lib/hooks/UseFeatureFlags';
-import {
-  DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES,
-  TRUSTEE_ASSIGNED_STAFF_ENABLED,
-} from '@/lib/hooks/UseFeatureFlags';
+import useFeatureFlags from '@/lib/hooks/UseFeatureFlags';
+import { testFeatureFlags } from '@common/feature-flags';
+
+vi.mock('@/lib/hooks/UseFeatureFlags');
+const mockUseFeatureFlags = vi.mocked(useFeatureFlags);
 
 const mockOnEditPublicProfile = vi.fn();
 const mockOnEditInternalProfile = vi.fn();
@@ -87,10 +87,7 @@ describe('TrusteeDetailScreen', () => {
     mockOnEditInternalProfile.mockClear();
 
     vi.spyOn(Api2, 'getTrusteeNotes').mockResolvedValue({ data: [] });
-    vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-      [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
-      [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
-    });
+    mockUseFeatureFlags.mockReturnValue(testFeatureFlags);
   });
 
   afterEach(() => {
@@ -542,8 +539,9 @@ describe('TrusteeDetailScreen', () => {
     });
 
     test('should render UpcomingKeyDatesForm when DISPLAY_CHPT7_PANEL_UPCOMING_REPORT_DATES flag is enabled', async () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
+      mockUseFeatureFlags.mockReturnValue({
+        ...testFeatureFlags,
+        'display-chpt7-panel-upcoming-key-dates': true,
       });
       vi.spyOn(Api2, 'getUpcomingKeyDates').mockResolvedValue({ data: null });
 
@@ -555,8 +553,9 @@ describe('TrusteeDetailScreen', () => {
     });
 
     test('should redirect home when DISPLAY_CHPT7_PANEL_UPCOMING_REPORT_DATES flag is disabled', async () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: false,
+      mockUseFeatureFlags.mockReturnValue({
+        ...testFeatureFlags,
+        'display-chpt7-panel-upcoming-key-dates': false,
       });
 
       renderWithRouter(['/trustees/123/appointments/appt-1/upcoming-key-dates/edit']);
@@ -568,16 +567,9 @@ describe('TrusteeDetailScreen', () => {
   });
 
   describe('assigned-staff route', () => {
-    beforeEach(() => {
+    test('should render TrusteeAssignedStaff when trustee-assigned-staff-enabled flag is enabled', async () => {
       vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
       vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
-    });
-
-    test('should render TrusteeAssignedStaff when TRUSTEE_ASSIGNED_STAFF_ENABLED flag is enabled', async () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
-        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: true,
-      });
 
       renderWithRouter(['/trustees/123/assigned-staff']);
 
@@ -586,11 +578,13 @@ describe('TrusteeDetailScreen', () => {
       });
     });
 
-    test('should redirect home when TRUSTEE_ASSIGNED_STAFF_ENABLED flag is disabled', async () => {
-      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-        [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
-        [TRUSTEE_ASSIGNED_STAFF_ENABLED]: false,
+    test('should redirect home when trustee-assigned-staff-enabled flag is disabled', async () => {
+      mockUseFeatureFlags.mockReturnValue({
+        ...testFeatureFlags,
+        'trustee-assigned-staff-enabled': false,
       });
+      vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
 
       renderWithRouter(['/trustees/123/assigned-staff']);
 

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -30,6 +30,7 @@ import TrusteeMeetingOfCreditorsInfoForm from './forms/TrusteeMeetingOfCreditors
 import TrusteeNotes from '@/trustees/panels/trustee-notes/TrusteeNotes';
 import useFeatureFlags, {
   DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES,
+  TRUSTEE_ASSIGNED_STAFF_ENABLED,
 } from '@/lib/hooks/UseFeatureFlags';
 
 type TrusteeHeaderProps = JSX.IntrinsicElements['div'] & {
@@ -253,6 +254,7 @@ export default function TrusteeDetailScreen() {
     },
     {
       path: 'assigned-staff',
+      disabled: !featureFlags[TRUSTEE_ASSIGNED_STAFF_ENABLED],
       subHeading: 'Trustee',
       content: (
         <div className="trustee-detail-screen-info-container">


### PR DESCRIPTION
# Purpose

Add trustee-assigned-staff-enabled flag (default: true) to allow administrators to hide the assigned staff section on trustee profiles. When disabled, the nav link is hidden and direct URL access redirects to home.

- Add flag definition and constant export
- Hide Assigned Staff nav link when flag is disabled
- Add route-level protection with redirect to home
- Add comprehensive tests for both navigation and route behavior
- Follows established pattern from CaseDetailNavigation

Jira ticket: CAMS-732

# Major Changes
                                                                                                                                                     
  - Flag definition: Added to common/src/feature-flags.ts (default: true)                                                                            
  - Navigation: Assigned Staff nav link conditionally renders based on flag state                                                                    
  - Route protection: Direct URL access redirects to home when flag is disabled                                                                      
  - Pattern: Follows established approach from CaseDetailNavigation (lines 82-97)                                                                    
  - Tests: Added 7 comprehensive tests covering both flag states (2,611 total tests pass)                                                            
                                                                                                                                                     
  When flag is disabled:                                                                                                                             
  - Nav link hidden from left navigation                                                                                                             
  - Direct URL access to /trustees/{id}/assigned-staff redirects to /my-cases                                                                        
  - UI remains balanced with 4 nav items instead of 5 

# Testing/Validation

Added unit tests

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
