### PR TITLE
CAMS-731 Trustee verification text, style, and coverage fixes

### DIFF
--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchConfirmationModal.test.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchConfirmationModal.test.tsx
@@ -140,4 +140,51 @@ describe('TrusteeMatchConfirmationModal', () => {
       expect(screen.getByText('Bob Jones')).toBeInTheDocument();
     });
   });
+
+  test('shows phone number without extension when extension is absent', async () => {
+    const candidateNoExtension: CandidateScore = {
+      ...sampleCandidate,
+      phone: { number: '555-9999' },
+    };
+    renderWithProps();
+    act(() => modalRef.current?.show(candidateNoExtension));
+
+    await waitFor(() => {
+      const content = document.querySelector('.usa-modal__main');
+      expect(content?.textContent).toContain('555-9999');
+      expect(content?.textContent).not.toContain(' x');
+    });
+  });
+
+  test('does not call onConfirm when confirm is clicked before show() is called', async () => {
+    const { onConfirm } = renderWithProps();
+
+    const submitButton = screen.getByTestId(
+      `button-trustee-confirmation-modal-${modalId}-submit-button`,
+    );
+    fireEvent.click(submitButton);
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  test('hides modal when Cancel is clicked and no onCancel prop is provided', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <BrowserRouter>
+        <TrusteeMatchConfirmationModal ref={modalRef} id={modalId} onConfirm={onConfirm} />
+      </BrowserRouter>,
+    );
+    act(() => modalRef.current?.show(sampleCandidate));
+
+    const cancelButton = screen.getByTestId(
+      `button-trustee-confirmation-modal-${modalId}-cancel-button`,
+    );
+    await waitFor(() => expect(cancelButton).toBeEnabled());
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      const wrapper = document.getElementById(`trustee-confirmation-modal-${modalId}-wrapper`);
+      expect(wrapper).toHaveClass('is-hidden');
+    });
+  });
 });

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchRejectionModal.test.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchRejectionModal.test.tsx
@@ -96,6 +96,23 @@ describe('TrusteeMatchRejectionModal', () => {
     });
   });
 
+  test('hides modal when Cancel is clicked and no onCancel prop is provided', async () => {
+    const modalRef2 = React.createRef<TrusteeMatchRejectionModalImperative>();
+    render(<TrusteeMatchRejectionModal ref={modalRef2} id={modalId} onConfirm={vi.fn()} />);
+    act(() => modalRef2.current?.show());
+
+    const cancelButton = screen.getByTestId(
+      `button-trustee-rejection-modal-${modalId}-cancel-button`,
+    );
+    await waitFor(() => expect(cancelButton).toBeEnabled());
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      const wrapper = document.getElementById(`trustee-rejection-modal-${modalId}-wrapper`);
+      expect(wrapper).toHaveClass('is-hidden');
+    });
+  });
+
   test('clears the reason textarea when show() is called', async () => {
     renderWithProps();
     act(() => modalRef.current?.show());

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.scss
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.scss
@@ -5,9 +5,14 @@
 }
 
 .trustee-match-content {
-  p.problem-statement {
+  p.problem-statement,
+  p.resolved-statement {
     margin: 1.5rem 0;
     font-size: 1rem;
+    line-height: 1.25;
+    .new-tab-link {
+      vertical-align: top;
+    }
   }
 
   p.other-matches-subtext {
@@ -101,13 +106,11 @@
   }
 
   .search-link-container {
+    padding-top: 0.5rem;
     .link-message {
       vertical-align: text-bottom;
       line-height: 1.59rem;
-      padding-right: 0.5rem;
-    }
-    .search-trustee-link {
-      margin-top: 0.5rem;
+      padding-right: 0.25rem;
     }
   }
 

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.test.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.test.tsx
@@ -686,6 +686,53 @@ describe('TrusteeMatchVerificationAccordion', () => {
     });
   });
 
+  describe('reject flow via rejection modal', () => {
+    function submitRejectionModal(orderId: string, reason: string) {
+      const textarea = screen.getByTestId(`rejection-reason-input-${orderId}`);
+      fireEvent.change(textarea, { target: { value: reason } });
+      const submitButton = document.getElementById(
+        `trustee-rejection-modal-${orderId}-submit-button`,
+      );
+      fireEvent.click(submitButton!);
+    }
+
+    test('calls rejection API and onOrderUpdate with warning on reject success', async () => {
+      vi.spyOn(Api2, 'patchTrusteeVerificationOrderRejection').mockResolvedValue(undefined);
+      const onOrderUpdate = vi.fn();
+      renderWithProps({ order: sampleOrderWithCandidates, onOrderUpdate });
+
+      submitRejectionModal(sampleOrderWithCandidates.id, 'Wrong person');
+
+      await waitFor(() => {
+        expect(Api2.patchTrusteeVerificationOrderRejection).toHaveBeenCalledWith(
+          sampleOrderWithCandidates.id,
+          'Wrong person',
+        );
+        expect(onOrderUpdate).toHaveBeenCalledWith(
+          { message: 'Trustee match rejected.', type: UswdsAlertStyle.Warning, timeOut: 8 },
+          expect.objectContaining({ status: 'rejected', reason: 'Wrong person' }),
+        );
+      });
+    });
+
+    test('calls onOrderUpdate with error alert on reject failure', async () => {
+      vi.spyOn(Api2, 'patchTrusteeVerificationOrderRejection').mockRejectedValue(
+        new Error('Network error'),
+      );
+      const onOrderUpdate = vi.fn();
+      renderWithProps({ order: sampleOrderWithCandidates, onOrderUpdate });
+
+      submitRejectionModal(sampleOrderWithCandidates.id, 'Wrong person');
+
+      await waitFor(() => {
+        expect(onOrderUpdate).toHaveBeenCalledWith(
+          { message: 'Failed to reject trustee match.', type: UswdsAlertStyle.Error, timeOut: 8 },
+          sampleOrderWithCandidates,
+        );
+      });
+    });
+  });
+
   describe('Other Potential Matches pagination', () => {
     function makeMultipleMatchOrder(totalCandidates: number): TrusteeMatchVerification {
       return {
@@ -760,6 +807,54 @@ describe('TrusteeMatchVerificationAccordion', () => {
       const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
       expect(content.textContent).toContain('Candidate 12'); // last candidate on page 3
       expect(content.textContent).not.toContain('Candidate 2');
+    });
+
+    test('shows ellipsis before last pages when current page is near the end', () => {
+      // N=37: 1 strongest + 36 others, totalPages=8; page 5 triggers the right-tail branch
+      renderWithProps({ order: makeMultipleMatchOrder(37) });
+
+      // Navigate to page 5 (near the end, triggers last-pages branch)
+      fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
+      fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
+      fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
+      fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
+
+      // Page 5 of 8 is in the right-tail branch: pages = [1, '...', 4, 5, 6, 7, 8]
+      expect(screen.getByTestId('pagination-button-other-matches-page-8')).toBeInTheDocument();
+      expect(screen.getByTestId('pagination-button-other-matches-page-1')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('pagination-button-other-matches-page-2'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('pagination-button-other-matches-page-3'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('shows ellipsis on both sides when current page is in the middle', () => {
+      // N=51: 1 strongest + 50 others, totalPages=10; pages 5-6 trigger the middle-window branch
+      renderWithProps({ order: makeMultipleMatchOrder(51) });
+
+      // Navigate to page 5
+      fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
+      fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
+      fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
+      fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
+
+      // Middle-window branch: pages = [1, '...', 4, 5, 6, '...', 10]
+      expect(screen.getByTestId('pagination-button-other-matches-page-1')).toBeInTheDocument();
+      expect(screen.getByTestId('pagination-button-other-matches-page-4')).toBeInTheDocument();
+      expect(screen.getByTestId('pagination-button-other-matches-page-5')).toBeInTheDocument();
+      expect(screen.getByTestId('pagination-button-other-matches-page-6')).toBeInTheDocument();
+      expect(screen.getByTestId('pagination-button-other-matches-page-10')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('pagination-button-other-matches-page-2'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('pagination-button-other-matches-page-3'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('pagination-button-other-matches-page-7'),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -1005,16 +1100,6 @@ describe('TrusteeMatchVerificationAccordion', () => {
       const heading = screen.getByTestId(`accordion-heading-${sampleOrder.id}`);
       expect(heading.textContent).toContain('Multiple Match');
       expect(heading.textContent).not.toContain('Trustee Mismatch');
-    });
-
-    test('shows multiple-match problem statement', () => {
-      renderWithProps({ order: multipleCandidatesOrder });
-
-      const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
-      expect(content.textContent).toContain('Multiple potential trustee matches found for case');
-      expect(content.textContent).toContain(
-        'review the candidates below and select the correct trustee',
-      );
     });
 
     test('shows both "CAMS Strongest Match" and "Other Potential Matches" headings', () => {

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -442,22 +442,20 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
         >
           {viewMode === 'resolved' ? (
             <p className="resolved-statement" data-testid="resolved-statement">
-              Trustee {getResolvedTrusteeDisplayName()} was appointed to case: {caseLink}
+              <span>Trustee {getResolvedTrusteeDisplayName()} was appointed to case: </span>
+              {caseLink}
             </p>
           ) : (
             <>
-              {isMultipleMatch ? (
+              {isInactiveStatus ? (
                 <p className="problem-statement">
-                  Multiple potential trustee matches found for case: {caseLink}. Please review the
-                  candidates below and select the correct trustee.
-                </p>
-              ) : isInactiveStatus ? (
-                <p className="problem-statement">
-                  Trustee is inactive in CAMS but was appointed to case: {caseLink}
+                  <span>Trustee is inactive in CAMS but was appointed to case: </span>
+                  {caseLink}
                 </p>
               ) : (
                 <p className="problem-statement">
-                  Trustee sent from the court does not match a CAMS Trustee for case: {caseLink}
+                  <span>Trustee sent from the court does not match a CAMS Trustee for case: </span>
+                  {caseLink}
                 </p>
               )}
 

--- a/user-interface/src/data-verification/trustee-verification/TrusteeSearchModal.test.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeSearchModal.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import TrusteeSearchModal, { TrusteeSearchModalImperative } from './TrusteeSearchModal';
 import Api2 from '@/lib/models/api2';
 import { TrusteeSearchResult } from '@common/cams/trustee-search';
 import { COURT_DIVISIONS } from '@common/cams/test-utilities/courts.mock';
+import MockData from '@common/cams/test-utilities/mock-data';
 import TestingUtilities from '@/lib/testing/testing-utilities';
 import * as UseDebounceModule from '@/lib/hooks/UseDebounce';
 
@@ -353,6 +354,102 @@ describe('TrusteeSearchModal', () => {
 
     await waitFor(() => {
       expect(wrapper).toHaveClass('is-hidden');
+    });
+  });
+
+  test('clears court filter and resets search results when district selection is cleared', async () => {
+    const searchSpy = vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({ data: [] });
+
+    render(
+      <BrowserRouter>
+        <TrusteeSearchModal
+          ref={modalRef}
+          id={modalId}
+          dxtrTrusteeName="DOE, JOHN"
+          courtId="0208"
+          onConfirm={vi.fn()}
+        />
+      </BrowserRouter>,
+    );
+    act(() => modalRef.current?.show());
+
+    // Clear the pre-selected district by clicking clear-all
+    await waitFor(() => {
+      expect(document.querySelector(`#${districtComboBoxId}-clear-all`)).toBeInTheDocument();
+    });
+    fireEvent.click(document.querySelector(`#${districtComboBoxId}-clear-all`)!);
+
+    // Search without a district — courtId passed to API should be undefined
+    await expandComboBoxAndType('sm');
+
+    await waitFor(() => {
+      expect(searchSpy).toHaveBeenCalledWith('sm', undefined);
+    });
+  });
+
+  test('shows appointment court name from courts list when available', async () => {
+    const resultWithAppointment: TrusteeSearchResult = {
+      trusteeId: 'trustee-appt',
+      name: 'Appt Trustee',
+      appointments: [
+        {
+          ...MockData.getTrusteeAppointment({
+            courtDivisionName: 'Manhattan',
+            chapter: '7',
+          }),
+          courtId: '0208',
+          courtName: undefined,
+        },
+      ],
+      matchType: 'exact',
+    };
+    vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({ data: [resultWithAppointment] });
+
+    renderWithProps();
+    act(() => modalRef.current?.show());
+
+    await expandComboBoxAndType('appt');
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`${comboBoxId}-option-item-0`)).toBeVisible();
+    });
+    await userEvent.click(screen.getByTestId(`${comboBoxId}-option-item-0`));
+
+    await waitFor(() => {
+      // Court name from the COURT_DIVISIONS list (courtId 0208 = Southern District of New York)
+      const details = document.querySelector('.trustee-details');
+      expect(details?.textContent).toContain('Southern District of New York');
+    });
+  });
+
+  test('clears selected trustee and disables Confirm button when selection is removed', async () => {
+    vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({ data: sampleResults });
+
+    renderWithProps();
+    act(() => modalRef.current?.show());
+
+    await expandComboBoxAndType('smith');
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`${comboBoxId}-option-item-0`)).toBeVisible();
+    });
+    await userEvent.click(screen.getByTestId(`${comboBoxId}-option-item-0`));
+
+    await waitFor(() => {
+      expect(screen.getByText('123 Main St')).toBeInTheDocument();
+    });
+
+    // Deselect by clicking the remove pill / clear-all button on the trustee combobox
+    const clearButton = document.querySelector(`#${comboBoxId}-clear-all`);
+    expect(clearButton).toBeInTheDocument();
+    fireEvent.click(clearButton!);
+
+    await waitFor(() => {
+      const submitButton = screen.getByTestId(
+        `button-trustee-search-modal-${modalId}-submit-button`,
+      );
+      expect(submitButton).toBeDisabled();
+      expect(screen.queryByText('123 Main St')).not.toBeInTheDocument();
     });
   });
 

--- a/user-interface/vitest.config.mts
+++ b/user-interface/vitest.config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       exclude: [
+        '**/*.scss',
         '**/index.tsx',
         '**/.dependency-cruiser.js',
         'src/configuration/apiConfiguration.ts',


### PR DESCRIPTION
# Purpose

Polish the trustee match verification UI with corrected wording for multi-match scenarios and better visual alignment of buttons and links with adjacent text. Close coverage gaps left by the Vitest 4 upgrade.

# Major Changes

- Updated problem statement and description wording for multiple-match cases in `TrusteeMatchVerificationAccordion`
- Adjusted button/link alignment in `TrusteeMatchVerificationAccordion.scss` to better align with surrounding text
- Added tests for uncovered branches: modal `if (candidate)` guard, phone extension rendering, optional `onCancel`, pagination ellipsis (right-tail and middle-window branches), reject error path, search modal court deselection, appointment court name lookup, and trustee deselection
- Excluded `**/*.scss` from the coverage report (`vitest.config.mts`) — `coverageConfigDefaults.exclude` became empty in Vitest 4, which caused SCSS files to appear in coverage

# Testing/Validation

New unit tests added for all previously uncovered branches. All 101 tests in the trustee-verification directory pass.

# Notes

The SCSS coverage issue was a side effect of the Vitest 4 upgrade (`326a9a8`), which emptied `coverageConfigDefaults.exclude`. The fix adds an explicit `**/*.scss` entry at the top of the coverage exclude list.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Polish trustee match verification messaging and layout while tightening test coverage around trustee search, confirmation, and rejection flows.

Bug Fixes:
- Ensure trustee match rejection correctly surfaces error alerts when the API call fails.
- Prevent trustee match confirmation from firing when the modal confirm button is clicked before the modal is shown.
- Hide trustee confirmation and rejection modals correctly when Cancel is clicked even if no onCancel handler is provided.
- Reset trustee search filters and selected trustee state when district or trustee selections are cleared, disabling confirmation as appropriate.

Enhancements:
- Refine trustee match problem and resolved statements to better separate explanatory text from the linked case reference.
- Improve alignment and spacing of trustee verification links and buttons with surrounding text for clearer presentation.

Build:
- Exclude SCSS files from Vitest coverage reporting to restore expected coverage behavior after the Vitest 4 upgrade.

Tests:
- Add coverage for trustee match rejection modal success and failure flows, including alerts and order updates.
- Extend pagination tests to cover ellipsis behavior near the end pages and in the middle window for other potential matches.
- Add tests for trustee search behavior when clearing the court filter, resolving appointment court names, and deselecting trustees.
- Add tests for trustee match confirmation modal behavior with and without phone extensions and optional onCancel handling.
- Add tests ensuring trustee rejection modal hides correctly when Cancel is invoked without an onCancel prop.