### PR TITLE
Harden nginx security headers and request filtering

### DIFF
--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -34,8 +34,15 @@ server {
         log_not_found off;
     }
 
+    # Never cache HTML — index.html is the SPA entry point and must always be fresh
+    location ~* \.html$ {
+        access_log off;
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+
     # Allowlisted static file types served by the SPA
-    location ~* \.(html|js|css|json|svg|png|jpg|webp|gif|ico|txt|woff|woff2|ttf)$ {
+    location ~* \.(js|css|json|svg|png|jpg|webp|gif|ico|txt|woff|woff2|ttf)$ {
         access_log off;
         expires 1h;
     }

--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -38,7 +38,6 @@ server {
     location ~* \.html$ {
         access_log off;
         expires -1;
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
     }
 
     # Allowlisted static file types served by the SPA

--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -9,12 +9,6 @@ server {
     port_in_redirect off;
     server_tokens off;
 
-    location / {
-        index index.html;
-        try_files ${NGINX_URI_VAR_VALUE} ${NGINX_URI_VAR_VALUE}/ /index.html =404;
-        expires -1;
-    }
-
     # Security headers
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -29,6 +23,12 @@ server {
     #   CSP_API_SERVER_HOST               - refers to the backend api host uri
     #   CSP_USTP_ISSUE_COLLECTOR_HASH     - USTP issue collector hash
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com atl.cld.prd.ust.doj.gov; connect-src 'self' ${CSP_API_SERVER_HOST} ${OKTA_URL} clientsdk.launchdarkly.us clientstream.launchdarkly.us events.launchdarkly.us js.monitor.azure.com usgovvirginia-1.in.applicationinsights.azure.us; img-src 'self' data: ; style-src 'self' '${CSP_USTP_ISSUE_COLLECTOR_HASH}' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; base-uri 'self'; form-action 'self'; frame-src 'self' ${OKTA_URL} atl.cld.prd.ust.doj.gov; frame-ancestors 'none'" always;
+
+    location / {
+        index index.html;
+        try_files ${NGINX_URI_VAR_VALUE} ${NGINX_URI_VAR_VALUE}/ /index.html =404;
+        expires -1;
+    }
 
     # Disable access to all dot files and directories
     location ~ /\. {

--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -38,11 +38,10 @@ server {
 
     # Never cache HTML — index.html is the SPA entry point and must always be fresh
     location ~* \.html$ {
-        access_log off;
         expires -1;
     }
 
-    # Allowlisted static file types served by the SPA
+    # Allow listed static file types served by the SPA
     location ~* \.(js|css|json|svg|png|jpg|webp|gif|ico|txt|woff|woff2|ttf)$ {
         access_log off;
         expires 1h;

--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -15,27 +15,33 @@ server {
         try_files ${NGINX_URI_VAR_VALUE} ${NGINX_URI_VAR_VALUE}/ /index.html =404;
     }
 
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /html/;
-    }
-
-    # Disable .git directory
-    location ~ /\.git {
-        deny all;
-        access_log off;
-        log_not_found off;
-    }
-
     # Security headers
-    add_header X-Frame-Options "DENY";
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
 
     # Set Content-Security-Policy
     # NOTE on variables:
     #   OKTA_URL                          - Url for the okta host
     #   CSP_API_SERVER_HOST               - refers to the backend api host uri
     #   CSP_USTP_ISSUE_COLLECTOR_HASH     - USTP issue collector hash
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com atl.cld.prd.ust.doj.gov; connect-src 'self' ${CSP_API_SERVER_HOST} ${OKTA_URL} clientsdk.launchdarkly.us clientstream.launchdarkly.us events.launchdarkly.us js.monitor.azure.com usgovvirginia-1.in.applicationinsights.azure.us; img-src 'self' data: ; style-src 'self' '${CSP_USTP_ISSUE_COLLECTOR_HASH}' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; base-uri 'self'; form-action 'self'; frame-src 'self' ${OKTA_URL} atl.cld.prd.ust.doj.gov";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com atl.cld.prd.ust.doj.gov; connect-src 'self' ${CSP_API_SERVER_HOST} ${OKTA_URL} clientsdk.launchdarkly.us clientstream.launchdarkly.us events.launchdarkly.us js.monitor.azure.com usgovvirginia-1.in.applicationinsights.azure.us; img-src 'self' data: ; style-src 'self' '${CSP_USTP_ISSUE_COLLECTOR_HASH}' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; base-uri 'self'; form-action 'self'; frame-src 'self' ${OKTA_URL} atl.cld.prd.ust.doj.gov" always;
+
+    # Disable access to all dot files and directories
+    location ~ /\. {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
+    # Allowlisted static file types served by the SPA
+    location ~* \.(html|js|css|json|svg|png|jpg|webp|gif|ico|txt|woff|woff2|ttf)$ {
+        access_log off;
+        expires 1h;
+    }
+
+    # Block all other file extension requests (e.g. .php, .exe, .bak, .conf)
+    location ~* \.[a-z0-9][a-z0-9]+$ {
+        return 404;
+    }
 }

--- a/user-interface/public/nginx.conf
+++ b/user-interface/public/nginx.conf
@@ -6,31 +6,33 @@ server {
 
     root /home/site/wwwroot;
 
-    index index.html index.htm;
-    server_name  example.com www.example.com;
     port_in_redirect off;
+    server_tokens off;
 
     location / {
-        index index.html index.htm;
+        index index.html;
         try_files ${NGINX_URI_VAR_VALUE} ${NGINX_URI_VAR_VALUE}/ /index.html =404;
+        expires -1;
     }
 
     # Security headers
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer" always;
+    add_header Referrer-Policy "same-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # intentionally disables the use of APIs, limiting the blast radius if an XSS somehow executes.
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Set Content-Security-Policy
     # NOTE on variables:
     #   OKTA_URL                          - Url for the okta host
     #   CSP_API_SERVER_HOST               - refers to the backend api host uri
     #   CSP_USTP_ISSUE_COLLECTOR_HASH     - USTP issue collector hash
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com atl.cld.prd.ust.doj.gov; connect-src 'self' ${CSP_API_SERVER_HOST} ${OKTA_URL} clientsdk.launchdarkly.us clientstream.launchdarkly.us events.launchdarkly.us js.monitor.azure.com usgovvirginia-1.in.applicationinsights.azure.us; img-src 'self' data: ; style-src 'self' '${CSP_USTP_ISSUE_COLLECTOR_HASH}' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; base-uri 'self'; form-action 'self'; frame-src 'self' ${OKTA_URL} atl.cld.prd.ust.doj.gov" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com atl.cld.prd.ust.doj.gov; connect-src 'self' ${CSP_API_SERVER_HOST} ${OKTA_URL} clientsdk.launchdarkly.us clientstream.launchdarkly.us events.launchdarkly.us js.monitor.azure.com usgovvirginia-1.in.applicationinsights.azure.us; img-src 'self' data: ; style-src 'self' '${CSP_USTP_ISSUE_COLLECTOR_HASH}' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; base-uri 'self'; form-action 'self'; frame-src 'self' ${OKTA_URL} atl.cld.prd.ust.doj.gov; frame-ancestors 'none'" always;
 
     # Disable access to all dot files and directories
     location ~ /\. {
         deny all;
-        access_log off;
         log_not_found off;
     }
 


### PR DESCRIPTION
# Purpose

Reduce the attack surface of the frontend nginx server by adding missing security response headers and blocking requests for file types that should never be served by an SPA.

# Major Changes

* Added `X-Content-Type-Options: nosniff` and `Referrer-Policy: no-referrer` headers
* Added `always` flag to all security headers so they apply on error responses, not just 200s
* Expanded dot-file blocking from `.git` only to all dot files and directories
* Added static file type allowlist (`html`, `js`, `css`, `json`, `svg`, `png`, `jpg`, `webp`, `gif`, `ico`, `txt`, `woff`, `woff2`, `ttf`)
* Added catch-all block returning 404 for any other file extension requests (e.g. `.php`, `.exe`, `.bak`, `.conf`)
* Removed dead 50x error page block referencing non-existent `/html/` path

# Testing/Validation

Changes can be validated by deploying the branch and verifying:
- Security headers are present on both 200 and error responses
- Requests to `.php`, `.conf`, and other non-allowlisted extensions return 404
- SPA routing and static assets continue to load normally

# Notes

The `.conf` extension is intentionally excluded from the allowlist — `nginx.conf` is deployed into `wwwroot` and would be accessible at `/nginx.conf` without this block. Excluding it prevents reconnaissance of the server configuration.

The `$block_scan` directive present in local development configs was intentionally omitted — it requires an nginx `map {}` block that is incompatible with the `envsubst`-based startup used in Azure.

## X-Frame-Options

The X-Frame-Options header is a security feature that helps prevent clickjacking attacks, which occur when an attacker embeds a website within an iframe on a malicious website, tricking the user into clicking on something they didn't intend to. This can lead to phishing, account compromise, or other malicious activities.

In the context of a React application served by Nginx, the add_header X-Frame-Options "DENY" always directive is crucial for security. Here's why:

### Why it's necessary:

- Prevents clickjacking: By setting X-Frame-Options to DENY, you're telling the browser not to render your application within an iframe, even if it's embedded on a malicious website. This prevents an attacker from tricking users into clicking on something they shouldn't.
- Protects sensitive data: If your application handles sensitive data, such as user credentials, financial information, or personal identifiable information (PII), it's essential to prevent clickjacking to avoid exposing this data to unauthorized parties.
- Compliance with security standards: Many security standards, like OWASP (Open Web Application Security Project), recommend using X-Frame-Options to prevent clickjacking.

## X-Content-Type-Options

What is X-Content-Type-Options?

X-Content-Type-Options is a header that tells the browser not to sniff the MIME type of a response from the server. By default, browsers use a technique called "Content Sniffing" to determine the MIME type of a response, even if the server doesn't specify one. This can lead to security issues, as it can allow an attacker to exploit vulnerabilities in the browser or the application.

### What does nosniff do?

By setting X-Content-Type-Options to nosniff, you're telling the browser to:

- Not sniff the MIME type: The browser will not attempt to determine the MIME type of the response based on the content.
- Use the server-provided MIME type: The browser will use the MIME type specified in the Content-Type header, if present.

### Why is it important?

- Prevents MIME type confusion: By not sniffing the MIME type, the browser can't mistakenly identify a response as a different type, which can lead to security vulnerabilities.
- Prevents XSS attacks: Some XSS attacks rely on the browser's content sniffing to execute malicious code. By disabling content sniffing, you reduce the attack surface.
- Ensures proper caching: When the browser knows the correct MIME type, it can cache the response correctly, improving performance.

## Referrer-Policy

### What is Referrer-Policy?

Referrer-Policy is a header that controls the sharing of referrer information between websites. When a user navigates from one website to another, the browser typically sends the referrer information (e.g., the URL of the previous page) in the Referer header. However, this can be a security risk if not properly managed.

### What does no-referrer do?

By setting Referrer-Policy to no-referrer, you're telling the browser to:

- Not send referrer information: The browser will not send any referrer information to the new website, even if the user navigates from your website.
- Block referrer information: The browser will not send any referrer information, including the URL of the previous page, the protocol (HTTP or HTTPS), or any other relevant details.

### Why is it important?

- Prevents tracking: By not sharing referrer information, you're preventing websites from tracking user behavior, which can be a concern for user privacy.
- Reduces data leakage: Referrer information can contain sensitive data, such as the URL of a login page or a sensitive resource. By blocking referrer information, you reduce the risk of data leakage.
- Compliance with regulations: Some regulations, like the General Data Protection Regulation (GDPR), require websites to protect user data, including referrer information.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Harden frontend nginx configuration by strengthening security headers and tightening which files can be served by the SPA.

New Features:
- Add X-Content-Type-Options and Referrer-Policy security headers to all responses.
- Introduce an allowlist of static asset file types that the SPA is permitted to serve and cache.

Enhancements:
- Ensure all security-related response headers are applied on error responses as well as successful ones.
- Block access to all dot-prefixed files and directories, including configuration artifacts, and return 404 for any disallowed file extensions.
- Remove obsolete custom 50x error page configuration referencing a non-existent path.