### PR TITLE
CAMS-731 remove parens from the screen reader aria label

### DIFF
--- a/user-interface/src/lib/components/cams/NewTabLink/NewTabLink.test.tsx
+++ b/user-interface/src/lib/components/cams/NewTabLink/NewTabLink.test.tsx
@@ -38,7 +38,7 @@ describe('NewTabLink component', () => {
     renderComponent('/some/path', 'My Link');
 
     const link = screen.getByRole('link', { name: /my link/i });
-    expect(link).toHaveAttribute('aria-label', 'My Link (opens in a new tab)');
+    expect(link).toHaveAttribute('aria-label', 'My Link opens in a new tab');
   });
 
   test('should always include the new-tab-link class', () => {

--- a/user-interface/src/lib/components/cams/NewTabLink/NewTabLink.tsx
+++ b/user-interface/src/lib/components/cams/NewTabLink/NewTabLink.tsx
@@ -16,7 +16,7 @@ export function NewTabLink({ to, label, className }: Readonly<NewTabLinkProps>) 
       className={classes}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={`${label} (opens in a new tab)`}
+      aria-label={`${label} opens in a new tab`}
     >
       <Icon name="launch" />
       {label}


### PR DESCRIPTION
# Purpose

Remove parens from aria label to make sure screen reader doesn't read it.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhancements:
- Adjust the accessible label for links opening in a new tab so screen readers read a more natural phrase without parentheses.