### PR TITLE
CAMS-709: Skip KV role assignment in USTP deployments

### DIFF
--- a/ops/cloud-deployment/lib/keyvault/keyvault.bicep
+++ b/ops/cloud-deployment/lib/keyvault/keyvault.bicep
@@ -55,6 +55,7 @@ param makeRoleAssignment bool = true
 
 param tags object = {}
 
+// 'Disabled' was attempted and reverted (c7006f8ff) — private endpoint constraints block portal and pipeline access. RBAC (enableRbacAuthorization) is enforced as the primary access control.
 @description('Controls whether the key vault is accessible from the public internet.')
 @allowed([
   'Enabled'

--- a/ops/cloud-deployment/lib/keyvault/keyvault.bicep
+++ b/ops/cloud-deployment/lib/keyvault/keyvault.bicep
@@ -50,6 +50,9 @@ var roleIdMapping = {
   'Key Vault Secrets User': '4633458b-17de-408a-b874-0445c86b69e6'
 }
 
+@description('Controls whether the role assignment granting the objectId access to the vault is created.')
+param makeRoleAssignment bool = true
+
 param tags object = {}
 
 @description('Controls whether the key vault is accessible from the public internet.')
@@ -84,7 +87,7 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
   }
 }
 
-resource kvRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource kvRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (makeRoleAssignment) {
   name: guid(roleIdMapping[roleName], objectId, kv.id)
   scope: kv
   properties: {

--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -197,6 +197,7 @@ module kvSetup './ustp-cams-kv-app-config-setup.bicep' = {
     privateDnsZoneResourceGroup: privateDnsZoneResourceGroup
     privateDnsZoneSubscriptionId: privateDnsZoneSubscriptionId
     managedIdentityName: idKeyvaultAppConfiguration
+    makeRoleAssignment: !isUstpDeployment
   }
 }
 

--- a/ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep
+++ b/ops/cloud-deployment/ustp-cams-kv-app-config-setup.bicep
@@ -28,6 +28,8 @@ param deployedAt string = utcNow()
 
 param deployDns bool = true
 
+param makeRoleAssignment bool = true
+
 param location string = resourceGroup().location
 
 @description('Target resource group to provision App Configuration Keyvault')
@@ -88,6 +90,7 @@ module appConfigKeyvault './lib/keyvault/keyvault.bicep' = {
     keyVaultName: kvName
     objectId: appConfigIdentity.outputs.principalId
     roleName: 'Key Vault Secrets User'
+    makeRoleAssignment: makeRoleAssignment
     networkAcls: kvNetworkAcls
     tags: tags
   }


### PR DESCRIPTION
# Purpose

The ADO service principal does not have permission to write role assignments and EA will not grant it those permissions.

# Major Changes

- Add a makeRoleAssignment param to `keyvault.bicep`, defaulting true, and pass `!isUstpDeployment` from `main.bicep` so USTP deployments skip the assignment without affecting Flexion environments.

# Testing/Validation

- [x] Run prod deployment. This was successful.

# Definition of Done:

- [x] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed: More important code doesn’t directly depend on less important code
- [x] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [x] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhancements:
- Add a configurable makeRoleAssignment parameter to the shared Key Vault Bicep module and propagate it through USTP App Configuration setup and main deployment templates to control role assignment creation behavior.

## Summary by Sourcery

Make Key Vault role assignment creation configurable and disable it for USTP deployments while preserving existing behavior elsewhere.

Enhancements:
- Introduce a makeRoleAssignment parameter to the shared Key Vault module to optionally create the role assignment.
- Plumb the makeRoleAssignment parameter through the USTP Key Vault App Configuration setup template to control role assignment behavior.
- Configure the main deployment template to skip Key Vault role assignment creation for USTP environments.