### PR TITLE
Fix USWDS icon sprite and SCSS font units in dev

### DIFF
--- a/test/uswds/src/App.css
+++ b/test/uswds/src/App.css
@@ -1,3 +1,9 @@
+* {
+  font-family:
+    'Source Sans Pro', 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica', 'Roboto', 'Arial',
+    sans-serif;
+}
+
 .uswds-showcase {
   min-height: 100vh;
   background-color: #f0f0f0;
@@ -61,5 +67,4 @@
 
 body {
   margin: 0;
-  font-family: 'Source Sans Pro', 'Helvetica Neue', 'Helvetica', 'Roboto', 'Arial', sans-serif;
 }

--- a/user-interface/src/data-verification/DataVerificationScreen.scss
+++ b/user-interface/src/data-verification/DataVerificationScreen.scss
@@ -69,7 +69,6 @@
     h3 {
       margin: 0;
       font-size: 1rem;
-      font-family: "Source Sans Pro", sans-serif;
     }
   }
 }

--- a/user-interface/src/lib/components/uswds/Card.scss
+++ b/user-interface/src/lib/components/uswds/Card.scss
@@ -18,8 +18,6 @@
     h4 {
       margin-top: 0;
       margin-bottom: 1rem;
-      font-family: "Source Sans Pro", sans-serif;
-      font-size: 1rem;
       font-weight: 600;
     }
 
@@ -50,7 +48,8 @@
             margin-bottom: 0;
           }
 
-          dt, dd {
+          dt,
+          dd {
             margin: 0;
           }
         }

--- a/user-interface/src/styles/theme.scss
+++ b/user-interface/src/styles/theme.scss
@@ -1,5 +1,11 @@
 $cams-theme-background: white;
 
+* {
+  font-family:
+    'Source Sans Pro', 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica', 'Roboto', 'Arial',
+    sans-serif;
+}
+
 a {
   color: #005ea2;
 
@@ -12,21 +18,6 @@ a {
    Icon Buttons that are used often in H1 and H3 tags. Icon Button classes for those are
    defined below.
 */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family:
-    Source Sans Pro Web,
-    Helvetica Neue,
-    Helvetica,
-    Roboto,
-    Arial,
-    sans-serif;
-}
-
 h1 {
   font-size: 2.5rem;
   margin: 1rem 0;

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -1,7 +1,6 @@
 .trustees-list {
   .trustees-list-count {
     font-size: 1rem;
-    font-family: 'Source Sans Pro', sans-serif;
     font-weight: bold;
     line-height: 1.5rem;
     margin-bottom: 1.25rem;
@@ -24,7 +23,6 @@
   }
 
   .trustees-list-row {
-    font-family: 'Source Sans Pro', sans-serif;
     font-size: 1rem;
     line-height: 1.625rem;
     display: block;
@@ -59,7 +57,6 @@
       display: flex;
       flex-direction: row;
       gap: 1rem;
-      font-family: 'Source Sans Pro', sans-serif;
       font-weight: bold;
       font-size: 1rem;
       line-height: 1.5rem;

--- a/user-interface/src/trustees/panels/InfoCard.scss
+++ b/user-interface/src/trustees/panels/InfoCard.scss
@@ -32,7 +32,6 @@
         }
 
         .info-card-label {
-          font-family: "Source Sans Pro", sans-serif;
           font-weight: 600;
         }
       }

--- a/user-interface/vite.config.mts
+++ b/user-interface/vite.config.mts
@@ -8,6 +8,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import path from 'path';
 import svgr from 'vite-plugin-svgr';
 import { fileURLToPath } from 'node:url';
+import { createReadStream, existsSync } from 'node:fs';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -44,6 +45,23 @@ export default defineConfig({
     // svgr options: https://react-svgr.com/docs/options/
     svgr({ svgrOptions: { icon: true } }),
     viteTsconfigPaths(),
+    {
+      name: 'serve-uswds-img',
+      configureServer(server) {
+        const uswdsImgDir = fileURLToPath(
+          new URL('../node_modules/@uswds/uswds/dist/img/', import.meta.url),
+        );
+        server.middlewares.use('/assets/styles/img', (req, res, next) => {
+          const filePath = path.join(uswdsImgDir, req.url ?? '');
+          if (existsSync(filePath)) {
+            if (filePath.endsWith('.svg')) res.setHeader('Content-Type', 'image/svg+xml');
+            createReadStream(filePath).pipe(res);
+          } else {
+            next();
+          }
+        });
+      },
+    },
   ],
   envPrefix: 'CAMS_',
   resolve: {

--- a/user-interface/vite.config.mts
+++ b/user-interface/vite.config.mts
@@ -51,10 +51,21 @@ export default defineConfig({
         const uswdsImgDir = fileURLToPath(
           new URL('../node_modules/@uswds/uswds/dist/img/', import.meta.url),
         );
+        const mimeTypes: Record<string, string> = {
+          '.svg': 'image/svg+xml',
+          '.png': 'image/png',
+          '.jpg': 'image/jpeg',
+          '.jpeg': 'image/jpeg',
+          '.gif': 'image/gif',
+          '.webp': 'image/webp',
+        };
         server.middlewares.use('/assets/styles/img', (req, res, next) => {
-          const filePath = path.join(uswdsImgDir, req.url ?? '');
+          const sanitized = (req.url ?? '').replace(/^\/+/, '').replace(/\.\./g, '');
+          const filePath = path.resolve(uswdsImgDir, sanitized);
+          if (!filePath.startsWith(uswdsImgDir)) return next();
           if (existsSync(filePath)) {
-            if (filePath.endsWith('.svg')) res.setHeader('Content-Type', 'image/svg+xml');
+            const ext = path.extname(filePath).toLowerCase();
+            if (mimeTypes[ext]) res.setHeader('Content-Type', mimeTypes[ext]);
             createReadStream(filePath).pipe(res);
           } else {
             next();


### PR DESCRIPTION
# Purpose

Vite dev server did not serve uswds assets at
/assets/styles/img/, causing icons to fail to render. Added a configureServer middleware to stream files directly from node_modules during dev, matching the path that viteStaticCopy uses in production builds. Also includes SCSS unit and font-stack cleanup across several stylesheets.

# Testing/Validation

Manually tested locally.
Icons load
Fonts look correct.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Serve USWDS image assets correctly in the Vite dev server and consolidate font-family definitions to use a consistent global stack.

Bug Fixes:
- Ensure USWDS icon and image assets are served from node_modules at /assets/styles/img during local Vite development so icons render correctly.

Enhancements:
- Apply a global Source Sans Pro–based font stack via the universal selector and remove redundant per-component font-family declarations in SCSS and test styles.