### PR TITLE
Allow ts eslint versions to upgrade to unblock ts 6 upgrade

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,8 +78,7 @@
     {
       "description": "Group TypeScript ESLint packages",
       "matchPackageNames": ["typescript-eslint", "@typescript-eslint/eslint-plugin", "@typescript-eslint/parser"],
-      "groupName": "typescript-eslint",
-      "allowedVersions": "8.54.x"
+      "groupName": "typescript-eslint"
     },
     {
       "description": "Pin ESLint package until full support of V10",


### PR DESCRIPTION
# Purpose

Describe the reason why this was developed.
Allow ts eslint version upgrades to partially unblock TS v6 upgrade
# Major Changes

Describe what has changed.
- Allow ts eslint version to upgrade
- this should help partially unblock ts v6 upgrade
# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Build:
- Adjust Renovate configuration to allow newer TypeScript ESLint versions and enable automated upgrades aligned with the TS 6 migration path.