### PR TITLE
CAMS-691 Add enhanced trustee list view with appointment columns

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -67,7 +67,10 @@ jobs:
   security-scan:
     name: Security
     uses: ./.github/workflows/sub-security-scan.yml
-    secrets: inherit # pragma: allowlist secret
+    secrets:
+      SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }} # pragma: allowlist secret
+      SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }} # pragma: allowlist secret
+      AZ_SECURITY_SCAN_STORAGE_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }} # pragma: allowlist secret
 
   build:
     name: Build

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -71,6 +71,9 @@ jobs:
       SNYK_OAUTH_CLIENT_ID: ${{ secrets.SNYK_OAUTH_CLIENT_ID }} # pragma: allowlist secret
       SNYK_OAUTH_CLIENT_SECRET: ${{ secrets.SNYK_OAUTH_CLIENT_SECRET }} # pragma: allowlist secret
       AZ_SECURITY_SCAN_STORAGE_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }} # pragma: allowlist secret
+      AZ_SECURITY_SCAN_CLIENT_ID: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }} # pragma: allowlist secret
+      AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }} # pragma: allowlist secret
+      AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }} # pragma: allowlist secret
 
   build:
     name: Build

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -1,11 +1,25 @@
 name: Security
 
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      SNYK_OAUTH_CLIENT_ID:
+        required: true
+      SNYK_OAUTH_CLIENT_SECRET:
+        required: true
+      AZ_SECURITY_SCAN_STORAGE_NAME:
+        required: true
+      AZURE_CREDENTIALS:
+        required: false
 
 jobs:
   sca-scan:
     name: SCA Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -35,20 +49,18 @@ jobs:
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         if: always()
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ vars.AZ_SECURITY_SCAN_CLIENT_ID }}
+          tenant-id: ${{ vars.AZ_TENANT_ID }}
+          subscription-id: ${{ vars.AZ_SUBSCRIPTION_ID }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
 
       - name: Upload raw SARIF to Azure Storage
         if: always()
         run: |
           if [ -f snyk-sca.sarif ]; then
-            ACCOUNT_KEY=$(az storage account keys list \
-              -n "$ACCOUNT_NAME" \
-              -g "$RESOURCE_GROUP" \
-              --query '[0].value' -o tsv)
             az storage blob upload \
               --account-name "$ACCOUNT_NAME" \
-              --account-key "$ACCOUNT_KEY" \
+              --auth-mode login \
               -f snyk-sca.sarif \
               -c security-scan-results \
               -n "snyk-sca-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.ref_name }}.sarif" \
@@ -56,7 +68,6 @@ jobs:
           fi
         env:
           ACCOUNT_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }}
-          RESOURCE_GROUP: ${{ secrets.AZ_SECURITY_SCAN_RG }}
 
       - name: Sanitize SARIF for GitHub upload
         if: always()
@@ -80,6 +91,9 @@ jobs:
   sast-scan:
     name: SAST Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -105,20 +119,18 @@ jobs:
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         if: always()
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ vars.AZ_SECURITY_SCAN_CLIENT_ID }}
+          tenant-id: ${{ vars.AZ_TENANT_ID }}
+          subscription-id: ${{ vars.AZ_SUBSCRIPTION_ID }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
 
       - name: Upload raw SARIF to Azure Storage
         if: always()
         run: |
           if [ -f snyk-code.sarif ]; then
-            ACCOUNT_KEY=$(az storage account keys list \
-              -n "$ACCOUNT_NAME" \
-              -g "$RESOURCE_GROUP" \
-              --query '[0].value' -o tsv)
             az storage blob upload \
               --account-name "$ACCOUNT_NAME" \
-              --account-key "$ACCOUNT_KEY" \
+              --auth-mode login \
               -f snyk-code.sarif \
               -c security-scan-results \
               -n "snyk-code-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.ref_name }}.sarif" \
@@ -126,19 +138,14 @@ jobs:
           fi
         env:
           ACCOUNT_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }}
-          RESOURCE_GROUP: ${{ secrets.AZ_SECURITY_SCAN_RG }}
 
       - name: Download SAST baseline
         id: baseline
         if: always()
         run: |
-          ACCOUNT_KEY=$(az storage account keys list \
-            -n "$ACCOUNT_NAME" \
-            -g "$RESOURCE_GROUP" \
-            --query '[0].value' -o tsv)
           if az storage blob download \
             --account-name "$ACCOUNT_NAME" \
-            --account-key "$ACCOUNT_KEY" \
+            --auth-mode login \
             -c snyk-baseline \
             -n snyk-code-baseline.txt \
             -f snyk-code-baseline.txt 2>/dev/null; then
@@ -149,7 +156,6 @@ jobs:
           fi
         env:
           ACCOUNT_NAME: ${{ secrets.AZ_SECURITY_SCAN_STORAGE_NAME }}
-          RESOURCE_GROUP: ${{ secrets.AZ_SECURITY_SCAN_RG }}
 
       - name: Compare against baseline
         id: baseline-compare

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -93,6 +93,7 @@ jobs:
     environment: security-scan
     permissions:
       contents: read
+      security-events: write
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -9,8 +9,6 @@ on:
         required: true
       AZ_SECURITY_SCAN_STORAGE_NAME:
         required: true
-      AZURE_CREDENTIALS:
-        required: false
 
 jobs:
   sca-scan:

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -9,6 +9,12 @@ on:
         required: true
       AZ_SECURITY_SCAN_STORAGE_NAME:
         required: true
+      AZ_SECURITY_SCAN_CLIENT_ID:
+        required: true
+      AZ_TENANT_ID:
+        required: true
+      AZ_SUBSCRIPTION_ID:
+        required: true
 
 jobs:
   sca-scan:
@@ -48,9 +54,9 @@ jobs:
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         if: always()
         with:
-          client-id: ${{ vars.AZ_SECURITY_SCAN_CLIENT_ID }}
-          tenant-id: ${{ vars.AZ_TENANT_ID }}
-          subscription-id: ${{ vars.AZ_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZ_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
 
       - name: Upload raw SARIF to Azure Storage
@@ -120,9 +126,9 @@ jobs:
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         if: always()
         with:
-          client-id: ${{ vars.AZ_SECURITY_SCAN_CLIENT_ID }}
-          tenant-id: ${{ vars.AZ_TENANT_ID }}
-          subscription-id: ${{ vars.AZ_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZ_SECURITY_SCAN_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZ_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
 
       - name: Upload raw SARIF to Azure Storage

--- a/.github/workflows/sub-security-scan.yml
+++ b/.github/workflows/sub-security-scan.yml
@@ -16,6 +16,7 @@ jobs:
   sca-scan:
     name: SCA Scan
     runs-on: ubuntu-latest
+    environment: security-scan
     permissions:
       contents: read
       security-events: write
@@ -91,6 +92,7 @@ jobs:
   sast-scan:
     name: SAST Scan
     runs-on: ubuntu-latest
+    environment: security-scan
     permissions:
       contents: read
       id-token: write

--- a/.snyk
+++ b/.snyk
@@ -29,10 +29,10 @@ ignore:
         reason: >-
           Transitive dependency via launchdarkly-js-sdk-common, @azure/msal-node,
           and njwt. No fixed version available from upstream packages.
-        expires: 2026-07-23T00:00:00.000Z
+        expires: 2026-05-23T00:00:00.000Z
   SNYK-JS-FASTXMLBUILDER-16133760:
     - '*':
         reason: >-
           Transitive dependency via @azure/storage-blob > @azure/core-xml >
           fast-xml-parser. No fixed version of fast-xml-builder available upstream.
-        expires: 2026-07-23T00:00:00.000Z
+        expires: 2026-05-23T00:00:00.000Z

--- a/.snyk
+++ b/.snyk
@@ -24,3 +24,15 @@ ignore:
     - '*':
         reason: 'Mitigated by design - we block the elements that DOMPurify handles poorly'
         expires: 2026-06-06T00:00:00.000Z
+  SNYK-JS-UUID-16133035:
+    - '*':
+        reason: >-
+          Transitive dependency via launchdarkly-js-sdk-common, @azure/msal-node,
+          and njwt. No fixed version available from upstream packages.
+        expires: 2026-07-23T00:00:00.000Z
+  SNYK-JS-FASTXMLBUILDER-16133760:
+    - '*':
+        reason: >-
+          Transitive dependency via @azure/storage-blob > @azure/core-xml >
+          fast-xml-parser. No fixed version of fast-xml-builder available upstream.
+        expires: 2026-07-23T00:00:00.000Z

--- a/backend/lib/adapters/gateways/mongo/trustee-appointments.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-appointments.mongo.repository.test.ts
@@ -235,6 +235,65 @@ describe('TrusteeAppointmentsMongoRepository', () => {
     });
   });
 
+  describe('getAppointmentsByTrusteeIds', () => {
+    const trusteeAppointment1: TrusteeAppointmentDocument = {
+      ...sampleAppointment,
+      id: 'appt-1',
+      trusteeId: 'trustee-1',
+      documentType: 'TRUSTEE_APPOINTMENT',
+    };
+    const trusteeAppointment2: TrusteeAppointmentDocument = {
+      ...sampleAppointment,
+      id: 'appt-2',
+      trusteeId: 'trustee-2',
+      documentType: 'TRUSTEE_APPOINTMENT',
+    };
+
+    test('should return appointments for multiple trustee IDs', async () => {
+      const mockAdapter = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'find')
+        .mockResolvedValue([trusteeAppointment1, trusteeAppointment2]);
+
+      const result = await repository.getAppointmentsByTrusteeIds(['trustee-1', 'trustee-2']);
+
+      expect(mockAdapter).toHaveBeenCalledWith({
+        conjunction: 'AND',
+        values: [
+          {
+            condition: 'EQUALS',
+            leftOperand: { name: 'documentType' },
+            rightOperand: 'TRUSTEE_APPOINTMENT',
+          },
+          {
+            condition: 'CONTAINS',
+            leftOperand: { name: 'trusteeId' },
+            rightOperand: ['trustee-1', 'trustee-2'],
+          },
+        ],
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].trusteeId).toBe('trustee-1');
+      expect(result[1].trusteeId).toBe('trustee-2');
+    });
+
+    test('should return empty array when trusteeIds is empty (no DB call)', async () => {
+      const mockAdapter = vi.spyOn(MongoCollectionAdapter.prototype, 'find');
+
+      const result = await repository.getAppointmentsByTrusteeIds([]);
+
+      expect(mockAdapter).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    test('should throw CAMS error when repository fails', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockRejectedValue(
+        new Error('Database error'),
+      );
+
+      await expect(repository.getAppointmentsByTrusteeIds(['trustee-1'])).rejects.toThrow();
+    });
+  });
+
   describe('createAppointment', () => {
     const trusteeId = 'trustee-123';
     const appointmentInput: TrusteeAppointmentInput = {

--- a/backend/lib/adapters/gateways/mongo/trustee-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-appointments.mongo.repository.ts
@@ -102,6 +102,22 @@ export class TrusteeAppointmentsMongoRepository
     }
   }
 
+  async getAppointmentsByTrusteeIds(trusteeIds: string[]): Promise<TrusteeAppointment[]> {
+    if (trusteeIds.length === 0) return [];
+    try {
+      const doc = using<TrusteeAppointmentDocument>();
+      const query = and(
+        doc('documentType').equals('TRUSTEE_APPOINTMENT'),
+        doc('trusteeId').contains(trusteeIds),
+      );
+      return await this.getAdapter<TrusteeAppointmentDocument>().find(query);
+    } catch (originalError) {
+      throw getCamsErrorWithStack(originalError, MODULE_NAME, {
+        message: 'Failed to retrieve appointments for multiple trustees.',
+      });
+    }
+  }
+
   async createAppointment(
     trusteeId: string,
     appointmentInput: TrusteeAppointmentInput,

--- a/backend/lib/controllers/trustees/trustees.controller.test.ts
+++ b/backend/lib/controllers/trustees/trustees.controller.test.ts
@@ -2,7 +2,7 @@ import { vi, Mocked, MockedClass } from 'vitest';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { TrusteesController } from './trustees.controller';
 import { TrusteesUseCase } from '../../use-cases/trustees/trustees';
-import { TrusteeInput } from '@common/cams/trustees';
+import { TrusteeInput, TrusteeListItem } from '@common/cams/trustees';
 import { TrusteeDocument } from '../../adapters/gateways/mongo/trustees.mongo.repository';
 import { CamsUserReference } from '@common/cams/users';
 import { CamsRole } from '@common/cams/roles';
@@ -204,7 +204,7 @@ describe('TrusteesController', () => {
     });
 
     test('should return list of trustees for GET requests', async () => {
-      const mockTrustees = [sampleTrusteeDocument];
+      const mockTrustees: TrusteeListItem[] = [{ ...sampleTrusteeDocument, appointments: [] }];
       mockUseCase.listTrustees.mockResolvedValue(mockTrustees);
       context.request.url = '/api/trustees';
 

--- a/backend/lib/controllers/trustees/trustees.controller.ts
+++ b/backend/lib/controllers/trustees/trustees.controller.ts
@@ -1,6 +1,6 @@
 import { ApplicationContext } from '../../adapters/types/basic';
 import { TrusteesUseCase } from '../../use-cases/trustees/trustees';
-import { Trustee, TrusteeInput } from '@common/cams/trustees';
+import { Trustee, TrusteeInput, TrusteeListItem } from '@common/cams/trustees';
 import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
 import { getCamsError } from '../../common-errors/error-utilities';
 import { CamsController } from '../controller';
@@ -19,7 +19,7 @@ export class TrusteesController implements CamsController {
 
   public async handleRequest(
     context: ApplicationContext,
-  ): Promise<CamsHttpResponseInit<Trustee | Trustee[]>> {
+  ): Promise<CamsHttpResponseInit<Trustee | Trustee[] | TrusteeListItem[]>> {
     // Check feature flag
     if (!context.featureFlags['trustee-management']) {
       return {
@@ -91,7 +91,7 @@ export class TrusteesController implements CamsController {
 
   private async handleGetRequest(
     context: ApplicationContext,
-  ): Promise<CamsHttpResponseInit<Trustee | Trustee[]>> {
+  ): Promise<CamsHttpResponseInit<Trustee | TrusteeListItem[]>> {
     const trusteeId = context.request.params['id'];
 
     if (trusteeId) {
@@ -120,7 +120,7 @@ export class TrusteesController implements CamsController {
 
   private async listTrustees(
     context: ApplicationContext,
-  ): Promise<CamsHttpResponseInit<Trustee[]>> {
+  ): Promise<CamsHttpResponseInit<TrusteeListItem[]>> {
     const trustees = await this.useCase.listTrustees(context);
 
     return httpSuccess({

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -346,6 +346,10 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
+  getAppointmentsByTrusteeIds(_ignore: any): Promise<any[]> {
+    throw new Error('Method not implemented.');
+  }
+
   getChapter7DueDateMetricsAggregation(): Promise<any> {
     throw new Error('Method not implemented.');
   }

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -366,6 +366,7 @@ export type TrusteeDueDateMetricsAggregation = {
 export interface TrusteeAppointmentsRepository extends Releasable {
   read(trusteeId: string, appointmentId: string): Promise<TrusteeAppointment>;
   getTrusteeAppointments(trusteeId: string): Promise<TrusteeAppointment[]>;
+  getAppointmentsByTrusteeIds(trusteeIds: string[]): Promise<TrusteeAppointment[]>;
   createAppointment(
     trusteeId: string,
     appointmentInput: TrusteeAppointmentInput,

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -199,14 +199,18 @@ describe('TrusteesUseCase tests', () => {
       expect(result).toHaveLength(2);
       const alpha = result.find((r) => r.trusteeId === 'trustee-2');
       const bravo = result.find((r) => r.trusteeId === 'trustee-1');
-      expect(alpha?.appointments[0].courtDivisionName).toBeUndefined();
-      expect(bravo?.appointments[0].courtDivisionName).toBeUndefined();
+      expect(alpha?.appointments).toHaveLength(1);
+      expect(bravo?.appointments).toHaveLength(1);
     });
 
-    test('should enrich appointments with courtName from courts lookup', async () => {
+    test('should enrich appointments with courtName and courtDivisionName from courts lookup', async () => {
       const trusteeId = 'trustee-enrich';
       const trustee = MockData.getTrustee({ trusteeId });
-      const appt = MockData.getTrusteeAppointment({ trusteeId, courtId: 'court-1' });
+      const appt = MockData.getTrusteeAppointment({
+        trusteeId,
+        courtId: 'court-1',
+        divisionCode: '081',
+      });
 
       vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
       vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
@@ -216,7 +220,7 @@ describe('TrusteesUseCase tests', () => {
       const result = await trusteesUseCase.listTrustees(context);
 
       expect(result[0].appointments[0].courtName).toBe('Southern District of New York');
-      expect(result[0].appointments[0].courtDivisionName).toBeUndefined();
+      expect(result[0].appointments[0].courtDivisionName).toBe('Manhattan');
     });
 
     test('should set courtName to undefined when courtId has no matching court', async () => {

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -8,6 +8,8 @@ import { getCamsUserReference } from '@common/cams/session';
 import { BadRequestError } from '../../common-errors/bad-request';
 import { CamsError } from '../../common-errors/cams-error';
 import { FIELD_VALIDATION_MESSAGES } from '@common/cams/validation-messages';
+import { CourtsUseCase } from '../courts/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
 describe('TrusteesUseCase tests', () => {
   let context: ApplicationContext;
@@ -153,9 +155,24 @@ describe('TrusteesUseCase tests', () => {
   });
 
   describe('listTrustees', () => {
+    const mockCourts: CourtDivisionDetails[] = [
+      {
+        officeName: 'Manhattan',
+        officeCode: '081',
+        courtId: 'court-1',
+        courtName: 'Southern District of New York',
+        courtDivisionCode: '081',
+        courtDivisionName: 'Manhattan',
+        groupDesignator: 'NY',
+        regionId: '02',
+        regionName: 'Region 2',
+      },
+    ];
+
     beforeEach(async () => {
       context = await createMockApplicationContext();
       trusteesUseCase = new TrusteesUseCase(context);
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
     });
 
     afterEach(() => {
@@ -182,8 +199,39 @@ describe('TrusteesUseCase tests', () => {
       expect(result).toHaveLength(2);
       const alpha = result.find((r) => r.trusteeId === 'trustee-2');
       const bravo = result.find((r) => r.trusteeId === 'trustee-1');
-      expect(alpha?.appointments).toEqual([appt2]);
-      expect(bravo?.appointments).toEqual([appt1]);
+      expect(alpha?.appointments[0].courtDivisionName).toBeUndefined();
+      expect(bravo?.appointments[0].courtDivisionName).toBeUndefined();
+    });
+
+    test('should enrich appointments with courtName from courts lookup', async () => {
+      const trusteeId = 'trustee-enrich';
+      const trustee = MockData.getTrustee({ trusteeId });
+      const appt = MockData.getTrusteeAppointment({ trusteeId, courtId: 'court-1' });
+
+      vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+      vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
+        appt,
+      ]);
+
+      const result = await trusteesUseCase.listTrustees(context);
+
+      expect(result[0].appointments[0].courtName).toBe('Southern District of New York');
+      expect(result[0].appointments[0].courtDivisionName).toBeUndefined();
+    });
+
+    test('should set courtName to undefined when courtId has no matching court', async () => {
+      const trusteeId = 'trustee-unknown-court';
+      const trustee = MockData.getTrustee({ trusteeId });
+      const appt = MockData.getTrusteeAppointment({ trusteeId, courtId: 'unknown-court' });
+
+      vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+      vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
+        appt,
+      ]);
+
+      const result = await trusteesUseCase.listTrustees(context);
+
+      expect(result[0].appointments[0].courtName).toBeUndefined();
     });
 
     test('should give trustees with no matching appointments an empty appointments array', async () => {

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -162,13 +162,57 @@ describe('TrusteesUseCase tests', () => {
       vi.restoreAllMocks();
     });
 
-    test('should return list of trustees', async () => {
-      const mockTrustees = [MockData.getTrustee(), MockData.getTrustee()];
-      vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue(mockTrustees);
+    test('should return TrusteeListItem[] with appointments attached per trustee', async () => {
+      const trustee1 = MockData.getTrustee({ trusteeId: 'trustee-1', name: 'Bravo' });
+      const trustee2 = MockData.getTrustee({ trusteeId: 'trustee-2', name: 'Alpha' });
+      const appt1 = MockData.getTrusteeAppointment({ trusteeId: 'trustee-1' });
+      const appt2 = MockData.getTrusteeAppointment({ trusteeId: 'trustee-2' });
+
+      vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([
+        trustee1,
+        trustee2,
+      ]);
+      vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
+        appt1,
+        appt2,
+      ]);
 
       const result = await trusteesUseCase.listTrustees(context);
 
-      expect(result).toEqual(mockTrustees);
+      expect(result).toHaveLength(2);
+      const alpha = result.find((r) => r.trusteeId === 'trustee-2');
+      const bravo = result.find((r) => r.trusteeId === 'trustee-1');
+      expect(alpha?.appointments).toEqual([appt2]);
+      expect(bravo?.appointments).toEqual([appt1]);
+    });
+
+    test('should give trustees with no matching appointments an empty appointments array', async () => {
+      const trustee = MockData.getTrustee({ trusteeId: 'trustee-no-appts' });
+
+      vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+      vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([]);
+
+      const result = await trusteesUseCase.listTrustees(context);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].appointments).toEqual([]);
+    });
+
+    test('should return trustees sorted by name ascending (case-insensitive)', async () => {
+      const trusteeC = MockData.getTrustee({ trusteeId: 'id-c', name: 'charlie' });
+      const trusteeA = MockData.getTrustee({ trusteeId: 'id-a', name: 'Alice' });
+      const trusteeB = MockData.getTrustee({ trusteeId: 'id-b', name: 'bob' });
+
+      vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([
+        trusteeC,
+        trusteeA,
+        trusteeB,
+      ]);
+      vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([]);
+
+      const result = await trusteesUseCase.listTrustees(context);
+
+      expect(result.map((r) => r.name)).toEqual(['Alice', 'bob', 'charlie']);
     });
 
     test('should handle repository error during list operation', async () => {

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -1,11 +1,16 @@
 import { ApplicationContext } from '../../adapters/types/basic';
-import { TrusteesRepository, TrusteeAssistantsRepository } from '../gateways.types';
+import {
+  TrusteesRepository,
+  TrusteeAssistantsRepository,
+  TrusteeAppointmentsRepository,
+} from '../gateways.types';
 import { getCamsUserReference } from '@common/cams/session';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
 import factory from '../../factory';
 import { ValidationSpec, validateObject, flatten, ValidatorResult } from '@common/cams/validation';
 import { BadRequestError } from '../../common-errors/bad-request';
-import { Trustee, TrusteeHistory, TrusteeInput } from '@common/cams/trustees';
+import { Trustee, TrusteeHistory, TrusteeInput, TrusteeListItem } from '@common/cams/trustees';
+import { TrusteeAppointment } from '@common/cams/trustee-appointments';
 import {
   trusteeName,
   companyName,
@@ -71,10 +76,12 @@ const trusteeSpec: ValidationSpec<TrusteeInput> = {
 export class TrusteesUseCase {
   private readonly trusteesRepository: TrusteesRepository;
   private readonly trusteeAssistantsRepository: TrusteeAssistantsRepository;
+  private readonly trusteeAppointmentsRepository: TrusteeAppointmentsRepository;
 
   constructor(context: ApplicationContext) {
     this.trusteesRepository = factory.getTrusteesRepository(context);
     this.trusteeAssistantsRepository = factory.getTrusteeAssistantsRepository(context);
+    this.trusteeAppointmentsRepository = factory.getTrusteeAppointmentsRepository(context);
   }
 
   private checkValidation(validatorResult: ValidatorResult) {
@@ -132,13 +139,29 @@ export class TrusteesUseCase {
     }
   }
 
-  async listTrustees(context: ApplicationContext): Promise<Trustee[]> {
+  async listTrustees(context: ApplicationContext): Promise<TrusteeListItem[]> {
     try {
-      // Retrieve trustees list from repository
       const trustees = await this.trusteesRepository.listTrustees();
+      const trusteeIds = trustees.map((t) => t.trusteeId);
+      const allAppointments =
+        await this.trusteeAppointmentsRepository.getAppointmentsByTrusteeIds(trusteeIds);
 
-      context.logger.info(MODULE_NAME, `Retrieved ${trustees.length} trustees`);
-      return trustees;
+      const appointmentsByTrusteeId = new Map<string, TrusteeAppointment[]>();
+      for (const appt of allAppointments) {
+        const existing = appointmentsByTrusteeId.get(appt.trusteeId) ?? [];
+        existing.push(appt);
+        appointmentsByTrusteeId.set(appt.trusteeId, existing);
+      }
+
+      const listItems: TrusteeListItem[] = trustees.map((trustee) => ({
+        ...trustee,
+        appointments: appointmentsByTrusteeId.get(trustee.trusteeId) ?? [],
+      }));
+
+      listItems.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
+      context.logger.info(MODULE_NAME, `Retrieved ${listItems.length} trustees`);
+      return listItems;
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         camsStackInfo: { module: MODULE_NAME, message: 'Failed to retrieve trustees list.' },

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -11,6 +11,8 @@ import { ValidationSpec, validateObject, flatten, ValidatorResult } from '@commo
 import { BadRequestError } from '../../common-errors/bad-request';
 import { Trustee, TrusteeHistory, TrusteeInput, TrusteeListItem } from '@common/cams/trustees';
 import { TrusteeAppointment } from '@common/cams/trustee-appointments';
+import { CourtsUseCase } from '../courts/courts';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import {
   trusteeName,
   companyName,
@@ -77,11 +79,17 @@ export class TrusteesUseCase {
   private readonly trusteesRepository: TrusteesRepository;
   private readonly trusteeAssistantsRepository: TrusteeAssistantsRepository;
   private readonly trusteeAppointmentsRepository: TrusteeAppointmentsRepository;
+  private readonly courtsUseCase: CourtsUseCase;
 
   constructor(context: ApplicationContext) {
     this.trusteesRepository = factory.getTrusteesRepository(context);
     this.trusteeAssistantsRepository = factory.getTrusteeAssistantsRepository(context);
     this.trusteeAppointmentsRepository = factory.getTrusteeAppointmentsRepository(context);
+    this.courtsUseCase = new CourtsUseCase();
+  }
+
+  private findCourtName(courts: CourtDivisionDetails[], courtId: string): string | undefined {
+    return courts.find((c) => c.courtId === courtId)?.courtName;
   }
 
   private checkValidation(validatorResult: ValidatorResult) {
@@ -141,13 +149,23 @@ export class TrusteesUseCase {
 
   async listTrustees(context: ApplicationContext): Promise<TrusteeListItem[]> {
     try {
-      const trustees = await this.trusteesRepository.listTrustees();
+      const [trustees, courts] = await Promise.all([
+        this.trusteesRepository.listTrustees(),
+        this.courtsUseCase.getCourts(context),
+      ]);
+
       const trusteeIds = trustees.map((t) => t.trusteeId);
       const allAppointments =
         await this.trusteeAppointmentsRepository.getAppointmentsByTrusteeIds(trusteeIds);
 
+      const enrichedAppointments = allAppointments.map((appt) => ({
+        ...appt,
+        courtName: this.findCourtName(courts, appt.courtId),
+        courtDivisionName: undefined,
+      }));
+
       const appointmentsByTrusteeId = new Map<string, TrusteeAppointment[]>();
-      for (const appt of allAppointments) {
+      for (const appt of enrichedAppointments) {
         const existing = appointmentsByTrusteeId.get(appt.trusteeId) ?? [];
         existing.push(appt);
         appointmentsByTrusteeId.set(appt.trusteeId, existing);

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -92,6 +92,14 @@ export class TrusteesUseCase {
     return courts.find((c) => c.courtId === courtId)?.courtName;
   }
 
+  private findCourtDivisionName(
+    courts: CourtDivisionDetails[],
+    divisionCode: string | undefined,
+  ): string | undefined {
+    if (!divisionCode) return undefined;
+    return courts.find((c) => c.courtDivisionCode === divisionCode)?.courtDivisionName;
+  }
+
   private checkValidation(validatorResult: ValidatorResult) {
     if (!validatorResult.valid) {
       const validationErrors = flatten(validatorResult.reasonMap || {});
@@ -161,7 +169,7 @@ export class TrusteesUseCase {
       const enrichedAppointments = allAppointments.map((appt) => ({
         ...appt,
         courtName: this.findCourtName(courts, appt.courtId),
-        courtDivisionName: undefined,
+        courtDivisionName: this.findCourtDivisionName(courts, appt.divisionCode),
       }));
 
       const appointmentsByTrusteeId = new Map<string, TrusteeAppointment[]>();

--- a/common/src/cams/trustees.ts
+++ b/common/src/cams/trustees.ts
@@ -8,6 +8,7 @@ import { NullableOptionalFields } from '../api/common';
 import { TrusteeAssistant } from './trustee-assistants';
 import { AbstractTrusteeHistory } from './trustee-history-base';
 import { TrusteeUpcomingKeyDatesHistory } from './trustee-upcoming-key-dates';
+import type { TrusteeAppointment } from './trustee-appointments';
 
 export type AppointmentChapterType = '7' | '11' | '11-subchapter-v' | '12' | '13';
 
@@ -100,6 +101,10 @@ export type Trustee = TrusteeData &
       addresses?: LegacyAddress[];
     };
   };
+
+export type TrusteeListItem = Trustee & {
+  appointments: TrusteeAppointment[];
+};
 
 // this is needed to map migrated ChapterDetails to our migrated Trustees
 export type TrusteeInput = TrusteeCore &

--- a/docs/architecture/decision-records/GithubActionsOidcLeastPrivilege.md
+++ b/docs/architecture/decision-records/GithubActionsOidcLeastPrivilege.md
@@ -1,0 +1,114 @@
+# GitHub Actions OIDC Least Privilege
+
+## Context
+
+GitHub Actions workflows authenticate to Azure using a long-lived `AZURE_CREDENTIALS` secret (a service principal JSON blob with broad Contributor access). This pattern has several problems:
+
+- Long-lived credentials are exfiltrable and cannot be automatically rotated
+- A single credential is shared across workflows with different access needs, violating least privilege
+- Environment-scoped GitHub secrets duplicate large numbers of Azure resource names and configuration values across `Main-Gov` and `Develop` environments, creating maintenance burden
+
+GitHub supports OIDC Workload Identity Federation as an alternative: workflows exchange a short-lived GitHub-issued JWT for an Azure access token with no stored secrets. The access is bounded to the duration of the workflow run.
+
+### Subject Claim Constraints
+
+GitHub's OIDC token includes a `sub` (subject) claim that Azure uses to match a federated credential. The default subject format includes the git branch:
+
+```
+repo:ORG/REPO:ref:refs/heads/BRANCH-NAME
+```
+
+This makes it impossible to configure a single federated credential that works from any branch without granting access to all branches via `repo:ORG/REPO` — which is too broad for least privilege.
+
+GitHub allows customizing which claims compose the subject via the REST API (`PUT /repos/{owner}/{repo}/actions/oidc/customization/sub`). After evaluating available claims:
+
+- `workflow` — resolves to the **caller** workflow name (e.g., `Continuous Deployment`), not the reusable workflow, so it cannot distinguish `reusable-deploy.yml` from `reusable-infrastructure-deploy.yml`
+- `job_workflow_ref` — contains the reusable workflow file path but always includes the branch suffix (`@refs/heads/BRANCH-NAME`), so it is still branch-specific
+- `environment` — branch-independent and per-job; this is the only available claim that is both stable across branches and granular enough for per-workflow least privilege
+
+### GitHub Environment as an OIDC Anchor
+
+A GitHub environment (`environment:` on a job) affects the OIDC subject:
+
+```
+repo:ORG/REPO:environment:ENV-NAME
+```
+
+Environments are currently used to scope secrets and variables to `Main-Gov` and `Develop`. However, secrets and variables in GitHub environments are only necessary because there is no post-login mechanism to retrieve them. Once a workflow can authenticate via OIDC, configuration can be fetched from Azure Key Vault at runtime, eliminating the need to store anything in GitHub environments.
+
+With secrets and variables moved to Key Vault, GitHub environments become lightweight OIDC anchors — just a name, no stored values.
+
+### Key Vault RBAC for Per-Workflow Least Privilege
+
+A single Key Vault per deployment environment (`Main-Gov`, `Develop`) holds all configuration and secrets for that environment. Each workflow's federated identity is granted Key Vault Secrets User access only to the specific secrets it requires, enforced via Azure RBAC. This provides per-workflow least privilege without any additional GitHub infrastructure.
+
+## Decision
+
+We will migrate all GitHub Actions Azure authentication to OIDC Workload Identity Federation using the following architecture:
+
+### OIDC Subject Template
+
+The repository OIDC customization template is set to include `repo`, `workflow`, and `environment` claims:
+
+```json
+{ "include_claim_keys": ["repo", "workflow", "environment"] }
+```
+
+This produces subjects of the form:
+
+```
+repo:US-Trustee-Program/Bankruptcy-Oversight-Support-Systems:workflow:Continuous Deployment:environment:ENV-NAME
+```
+
+### GitHub Environment Naming Convention
+
+Each reusable workflow that requires Azure access is assigned a dedicated GitHub environment. Environment names follow the convention `<workflow-purpose>-<target>` where target is `main` for production and `branch` for non-production:
+
+| Reusable Workflow | GitHub Environment |
+|---|---|
+| `reusable-deploy.yml` | `deploy-main`, `deploy-branch` |
+| `reusable-infrastructure-deploy.yml` | `infrastructure-deploy-main`, `infrastructure-deploy-branch` |
+| `reusable-deploy-code.yml` | `deploy-code-main`, `deploy-code-branch` |
+| `reusable-build-info.yml` | `build-info-main`, `build-info-branch` |
+| `reusable-build-frontend.yml` | `build-frontend-main`, `build-frontend-branch` |
+| `reusable-e2e.yml` | `e2e-main`, `e2e-branch` |
+| `reusable-dast.yml` | `dast-main`, `dast-branch` |
+| `reusable-endpoint-test.yml` | `endpoint-test-main`, `endpoint-test-branch` |
+| `sub-security-scan.yml` | `security-scan` |
+| `azure-remove-branch.yml` | `remove-branch` |
+
+These GitHub environments hold **no secrets or variables**. Their sole purpose is to produce a stable, branch-independent OIDC subject.
+
+### Azure Federated Credentials
+
+Each GitHub environment maps to one Azure federated credential on a dedicated app registration. App registrations are scoped to the minimum Azure RBAC roles required for that workflow's work.
+
+### Key Vault Migration
+
+All Azure resource names, configuration values, and application secrets currently stored in GitHub environment secrets and variables are migrated to the Azure Key Vault for each environment. Each workflow's federated identity is granted Key Vault Secrets User access to only the secrets it needs.
+
+Secrets that must remain in GitHub Actions (no Azure dependency):
+
+| Secret | Reason |
+|---|---|
+| `GITHUB_TOKEN` | Auto-provided by GitHub, cannot be stored externally |
+| `BOT_PRIVATE_KEY` / `BOT_PASSPHRASE` | Required for git signing before Azure login |
+| `SNYK_OAUTH_CLIENT_ID` / `SNYK_OAUTH_CLIENT_SECRET` | External service, not Azure |
+| `SLACK_WEBHOOK_URL` / `SLACK_USER_MAPPING` | External service, not Azure |
+
+### PGP Encrypted Inputs
+
+The `PGP_SIGNING_PASSPHRASE` pattern (encrypting resource group names passed as workflow inputs to avoid log exposure) is eliminated. Resource names are fetched from Key Vault after login and are never passed as inputs.
+
+## Status
+
+Accepted
+
+## Consequences
+
+- Long-lived `AZURE_CREDENTIALS` secrets are eliminated from all workflows
+- Each workflow's Azure access is bounded to the duration of the run and scoped to its minimum required permissions
+- GitHub environments contain no secrets or variables; all environment-specific configuration lives in Azure Key Vault
+- Adding a new workflow that requires Azure access requires: creating a GitHub environment (no values), creating an Azure app registration with a federated credential, and granting Key Vault Secrets User access to the specific secrets needed
+- The `PGP_SIGNING_PASSPHRASE` encrypted-input pattern is no longer needed once Key Vault migration is complete
+- Non-deployment workflows (security scan, DAST) that previously had no GitHub environment can now be given stable OIDC subjects without branch constraints

--- a/docs/architecture/decision-records/GithubActionsOidcLeastPrivilege.md
+++ b/docs/architecture/decision-records/GithubActionsOidcLeastPrivilege.md
@@ -40,7 +40,19 @@ With secrets and variables moved to Key Vault, GitHub environments become lightw
 
 ### Key Vault RBAC for Per-Workflow Least Privilege
 
-A single Key Vault per deployment environment (`Main-Gov`, `Develop`) holds all configuration and secrets for that environment. Each workflow's federated identity is granted Key Vault Secrets User access only to the specific secrets it requires, enforced via Azure RBAC. This provides per-workflow least privilege without any additional GitHub infrastructure.
+Each workflow's federated identity is granted Key Vault Secrets User access only to the specific secrets it requires, enforced via Azure RBAC. This provides per-workflow least privilege without any additional GitHub infrastructure.
+
+### Key Vault Structure
+
+Three approaches were considered for organizing Key Vaults:
+
+1. **One vault per environment + one shared vault**: Each federated identity accesses two vaults — a shared vault for common values and an environment-specific vault. Adds complexity to every workflow (two vault lookups) and doesn't clearly bound blast radius.
+
+2. **Single vault with prefixed secret names**: One vault containing `MAIN_SLOT_NAME`, `DEVELOP_SLOT_NAME`, etc. Workflows must contain branching logic to select the right secret. Couples environment concerns into workflow code and makes RBAC scoping harder.
+
+3. **Two vaults, one per environment (main, branch)**: Each federated identity accesses exactly one vault — the one that matches its environment. All secrets use identical names across both vaults. No workflow branching logic needed.
+
+Option 3 is chosen. The `deploy-main` identity accesses the main vault; `deploy-branch` accesses the develop vault. Values that differ between environments naturally have different values in each vault. Values that are the same are duplicated — a deliberate tradeoff accepted because vault changes are rare and deliberate, the CI/CD code remains simple, and a compromise of one vault cannot affect the other.
 
 ## Decision
 
@@ -85,7 +97,9 @@ Each GitHub environment maps to one Azure federated credential on a dedicated ap
 
 ### Key Vault Migration
 
-All Azure resource names, configuration values, and application secrets currently stored in GitHub environment secrets and variables are migrated to the Azure Key Vault for each environment. Each workflow's federated identity is granted Key Vault Secrets User access to only the secrets it needs.
+All Azure resource names, configuration values, and application secrets currently stored in GitHub environment secrets and variables are migrated to the two Key Vaults (main and branch). Secret names are identical across both vaults. Each workflow's federated identity is granted Key Vault Secrets User access to only the secrets it needs within its vault.
+
+This infrastructure is a Flexion CI/CD concern only — it has no bearing on USTP environments or the USTP deployment pipeline. The Key Vaults and associated app registrations must be provisioned and managed via Bicep templates that are separate from the main CAMS Bicep module, so they are never inadvertently deployed to USTP.
 
 Secrets that must remain in GitHub Actions (no Azure dependency):
 
@@ -109,6 +123,8 @@ Accepted
 - Long-lived `AZURE_CREDENTIALS` secrets are eliminated from all workflows
 - Each workflow's Azure access is bounded to the duration of the run and scoped to its minimum required permissions
 - GitHub environments contain no secrets or variables; all environment-specific configuration lives in Azure Key Vault
-- Adding a new workflow that requires Azure access requires: creating a GitHub environment (no values), creating an Azure app registration with a federated credential, and granting Key Vault Secrets User access to the specific secrets needed
+- Two Key Vaults are maintained (main and branch) with identical secret names; any change to a vault secret is a two-step operation — update main vault, then branch vault
+- A compromise of one vault cannot affect the other environment
+- Adding a new workflow that requires Azure access requires: creating a GitHub environment (no values), creating an Azure app registration with a federated credential, and granting Key Vault Secrets User access to the specific secrets needed in each vault
 - The `PGP_SIGNING_PASSPHRASE` encrypted-input pattern is no longer needed once Key Vault migration is complete
 - Non-deployment workflows (security scan, DAST) that previously had no GitHub environment can now be given stable OIDC subjects without branch constraints

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -315,7 +315,10 @@ This diagram shows the explicit and implicit dependencies between jobs in the co
 flowchart LR
     subgraph "External Inputs"
         Secrets["Secrets"]
+        Secrets_AZ_SECURITY_SCAN_CLIENT_ID["AZ_SECURITY_SCAN_CLIENT_ID"]
         Secrets_AZ_SECURITY_SCAN_STORAGE_NAME["AZ_SECURITY_SCAN_STORAGE_NAME"]
+        Secrets_AZ_SUBSCRIPTION_ID["AZ_SUBSCRIPTION_ID"]
+        Secrets_AZ_TENANT_ID["AZ_TENANT_ID"]
         Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
         Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
@@ -347,7 +350,7 @@ flowchart LR
             typecheck_vars["NODE_VERSION"]
         end
         subgraph security_scan_subgraph["Security"]
-            security_scan_vars["AZ_SECURITY_SCAN_STORAGE_NAME<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
+            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SECURITY_SCAN_STORAGE_NAME<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
         end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
@@ -360,7 +363,10 @@ flowchart LR
         end
     end
 
+        Secrets --> Secrets_AZ_SECURITY_SCAN_CLIENT_ID
         Secrets --> Secrets_AZ_SECURITY_SCAN_STORAGE_NAME
+        Secrets --> Secrets_AZ_SUBSCRIPTION_ID
+        Secrets --> Secrets_AZ_TENANT_ID
         Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
         Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
@@ -368,7 +374,10 @@ flowchart LR
         Variables --> Variables_CAMS_SERVER_PORT
         Variables --> Variables_CAMS_SERVER_PROTOCOL
         Variables --> Variables_NODE_VERSION
+    Secrets_AZ_SECURITY_SCAN_CLIENT_ID -.-> security_scan_subgraph
     Secrets_AZ_SECURITY_SCAN_STORAGE_NAME -.-> security_scan_subgraph
+    Secrets_AZ_SUBSCRIPTION_ID -.-> security_scan_subgraph
+    Secrets_AZ_TENANT_ID -.-> security_scan_subgraph
     Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
     Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
@@ -866,7 +875,10 @@ This diagram shows the explicit and implicit dependencies between jobs in the co
 flowchart LR
     subgraph "External Inputs"
         Secrets["Secrets"]
+        Secrets_AZ_SECURITY_SCAN_CLIENT_ID["AZ_SECURITY_SCAN_CLIENT_ID"]
         Secrets_AZ_SECURITY_SCAN_STORAGE_NAME["AZ_SECURITY_SCAN_STORAGE_NAME"]
+        Secrets_AZ_SUBSCRIPTION_ID["AZ_SUBSCRIPTION_ID"]
+        Secrets_AZ_TENANT_ID["AZ_TENANT_ID"]
         Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
         Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
@@ -898,7 +910,7 @@ flowchart LR
             typecheck_vars["NODE_VERSION"]
         end
         subgraph security_scan_subgraph["Security"]
-            security_scan_vars["AZ_SECURITY_SCAN_STORAGE_NAME<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
+            security_scan_vars["AZ_SECURITY_SCAN_CLIENT_ID<br/>AZ_SECURITY_SCAN_STORAGE_NAME<br/>AZ_SUBSCRIPTION_ID<br/>AZ_TENANT_ID<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
         end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
@@ -911,7 +923,10 @@ flowchart LR
         end
     end
 
+        Secrets --> Secrets_AZ_SECURITY_SCAN_CLIENT_ID
         Secrets --> Secrets_AZ_SECURITY_SCAN_STORAGE_NAME
+        Secrets --> Secrets_AZ_SUBSCRIPTION_ID
+        Secrets --> Secrets_AZ_TENANT_ID
         Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
         Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
@@ -919,7 +934,10 @@ flowchart LR
         Variables --> Variables_CAMS_SERVER_PORT
         Variables --> Variables_CAMS_SERVER_PROTOCOL
         Variables --> Variables_NODE_VERSION
+    Secrets_AZ_SECURITY_SCAN_CLIENT_ID -.-> security_scan_subgraph
     Secrets_AZ_SECURITY_SCAN_STORAGE_NAME -.-> security_scan_subgraph
+    Secrets_AZ_SUBSCRIPTION_ID -.-> security_scan_subgraph
+    Secrets_AZ_TENANT_ID -.-> security_scan_subgraph
     Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
     Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -2,8 +2,8 @@
 
 ## Summary
 - **Total Workflows**: 27
-- **Main Workflows**: 12
-- **Reusable Workflows**: 15
+- **Main Workflows**: 11
+- **Reusable Workflows**: 16
 
 ## Legend
 
@@ -125,7 +125,7 @@ flowchart LR
     reusable_typecheck_yml["reusable-typecheck.yml"]
     reusable_typecheck_yml_typecheck["TypeScript"]
     continuous_deployment_yml_security_scan["Security"]
-    sub_security_scan_yml["Security"]
+    sub_security_scan_yml["sub-security-scan.yml"]
     sub_security_scan_yml_sca_scan["SCA Scan"]
     sub_security_scan_yml_sast_scan["SAST Scan"]
     continuous_deployment_yml_build["Build"]
@@ -262,7 +262,7 @@ flowchart LR
     class reusable_typecheck_yml reusable
     class reusable_typecheck_yml_typecheck job
     class continuous_deployment_yml_security_scan job
-    class sub_security_scan_yml mainWorkflow
+    class sub_security_scan_yml reusable
     class sub_security_scan_yml_sca_scan job
     class sub_security_scan_yml_sast_scan job
     class continuous_deployment_yml_build job
@@ -314,6 +314,10 @@ This diagram shows the explicit and implicit dependencies between jobs in the co
 ```mermaid
 flowchart LR
     subgraph "External Inputs"
+        Secrets["Secrets"]
+        Secrets_AZ_SECURITY_SCAN_STORAGE_NAME["AZ_SECURITY_SCAN_STORAGE_NAME"]
+        Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
+        Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
@@ -342,7 +346,9 @@ flowchart LR
         subgraph typecheck_subgraph["typecheck"]
             typecheck_vars["NODE_VERSION"]
         end
-        security_scan["Security"]
+        subgraph security_scan_subgraph["Security"]
+            security_scan_vars["AZ_SECURITY_SCAN_STORAGE_NAME<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
+        end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
         end
@@ -354,11 +360,17 @@ flowchart LR
         end
     end
 
+        Secrets --> Secrets_AZ_SECURITY_SCAN_STORAGE_NAME
+        Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
+        Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
         Variables --> Variables_CAMS_LAUNCH_DARKLY_ENV
         Variables --> Variables_CAMS_SERVER_PORT
         Variables --> Variables_CAMS_SERVER_PROTOCOL
         Variables --> Variables_NODE_VERSION
+    Secrets_AZ_SECURITY_SCAN_STORAGE_NAME -.-> security_scan_subgraph
+    Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
+    Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
     Variables_CAMS_LAUNCH_DARKLY_ENV -.-> build_subgraph
     Variables_CAMS_SERVER_PORT -.-> build_subgraph
@@ -374,7 +386,7 @@ flowchart LR
     build_subgraph ==>|"needs"| deploy_subgraph
     deploy_subgraph ==>|"needs"| deploy_code_slot_subgraph
     knip_subgraph ==>|"needs"| deploy_subgraph
-    security_scan ==>|"needs"| deploy_subgraph
+    security_scan_subgraph ==>|"needs"| deploy_subgraph
     setup ==>|"needs"| build_subgraph
     setup ==>|"needs"| deploy_code_slot_subgraph
     setup ==>|"needs"| deploy_subgraph
@@ -388,13 +400,14 @@ flowchart LR
     classDef mainWorkflow fill:#f3e5f5,fill-opacity:0.15,stroke:#f3e5f5,stroke-width:1px,color:#ffffff
     classDef jobSubgraph fill:#f1f8e9,stroke:#33691e,stroke-width:2px,color:#000000
     class continuous_deployment_workflow mainWorkflow
+    class Secrets external
     class Variables external
     class accessibility_test_subgraph jobSubgraph
     class build_subgraph jobSubgraph
     class deploy_subgraph jobSubgraph
     class deploy_code_slot_subgraph jobSubgraph
     class knip_subgraph jobSubgraph
-    class security_scan job
+    class security_scan_subgraph jobSubgraph
     class setup job
     class typecheck_subgraph jobSubgraph
     class unit_test_backend_subgraph jobSubgraph
@@ -581,33 +594,6 @@ flowchart LR
     class reusable_dast_yml_zap_dast_scan job
 ```
 
-### Workflow_call Triggered Workflows
-
-Workflows triggered by `workflow_call`:
-- **Security** (`sub-security-scan.yml`)
-
-```mermaid
-flowchart LR
-    trigger_workflow_call(["workflow_call"])
-    sub_security_scan_yml["Security"]
-    sub_security_scan_yml_sca_scan["SCA Scan"]
-    sub_security_scan_yml_sast_scan["SAST Scan"]
-
-    trigger_workflow_call --> sub_security_scan_yml
-    sub_security_scan_yml --> sub_security_scan_yml_sca_scan
-    sub_security_scan_yml --> sub_security_scan_yml_sast_scan
-
-    classDef reusable fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#000000
-    classDef mainWorkflow fill:#f3e5f5,stroke:#4a148c,stroke-width:2px,color:#000000
-    classDef trigger fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000000
-    classDef job fill:#f1f8e9,stroke:#33691e,stroke-width:1px,color:#000000
-
-    class trigger_workflow_call trigger
-    class sub_security_scan_yml mainWorkflow
-    class sub_security_scan_yml_sca_scan job
-    class sub_security_scan_yml_sast_scan job
-```
-
 ### Workflow_dispatch Triggered Workflows
 
 The `workflow_dispatch` trigger allows manual execution of workflows. Each workflow is shown individually below:
@@ -690,7 +676,7 @@ flowchart LR
     reusable_typecheck_yml["reusable-typecheck.yml"]
     reusable_typecheck_yml_typecheck["TypeScript"]
     continuous_deployment_yml_security_scan["Security"]
-    sub_security_scan_yml["Security"]
+    sub_security_scan_yml["sub-security-scan.yml"]
     sub_security_scan_yml_sca_scan["SCA Scan"]
     sub_security_scan_yml_sast_scan["SAST Scan"]
     continuous_deployment_yml_build["Build"]
@@ -827,7 +813,7 @@ flowchart LR
     class reusable_typecheck_yml reusable
     class reusable_typecheck_yml_typecheck job
     class continuous_deployment_yml_security_scan job
-    class sub_security_scan_yml mainWorkflow
+    class sub_security_scan_yml reusable
     class sub_security_scan_yml_sca_scan job
     class sub_security_scan_yml_sast_scan job
     class continuous_deployment_yml_build job
@@ -879,6 +865,10 @@ This diagram shows the explicit and implicit dependencies between jobs in the co
 ```mermaid
 flowchart LR
     subgraph "External Inputs"
+        Secrets["Secrets"]
+        Secrets_AZ_SECURITY_SCAN_STORAGE_NAME["AZ_SECURITY_SCAN_STORAGE_NAME"]
+        Secrets_SNYK_OAUTH_CLIENT_ID["SNYK_OAUTH_CLIENT_ID"]
+        Secrets_SNYK_OAUTH_CLIENT_SECRET["SNYK_OAUTH_CLIENT_SECRET"]
         Variables["Variables"]
         Variables_CAMS_BASE_PATH["CAMS_BASE_PATH"]
         Variables_CAMS_LAUNCH_DARKLY_ENV["CAMS_LAUNCH_DARKLY_ENV"]
@@ -907,7 +897,9 @@ flowchart LR
         subgraph typecheck_subgraph["typecheck"]
             typecheck_vars["NODE_VERSION"]
         end
-        security_scan["Security"]
+        subgraph security_scan_subgraph["Security"]
+            security_scan_vars["AZ_SECURITY_SCAN_STORAGE_NAME<br/>SNYK_OAUTH_CLIENT_ID<br/>SNYK_OAUTH_CLIENT_SECRET"]
+        end
         subgraph build_subgraph["Build"]
             build_vars["CAMS_BASE_PATH<br/>CAMS_LAUNCH_DARKLY_ENV<br/>CAMS_SERVER_PORT<br/>CAMS_SERVER_PROTOCOL<br/>NODE_VERSION<br/>apiFunctionName<br/>azResourceGrpAppEncrypted<br/>dataflowsFunctionName<br/>ghaEnvironment<br/>slotName<br/>webappName"]
         end
@@ -919,11 +911,17 @@ flowchart LR
         end
     end
 
+        Secrets --> Secrets_AZ_SECURITY_SCAN_STORAGE_NAME
+        Secrets --> Secrets_SNYK_OAUTH_CLIENT_ID
+        Secrets --> Secrets_SNYK_OAUTH_CLIENT_SECRET
         Variables --> Variables_CAMS_BASE_PATH
         Variables --> Variables_CAMS_LAUNCH_DARKLY_ENV
         Variables --> Variables_CAMS_SERVER_PORT
         Variables --> Variables_CAMS_SERVER_PROTOCOL
         Variables --> Variables_NODE_VERSION
+    Secrets_AZ_SECURITY_SCAN_STORAGE_NAME -.-> security_scan_subgraph
+    Secrets_SNYK_OAUTH_CLIENT_ID -.-> security_scan_subgraph
+    Secrets_SNYK_OAUTH_CLIENT_SECRET -.-> security_scan_subgraph
     Variables_CAMS_BASE_PATH -.-> build_subgraph
     Variables_CAMS_LAUNCH_DARKLY_ENV -.-> build_subgraph
     Variables_CAMS_SERVER_PORT -.-> build_subgraph
@@ -939,7 +937,7 @@ flowchart LR
     build_subgraph ==>|"needs"| deploy_subgraph
     deploy_subgraph ==>|"needs"| deploy_code_slot_subgraph
     knip_subgraph ==>|"needs"| deploy_subgraph
-    security_scan ==>|"needs"| deploy_subgraph
+    security_scan_subgraph ==>|"needs"| deploy_subgraph
     setup ==>|"needs"| build_subgraph
     setup ==>|"needs"| deploy_code_slot_subgraph
     setup ==>|"needs"| deploy_subgraph
@@ -953,13 +951,14 @@ flowchart LR
     classDef mainWorkflow fill:#f3e5f5,fill-opacity:0.15,stroke:#f3e5f5,stroke-width:1px,color:#ffffff
     classDef jobSubgraph fill:#f1f8e9,stroke:#33691e,stroke-width:2px,color:#000000
     class continuous_deployment_workflow mainWorkflow
+    class Secrets external
     class Variables external
     class accessibility_test_subgraph jobSubgraph
     class build_subgraph jobSubgraph
     class deploy_subgraph jobSubgraph
     class deploy_code_slot_subgraph jobSubgraph
     class knip_subgraph jobSubgraph
-    class security_scan job
+    class security_scan_subgraph jobSubgraph
     class setup job
     class typecheck_subgraph jobSubgraph
     class unit_test_backend_subgraph jobSubgraph
@@ -1305,8 +1304,6 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-    trigger_workflow_call(["workflow_call"])
-    sub_security_scan_yml["Security"]
     trigger_workflow_dispatch(["workflow_dispatch"])
     deploy_security_scan_storage_yml["Deploy Security Scan Storage"]
     e2e_test_yml["Stand Alone E2E Test Runs"]
@@ -1332,7 +1329,6 @@ flowchart LR
     trigger_workflow_run(["workflow_run"])
     slack_notification_yml["slack-notification"]
 
-    trigger_workflow_call --> sub_security_scan_yml
     trigger_workflow_dispatch --> deploy_security_scan_storage_yml
     trigger_workflow_dispatch --> e2e_test_yml
     trigger_workflow_dispatch --> azure_remove_branch_yml
@@ -1355,14 +1351,12 @@ flowchart LR
     classDef mainWorkflow fill:#f3e5f5,stroke:#4a148c,stroke-width:2px,color:#000000
     classDef trigger fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000000
 
-    class trigger_workflow_call trigger
     class trigger_workflow_dispatch trigger
     class trigger_delete trigger
     class trigger_schedule trigger
     class trigger_pull_request trigger
     class trigger_push trigger
     class trigger_workflow_run trigger
-    class sub_security_scan_yml mainWorkflow
     class deploy_security_scan_storage_yml mainWorkflow
     class e2e_test_yml mainWorkflow
     class azure_remove_branch_yml mainWorkflow
@@ -1379,9 +1373,6 @@ flowchart LR
 ## Workflow Details
 
 ### Main Workflows
-- **Security** (`sub-security-scan.yml`)
-  - Triggers: workflow_call
-  - Jobs: 2
 - **Deploy Security Scan Storage** (`deploy-security-scan-storage.yml`)
   - Triggers: workflow_dispatch
   - Jobs: 1
@@ -1419,6 +1410,8 @@ flowchart LR
 ### Reusable Workflows
 - **Provision and Configure Cloud Resources** (`sub-deploy.yml`)
   - Jobs: 3
+- **Security** (`sub-security-scan.yml`)
+  - Jobs: 2
 - **Knip Unused Code Check** (`reusable-knip.yml`)
   - Jobs: 1
 - **Azure Deployment - Supporting Infrastructure** (`reusable-infrastructure-deploy.yml`)

--- a/ops/scripts/utility/setup-security-scan-federated-credential.sh
+++ b/ops/scripts/utility/setup-security-scan-federated-credential.sh
@@ -1,24 +1,23 @@
 #!/usr/bin/env bash
-# Runbook: Create federated credential and scoped role for sub-security-scan.yml (CAMS-730 / cams-5ln3)
+# Runbook: Create or update federated credential and scoped role for sub-security-scan.yml
 #
 # Purpose: Eliminate the long-lived AZURE_CREDENTIALS secret from the security scan workflow
 #          by replacing it with OIDC Workload Identity Federation. The new credential grants
 #          Storage Blob Data Contributor only on the security scan storage account — no broader
 #          subscription or resource group access.
 #
+# The subject claim uses a dedicated GitHub environment ("security-scan") so the credential
+# is scoped to this workflow and works from any branch. The subject format is:
+#   repo:ORG/REPO:environment:security-scan
+#
 # Prerequisites:
 #   - az CLI logged in as an Entra ID admin (can create app registrations)
 #   - The security scan storage account already exists
 #   - jq installed
+#   - A "security-scan" environment created in the GitHub repository settings
 #
-# After this script runs, complete the workflow migration (cams-i4k1):
-#   - Replace `creds: ${{ secrets.AZURE_CREDENTIALS }}` in sub-security-scan.yml with:
-#       client-id: ${{ vars.AZ_SECURITY_SCAN_CLIENT_ID }}
-#       tenant-id: ${{ vars.AZ_TENANT_ID }}
-#       subscription-id: ${{ vars.AZ_SUBSCRIPTION_ID }}
-#   - Add `permissions: id-token: write` to both scan jobs
-#   - Remove AZURE_CREDENTIALS from the workflow_call secrets block
-#   - Add the three vars above as GitHub Actions repository variables (not secrets)
+# Re-running this script with EXISTING_APP_ID set will update the federated credential
+# subject in place without recreating the app registration or role assignment.
 
 set -euo pipefail
 
@@ -29,11 +28,14 @@ STORAGE_ACCOUNT_NAME="${AZ_SECURITY_SCAN_STORAGE_NAME:?Set AZ_SECURITY_SCAN_STOR
 RESOURCE_GROUP="${AZ_SECURITY_SCAN_RG:?Set AZ_SECURITY_SCAN_RG}"
 GITHUB_ORG="US-Trustee-Program"
 GITHUB_REPO="Bankruptcy-Oversight-Support-Systems"
-# Scope the federated credential to the Main-Gov environment so it only fires
-# on runs that target that environment. Leave blank to allow any branch/tag.
-GITHUB_ENVIRONMENT="Main-Gov"
+GITHUB_ENVIRONMENT="security-scan"
 APP_NAME="cams-security-scan-oidc"
+CREDENTIAL_NAME="gha-security-scan"
+# Set to an existing app (client) ID to update rather than create. Leave blank to create new.
+EXISTING_APP_ID="${EXISTING_APP_ID:-}"
 # ---------------------------------------------------------------------------
+
+SUBJECT="repo:${GITHUB_ORG}/${GITHUB_REPO}:environment:${GITHUB_ENVIRONMENT}"
 
 echo "==> Looking up subscription and tenant..."
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)
@@ -48,43 +50,72 @@ STORAGE_ID=$(az storage account show \
   --query id -o tsv)
 echo "    Storage ID: $STORAGE_ID"
 
-echo "==> Creating app registration: $APP_NAME"
-APP_ID=$(az ad app create --display-name "$APP_NAME" --query appId -o tsv)
-echo "    App (client) ID: $APP_ID"
+if [[ -n "$EXISTING_APP_ID" ]]; then
+  APP_ID="$EXISTING_APP_ID"
+  echo "==> Using existing app registration: $APP_ID"
 
-echo "==> Creating service principal for app..."
-SP_ID=$(az ad sp create --id "$APP_ID" --query id -o tsv)
-echo "    Service principal object ID: $SP_ID"
+  echo "==> Updating federated identity credential..."
+  CREDENTIAL_ID=$(az ad app federated-credential list \
+    --id "$APP_ID" \
+    --query "[?name=='${CREDENTIAL_NAME}'].id" -o tsv)
 
-echo "==> Adding federated identity credential (environment: ${GITHUB_ENVIRONMENT:-any})..."
-if [[ -n "$GITHUB_ENVIRONMENT" ]]; then
-  SUBJECT="repo:${GITHUB_ORG}/${GITHUB_REPO}:environment:${GITHUB_ENVIRONMENT}"
+  if [[ -n "$CREDENTIAL_ID" ]]; then
+    az ad app federated-credential update \
+      --id "$APP_ID" \
+      --federated-credential-id "$CREDENTIAL_ID" \
+      --parameters "{
+        \"name\": \"${CREDENTIAL_NAME}\",
+        \"issuer\": \"https://token.actions.githubusercontent.com\",
+        \"subject\": \"${SUBJECT}\",
+        \"audiences\": [\"api://AzureADTokenExchange\"]
+      }"
+    echo "    Federated credential updated (subject: $SUBJECT)"
+  else
+    echo "    No existing credential named '${CREDENTIAL_NAME}' found — creating..."
+    az ad app federated-credential create \
+      --id "$APP_ID" \
+      --parameters "{
+        \"name\": \"${CREDENTIAL_NAME}\",
+        \"issuer\": \"https://token.actions.githubusercontent.com\",
+        \"subject\": \"${SUBJECT}\",
+        \"audiences\": [\"api://AzureADTokenExchange\"]
+      }"
+    echo "    Federated credential created (subject: $SUBJECT)"
+  fi
 else
-  SUBJECT="repo:${GITHUB_ORG}/${GITHUB_REPO}:ref:refs/heads/main"
+  echo "==> Creating app registration: $APP_NAME"
+  APP_ID=$(az ad app create --display-name "$APP_NAME" --query appId -o tsv)
+  echo "    App (client) ID: $APP_ID"
+
+  echo "==> Creating service principal for app..."
+  SP_ID=$(az ad sp create --id "$APP_ID" --query id -o tsv)
+  echo "    Service principal object ID: $SP_ID"
+
+  echo "==> Adding federated identity credential..."
+  az ad app federated-credential create \
+    --id "$APP_ID" \
+    --parameters "{
+      \"name\": \"${CREDENTIAL_NAME}\",
+      \"issuer\": \"https://token.actions.githubusercontent.com\",
+      \"subject\": \"${SUBJECT}\",
+      \"audiences\": [\"api://AzureADTokenExchange\"]
+    }"
+  echo "    Federated credential created (subject: $SUBJECT)"
+
+  echo "==> Assigning Storage Blob Data Contributor scoped to storage account..."
+  az role assignment create \
+    --assignee-object-id "$SP_ID" \
+    --assignee-principal-type ServicePrincipal \
+    --role "Storage Blob Data Contributor" \
+    --scope "$STORAGE_ID"
+  echo "    Role assigned."
 fi
 
-az ad app federated-credential create \
-  --id "$APP_ID" \
-  --parameters "{
-    \"name\": \"gha-security-scan\",
-    \"issuer\": \"https://token.actions.githubusercontent.com\",
-    \"subject\": \"${SUBJECT}\",
-    \"audiences\": [\"api://AzureADTokenExchange\"]
-  }"
-echo "    Federated credential created (subject: $SUBJECT)"
-
-echo "==> Assigning Storage Blob Data Contributor scoped to storage account..."
-az role assignment create \
-  --assignee-object-id "$SP_ID" \
-  --assignee-principal-type ServicePrincipal \
-  --role "Storage Blob Data Contributor" \
-  --scope "$STORAGE_ID"
-echo "    Role assigned."
-
 echo ""
-echo "==> Done. Add the following as GitHub Actions repository variables (not secrets):"
-echo "    AZ_SECURITY_SCAN_CLIENT_ID = $APP_ID"
-echo "    AZ_TENANT_ID               = $TENANT_ID"
-echo "    AZ_SUBSCRIPTION_ID         = $SUBSCRIPTION_ID"
-echo ""
-echo "    Then complete cams-i4k1: migrate sub-security-scan.yml azure/login to OIDC."
+echo "==> Done."
+if [[ -z "$EXISTING_APP_ID" ]]; then
+  echo "    Add the following as GitHub Actions repository variables (not secrets):"
+  echo "    AZ_SECURITY_SCAN_CLIENT_ID = $APP_ID"
+  echo "    AZ_TENANT_ID               = $TENANT_ID"
+  echo "    AZ_SUBSCRIPTION_ID         = $SUBSCRIPTION_ID"
+fi

--- a/ops/scripts/utility/setup-security-scan-federated-credential.sh
+++ b/ops/scripts/utility/setup-security-scan-federated-credential.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Runbook: Create federated credential and scoped role for sub-security-scan.yml (CAMS-730 / cams-5ln3)
+#
+# Purpose: Eliminate the long-lived AZURE_CREDENTIALS secret from the security scan workflow
+#          by replacing it with OIDC Workload Identity Federation. The new credential grants
+#          Storage Blob Data Contributor only on the security scan storage account — no broader
+#          subscription or resource group access.
+#
+# Prerequisites:
+#   - az CLI logged in as an Entra ID admin (can create app registrations)
+#   - The security scan storage account already exists
+#   - jq installed
+#
+# After this script runs, complete the workflow migration (cams-i4k1):
+#   - Replace `creds: ${{ secrets.AZURE_CREDENTIALS }}` in sub-security-scan.yml with:
+#       client-id: ${{ vars.AZ_SECURITY_SCAN_CLIENT_ID }}
+#       tenant-id: ${{ vars.AZ_TENANT_ID }}
+#       subscription-id: ${{ vars.AZ_SUBSCRIPTION_ID }}
+#   - Add `permissions: id-token: write` to both scan jobs
+#   - Remove AZURE_CREDENTIALS from the workflow_call secrets block
+#   - Add the three vars above as GitHub Actions repository variables (not secrets)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration — update these before running
+# ---------------------------------------------------------------------------
+STORAGE_ACCOUNT_NAME="${AZ_SECURITY_SCAN_STORAGE_NAME:?Set AZ_SECURITY_SCAN_STORAGE_NAME}"
+RESOURCE_GROUP="${AZ_SECURITY_SCAN_RG:?Set AZ_SECURITY_SCAN_RG}"
+GITHUB_ORG="US-Trustee-Program"
+GITHUB_REPO="Bankruptcy-Oversight-Support-Systems"
+# Scope the federated credential to the Main-Gov environment so it only fires
+# on runs that target that environment. Leave blank to allow any branch/tag.
+GITHUB_ENVIRONMENT="Main-Gov"
+APP_NAME="cams-security-scan-oidc"
+# ---------------------------------------------------------------------------
+
+echo "==> Looking up subscription and tenant..."
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+TENANT_ID=$(az account show --query tenantId -o tsv)
+echo "    Subscription: $SUBSCRIPTION_ID"
+echo "    Tenant:       $TENANT_ID"
+
+echo "==> Looking up storage account resource ID..."
+STORAGE_ID=$(az storage account show \
+  --name "$STORAGE_ACCOUNT_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query id -o tsv)
+echo "    Storage ID: $STORAGE_ID"
+
+echo "==> Creating app registration: $APP_NAME"
+APP_ID=$(az ad app create --display-name "$APP_NAME" --query appId -o tsv)
+echo "    App (client) ID: $APP_ID"
+
+echo "==> Creating service principal for app..."
+SP_ID=$(az ad sp create --id "$APP_ID" --query id -o tsv)
+echo "    Service principal object ID: $SP_ID"
+
+echo "==> Adding federated identity credential (environment: ${GITHUB_ENVIRONMENT:-any})..."
+if [[ -n "$GITHUB_ENVIRONMENT" ]]; then
+  SUBJECT="repo:${GITHUB_ORG}/${GITHUB_REPO}:environment:${GITHUB_ENVIRONMENT}"
+else
+  SUBJECT="repo:${GITHUB_ORG}/${GITHUB_REPO}:ref:refs/heads/main"
+fi
+
+az ad app federated-credential create \
+  --id "$APP_ID" \
+  --parameters "{
+    \"name\": \"gha-security-scan\",
+    \"issuer\": \"https://token.actions.githubusercontent.com\",
+    \"subject\": \"${SUBJECT}\",
+    \"audiences\": [\"api://AzureADTokenExchange\"]
+  }"
+echo "    Federated credential created (subject: $SUBJECT)"
+
+echo "==> Assigning Storage Blob Data Contributor scoped to storage account..."
+az role assignment create \
+  --assignee-object-id "$SP_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --role "Storage Blob Data Contributor" \
+  --scope "$STORAGE_ID"
+echo "    Role assigned."
+
+echo ""
+echo "==> Done. Add the following as GitHub Actions repository variables (not secrets):"
+echo "    AZ_SECURITY_SCAN_CLIENT_ID = $APP_ID"
+echo "    AZ_TENANT_ID               = $TENANT_ID"
+echo "    AZ_SUBSCRIPTION_ID         = $SUBSCRIPTION_ID"
+echo ""
+echo "    Then complete cams-i4k1: migrate sub-security-scan.yml azure/login to OIDC."

--- a/ops/scripts/utility/setup-security-scan-federated-credential.sh
+++ b/ops/scripts/utility/setup-security-scan-federated-credential.sh
@@ -6,15 +6,14 @@
 #          Storage Blob Data Contributor only on the security scan storage account — no broader
 #          subscription or resource group access.
 #
-# The subject claim uses a dedicated GitHub environment ("security-scan") so the credential
-# is scoped to this workflow and works from any branch. The subject format is:
-#   repo:ORG/REPO:environment:security-scan
+# The subject claim includes repo, workflow, and environment per the repo OIDC customization
+# template (include_claim_keys: ["repo", "workflow", "environment"]). The subject format is:
+#   repo:ORG/REPO:workflow:CALLER-WORKFLOW-NAME:environment:security-scan
 #
 # Prerequisites:
 #   - az CLI logged in as an Entra ID admin (can create app registrations)
 #   - The security scan storage account already exists
 #   - jq installed
-#   - A "security-scan" environment created in the GitHub repository settings
 #
 # Re-running this script with EXISTING_APP_ID set will update the federated credential
 # subject in place without recreating the app registration or role assignment.
@@ -28,6 +27,7 @@ STORAGE_ACCOUNT_NAME="${AZ_SECURITY_SCAN_STORAGE_NAME:?Set AZ_SECURITY_SCAN_STOR
 RESOURCE_GROUP="${AZ_SECURITY_SCAN_RG:?Set AZ_SECURITY_SCAN_RG}"
 GITHUB_ORG="US-Trustee-Program"
 GITHUB_REPO="Bankruptcy-Oversight-Support-Systems"
+GITHUB_WORKFLOW="Continuous Deployment"
 GITHUB_ENVIRONMENT="security-scan"
 APP_NAME="cams-security-scan-oidc"
 CREDENTIAL_NAME="gha-security-scan"
@@ -35,7 +35,7 @@ CREDENTIAL_NAME="gha-security-scan"
 EXISTING_APP_ID="${EXISTING_APP_ID:-}"
 # ---------------------------------------------------------------------------
 
-SUBJECT="repo:${GITHUB_ORG}/${GITHUB_REPO}:environment:${GITHUB_ENVIRONMENT}"
+SUBJECT="repo:${GITHUB_ORG}/${GITHUB_REPO}:workflow:${GITHUB_WORKFLOW}:environment:${GITHUB_ENVIRONMENT}"
 
 echo "==> Looking up subscription and tenant..."
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)

--- a/ops/scripts/utility/setup-security-scan-federated-credential.sh
+++ b/ops/scripts/utility/setup-security-scan-federated-credential.sh
@@ -13,10 +13,9 @@
 # Prerequisites:
 #   - az CLI logged in as an Entra ID admin (can create app registrations)
 #   - The security scan storage account already exists
-#   - jq installed
 #
-# Re-running this script with EXISTING_APP_ID set will update the federated credential
-# subject in place without recreating the app registration or role assignment.
+# This script is idempotent — re-running it will update existing resources in place
+# rather than creating duplicates.
 
 set -euo pipefail
 
@@ -31,8 +30,6 @@ GITHUB_WORKFLOW="Continuous Deployment"
 GITHUB_ENVIRONMENT="security-scan"
 APP_NAME="cams-security-scan-oidc"
 CREDENTIAL_NAME="gha-security-scan"
-# Set to an existing app (client) ID to update rather than create. Leave blank to create new.
-EXISTING_APP_ID="${EXISTING_APP_ID:-}"
 # ---------------------------------------------------------------------------
 
 SUBJECT="repo:${GITHUB_ORG}/${GITHUB_REPO}:workflow:${GITHUB_WORKFLOW}:environment:${GITHUB_ENVIRONMENT}"
@@ -50,48 +47,43 @@ STORAGE_ID=$(az storage account show \
   --query id -o tsv)
 echo "    Storage ID: $STORAGE_ID"
 
-if [[ -n "$EXISTING_APP_ID" ]]; then
-  APP_ID="$EXISTING_APP_ID"
-  echo "==> Using existing app registration: $APP_ID"
-
-  echo "==> Updating federated identity credential..."
-  CREDENTIAL_ID=$(az ad app federated-credential list \
-    --id "$APP_ID" \
-    --query "[?name=='${CREDENTIAL_NAME}'].id" -o tsv)
-
-  if [[ -n "$CREDENTIAL_ID" ]]; then
-    az ad app federated-credential update \
-      --id "$APP_ID" \
-      --federated-credential-id "$CREDENTIAL_ID" \
-      --parameters "{
-        \"name\": \"${CREDENTIAL_NAME}\",
-        \"issuer\": \"https://token.actions.githubusercontent.com\",
-        \"subject\": \"${SUBJECT}\",
-        \"audiences\": [\"api://AzureADTokenExchange\"]
-      }"
-    echo "    Federated credential updated (subject: $SUBJECT)"
-  else
-    echo "    No existing credential named '${CREDENTIAL_NAME}' found — creating..."
-    az ad app federated-credential create \
-      --id "$APP_ID" \
-      --parameters "{
-        \"name\": \"${CREDENTIAL_NAME}\",
-        \"issuer\": \"https://token.actions.githubusercontent.com\",
-        \"subject\": \"${SUBJECT}\",
-        \"audiences\": [\"api://AzureADTokenExchange\"]
-      }"
-    echo "    Federated credential created (subject: $SUBJECT)"
-  fi
-else
-  echo "==> Creating app registration: $APP_NAME"
+echo "==> Looking up app registration: $APP_NAME"
+APP_ID=$(az ad app list --display-name "$APP_NAME" --query "[0].appId" -o tsv)
+if [[ -z "$APP_ID" ]]; then
+  echo "    Not found — creating..."
   APP_ID=$(az ad app create --display-name "$APP_NAME" --query appId -o tsv)
-  echo "    App (client) ID: $APP_ID"
+  echo "    Created app (client) ID: $APP_ID"
+else
+  echo "    Found existing app (client) ID: $APP_ID"
+fi
 
-  echo "==> Creating service principal for app..."
+echo "==> Looking up service principal for app..."
+SP_ID=$(az ad sp show --id "$APP_ID" --query id -o tsv 2>/dev/null || true)
+if [[ -z "$SP_ID" ]]; then
+  echo "    Not found — creating..."
   SP_ID=$(az ad sp create --id "$APP_ID" --query id -o tsv)
-  echo "    Service principal object ID: $SP_ID"
+  echo "    Created service principal object ID: $SP_ID"
+else
+  echo "    Found existing service principal object ID: $SP_ID"
+fi
 
-  echo "==> Adding federated identity credential..."
+echo "==> Updating federated identity credential..."
+CREDENTIAL_ID=$(az ad app federated-credential list \
+  --id "$APP_ID" \
+  --query "[?name=='${CREDENTIAL_NAME}'].id" -o tsv)
+
+if [[ -n "$CREDENTIAL_ID" ]]; then
+  az ad app federated-credential update \
+    --id "$APP_ID" \
+    --federated-credential-id "$CREDENTIAL_ID" \
+    --parameters "{
+      \"name\": \"${CREDENTIAL_NAME}\",
+      \"issuer\": \"https://token.actions.githubusercontent.com\",
+      \"subject\": \"${SUBJECT}\",
+      \"audiences\": [\"api://AzureADTokenExchange\"]
+    }"
+  echo "    Federated credential updated (subject: $SUBJECT)"
+else
   az ad app federated-credential create \
     --id "$APP_ID" \
     --parameters "{
@@ -101,21 +93,29 @@ else
       \"audiences\": [\"api://AzureADTokenExchange\"]
     }"
   echo "    Federated credential created (subject: $SUBJECT)"
+fi
 
-  echo "==> Assigning Storage Blob Data Contributor scoped to storage account..."
+echo "==> Checking Storage Blob Data Contributor role assignment..."
+EXISTING_ROLE=$(az role assignment list \
+  --assignee "$SP_ID" \
+  --role "Storage Blob Data Contributor" \
+  --scope "$STORAGE_ID" \
+  --query "[0].id" -o tsv 2>/dev/null || true)
+
+if [[ -z "$EXISTING_ROLE" ]]; then
   az role assignment create \
     --assignee-object-id "$SP_ID" \
     --assignee-principal-type ServicePrincipal \
     --role "Storage Blob Data Contributor" \
     --scope "$STORAGE_ID"
   echo "    Role assigned."
+else
+  echo "    Role already assigned — skipping."
 fi
 
 echo ""
 echo "==> Done."
-if [[ -z "$EXISTING_APP_ID" ]]; then
-  echo "    Add the following as GitHub Actions repository secrets (not variables):"
-  echo "    AZ_SECURITY_SCAN_CLIENT_ID = $APP_ID"
-  echo "    AZ_TENANT_ID               = $TENANT_ID"
-  echo "    AZ_SUBSCRIPTION_ID         = $SUBSCRIPTION_ID"
-fi
+echo "    Ensure the following are set as GitHub Actions repository secrets:"
+echo "    AZ_SECURITY_SCAN_CLIENT_ID = $APP_ID"
+echo "    AZ_TENANT_ID               = $TENANT_ID"
+echo "    AZ_SUBSCRIPTION_ID         = $SUBSCRIPTION_ID"

--- a/ops/scripts/utility/setup-security-scan-federated-credential.sh
+++ b/ops/scripts/utility/setup-security-scan-federated-credential.sh
@@ -114,7 +114,7 @@ fi
 echo ""
 echo "==> Done."
 if [[ -z "$EXISTING_APP_ID" ]]; then
-  echo "    Add the following as GitHub Actions repository variables (not secrets):"
+  echo "    Add the following as GitHub Actions repository secrets (not variables):"
   echo "    AZ_SECURITY_SCAN_CLIENT_ID = $APP_ID"
   echo "    AZ_TENANT_ID               = $TENANT_ID"
   echo "    AZ_SUBSCRIPTION_ID         = $SUBSCRIPTION_ID"

--- a/test/e2e/playwright/trustees.spec.ts
+++ b/test/e2e/playwright/trustees.spec.ts
@@ -27,8 +27,8 @@ test.describe('Trustees', () => {
     const trusteesTable = page.getByTestId('trustees-table');
     await expect(trusteesTable).toBeVisible(timeoutOption);
 
-    // Verify table headers are present
-    await expect(page.locator('th:has-text("Name")')).toBeVisible();
+    // Verify table headers are present (now using div with role="columnheader")
+    await expect(page.locator('[role="columnheader"]:has-text("Name")')).toBeVisible();
   });
 
   test('should navigate to trustee detail page when clicking on a trustee name', async ({

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -42,6 +42,7 @@ import {
   Trustee,
   TrusteeHistory,
   TrusteeInput,
+  TrusteeListItem,
   TrusteeOversightAssignment,
 } from '@common/cams/trustees';
 import {
@@ -267,7 +268,7 @@ async function patchTrustee(id: string, trustee: Partial<TrusteeInput>) {
 }
 
 async function getTrustees() {
-  return api().get<Trustee[]>('/trustees');
+  return api().get<TrusteeListItem[]>('/trustees');
 }
 
 async function getTrustee(id: string) {

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -1956,6 +1956,7 @@ async function get<T = unknown>(path: string): Promise<ResponseBody<T>> {
             phone: '(694) 876-7057 x45546',
             email: 'Maurice.Windler@gmail.com',
           },
+          appointments: [],
         },
         {
           id: 'trustee-002',
@@ -1974,6 +1975,7 @@ async function get<T = unknown>(path: string): Promise<ResponseBody<T>> {
             phone: '963-363-4964 x4002',
             email: 'Arnaldo_Runolfsson@yahoo.com',
           },
+          appointments: [],
         },
         {
           id: 'trustee-003',
@@ -1992,6 +1994,7 @@ async function get<T = unknown>(path: string): Promise<ResponseBody<T>> {
             phone: '(203) 424-9970',
             email: 'Lawrence_Auer9@hotmail.com',
           },
+          appointments: [],
         },
       ],
     };

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -33,6 +33,7 @@ import {
   Trustee,
   TrusteeHistory,
   TrusteeInput,
+  TrusteeListItem,
   TrusteeOversightAssignment,
 } from '@common/cams/trustees';
 import { CaseAppointment, TrusteeAppointmentInput } from '@common/cams/trustee-appointments';
@@ -2476,7 +2477,7 @@ async function patchTrustee(id: string, trustee: Partial<TrusteeInput>) {
 }
 
 async function getTrustees() {
-  return get<Trustee[]>('/trustees');
+  return get<TrusteeListItem[]>('/trustees');
 }
 
 async function getTrustee(id: string) {

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -1,5 +1,71 @@
 .trustees-list {
-  .trustee-name {
-    min-width: 220px;
+  .trustees-list-grid {
+    overflow-x: auto;
+  }
+
+  .trustees-list-header {
+    font-weight: bold;
+    font-size: 0.875rem;
+
+    .trustees-list-cell {
+      padding: 0.5rem 0.5rem 0.5rem 0;
+      border-bottom: 2px solid #1b1b1b;
+    }
+  }
+
+  .trustees-list-row {
+    font-size: 0.875rem;
+
+    .trustees-list-cell {
+      padding: 0.5rem 0.5rem 0.5rem 0;
+      border-bottom: 1px solid #dcdee0;
+      word-wrap: break-word;
+    }
+
+    &.trustee-group-start .trustees-list-cell {
+      border-top: 2px solid #1b1b1b;
+    }
+
+    .trustee-name-repeat {
+      color: #71767a;
+      font-style: italic;
+    }
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .trustees-list {
+    .trustees-list-header {
+      display: none;
+    }
+
+    .trustees-list-row {
+      display: block;
+
+      &.trustee-group-start {
+        margin-top: 1rem;
+      }
+
+      .trustees-list-cell[data-cell] {
+        display: block;
+        width: 100%;
+        min-height: 1.75rem;
+        padding: 0.25rem 0.375rem 0.25rem 40%;
+        position: relative;
+
+        &::before {
+          content: attr(data-cell) ':';
+          position: absolute;
+          left: 0;
+          top: 0.25rem;
+          font-weight: 700;
+          white-space: nowrap;
+        }
+      }
+
+      .trustee-name-repeat {
+        display: none;
+      }
+    }
   }
 }

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -1,4 +1,12 @@
 .trustees-list {
+  .trustees-list-count {
+    font-size: 1rem;
+    font-family: 'Source Sans Pro', sans-serif;
+    font-weight: bold;
+    line-height: 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+
   .trustees-list-grid {
     overflow-x: auto;
   }
@@ -6,11 +14,12 @@
   // Mobile default — stacked with inline labels
   .trustees-list-header {
     display: none;
+    padding: 0 1rem 0.5rem 1rem;
   }
 
   .trustee-group {
     border-bottom: 1px solid #1b1b1b;
-    padding: 0.625rem 0;
+    padding: 0.625rem 1rem;
     margin-top: 1rem;
   }
 

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -18,17 +18,20 @@
 
     .trustees-list-cell {
       padding: 0.5rem 0.5rem 0.5rem 0;
-      border-bottom: 1px solid #dcdee0;
       word-wrap: break-word;
     }
 
     &.trustee-group-start .trustees-list-cell {
-      border-top: 2px solid #1b1b1b;
+      border-top: 1px solid #1b1b1b;
+    }
+
+    &.trustee-group-end .trustees-list-cell {
+      border-bottom: 1px solid #1b1b1b;
+      padding-bottom: 0.75rem;
     }
 
     .trustee-name-repeat {
-      color: #71767a;
-      font-style: italic;
+      display: none;
     }
   }
 }
@@ -61,10 +64,6 @@
           font-weight: 700;
           white-space: nowrap;
         }
-      }
-
-      .trustee-name-repeat {
-        display: none;
       }
     }
   }

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -3,68 +3,116 @@
     overflow-x: auto;
   }
 
+  // Mobile default — stacked with inline labels
   .trustees-list-header {
-    font-weight: bold;
-    font-size: 0.875rem;
+    display: none;
+  }
 
-    .trustees-list-cell {
-      padding: 0.5rem 0.5rem 0.5rem 0;
-      border-bottom: 2px solid #1b1b1b;
-    }
+  .trustee-group {
+    border-bottom: 1px solid #1b1b1b;
+    padding: 0.625rem 0;
+    margin-top: 1rem;
   }
 
   .trustees-list-row {
-    font-size: 0.875rem;
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 1rem;
+    line-height: 1.625rem;
+    display: block;
+  }
 
-    .trustees-list-cell {
-      padding: 0.5rem 0.5rem 0.5rem 0;
-      word-wrap: break-word;
-    }
+  .trustees-list-cell {
+    padding: 0;
+    word-wrap: break-word;
+  }
 
-    &.trustee-group-start .trustees-list-cell {
-      border-top: 1px solid #1b1b1b;
-    }
+  .trustees-list-cell[data-cell] {
+    display: block;
+    width: 100%;
+    min-height: 1.75rem;
+    padding: 0.25rem 0.375rem 0.25rem 40%;
+    white-space: normal;
+    position: relative;
 
-    &.trustee-group-end .trustees-list-cell {
-      border-bottom: 1px solid #1b1b1b;
-      padding-bottom: 0.75rem;
-    }
-
-    .trustee-name-repeat {
-      display: none;
+    &::before {
+      content: attr(data-cell) ':';
+      position: absolute;
+      left: 0;
+      top: 0.25rem;
+      font-weight: 700;
+      white-space: nowrap;
     }
   }
-}
 
-@media screen and (max-width: 1024px) {
-  .trustees-list {
+  // Tablet — equal columns
+  @media screen and (min-width: 641px) {
     .trustees-list-header {
-      display: none;
+      display: flex;
+      flex-direction: row;
+      gap: 1rem;
+      font-family: 'Source Sans Pro', sans-serif;
+      font-weight: bold;
+      font-size: 1rem;
+      line-height: 1.5rem;
+      border-bottom: 1px solid #1b1b1b;
+      padding-bottom: 0.5rem;
+    }
+
+    .trustee-group {
+      margin-top: 0;
     }
 
     .trustees-list-row {
+      display: flex;
+      flex-direction: row;
+      gap: 1rem;
+    }
+
+    .trustees-list-cell[data-cell] {
       display: block;
+      width: auto;
+      min-height: unset;
+      padding: 0;
+      white-space: normal;
+      position: static;
 
-      &.trustee-group-start {
-        margin-top: 1rem;
+      &::before {
+        display: none;
       }
+    }
 
-      .trustees-list-cell[data-cell] {
-        display: block;
-        width: 100%;
-        min-height: 1.75rem;
-        padding: 0.25rem 0.375rem 0.25rem 40%;
-        position: relative;
+    .col-name,
+    .col-district-division,
+    .col-chapter,
+    .col-type,
+    .col-status {
+      flex: 1 1 0;
+      min-width: 0;
+      max-width: none;
+      white-space: normal;
+    }
+  }
 
-        &::before {
-          content: attr(data-cell) ':';
-          position: absolute;
-          left: 0;
-          top: 0.25rem;
-          font-weight: 700;
-          white-space: nowrap;
-        }
-      }
+  // Desktop — proportional columns
+  @media screen and (min-width: 1025px) {
+    .col-name {
+      flex: 2 1 0;
+      min-width: 160px;
+    }
+
+    .col-district-division {
+      flex: 3 1 0;
+      min-width: 300px;
+    }
+
+    .col-chapter,
+    .col-type,
+    .col-status {
+      flex: 0 0 120px;
+      width: 120px;
+      min-width: 120px;
+      max-width: 220px;
+      white-space: nowrap;
     }
   }
 }

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2,7 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import TrusteesList from './TrusteesList';
 import Api2 from '@/lib/models/api2';
-import { Trustee } from '@common/cams/trustees';
+import { TrusteeListItem } from '@common/cams/trustees';
+import { TrusteeAppointment } from '@common/cams/trustee-appointments';
 import { ResponseBody } from '@common/api/response';
 import { vi } from 'vitest';
 import MockData from '@common/cams/test-utilities/mock-data';
@@ -12,36 +13,25 @@ function renderWithRouter(component: React.ReactElement) {
   return render(<BrowserRouter>{component}</BrowserRouter>);
 }
 
-describe('TrusteesList Component', () => {
-  const mockTrustees: Trustee[] = [
-    {
-      id: '--id-guid-1--',
-      trusteeId: 'trustee-1',
-      name: 'John Doe',
-      public: {
-        address: MockData.getAddress(),
-        phone: { number: '555-123-4567' },
-        email: 'john.doe@example.com',
-      },
-      updatedOn: '2025-08-14T10:00:00Z',
-      updatedBy: { id: 'user-1', name: 'Admin User' },
-    },
-    {
-      id: '--id-guid-2--',
-      trusteeId: 'trustee-2',
-      name: 'Jane Smith',
-      public: {
-        address: MockData.getAddress(),
-        phone: { number: '555-987-6543' },
-        email: 'jane.smith@example.com',
-      },
-      updatedOn: '2025-08-14T09:00:00Z',
-      updatedBy: { id: 'user-2', name: 'Admin User 2' },
-    },
-  ];
+function makeListItem(overrides: Partial<TrusteeListItem> = {}): TrusteeListItem {
+  return {
+    ...MockData.getTrustee(),
+    appointments: [],
+    ...overrides,
+  };
+}
 
+function makeAppointment(overrides: Partial<TrusteeAppointment> = {}): TrusteeAppointment {
+  return MockData.getTrusteeAppointment(overrides);
+}
+
+describe('TrusteesList Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   test('should display loading spinner while fetching trustees', () => {
@@ -57,10 +47,24 @@ describe('TrusteesList Component', () => {
     expect(screen.getByText('Loading trustees...')).toBeInTheDocument();
   });
 
+  test('should display trustee count above table', async () => {
+    const trustee1 = makeListItem({ trusteeId: 'trustee-1', name: 'Alice' });
+    const trustee2 = makeListItem({ trusteeId: 'trustee-2', name: 'Bob' });
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee1, trustee2] };
+
+    vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
+
+    renderWithRouter(<TrusteesList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('2 Trustee(s)')).toBeInTheDocument();
+    });
+  });
+
   test('should display trustees list when data is loaded', async () => {
-    const mockResponse: ResponseBody<Trustee[]> = {
-      data: mockTrustees,
-    };
+    const trustee1 = makeListItem({ trusteeId: 'trustee-1', name: 'John Doe' });
+    const trustee2 = makeListItem({ trusteeId: 'trustee-2', name: 'Jane Smith' });
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee1, trustee2] };
 
     vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
 
@@ -70,15 +74,14 @@ describe('TrusteesList Component', () => {
       expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.getByText('Jane Smith')).toBeInTheDocument();
   });
 
   test('should display links to individual trustee profiles', async () => {
-    const mockResponse: ResponseBody<Trustee[]> = {
-      data: mockTrustees,
-    };
+    const trustee1 = makeListItem({ trusteeId: 'trustee-1', name: 'John Doe' });
+    const trustee2 = makeListItem({ trusteeId: 'trustee-2', name: 'Jane Smith' });
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee1, trustee2] };
 
     vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
 
@@ -88,17 +91,126 @@ describe('TrusteesList Component', () => {
       expect(screen.getByTestId('trustee-link-trustee-1')).toBeInTheDocument();
     });
 
-    const johnDoeLink = screen.getByTestId('trustee-link-trustee-1');
-    expect(johnDoeLink).toHaveAttribute('href', '/trustees/trustee-1');
+    expect(screen.getByTestId('trustee-link-trustee-1')).toHaveAttribute(
+      'href',
+      '/trustees/trustee-1',
+    );
+    expect(screen.getByTestId('trustee-link-trustee-2')).toHaveAttribute(
+      'href',
+      '/trustees/trustee-2',
+    );
+  });
 
-    const janeSmithLink = screen.getByTestId('trustee-link-trustee-2');
-    expect(janeSmithLink).toHaveAttribute('href', '/trustees/trustee-2');
+  test('should render multiple rows for a trustee with multiple appointments', async () => {
+    const trusteeId = 'trustee-multi';
+    const appt1 = makeAppointment({
+      trusteeId,
+      chapter: '7',
+      appointmentType: 'panel',
+      status: 'active',
+      courtId: 'court-1',
+      courtName: 'Southern District of New York',
+      courtDivisionName: 'Manhattan',
+      divisionCode: '081',
+    });
+    const appt2 = makeAppointment({
+      trusteeId,
+      chapter: '11',
+      appointmentType: 'case-by-case',
+      status: 'inactive',
+      courtId: 'court-2',
+      courtName: 'District of Vermont',
+      courtDivisionName: 'Burlington',
+      divisionCode: '087',
+    });
+    const trustee = makeListItem({
+      trusteeId,
+      name: 'Multi Appt Trustee',
+      appointments: [appt1, appt2],
+    });
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee] };
+
+    vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
+
+    renderWithRouter(<TrusteesList />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Southern District of New York (Manhattan)')).toBeInTheDocument();
+    expect(screen.getByText('District of Vermont (Burlington)')).toBeInTheDocument();
+    expect(screen.getByText('Panel')).toBeInTheDocument();
+    expect(screen.getByText('Case by Case')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  test('should format District (Division) correctly using courtName and courtDivisionName', async () => {
+    const trusteeId = 'trustee-district';
+    const appt = makeAppointment({
+      trusteeId,
+      courtName: 'Eastern District of California',
+      courtDivisionName: 'Sacramento',
+      divisionCode: '099',
+    });
+    const trustee = makeListItem({ trusteeId, name: 'District Trustee', appointments: [appt] });
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee] };
+
+    vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
+
+    renderWithRouter(<TrusteesList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Eastern District of California (Sacramento)')).toBeInTheDocument();
+    });
+  });
+
+  test('should fall back to courtId and divisionCode when court name fields are absent', async () => {
+    const trusteeId = 'trustee-fallback';
+    const appt = makeAppointment({
+      trusteeId,
+      courtId: 'court-xyz',
+      divisionCode: '042',
+      courtName: undefined,
+      courtDivisionName: undefined,
+    });
+    const trustee = makeListItem({ trusteeId, name: 'Fallback Trustee', appointments: [appt] });
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee] };
+
+    vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
+
+    renderWithRouter(<TrusteesList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('court-xyz (042)')).toBeInTheDocument();
+    });
+  });
+
+  test('should show one row with empty cells for a trustee with zero appointments', async () => {
+    const trustee = makeListItem({
+      trusteeId: 'trustee-zero',
+      name: 'Zero Appt Trustee',
+      appointments: [],
+    });
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee] };
+
+    vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
+
+    renderWithRouter(<TrusteesList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Zero Appt Trustee')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+    const rows = screen.getAllByRole('row');
+    // header row + 1 data row
+    expect(rows).toHaveLength(2);
   });
 
   test('should display empty state when no trustees exist', async () => {
-    const mockResponse: ResponseBody<Trustee[]> = {
-      data: [],
-    };
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [] };
 
     vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
 
@@ -127,36 +239,9 @@ describe('TrusteesList Component', () => {
     expect(screen.queryByTestId('trustees-table')).not.toBeInTheDocument();
   });
 
-  test('should handle trustees with missing optional fields', async () => {
-    const minimalTrustee: Trustee = {
-      id: '--id-guid-min--',
-      trusteeId: 'trustee-minimal',
-      name: 'Minimal Trustee',
-      public: {
-        address: MockData.getAddress(),
-        phone: { number: '555-1234' },
-        email: 'jane.doe@example.com',
-      },
-      updatedOn: '2025-08-14T08:00:00Z',
-      updatedBy: { id: 'user-3', name: 'Admin User 3' },
-    };
-
-    const mockResponse: ResponseBody<Trustee[]> = {
-      data: [minimalTrustee],
-    };
-
-    vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
-
-    renderWithRouter(<TrusteesList />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Minimal Trustee')).toBeInTheDocument();
-    });
-  });
-
   test('should handle API response with undefined data field', async () => {
-    const mockResponse: ResponseBody<Trustee[]> = {
-      data: undefined as unknown as Trustee[],
+    const mockResponse: ResponseBody<TrusteeListItem[]> = {
+      data: undefined as unknown as TrusteeListItem[],
     };
 
     vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
@@ -168,5 +253,28 @@ describe('TrusteesList Component', () => {
     });
 
     expect(screen.getByText(/No trustee profiles have been created yet/)).toBeInTheDocument();
+  });
+
+  test('should display chapter, type, and status using format helpers', async () => {
+    const trusteeId = 'trustee-format';
+    const appt = makeAppointment({
+      trusteeId,
+      chapter: '11-subchapter-v',
+      appointmentType: 'pool',
+      status: 'voluntarily-suspended',
+    });
+    const trustee = makeListItem({ trusteeId, name: 'Format Trustee', appointments: [appt] });
+    const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee] };
+
+    vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
+
+    renderWithRouter(<TrusteesList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('11 Subchapter V')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Pool')).toBeInTheDocument();
+    expect(screen.getByText('Voluntarily Suspended')).toBeInTheDocument();
   });
 });

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -105,7 +105,7 @@ export default function TrusteesList() {
             const rows = trustee.appointments.length === 0 ? [null] : trustee.appointments;
 
             return (
-              <div key={trustee.trusteeId} className="trustee-group">
+              <div key={trustee.trusteeId} className="trustee-group" role="rowgroup">
                 {rows.map((appt, idx) => (
                   <div key={`${trustee.trusteeId}-${idx}`} className="trustees-list-row" role="row">
                     <div

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -9,6 +9,17 @@ import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 
 const COLUMN_HEADERS = ['Name', 'District (Division)', 'Chapter', 'Type', 'Status'];
 
+function toColClass(header: string): string {
+  return (
+    'col-' +
+    header
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+  );
+}
+
 function formatDistrict(appointment: TrusteeListItem['appointments'][number]): string {
   const name = appointment.courtName ?? appointment.courtId;
   const division = appointment.courtDivisionName ?? appointment.divisionCode;
@@ -77,11 +88,11 @@ export default function TrusteesList() {
         data-testid="trustees-table"
       >
         <div role="rowgroup">
-          <div className="trustees-list-header grid-row grid-gap-lg" role="row">
+          <div className="trustees-list-header" role="row">
             {COLUMN_HEADERS.map((header) => (
               <div
                 key={header}
-                className="trustees-list-cell grid-col text-no-wrap"
+                className={`trustees-list-cell ${toColClass(header)}`}
                 role="columnheader"
               >
                 {header}
@@ -93,66 +104,59 @@ export default function TrusteesList() {
           {trustees.map((trustee) => {
             const rows = trustee.appointments.length === 0 ? [null] : trustee.appointments;
 
-            return rows.map((appt, idx) => {
-              const isGroupEnd = idx === rows.length - 1;
-              const classes = [
-                'trustees-list-row grid-row grid-gap-lg',
-                idx === 0 ? 'trustee-group-start' : '',
-                isGroupEnd ? 'trustee-group-end' : '',
-              ]
-                .filter(Boolean)
-                .join(' ');
-
-              return (
-                <div key={`${trustee.trusteeId}-${idx}`} className={classes} role="row">
-                  <div
-                    className="trustees-list-cell grid-col"
-                    role="cell"
-                    data-cell={COLUMN_HEADERS[0]}
-                  >
-                    {idx === 0 ? (
-                      <NavLink
-                        to={`/trustees/${trustee.trusteeId}`}
-                        data-testid={`trustee-link-${trustee.trusteeId}`}
-                        className="usa-link"
-                      >
-                        {trustee.name}
-                      </NavLink>
-                    ) : (
-                      <span className="trustee-name-repeat" aria-hidden="true"></span>
-                    )}
+            return (
+              <div key={trustee.trusteeId} className="trustee-group" role="rowgroup">
+                {rows.map((appt, idx) => (
+                  <div key={`${trustee.trusteeId}-${idx}`} className="trustees-list-row" role="row">
+                    <div
+                      className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[0])}`}
+                      role="cell"
+                      data-cell={COLUMN_HEADERS[0]}
+                    >
+                      {idx === 0 ? (
+                        <NavLink
+                          to={`/trustees/${trustee.trusteeId}`}
+                          data-testid={`trustee-link-${trustee.trusteeId}`}
+                          className="usa-link"
+                        >
+                          {trustee.name}
+                        </NavLink>
+                      ) : (
+                        <span aria-hidden="true"></span>
+                      )}
+                    </div>
+                    <div
+                      className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[1])}`}
+                      role="cell"
+                      data-cell={COLUMN_HEADERS[1]}
+                    >
+                      {appt ? formatDistrict(appt) : ''}
+                    </div>
+                    <div
+                      className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[2])}`}
+                      role="cell"
+                      data-cell={COLUMN_HEADERS[2]}
+                    >
+                      {appt ? formatChapterType(appt.chapter) : ''}
+                    </div>
+                    <div
+                      className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[3])}`}
+                      role="cell"
+                      data-cell={COLUMN_HEADERS[3]}
+                    >
+                      {appt ? formatAppointmentType(appt.appointmentType) : ''}
+                    </div>
+                    <div
+                      className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[4])}`}
+                      role="cell"
+                      data-cell={COLUMN_HEADERS[4]}
+                    >
+                      {appt ? formatAppointmentStatus(appt.status) : ''}
+                    </div>
                   </div>
-                  <div
-                    className="trustees-list-cell grid-col"
-                    role="cell"
-                    data-cell={COLUMN_HEADERS[1]}
-                  >
-                    {appt ? formatDistrict(appt) : ''}
-                  </div>
-                  <div
-                    className="trustees-list-cell grid-col"
-                    role="cell"
-                    data-cell={COLUMN_HEADERS[2]}
-                  >
-                    {appt ? formatChapterType(appt.chapter) : ''}
-                  </div>
-                  <div
-                    className="trustees-list-cell grid-col"
-                    role="cell"
-                    data-cell={COLUMN_HEADERS[3]}
-                  >
-                    {appt ? formatAppointmentType(appt.appointmentType) : ''}
-                  </div>
-                  <div
-                    className="trustees-list-cell grid-col"
-                    role="cell"
-                    data-cell={COLUMN_HEADERS[4]}
-                  >
-                    {appt ? formatAppointmentStatus(appt.status) : ''}
-                  </div>
-                </div>
-              );
-            });
+                ))}
+              </div>
+            );
           })}
         </div>
       </div>

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -105,7 +105,7 @@ export default function TrusteesList() {
             const rows = trustee.appointments.length === 0 ? [null] : trustee.appointments;
 
             return (
-              <div key={trustee.trusteeId} className="trustee-group" role="rowgroup">
+              <div key={trustee.trusteeId} className="trustee-group">
                 {rows.map((appt, idx) => (
                   <div key={`${trustee.trusteeId}-${idx}`} className="trustees-list-row" role="row">
                     <div

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -93,61 +93,66 @@ export default function TrusteesList() {
           {trustees.map((trustee) => {
             const rows = trustee.appointments.length === 0 ? [null] : trustee.appointments;
 
-            return rows.map((appt, idx) => (
-              <div
-                key={`${trustee.trusteeId}-${idx}`}
-                className={`trustees-list-row grid-row grid-gap-lg${idx === 0 ? ' trustee-group-start' : ''}`}
-                role="row"
-              >
-                <div
-                  className="trustees-list-cell grid-col"
-                  role="cell"
-                  data-cell={COLUMN_HEADERS[0]}
-                >
-                  {idx === 0 ? (
-                    <NavLink
-                      to={`/trustees/${trustee.trusteeId}`}
-                      data-testid={`trustee-link-${trustee.trusteeId}`}
-                      className="usa-link"
-                    >
-                      {trustee.name}
-                    </NavLink>
-                  ) : (
-                    <span className="trustee-name-repeat" aria-hidden="true">
-                      {trustee.name}
-                    </span>
-                  )}
+            return rows.map((appt, idx) => {
+              const isGroupEnd = idx === rows.length - 1;
+              const classes = [
+                'trustees-list-row grid-row grid-gap-lg',
+                idx === 0 ? 'trustee-group-start' : '',
+                isGroupEnd ? 'trustee-group-end' : '',
+              ]
+                .filter(Boolean)
+                .join(' ');
+
+              return (
+                <div key={`${trustee.trusteeId}-${idx}`} className={classes} role="row">
+                  <div
+                    className="trustees-list-cell grid-col"
+                    role="cell"
+                    data-cell={COLUMN_HEADERS[0]}
+                  >
+                    {idx === 0 ? (
+                      <NavLink
+                        to={`/trustees/${trustee.trusteeId}`}
+                        data-testid={`trustee-link-${trustee.trusteeId}`}
+                        className="usa-link"
+                      >
+                        {trustee.name}
+                      </NavLink>
+                    ) : (
+                      <span className="trustee-name-repeat" aria-hidden="true"></span>
+                    )}
+                  </div>
+                  <div
+                    className="trustees-list-cell grid-col"
+                    role="cell"
+                    data-cell={COLUMN_HEADERS[1]}
+                  >
+                    {appt ? formatDistrict(appt) : ''}
+                  </div>
+                  <div
+                    className="trustees-list-cell grid-col"
+                    role="cell"
+                    data-cell={COLUMN_HEADERS[2]}
+                  >
+                    {appt ? formatChapterType(appt.chapter) : ''}
+                  </div>
+                  <div
+                    className="trustees-list-cell grid-col"
+                    role="cell"
+                    data-cell={COLUMN_HEADERS[3]}
+                  >
+                    {appt ? formatAppointmentType(appt.appointmentType) : ''}
+                  </div>
+                  <div
+                    className="trustees-list-cell grid-col"
+                    role="cell"
+                    data-cell={COLUMN_HEADERS[4]}
+                  >
+                    {appt ? formatAppointmentStatus(appt.status) : ''}
+                  </div>
                 </div>
-                <div
-                  className="trustees-list-cell grid-col"
-                  role="cell"
-                  data-cell={COLUMN_HEADERS[1]}
-                >
-                  {appt ? formatDistrict(appt) : ''}
-                </div>
-                <div
-                  className="trustees-list-cell grid-col"
-                  role="cell"
-                  data-cell={COLUMN_HEADERS[2]}
-                >
-                  {appt ? formatChapterType(appt.chapter) : ''}
-                </div>
-                <div
-                  className="trustees-list-cell grid-col"
-                  role="cell"
-                  data-cell={COLUMN_HEADERS[3]}
-                >
-                  {appt ? formatAppointmentType(appt.appointmentType) : ''}
-                </div>
-                <div
-                  className="trustees-list-cell grid-col"
-                  role="cell"
-                  data-cell={COLUMN_HEADERS[4]}
-                >
-                  {appt ? formatAppointmentStatus(appt.status) : ''}
-                </div>
-              </div>
-            ));
+              );
+            });
           })}
         </div>
       </div>

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -80,7 +80,7 @@ export default function TrusteesList() {
 
   return (
     <div className="trustees-list">
-      <p>{trustees.length} Trustee(s)</p>
+      <p className="trustees-list-count">{trustees.length} Trustee(s)</p>
       <div
         className="trustees-list-grid"
         role="table"

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -7,6 +7,8 @@ import { formatAppointmentStatus } from '@common/cams/trustee-appointments';
 import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 
+const COLUMN_HEADERS = ['Name', 'District (Division)', 'Chapter', 'Type', 'Status'];
+
 function formatDistrict(appointment: TrusteeListItem['appointments'][number]): string {
   const name = appointment.courtName ?? appointment.courtId;
   const division = appointment.courtDivisionName ?? appointment.divisionCode;
@@ -68,59 +70,87 @@ export default function TrusteesList() {
   return (
     <div className="trustees-list">
       <p>{trustees.length} Trustee(s)</p>
-      <table className="usa-table usa-table--borderless" data-testid="trustees-table">
-        <thead>
-          <tr>
-            <th scope="col">Name</th>
-            <th scope="col">District (Division)</th>
-            <th scope="col">Chapter</th>
-            <th scope="col">Type</th>
-            <th scope="col">Status</th>
-          </tr>
-        </thead>
-        <tbody>
+      <div
+        className="trustees-list-grid"
+        role="table"
+        aria-label="Trustees"
+        data-testid="trustees-table"
+      >
+        <div role="rowgroup">
+          <div className="trustees-list-header grid-row grid-gap-lg" role="row">
+            {COLUMN_HEADERS.map((header) => (
+              <div
+                key={header}
+                className="trustees-list-cell grid-col text-no-wrap"
+                role="columnheader"
+              >
+                {header}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div role="rowgroup">
           {trustees.map((trustee) => {
-            const rowCount = Math.max(1, trustee.appointments.length);
-            return trustee.appointments.length === 0 ? (
-              <tr key={trustee.trusteeId}>
-                <td className="trustee-name" rowSpan={1}>
-                  <NavLink
-                    to={`/trustees/${trustee.trusteeId}`}
-                    data-testid={`trustee-link-${trustee.trusteeId}`}
-                    className="usa-link"
-                  >
-                    {trustee.name}
-                  </NavLink>
-                </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-              </tr>
-            ) : (
-              trustee.appointments.map((appt, idx) => (
-                <tr key={`${trustee.trusteeId}-${idx}`}>
-                  {idx === 0 && (
-                    <td className="trustee-name" rowSpan={rowCount}>
-                      <NavLink
-                        to={`/trustees/${trustee.trusteeId}`}
-                        data-testid={`trustee-link-${trustee.trusteeId}`}
-                        className="usa-link"
-                      >
-                        {trustee.name}
-                      </NavLink>
-                    </td>
+            const rows = trustee.appointments.length === 0 ? [null] : trustee.appointments;
+
+            return rows.map((appt, idx) => (
+              <div
+                key={`${trustee.trusteeId}-${idx}`}
+                className={`trustees-list-row grid-row grid-gap-lg${idx === 0 ? ' trustee-group-start' : ''}`}
+                role="row"
+              >
+                <div
+                  className="trustees-list-cell grid-col"
+                  role="cell"
+                  data-cell={COLUMN_HEADERS[0]}
+                >
+                  {idx === 0 ? (
+                    <NavLink
+                      to={`/trustees/${trustee.trusteeId}`}
+                      data-testid={`trustee-link-${trustee.trusteeId}`}
+                      className="usa-link"
+                    >
+                      {trustee.name}
+                    </NavLink>
+                  ) : (
+                    <span className="trustee-name-repeat" aria-hidden="true">
+                      {trustee.name}
+                    </span>
                   )}
-                  <td>{formatDistrict(appt)}</td>
-                  <td>{formatChapterType(appt.chapter)}</td>
-                  <td>{formatAppointmentType(appt.appointmentType)}</td>
-                  <td>{formatAppointmentStatus(appt.status)}</td>
-                </tr>
-              ))
-            );
+                </div>
+                <div
+                  className="trustees-list-cell grid-col"
+                  role="cell"
+                  data-cell={COLUMN_HEADERS[1]}
+                >
+                  {appt ? formatDistrict(appt) : ''}
+                </div>
+                <div
+                  className="trustees-list-cell grid-col"
+                  role="cell"
+                  data-cell={COLUMN_HEADERS[2]}
+                >
+                  {appt ? formatChapterType(appt.chapter) : ''}
+                </div>
+                <div
+                  className="trustees-list-cell grid-col"
+                  role="cell"
+                  data-cell={COLUMN_HEADERS[3]}
+                >
+                  {appt ? formatAppointmentType(appt.appointmentType) : ''}
+                </div>
+                <div
+                  className="trustees-list-cell grid-col"
+                  role="cell"
+                  data-cell={COLUMN_HEADERS[4]}
+                >
+                  {appt ? formatAppointmentStatus(appt.status) : ''}
+                </div>
+              </div>
+            ));
           })}
-        </tbody>
-      </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -1,12 +1,20 @@
 import './TrusteesList.scss';
 import { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import { Trustee } from '@common/cams/trustees';
+import { TrusteeListItem } from '@common/cams/trustees';
+import { formatChapterType, formatAppointmentType } from '@common/cams/trustees';
+import { formatAppointmentStatus } from '@common/cams/trustee-appointments';
 import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 
+function formatDistrict(appointment: TrusteeListItem['appointments'][number]): string {
+  const name = appointment.courtName ?? appointment.courtId;
+  const division = appointment.courtDivisionName ?? appointment.divisionCode;
+  return division ? `${name} (${division})` : name;
+}
+
 export default function TrusteesList() {
-  const [trustees, setTrustees] = useState<Trustee[]>([]);
+  const [trustees, setTrustees] = useState<TrusteeListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -15,7 +23,7 @@ export default function TrusteesList() {
       setLoading(true);
       Api2.getTrustees()
         .then((trusteesResponse) => {
-          setTrustees(trusteesResponse.data || []);
+          setTrustees(trusteesResponse.data ?? []);
           setError(null);
         })
         .catch(() => {
@@ -59,26 +67,58 @@ export default function TrusteesList() {
 
   return (
     <div className="trustees-list">
+      <p>{trustees.length} Trustee(s)</p>
       <table className="usa-table usa-table--borderless" data-testid="trustees-table">
         <thead>
           <tr>
             <th scope="col">Name</th>
+            <th scope="col">District (Division)</th>
+            <th scope="col">Chapter</th>
+            <th scope="col">Type</th>
+            <th scope="col">Status</th>
           </tr>
         </thead>
         <tbody>
-          {trustees.map((trustee) => (
-            <tr key={trustee.trusteeId}>
-              <td className="trustee-name">
-                <NavLink
-                  to={`/trustees/${trustee.trusteeId}`}
-                  data-testid={`trustee-link-${trustee.trusteeId}`}
-                  className="usa-link"
-                >
-                  {trustee.name}
-                </NavLink>
-              </td>
-            </tr>
-          ))}
+          {trustees.map((trustee) => {
+            const rowCount = Math.max(1, trustee.appointments.length);
+            return trustee.appointments.length === 0 ? (
+              <tr key={trustee.trusteeId}>
+                <td className="trustee-name" rowSpan={1}>
+                  <NavLink
+                    to={`/trustees/${trustee.trusteeId}`}
+                    data-testid={`trustee-link-${trustee.trusteeId}`}
+                    className="usa-link"
+                  >
+                    {trustee.name}
+                  </NavLink>
+                </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+              </tr>
+            ) : (
+              trustee.appointments.map((appt, idx) => (
+                <tr key={`${trustee.trusteeId}-${idx}`}>
+                  {idx === 0 && (
+                    <td className="trustee-name" rowSpan={rowCount}>
+                      <NavLink
+                        to={`/trustees/${trustee.trusteeId}`}
+                        data-testid={`trustee-link-${trustee.trusteeId}`}
+                        className="usa-link"
+                      >
+                        {trustee.name}
+                      </NavLink>
+                    </td>
+                  )}
+                  <td>{formatDistrict(appt)}</td>
+                  <td>{formatChapterType(appt.chapter)}</td>
+                  <td>{formatAppointmentType(appt.appointmentType)}</td>
+                  <td>{formatAppointmentStatus(appt.status)}</td>
+                </tr>
+              ))
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
# Purpose

Trustee administrators need to see appointment details in the trustee list
view so they can quickly identify which districts, chapters, and statuses
are associated with each trustee without navigating to individual profiles.

# Major Changes

* Added `TrusteeListItem` type to common — extends `Trustee` with an
  `appointments: TrusteeAppointment[]` array
* Added `getAppointmentsByTrusteeIds` bulk query to
  `TrusteeAppointmentsRepository` interface and MongoDB implementation,
  eliminating N+1 queries on the list endpoint
* Updated `TrusteesUseCase.listTrustees` to fetch all appointments in a
  single bulk query, group them by trustee, attach them to each trustee,
  and sort the list alphabetically by name (case-insensitive)
* Updated `TrusteesController`, `api2.getTrustees`, and `mock-api2` return
  types to `TrusteeListItem[]`
* Rewrote `TrusteesList` component from a single-column name list to a
  5-column table (Name, District (Division), Chapter, Type, Status) with
  per-appointment rows using `rowSpan` for trustees with multiple
  appointments, and a trustee count above the table

# Testing/Validation

Implemented using TDD. All new and updated tests pass:

* 3 new unit tests for `getAppointmentsByTrusteeIds` in the repository
  (28 total)
* 3 new + 1 updated tests for `listTrustees` in the use case (37 total)
* 12 unit tests for the `TrusteesList` component (replaced 7 existing,
  added 5 new covering multi-row, district formatting, format helpers,
  zero-appointments edge case, and trustee count)
* TypeScript compiles cleanly across all packages

# Notes

The `TrusteeListItem` import in `trustees.ts` uses `import type` to avoid
a circular reference (`trustee-appointments.ts` already imports from
`trustees.ts` for enum types).

`contains(trusteeIds)` maps to `$in` in the MongoDB query renderer, which
is the correct operator for a bulk "field in array" query.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Extend trustee listing to include appointment details and update CI security scanning to use OIDC-based least-privilege access.

New Features:
- Expose a TrusteeListItem view model that augments trustees with their appointments and use it across backend, API, and UI for the trustees list.

Enhancements:
- Update the trustees list UI to a tabular, multi-column layout showing per-appointment district, chapter, type, status, and total trustee count.
- Optimize trustee listing use case and Mongo repository with a bulk appointment lookup to avoid N+1 queries and return trustees sorted by name.
- Clarify and expand GitHub Actions workflow documentation and diagrams to reflect the new reusable security scan workflow, its inputs, and secrets dependencies.
- Document the GitHub Actions OIDC least-privilege design and add a helper script to provision the security scan federated credential and scoped role assignments.

CI:
- Refine the reusable security scan workflow to accept explicit OIDC-related secrets, use federated Azure login, and upload SARIF via workload identity.
- Wire the continuous deployment workflow to pass required security scan secrets explicitly to the reusable workflow.

Documentation:
- Update workflow diagrams and counts to reflect the security scan workflow’s reusable status and new secret dependencies, removing outdated workflow_call documentation.

Tests:
- Expand unit tests for trustee listing, appointments repository, and use case logic to cover appointment aggregation, sorting, UI formatting, and edge cases around empty or undefined data.