### PR TITLE
CAMS-730: Add KV least-privilege to security scan setup script

### DIFF
--- a/ops/scripts/utility/setup-security-scan-federated-credential.sh
+++ b/ops/scripts/utility/setup-security-scan-federated-credential.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
-# Runbook: Create or update federated credential and scoped role for sub-security-scan.yml
+# Runbook: Create or update federated credential and scoped roles for sub-security-scan.yml
 #
 # Purpose: Eliminate the long-lived AZURE_CREDENTIALS secret from the security scan workflow
-#          by replacing it with OIDC Workload Identity Federation. The new credential grants
-#          Storage Blob Data Contributor only on the security scan storage account — no broader
-#          subscription or resource group access.
+#          by replacing it with OIDC Workload Identity Federation. The identity is granted:
+#            - Storage Blob Data Contributor on the security scan storage account
+#            - Key Vault Secrets User on each individual secret it reads from kv-ustp-cams
 #
 # The subject claim includes repo, workflow, and environment per the repo OIDC customization
 # template (include_claim_keys: ["repo", "workflow", "environment"]). The subject format is:
 #   repo:ORG/REPO:workflow:CALLER-WORKFLOW-NAME:environment:security-scan
 #
 # Prerequisites:
-#   - az CLI logged in as an Entra ID admin (can create app registrations)
+#   - az CLI logged in as an Entra ID admin (can create app registrations and role assignments)
 #   - The security scan storage account already exists
+#   - kv-ustp-cams already exists and contains the secrets listed in KV_SECRETS
 #
 # This script is idempotent — re-running it will update existing resources in place
 # rather than creating duplicates.
@@ -24,6 +25,11 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 STORAGE_ACCOUNT_NAME="${AZ_SECURITY_SCAN_STORAGE_NAME:?Set AZ_SECURITY_SCAN_STORAGE_NAME}"
 RESOURCE_GROUP="${AZ_SECURITY_SCAN_RG:?Set AZ_SECURITY_SCAN_RG}"
+KV_NAME="kv-ustp-cams"
+KV_RESOURCE_GROUP="${AZ_KV_RG:-$RESOURCE_GROUP}"
+# Secrets this workflow reads from the vault — must exist before running
+KV_SECRETS=("SNYK-OAUTH-CLIENT-ID" "SNYK-OAUTH-CLIENT-SECRET" "AZ-SECURITY-SCAN-STORAGE-NAME")
+KV_SECRETS_USER_ROLE="4633458b-17de-408a-b874-0445c86b69e6" # Key Vault Secrets User
 GITHUB_ORG="US-Trustee-Program"
 GITHUB_REPO="Bankruptcy-Oversight-Support-Systems"
 GITHUB_WORKFLOW="Continuous Deployment"
@@ -107,11 +113,34 @@ if [[ -z "$EXISTING_ROLE" ]]; then
     --assignee-object-id "$SP_ID" \
     --assignee-principal-type ServicePrincipal \
     --role "Storage Blob Data Contributor" \
-    --scope "$STORAGE_ID"
+    --scope "$STORAGE_ID" \
+    --output none
   echo "    Role assigned."
 else
   echo "    Role already assigned — skipping."
 fi
+
+echo "==> Checking Key Vault Secrets User role assignments (per-secret)..."
+for SECRET_NAME in "${KV_SECRETS[@]}"; do
+  SECRET_SCOPE="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${KV_RESOURCE_GROUP}/providers/Microsoft.KeyVault/vaults/${KV_NAME}/secrets/${SECRET_NAME}"
+  EXISTING_SECRET_ROLE=$(az role assignment list \
+    --assignee "$SP_ID" \
+    --role "$KV_SECRETS_USER_ROLE" \
+    --scope "$SECRET_SCOPE" \
+    --query "[0].id" -o tsv 2>/dev/null || true)
+
+  if [[ -z "$EXISTING_SECRET_ROLE" ]]; then
+    az role assignment create \
+      --assignee-object-id "$SP_ID" \
+      --assignee-principal-type ServicePrincipal \
+      --role "$KV_SECRETS_USER_ROLE" \
+      --scope "$SECRET_SCOPE" \
+      --output none
+    echo "    Key Vault Secrets User assigned on ${KV_NAME}/secrets/${SECRET_NAME}."
+  else
+    echo "    Key Vault Secrets User already assigned on ${KV_NAME}/secrets/${SECRET_NAME} — skipping."
+  fi
+done
 
 echo ""
 echo "==> Done."


### PR DESCRIPTION
# Purpose

The per-secret read access didn't make it into the last PR.

# Major Changes

Grant Key Vault Secrets User on each individual secret the workflow reads from kv-ustp-cams rather than relying on broader vault-level access. A fresh run of this script now leaves the identity with only the permissions it needs.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Tighten the security-scan federated credential setup so the workflow identity receives only the minimum Azure role assignments it needs.

New Features:
- Grant per-secret Key Vault Secrets User access for the security-scan federated identity on specific kv-ustp-cams secrets used by the workflow.

Enhancements:
- Document the newly required Key Vault, secrets, and admin capabilities in the security-scan setup script comments.
- Suppress unnecessary CLI output for role assignment operations to keep script runs cleaner.