### PR TITLE
CAMS-691 Mobile layout tweaks for TrusteesList

### DIFF
--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -75,6 +75,14 @@
     display: block;
   }
 
+  .trustees-list-row--continuation {
+    margin-top: 0.5rem;
+
+    .col-name {
+      display: none;
+    }
+  }
+
   .trustees-list-cell {
     padding: 0;
     word-wrap: break-word;
@@ -89,12 +97,26 @@
     position: relative;
 
     &::before {
-      content: attr(data-cell) ':';
+      content: attr(data-cell) ': ';
       position: absolute;
       left: 0;
       top: 0.25rem;
       font-weight: 700;
       white-space: nowrap;
+    }
+  }
+
+  // Small phones — inline label, full line wraps naturally
+  @media screen and (max-width: 479px) {
+    .trustees-list-cell[data-cell] {
+      padding: 0.25rem 0.375rem;
+      min-height: unset;
+
+      &::before {
+        position: static;
+        display: inline;
+        white-space: nowrap;
+      }
     }
   }
 
@@ -113,6 +135,14 @@
 
     .trustee-group {
       margin-top: 0;
+    }
+
+    .trustees-list-row--continuation {
+      margin-top: 0;
+
+      .col-name {
+        display: block;
+      }
     }
 
     .trustees-list-row {
@@ -135,11 +165,17 @@
     }
 
     .col-name,
-    .col-district-division,
     .col-chapter,
     .col-type,
     .col-status {
       flex: 1 1 0;
+      min-width: 0;
+      max-width: none;
+      white-space: normal;
+    }
+
+    .col-district-division {
+      flex: 2 1 0;
       min-width: 0;
       max-width: none;
       white-space: normal;

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -1,56 +1,11 @@
 .trustees-list {
-  .filter-pills-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-
-    .filter-pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-      background-color: #005EA2;
-      color: #ffffff;
-      padding: 0.25rem 0.75rem;
-      border-radius: 99rem;
-      font-size: 0.875rem;
-      font-weight: 700;
-      text-transform: none;
-
-      .usa-tag__remove-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0;
-        margin: 0 0 0 0.25rem;
-        background: transparent;
-        border: none;
-        cursor: pointer;
-        color: #ffffff;
-
-        &:hover {
-          color: #f0f0f0;
-        }
-
-        &:focus {
-          outline: 0.25rem solid #005ea2;
-          outline-offset: 0.25rem;
-          border-radius: 99rem;
-        }
-
-        .usa-icon {
-          width: 1rem;
-          height: 1rem;
-        }
-      }
-    }
-  }
-
+  margin-top: 20px;
   .trustees-list-count {
     font-size: 1rem;
     font-weight: bold;
     line-height: 1.5rem;
-    margin-bottom: 1.25rem;
+    margin-bottom: 0;
+    padding-left: 1rem;
   }
 
   .trustees-list-grid {
@@ -66,7 +21,7 @@
   .trustee-group {
     border-bottom: 1px solid #1b1b1b;
     padding: 0.625rem 1rem;
-    margin-top: 1rem;
+    margin-bottom: 0.25rem;
   }
 
   .trustees-list-row {
@@ -122,6 +77,10 @@
 
   // Tablet — equal columns
   @media screen and (min-width: 641px) {
+    .trustees-list-count {
+      margin-bottom: 1.25rem;
+    }
+
     .trustees-list-header {
       display: flex;
       flex-direction: row;

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -172,11 +172,15 @@ export default function TrusteesList() {
             return (
               <div key={trustee.trusteeId} className="trustee-group">
                 {rows.map((appt, idx) => (
-                  <div key={`${trustee.trusteeId}-${idx}`} className="trustees-list-row" role="row">
+                  <div
+                    key={`${trustee.trusteeId}-${idx}`}
+                    className={`trustees-list-row${idx > 0 ? ' trustees-list-row--continuation' : ''}`}
+                    role="row"
+                  >
                     <div
                       className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[0])}`}
                       role="cell"
-                      data-cell={COLUMN_HEADERS[0]}
+                      {...(idx === 0 ? { 'data-cell': COLUMN_HEADERS[0] } : {})}
                     >
                       {idx === 0 ? (
                         <NavLink

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -8,7 +8,6 @@ import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import TrusteeDistrictFilter from './filters/TrusteeDistrictFilter';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
-import Icon from '@/lib/components/uswds/Icon';
 import { TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types';
 
 const COLUMN_HEADERS = ['Name', 'District (Division)', 'Chapter', 'Type', 'Status'];
@@ -35,7 +34,6 @@ export default function TrusteesList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
-  const [isFilterExpanded, setIsFilterExpanded] = useState(false);
   const filterRef = useRef<TrusteeDistrictFilterRef>(null);
 
   useEffect(() => {
@@ -58,14 +56,6 @@ export default function TrusteesList() {
 
   const handleFilterDistrict = (districts: ComboOption[]) => {
     setSelectedDistricts(districts);
-  };
-
-  const handleExpandedChange = (isExpanded: boolean) => {
-    setIsFilterExpanded(isExpanded);
-  };
-
-  const handleRemovePill = (district: ComboOption) => {
-    filterRef.current?.removePill(district);
   };
 
   const { filteredTrustees, announcement } = useMemo(() => {
@@ -119,32 +109,10 @@ export default function TrusteesList() {
 
   return (
     <div className="trustees-list">
-      <TrusteeDistrictFilter
-        ref={filterRef}
-        handleFilterDistrict={handleFilterDistrict}
-        onExpandedChange={handleExpandedChange}
-      />
+      <TrusteeDistrictFilter ref={filterRef} handleFilterDistrict={handleFilterDistrict} />
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">
         {announcement}
       </div>
-      {/* Pills shown when filter is expanded */}
-      {isFilterExpanded && selectedDistricts.length > 0 && (
-        <div className="filter-pills-container">
-          {selectedDistricts.map((district) => (
-            <span key={district.value} className="usa-tag filter-pill">
-              {district.label}
-              <button
-                type="button"
-                className="usa-tag__remove-button"
-                onClick={() => handleRemovePill(district)}
-                aria-label={`Remove ${district.label} filter`}
-              >
-                <Icon name="close" />
-              </button>
-            </span>
-          ))}
-        </div>
-      )}
       <p className="trustees-list-count">{filteredTrustees.length} Trustee(s)</p>
       <div
         className="trustees-list-grid"

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
@@ -1,5 +1,4 @@
 .trustee-district-filter {
-  max-width: 1240px;
   margin-bottom: 1.5rem;
 
   .filter-header {
@@ -33,11 +32,6 @@
       color: #005ea2;
     }
 
-    &:focus {
-      outline: 0.25rem solid #005ea2;
-      outline-offset: 0.25rem;
-    }
-
     .usa-icon {
       width: 1.25rem;
       height: 1.25rem;
@@ -57,17 +51,26 @@
     }
   }
 
+  .usa-accordion__content:not([hidden]) + .filter-pills-container {
+    margin-top: 0.25rem;
+  }
+
+  .usa-accordion__content[hidden] + .filter-pills-container {
+    margin-top: 1.5rem;
+  }
+
   .filter-pills-container {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin-top: 1rem;
+    margin-bottom: 1rem;
+    padding-left: 1rem;
 
     .filter-pill {
       display: inline-flex;
       align-items: center;
       gap: 0.25rem;
-      background-color: #005EA2;
+      background-color: #005ea2;
       color: #ffffff;
       padding: 0.25rem 0.75rem;
       border-radius: 99rem;
@@ -90,18 +93,16 @@
           color: #f0f0f0;
         }
 
-        &:focus {
-          outline: 0.25rem solid #005ea2;
-          outline-offset: 0.25rem;
-          border-radius: 99rem;
-        }
-
         .usa-icon {
           width: 1rem;
           height: 1rem;
         }
       }
     }
+  }
+
+  .usa-accordion__content {
+    padding: 1rem 1.25rem;
   }
 
   @keyframes slideDown {

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -361,7 +361,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
     // Initially collapsed
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByLabelText('District (Division)')).not.toBeInTheDocument();
 
     // Expand
     await user.click(toggleButton);

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -71,7 +71,6 @@ describe('TrusteeDistrictFilter Component', () => {
     const toggleButton = screen.getByRole('button', { name: /filters/i });
     expect(toggleButton).toBeInTheDocument();
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByLabelText('District (Division)')).not.toBeInTheDocument();
 
     await user.click(toggleButton);
 
@@ -286,10 +285,13 @@ describe('TrusteeDistrictFilter Component', () => {
     });
 
     // Pills should be visible when collapsed (default state)
-    // Wait for districts to load
-
+    // Wait for districts to load and pill to appear
     await waitFor(() => {
-      expect(screen.getByText('Southern District of New York (Manhattan)')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {
+          name: /remove southern district of new york \(manhattan\) filter/i,
+        }),
+      ).toBeInTheDocument();
     });
 
     // Click remove button on pill

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -1,7 +1,7 @@
 import './TrusteeDistrictFilter.scss';
 import ComboBox from '@/lib/components/combobox/ComboBox';
-import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import Icon from '@/lib/components/uswds/Icon';
+import { Accordion } from '@/lib/components/uswds/Accordion';
 import { TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
 
 function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
@@ -9,44 +9,13 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
 
   return (
     <section className="trustee-district-filter" aria-label="District filter controls">
-      <div className="filter-header">
-        <Button
-          uswdsStyle={UswdsButtonStyle.Unstyled}
-          className="filter-toggle-button"
-          onClick={viewModel.handleToggleExpanded}
-          aria-expanded={viewModel.isExpanded}
-          aria-controls="district-filter-content"
-        >
-          <span className="filter-toggle-text">Filters</span>
-          <Icon name={viewModel.isExpanded ? 'remove' : 'add'} />
-        </Button>
-      </div>
-
-      {/* Selected district pills - visible when collapsed */}
-      {!viewModel.isExpanded && viewModel.selectedDistricts.length > 0 && (
-        <div className="filter-pills-container">
-          {viewModel.selectedDistricts.map((district) => (
-            <span key={district.value} className="usa-tag filter-pill">
-              {district.label}
-              <button
-                type="button"
-                className="usa-tag__remove-button"
-                onClick={() => viewModel.handleRemovePill(district)}
-                aria-label={`Remove ${district.label} filter`}
-              >
-                <Icon name="close" />
-              </button>
-            </span>
-          ))}
-        </div>
-      )}
-
-      {viewModel.isExpanded && (
+      <Accordion id="district-filter" onExpand={() => viewModel.handleToggleExpanded()}>
+        <span>Filters</span>
         <div id="district-filter-content" className="filter-content">
           {viewModel.districts.length > 0 && !viewModel.districtsError && (
             <div className="filter-control">
               <ComboBox
-                id="district-filter"
+                id="district-combobox"
                 label="District (Division)"
                 options={viewModel.districtsToComboOptions(viewModel.districts)}
                 selections={viewModel.selectedDistricts}
@@ -70,6 +39,24 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
               </div>
             </div>
           )}
+        </div>
+      </Accordion>
+
+      {viewModel.selectedDistricts.length > 0 && (
+        <div className="filter-pills-container">
+          {viewModel.selectedDistricts.map((district) => (
+            <span key={district.value} className="usa-tag filter-pill">
+              {district.label}
+              <button
+                type="button"
+                className="usa-tag__remove-button"
+                onClick={() => viewModel.handleRemovePill(district)}
+                aria-label={`Remove ${district.label} filter`}
+              >
+                <Icon name="close" />
+              </button>
+            </span>
+          ))}
         </div>
       )}
     </section>


### PR DESCRIPTION
# Purpose

Improve the TrusteesList and district filter experience on mobile and small-screen devices.

# Major Changes

* On mobile, continuation rows (a trustee with multiple districts) no longer repeat the trustee name — only the first row shows it, with 0.5rem spacing between subsequent district rows
* Below 480px, inline labels wrap naturally with their values instead of overlapping
* On tablet (641px–1024px), District (Division) column gets twice the flex width of other columns
* Replaced the custom expand/collapse toggle in `TrusteeDistrictFilterView` with the shared `Accordion` component
* Moved filter pill rendering from `TrusteesList` into `TrusteeDistrictFilterView` where it belongs, with co-located styles in `TrusteeDistrictFilter.scss`
* Pills now always show when selections exist; margin adjusts via CSS sibling selectors based on accordion open/closed state

# Testing/Validation

Manually tested across Chrome DevTools device emulations (iPhone 12, SE, and tablet breakpoints). Verified pill visibility, accordion toggle behavior, and label wrapping at all breakpoints.

# Notes

The `Accordion` component uses the `hidden` attribute on `.usa-accordion__content` to toggle visibility. CSS sibling selectors (`:not([hidden]) +` and `[hidden] +`) drive the pill `margin-top` without any additional JS state.

The `data-cell` attribute is conditionally omitted from continuation name cells so the `::before` label pseudo-element never renders for those rows, rather than fighting CSS specificity to hide it.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Refine the TrusteesList mobile and tablet UX and align the district filter with shared accordion and pill patterns.

New Features:
- Use the shared Accordion component to toggle the trustee district filter panel.
- Always display selected district filter pills beneath the accordion when selections exist.

Bug Fixes:
- Prevent mobile inline labels from overlapping their values by changing how data-cell labels render and by omitting them on continuation name cells.

Enhancements:
- Adjust TrusteesList spacing and count alignment to better integrate with the relocated filter pills.
- Hide duplicate trustee names on continuation rows for multi-district trustees on small screens while preserving them on tablet and larger breakpoints.
- Improve small-screen label/value layout by making data-cell labels inline and naturally wrapping below 480px.
- Give the District (Division) column increased flex width on tablet to prioritize that information.
- Co-locate district filter pill styles within TrusteeDistrictFilter styles and tweak accordion content padding and pill spacing for consistency.