### PR TITLE
Add custom GitHub Pages workflow with OIDC environment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -10,13 +10,11 @@ on:
   workflow_dispatch:
 
 # Allow only one concurrent deployment, skip runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -34,7 +32,6 @@ jobs:
         with:
           path: ./docs
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,13 +6,8 @@ on:
       - main
     paths:
       - 'docs/**'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skip runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -24,17 +19,18 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
+    permissions:
+      contents: read
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./docs
 
@@ -45,7 +41,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,51 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skip runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fix OIDC authentication error in Pages deployment by creating a custom workflow that explicitly specifies environment: github-pages. This satisfies the repository's OIDC token customization requirement for include_claim_keys: ["repo", "workflow", "environment"].

The auto-generated pages-build-deployment workflow does not set an environment, causing token generation to fail. This custom workflow replaces it while maintaining security hardening. Also switched Pages build_type from legacy to workflow via GitHub API.

Jira ticket: CAMS-730

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

CI:
- Introduce a dedicated Deploy GitHub Pages workflow triggered on main branch docs changes or manual dispatch, with appropriate permissions, concurrency, and OIDC-enabled environment configuration.