### PR TITLE
CAMS-740: Implement separate district and division selection

### DIFF
--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -136,7 +136,10 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       expect(MockMongoRepository.prototype.read).toHaveBeenCalledWith(trusteeId);
       expect(MockMongoRepository.prototype.createAppointment).toHaveBeenCalledWith(
         trusteeId,
-        appointmentInput,
+        expect.objectContaining({
+          ...appointmentInput,
+          divisionCodes: ['1'], // Normalized from divisionCode
+        }),
         expect.objectContaining({
           id: expect.any(String),
           name: expect.any(String),
@@ -348,7 +351,10 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       expect(MockMongoRepository.prototype.updateAppointment).toHaveBeenCalledWith(
         trusteeId,
         appointmentId,
-        appointmentUpdate,
+        expect.objectContaining({
+          ...appointmentUpdate,
+          divisionCodes: ['2'], // Normalized from divisionCode
+        }),
         expect.objectContaining({
           id: expect.any(String),
           name: expect.any(String),
@@ -723,6 +729,129 @@ describe('TrusteeAppointmentsUseCase tests', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('multi-division support', () => {
+    beforeEach(async () => {
+      context = await createMockApplicationContext();
+      trusteeAppointmentsUseCase = new TrusteeAppointmentsUseCase(context);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test('should accept divisionCodes array and normalize to both formats', async () => {
+      const trusteeId = 'trustee-123';
+      const mockTrustee = MockData.getTrustee({ trusteeId });
+
+      const appointmentInput: TrusteeAppointmentInput = {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['1', '2', '3'], // New format: array
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      };
+
+      const mockCreatedAppointment = MockData.getTrusteeAppointment({
+        trusteeId,
+        ...appointmentInput,
+        divisionCode: '1', // Should be normalized to first element
+        divisionCodes: ['1', '2', '3'],
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createAppointment').mockResolvedValue(
+        mockCreatedAppointment,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue(undefined);
+
+      const result = await trusteeAppointmentsUseCase.createAppointment(
+        context,
+        trusteeId,
+        appointmentInput,
+      );
+
+      expect(result).toEqual(mockCreatedAppointment);
+      expect(MockMongoRepository.prototype.createAppointment).toHaveBeenCalledWith(
+        trusteeId,
+        expect.objectContaining({
+          divisionCode: '1', // Normalized to first element
+          divisionCodes: ['1', '2', '3'], // Array preserved
+        }),
+        expect.any(Object),
+      );
+    });
+
+    test('should convert single divisionCode to divisionCodes array for backward compatibility', async () => {
+      const trusteeId = 'trustee-123';
+      const mockTrustee = MockData.getTrustee({ trusteeId });
+
+      const appointmentInput: TrusteeAppointmentInput = {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCode: '5', // Old format: single string
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      };
+
+      const mockCreatedAppointment = MockData.getTrusteeAppointment({
+        trusteeId,
+        ...appointmentInput,
+        divisionCode: '5',
+        divisionCodes: ['5'], // Should be normalized to array
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createAppointment').mockResolvedValue(
+        mockCreatedAppointment,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue(undefined);
+
+      const result = await trusteeAppointmentsUseCase.createAppointment(
+        context,
+        trusteeId,
+        appointmentInput,
+      );
+
+      expect(result).toEqual(mockCreatedAppointment);
+      expect(MockMongoRepository.prototype.createAppointment).toHaveBeenCalledWith(
+        trusteeId,
+        expect.objectContaining({
+          divisionCode: '5', // Original preserved
+          divisionCodes: ['5'], // Normalized to array
+        }),
+        expect.any(Object),
+      );
+    });
+
+    test('should reject appointment with no divisions specified', async () => {
+      const trusteeId = 'trustee-123';
+      const mockTrustee = MockData.getTrustee({ trusteeId });
+
+      const appointmentInput: TrusteeAppointmentInput = {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        // No divisionCode or divisionCodes specified
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+
+      const actualError = await getTheThrownError(() =>
+        trusteeAppointmentsUseCase.createAppointment(context, trusteeId, appointmentInput),
+      );
+
+      expect(actualError.isCamsError).toBe(true);
+      expect(actualError.message).toContain('At least one division must be specified');
     });
   });
 });

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -57,6 +57,35 @@ export class TrusteeAppointmentsUseCase {
     return court?.courtName;
   }
 
+  /**
+   * Normalize appointment data to ensure backward compatibility.
+   * Converts single divisionCode to divisionCodes array if needed.
+   */
+  private normalizeAppointmentData(
+    appointmentData: TrusteeAppointmentInput,
+  ): TrusteeAppointmentInput {
+    // If new format is provided, use it
+    if (appointmentData.divisionCodes && appointmentData.divisionCodes.length > 0) {
+      return {
+        ...appointmentData,
+        divisionCode: appointmentData.divisionCodes[0], // Keep first for backward compatibility
+        divisionCodes: appointmentData.divisionCodes,
+      };
+    }
+
+    // If old format is provided, convert to new format
+    if (appointmentData.divisionCode) {
+      return {
+        ...appointmentData,
+        divisionCode: appointmentData.divisionCode,
+        divisionCodes: [appointmentData.divisionCode],
+      };
+    }
+
+    // Neither provided - validation will catch this
+    return appointmentData;
+  }
+
   private validateAppointmentData(appointmentData: TrusteeAppointmentInput): void {
     const validationResult = validateObject(TRUSTEE_APPOINTMENTS_INTERNAL_SPEC, appointmentData);
 
@@ -174,13 +203,16 @@ export class TrusteeAppointmentsUseCase {
         });
       }
 
-      this.validateAppointmentData(appointmentData);
+      // Normalize data (convert old format to new format if needed)
+      const normalizedData = this.normalizeAppointmentData(appointmentData);
+
+      this.validateAppointmentData(normalizedData);
 
       const userReference = getCamsUserReference(context.session.user);
 
       const createdAppointment = await this.trusteeAppointmentsRepository.createAppointment(
         trusteeId,
-        appointmentData,
+        normalizedData,
         userReference,
       );
 
@@ -226,7 +258,10 @@ export class TrusteeAppointmentsUseCase {
     appointmentData: TrusteeAppointmentInput,
   ): Promise<TrusteeAppointment> {
     try {
-      this.validateAppointmentData(appointmentData);
+      // Normalize data (convert old format to new format if needed)
+      const normalizedData = this.normalizeAppointmentData(appointmentData);
+
+      this.validateAppointmentData(normalizedData);
 
       const userReference = getCamsUserReference(context.session.user);
 
@@ -238,7 +273,7 @@ export class TrusteeAppointmentsUseCase {
       const updatedAppointment = await this.trusteeAppointmentsRepository.updateAppointment(
         trusteeId,
         appointmentId,
-        appointmentData,
+        normalizedData,
         userReference,
       );
 

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -31,6 +31,7 @@ type AppointmentSnapshot = {
   appointmentType: AppointmentType;
   courtId: string;
   divisionCode: string;
+  divisionCodes?: string[];
   appointedDate: string;
   status: AppointmentStatus;
   effectiveDate: string;
@@ -227,6 +228,7 @@ export class TrusteeAppointmentsUseCase {
           appointmentType: createdAppointment.appointmentType,
           courtId: createdAppointment.courtId,
           divisionCode: createdAppointment.divisionCode,
+          divisionCodes: createdAppointment.divisionCodes,
           appointedDate: createdAppointment.appointedDate,
           status: createdAppointment.status,
           effectiveDate: createdAppointment.effectiveDate,
@@ -288,6 +290,7 @@ export class TrusteeAppointmentsUseCase {
             appointmentType: existingAppointment.appointmentType,
             courtId: existingAppointment.courtId,
             divisionCode: existingAppointment.divisionCode,
+            divisionCodes: existingAppointment.divisionCodes,
             appointedDate: existingAppointment.appointedDate,
             status: existingAppointment.status,
             effectiveDate: existingAppointment.effectiveDate,
@@ -297,6 +300,7 @@ export class TrusteeAppointmentsUseCase {
             appointmentType: updatedAppointment.appointmentType,
             courtId: updatedAppointment.courtId,
             divisionCode: updatedAppointment.divisionCode,
+            divisionCodes: updatedAppointment.divisionCodes,
             appointedDate: updatedAppointment.appointedDate,
             status: updatedAppointment.status,
             effectiveDate: updatedAppointment.effectiveDate,

--- a/common/src/cams/trustee-appointments.ts
+++ b/common/src/cams/trustee-appointments.ts
@@ -78,7 +78,8 @@ export type TrusteeAppointmentInput = {
   chapter: AppointmentChapterType;
   appointmentType: AppointmentType;
   courtId: string;
-  divisionCode?: string;
+  divisionCode?: string; // Deprecated: kept for backward compatibility
+  divisionCodes?: string[]; // New: array of division codes
   appointedDate: string;
   status: AppointmentStatus;
   effectiveDate: string;
@@ -90,7 +91,8 @@ export type TrusteeAppointment = Auditable &
     chapter: AppointmentChapterType;
     appointmentType: AppointmentType;
     courtId: string;
-    divisionCode?: string;
+    divisionCode?: string; // Deprecated: kept for backward compatibility
+    divisionCodes?: string[]; // New: array of division codes
     appointedDate: string;
     status: AppointmentStatus;
     effectiveDate: string;
@@ -146,9 +148,31 @@ const validateStatusForChapterAndAppointmentType: ValidatorFunction = (
   return VALID;
 };
 
+const validateDivisionCodes: ValidatorFunction = (obj: unknown): ValidatorResult => {
+  const appointment = obj as TrusteeAppointmentInput;
+  const { divisionCode, divisionCodes } = appointment;
+
+  // At least one division must be specified (either old or new format)
+  if (!divisionCode && (!divisionCodes || divisionCodes.length === 0)) {
+    return {
+      reasonMap: {
+        $: {
+          reasons: ['At least one division must be specified'],
+        },
+      },
+    };
+  }
+
+  return VALID;
+};
+
 export const TRUSTEE_APPOINTMENTS_INTERNAL_SPEC: Readonly<ValidationSpec<TrusteeAppointmentInput>> =
   {
-    $: [validateAppointmentTypeForChapter, validateStatusForChapterAndAppointmentType],
+    $: [
+      validateAppointmentTypeForChapter,
+      validateStatusForChapterAndAppointmentType,
+      validateDivisionCodes,
+    ],
   };
 
 export type CaseAppointmentInput = {

--- a/common/src/cams/trustees.ts
+++ b/common/src/cams/trustees.ts
@@ -216,6 +216,7 @@ type AppointmentData = {
   appointmentType: AppointmentType;
   courtId: string;
   divisionCode: string;
+  divisionCodes?: string[];
   courtName?: string;
   courtDivisionName?: string;
   appointedDate: string;

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -18,6 +18,7 @@ export const testFeatureFlags: FeatureFlagSet = {
   'show-debtor-name-column': true,
   'transfer-orders-enabled': true,
   'trustee-assigned-staff-enabled': true,
+  'trustee-district-division': true,
   'trustee-management': true,
   'trustee-software-bank-display': true,
   'trustee-verification-enabled': true,

--- a/user-interface/src/lib/hooks/UseCourts.ts
+++ b/user-interface/src/lib/hooks/UseCourts.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+import Api2 from '@/lib/models/api2';
+import { CourtDivisionDetails } from '@common/cams/courts';
+
+// Shared cache for courts data to avoid redundant API calls
+let courtsCache: CourtDivisionDetails[] | null = null;
+let courtsPromise: Promise<CourtDivisionDetails[]> | null = null;
+
+/**
+ * Shared hook for fetching courts data with caching.
+ *
+ * Multiple components can call this hook simultaneously without triggering
+ * redundant API calls. The first call initiates the fetch, subsequent calls
+ * reuse the same promise until the data is cached.
+ *
+ * @returns {courts, loading, error}
+ */
+export default function useCourts() {
+  const [courts, setCourts] = useState<CourtDivisionDetails[]>(courtsCache || []);
+  const [loading, setLoading] = useState<boolean>(!courtsCache);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    // If we already have cached data, use it immediately
+    if (courtsCache) {
+      setCourts(courtsCache);
+      setLoading(false);
+      return;
+    }
+
+    // If a fetch is already in progress, wait for it
+    if (courtsPromise) {
+      courtsPromise
+        .then((data) => {
+          setCourts(data);
+          setLoading(false);
+        })
+        .catch((err) => {
+          setError(err);
+          setLoading(false);
+        });
+      return;
+    }
+
+    // Start a new fetch
+    setLoading(true);
+    courtsPromise = Api2.getCourts()
+      .then((response) => {
+        courtsCache = response.data;
+        return response.data;
+      })
+      .catch((err) => {
+        courtsPromise = null; // Reset on error so retry is possible
+        throw err;
+      });
+
+    courtsPromise
+      .then((data) => {
+        setCourts(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err);
+        setLoading(false);
+      });
+  }, []);
+
+  return { courts, loading, error };
+}
+
+/**
+ * Clear the courts cache. Useful for testing or force-refresh scenarios.
+ */
+export function clearCourtsCache() {
+  courtsCache = null;
+  courtsPromise = null;
+}

--- a/user-interface/src/lib/hooks/UseCourts.ts
+++ b/user-interface/src/lib/hooks/UseCourts.ts
@@ -67,11 +67,3 @@ export default function useCourts() {
 
   return { courts, loading, error };
 }
-
-/**
- * Clear the courts cache. Useful for testing or force-refresh scenarios.
- */
-export function clearCourtsCache() {
-  courtsCache = null;
-  courtsPromise = null;
-}

--- a/user-interface/src/lib/hooks/UseFeatureFlags.ts
+++ b/user-interface/src/lib/hooks/UseFeatureFlags.ts
@@ -18,6 +18,7 @@ export const TRUSTEE_VERIFICATION_ENABLED = 'trustee-verification-enabled';
 export const VIEW_TRUSTEE_ON_CASE = 'view-trustee-on-case';
 export const TRUSTEE_SOFTWARE_BANK_DISPLAY = 'trustee-software-bank-display';
 export const TRUSTEE_ASSIGNED_STAFF_ENABLED = 'trustee-assigned-staff-enabled';
+export const TRUSTEE_DISTRICT_DIVISION = 'trustee-district-division';
 
 export default function useFeatureFlags(): FeatureFlagSet {
   const config = getFeatureFlagConfiguration();

--- a/user-interface/src/lib/utils/court-utils.test.ts
+++ b/user-interface/src/lib/utils/court-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from 'vitest';
-import { getStateNameFromCode, sortByCourtLocation } from './court-utils';
+import {
+  getStateNameFromCode,
+  sortByCourtLocation,
+  getUniqueDistricts,
+  getDivisionsForDistrict,
+} from './court-utils';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
 describe('court-utils', () => {
   describe('getStateNameFromCode', () => {
@@ -393,6 +399,219 @@ describe('court-utils', () => {
         // Both items should be present
         expect(sorted).toHaveLength(2);
         expect(sorted[0]).toEqual(sorted[1]);
+      });
+    });
+  });
+
+  describe('getUniqueDistricts', () => {
+    test('should deduplicate districts by courtId', () => {
+      const courts: CourtDivisionDetails[] = [
+        {
+          officeName: 'Juneau',
+          officeCode: '097-J',
+          courtId: '097',
+          courtName: 'District of Alaska',
+          courtDivisionCode: '710',
+          courtDivisionName: 'Juneau',
+          groupDesignator: 'AK',
+          regionId: '18',
+          regionName: 'Region 18',
+          state: 'AK',
+        },
+        {
+          officeName: 'Nome',
+          officeCode: '097-N',
+          courtId: '097',
+          courtName: 'District of Alaska',
+          courtDivisionCode: '711',
+          courtDivisionName: 'Nome',
+          groupDesignator: 'AK',
+          regionId: '18',
+          regionName: 'Region 18',
+          state: 'AK',
+        },
+      ];
+
+      const districts = getUniqueDistricts(courts);
+
+      expect(districts).toHaveLength(1);
+      expect(districts[0]).toEqual({
+        courtId: '097',
+        courtName: 'District of Alaska',
+        state: 'AK',
+      });
+    });
+
+    test('should sort districts by state name then court name', () => {
+      const courts: CourtDivisionDetails[] = [
+        {
+          officeName: 'Manhattan',
+          officeCode: '081-M',
+          courtId: '081',
+          courtName: 'Southern District of New York',
+          courtDivisionCode: '501',
+          courtDivisionName: 'Manhattan',
+          groupDesignator: 'NY',
+          regionId: '02',
+          regionName: 'Region 2',
+          state: 'NY',
+        },
+        {
+          officeName: 'Los Angeles',
+          officeCode: '052-LA',
+          courtId: '052',
+          courtName: 'Central District of California',
+          courtDivisionCode: '201',
+          courtDivisionName: 'Los Angeles',
+          groupDesignator: 'CA',
+          regionId: '15',
+          regionName: 'Region 15',
+          state: 'CA',
+        },
+        {
+          officeName: 'San Francisco',
+          officeCode: '053-SF',
+          courtId: '053',
+          courtName: 'Northern District of California',
+          courtDivisionCode: '301',
+          courtDivisionName: 'San Francisco',
+          groupDesignator: 'CA',
+          regionId: '15',
+          regionName: 'Region 15',
+          state: 'CA',
+        },
+      ];
+
+      const districts = getUniqueDistricts(courts);
+
+      expect(districts).toHaveLength(3);
+      // California < New York alphabetically
+      expect(districts[0].state).toBe('CA');
+      expect(districts[0].courtName).toBe('Central District of California');
+      expect(districts[1].state).toBe('CA');
+      expect(districts[1].courtName).toBe('Northern District of California');
+      expect(districts[2].state).toBe('NY');
+      expect(districts[2].courtName).toBe('Southern District of New York');
+    });
+
+    test('should handle empty array', () => {
+      const districts = getUniqueDistricts([]);
+      expect(districts).toEqual([]);
+    });
+
+    test('should handle missing state field', () => {
+      const courts: CourtDivisionDetails[] = [
+        {
+          officeName: 'Test Office',
+          officeCode: '999-T',
+          courtId: '999',
+          courtName: 'Test District',
+          courtDivisionCode: '001',
+          courtDivisionName: 'Test Division',
+          groupDesignator: 'XX',
+          regionId: '99',
+          regionName: 'Region 99',
+        },
+      ];
+
+      const districts = getUniqueDistricts(courts);
+
+      expect(districts).toHaveLength(1);
+      expect(districts[0]).toEqual({
+        courtId: '999',
+        courtName: 'Test District',
+        state: undefined,
+      });
+    });
+  });
+
+  describe('getDivisionsForDistrict', () => {
+    const courts: CourtDivisionDetails[] = [
+      {
+        officeName: 'Juneau',
+        officeCode: '097-J',
+        courtId: '097',
+        courtName: 'District of Alaska',
+        courtDivisionCode: '710',
+        courtDivisionName: 'Juneau',
+        groupDesignator: 'AK',
+        regionId: '18',
+        regionName: 'Region 18',
+        state: 'AK',
+      },
+      {
+        officeName: 'Nome',
+        officeCode: '097-N',
+        courtId: '097',
+        courtName: 'District of Alaska',
+        courtDivisionCode: '711',
+        courtDivisionName: 'Nome',
+        groupDesignator: 'AK',
+        regionId: '18',
+        regionName: 'Region 18',
+        state: 'AK',
+      },
+      {
+        officeName: 'Anchorage',
+        officeCode: '097-A',
+        courtId: '097',
+        courtName: 'District of Alaska',
+        courtDivisionCode: '709',
+        courtDivisionName: 'Anchorage',
+        groupDesignator: 'AK',
+        regionId: '18',
+        regionName: 'Region 18',
+        state: 'AK',
+      },
+      {
+        officeName: 'Manhattan',
+        officeCode: '081-M',
+        courtId: '081',
+        courtName: 'Southern District of New York',
+        courtDivisionCode: '501',
+        courtDivisionName: 'Manhattan',
+        groupDesignator: 'NY',
+        regionId: '02',
+        regionName: 'Region 2',
+        state: 'NY',
+      },
+    ];
+
+    test('should return divisions for a given courtId', () => {
+      const divisions = getDivisionsForDistrict(courts, '097');
+
+      expect(divisions).toHaveLength(3);
+      expect(divisions.map((d) => d.courtDivisionCode)).toContain('710');
+      expect(divisions.map((d) => d.courtDivisionCode)).toContain('711');
+      expect(divisions.map((d) => d.courtDivisionCode)).toContain('709');
+    });
+
+    test('should sort divisions alphabetically by division name', () => {
+      const divisions = getDivisionsForDistrict(courts, '097');
+
+      // Anchorage < Juneau < Nome alphabetically
+      expect(divisions[0].courtDivisionName).toBe('Anchorage');
+      expect(divisions[1].courtDivisionName).toBe('Juneau');
+      expect(divisions[2].courtDivisionName).toBe('Nome');
+    });
+
+    test('should return empty array for non-existent courtId', () => {
+      const divisions = getDivisionsForDistrict(courts, '999');
+      expect(divisions).toEqual([]);
+    });
+
+    test('should return empty array for empty input', () => {
+      const divisions = getDivisionsForDistrict([], '097');
+      expect(divisions).toEqual([]);
+    });
+
+    test('should handle district with single division', () => {
+      const divisions = getDivisionsForDistrict(courts, '081');
+
+      expect(divisions).toHaveLength(1);
+      expect(divisions[0]).toEqual({
+        courtDivisionCode: '501',
+        courtDivisionName: 'Manhattan',
       });
     });
   });

--- a/user-interface/src/lib/utils/court-utils.test.ts
+++ b/user-interface/src/lib/utils/court-utils.test.ts
@@ -4,6 +4,7 @@ import {
   sortByCourtLocation,
   getUniqueDistricts,
   getDivisionsForDistrict,
+  buildDivisionsDisplay,
 } from './court-utils';
 import { CourtDivisionDetails } from '@common/cams/courts';
 
@@ -613,6 +614,127 @@ describe('court-utils', () => {
         courtDivisionCode: '501',
         courtDivisionName: 'Manhattan',
       });
+    });
+  });
+
+  describe('buildDivisionsDisplay', () => {
+    const alaskaCourts: CourtDivisionDetails[] = [
+      {
+        officeName: 'Anchorage',
+        officeCode: '097-A',
+        courtId: '097',
+        courtName: 'District of Alaska',
+        courtDivisionCode: '709',
+        courtDivisionName: 'Anchorage',
+        groupDesignator: 'AK',
+        regionId: '18',
+        regionName: 'Region 18',
+        state: 'AK',
+      },
+      {
+        officeName: 'Juneau',
+        officeCode: '097-J',
+        courtId: '097',
+        courtName: 'District of Alaska',
+        courtDivisionCode: '710',
+        courtDivisionName: 'Juneau',
+        groupDesignator: 'AK',
+        regionId: '18',
+        regionName: 'Region 18',
+        state: 'AK',
+      },
+      {
+        officeName: 'Nome',
+        officeCode: '097-N',
+        courtId: '097',
+        courtName: 'District of Alaska',
+        courtDivisionCode: '711',
+        courtDivisionName: 'Nome',
+        groupDesignator: 'AK',
+        regionId: '18',
+        regionName: 'Region 18',
+        state: 'AK',
+      },
+    ];
+
+    test('should return "All" when all divisions for a district are selected', () => {
+      const result = buildDivisionsDisplay(
+        { courtId: '097', divisionCodes: ['709', '710', '711'] },
+        alaskaCourts,
+      );
+      expect(result).toBe('All');
+    });
+
+    test('should return sorted comma-separated names for partial division selection', () => {
+      const result = buildDivisionsDisplay(
+        { courtId: '097', divisionCodes: ['711', '709'] },
+        alaskaCourts,
+      );
+      expect(result).toBe('Anchorage, Nome');
+    });
+
+    test('should return single division name when one division code is selected', () => {
+      const result = buildDivisionsDisplay(
+        { courtId: '097', divisionCodes: ['710'] },
+        alaskaCourts,
+      );
+      expect(result).toBe('Juneau');
+    });
+
+    test('should fall back to raw codes when courts data is empty', () => {
+      const result = buildDivisionsDisplay({ courtId: '097', divisionCodes: ['710', '711'] }, []);
+      expect(result).toBe('710, 711');
+    });
+
+    test('should fall back to raw codes when courtId is missing', () => {
+      const result = buildDivisionsDisplay({ divisionCodes: ['710'] }, alaskaCourts);
+      expect(result).toBe('710');
+    });
+
+    test('should use courtDivisionName when provided (legacy enriched)', () => {
+      const result = buildDivisionsDisplay({ courtDivisionName: 'Juneau' }, alaskaCourts);
+      expect(result).toBe('Juneau');
+    });
+
+    test('should look up name from divisionCode when courts data is available', () => {
+      const result = buildDivisionsDisplay({ courtId: '097', divisionCode: '711' }, alaskaCourts);
+      expect(result).toBe('Nome');
+    });
+
+    test('should fall back to raw divisionCode when courts data is empty', () => {
+      const result = buildDivisionsDisplay({ courtId: '097', divisionCode: '711' }, []);
+      expect(result).toBe('711');
+    });
+
+    test('should fall back to raw divisionCode when courtId is missing', () => {
+      const result = buildDivisionsDisplay({ divisionCode: '711' }, alaskaCourts);
+      expect(result).toBe('711');
+    });
+
+    test('should return "Not specified" when no division data exists', () => {
+      const result = buildDivisionsDisplay({}, alaskaCourts);
+      expect(result).toBe('Not specified');
+    });
+
+    test('should return "Not specified" when divisionCodes is empty array', () => {
+      const result = buildDivisionsDisplay({ courtId: '097', divisionCodes: [] }, alaskaCourts);
+      expect(result).toBe('Not specified');
+    });
+
+    test('should fall back to code when division code is not found in courts data', () => {
+      const result = buildDivisionsDisplay(
+        { courtId: '097', divisionCodes: ['999'] },
+        alaskaCourts,
+      );
+      expect(result).toBe('999');
+    });
+
+    test('should prefer divisionCodes over legacy divisionCode when both present', () => {
+      const result = buildDivisionsDisplay(
+        { courtId: '097', divisionCodes: ['710', '711'], divisionCode: '709' },
+        alaskaCourts,
+      );
+      expect(result).toBe('Juneau, Nome');
     });
   });
 });

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -32,6 +32,40 @@ function getChapterNumber(chapter: string): number {
 }
 
 /**
+ * Case-insensitive string comparison for sorting.
+ * Uses locale-aware comparison with base sensitivity.
+ *
+ * @param a - First string to compare
+ * @param b - Second string to compare
+ * @returns Negative if a < b, positive if a > b, 0 if equal
+ */
+function caseInsensitiveCompare(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { sensitivity: 'base' });
+}
+
+/**
+ * Compare function for sorting by state name (from code) then court name.
+ * Use with Array.sort() for consistent state+court ordering across the application.
+ *
+ * @param a - First item with state and courtName properties
+ * @param b - Second item with state and courtName properties
+ * @returns Negative if a < b, positive if a > b, 0 if equal
+ */
+function compareByStateAndCourt<T extends { state?: string; courtName?: string }>(
+  a: T,
+  b: T,
+): number {
+  // Sort by state name (mapped from code to full name)
+  const stateA = getStateNameFromCode(a.state || '');
+  const stateB = getStateNameFromCode(b.state || '');
+  const stateComparison = stateA.localeCompare(stateB);
+  if (stateComparison !== 0) return stateComparison;
+
+  // Sort by court name within state
+  return (a.courtName || '').localeCompare(b.courtName || '');
+}
+
+/**
  * Item with court location properties for sorting.
  * Properties are optional to support types like TrusteeAppointment where they may be undefined.
  */
@@ -68,15 +102,9 @@ export function sortByCourtLocation<T extends CourtLocationSortable>(
   options?: SortOptions,
 ): T[] {
   return [...items].sort((a, b) => {
-    // 1. Sort by state name (mapped from state code to full name)
-    const stateA = getStateNameFromCode(a.state || '');
-    const stateB = getStateNameFromCode(b.state || '');
-    const stateComparison = stateA.localeCompare(stateB);
-    if (stateComparison !== 0) return stateComparison;
-
-    // 2. Sort by court name within state
-    const courtComparison = (a.courtName || '').localeCompare(b.courtName || '');
-    if (courtComparison !== 0) return courtComparison;
+    // 1-2. Sort by state name then court name
+    const locationComparison = compareByStateAndCourt(a, b);
+    if (locationComparison !== 0) return locationComparison;
 
     // 3. Sort by division name within court
     const divisionComparison = (a.courtDivisionName || '').localeCompare(b.courtDivisionName || '');
@@ -246,13 +274,11 @@ export function sortTrusteeAppointments(appointments: TrusteeAppointment[]): Tru
     })
     .sort((a, b) => {
       // 1. Sort by state name alphabetically
-      const stateComparison = a.state.localeCompare(b.state, undefined, { sensitivity: 'base' });
+      const stateComparison = caseInsensitiveCompare(a.state, b.state);
       if (stateComparison !== 0) return stateComparison;
 
       // 2. Sort by region (Eastern, Northern, Southern, Western, etc.)
-      const regionComparison = a.region.localeCompare(b.region, undefined, {
-        sensitivity: 'base',
-      });
+      const regionComparison = caseInsensitiveCompare(a.region, b.region);
       if (regionComparison !== 0) return regionComparison;
 
       // 3. Sort by chapter number
@@ -264,7 +290,7 @@ export function sortTrusteeAppointments(appointments: TrusteeAppointment[]): Tru
       // 4. Sort by appointment type
       const typeA = a.appointment.appointmentType ?? '';
       const typeB = b.appointment.appointmentType ?? '';
-      return typeA.localeCompare(typeB, undefined, { sensitivity: 'base' });
+      return caseInsensitiveCompare(typeA, typeB);
     })
     .map((wrapper) => wrapper.appointment);
 }
@@ -322,16 +348,7 @@ export function getUniqueDistricts(courts: CourtDivisionDetails[]): DistrictOpti
   // Convert to array and sort by state then court name
   const districts = Array.from(districtMap.values());
 
-  return districts.sort((a, b) => {
-    // Sort by state name (mapped from code to full name)
-    const stateA = getStateNameFromCode(a.state || '');
-    const stateB = getStateNameFromCode(b.state || '');
-    const stateComparison = stateA.localeCompare(stateB);
-    if (stateComparison !== 0) return stateComparison;
-
-    // Sort by court name within state
-    return a.courtName.localeCompare(b.courtName);
-  });
+  return districts.sort(compareByStateAndCourt);
 }
 
 /**

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -268,3 +268,98 @@ export function sortTrusteeAppointments(appointments: TrusteeAppointment[]): Tru
     })
     .map((wrapper) => wrapper.appointment);
 }
+
+/**
+ * Represents a unique district (court) for selection in a dropdown.
+ */
+export interface DistrictOption {
+  courtId: string;
+  courtName: string;
+  state?: string;
+}
+
+/**
+ * Represents a division within a district for selection in a dropdown.
+ */
+export interface DivisionOption {
+  courtDivisionCode: string;
+  courtDivisionName: string;
+}
+
+/**
+ * Extracts unique districts from a flat array of CourtDivisionDetails.
+ * Deduplicates by courtId and sorts by state name then court name.
+ *
+ * @param courts - Flat array of court division details (one entry per division)
+ * @returns Array of unique districts sorted by state and court name
+ *
+ * @example
+ * const courts = [
+ *   { courtId: '097', courtName: 'District of Alaska', state: 'AK', ... },
+ *   { courtId: '097', courtName: 'District of Alaska', state: 'AK', ... }, // duplicate
+ *   { courtId: '081', courtName: 'Northern District of California', state: 'CA', ... }
+ * ];
+ * getUniqueDistricts(courts);
+ * // Returns: [
+ * //   { courtId: '097', courtName: 'District of Alaska', state: 'AK' },
+ * //   { courtId: '081', courtName: 'Northern District of California', state: 'CA' }
+ * // ]
+ */
+export function getUniqueDistricts(courts: CourtDivisionDetails[]): DistrictOption[] {
+  // Deduplicate by courtId using a Map
+  const districtMap = new Map<string, DistrictOption>();
+
+  for (const court of courts) {
+    if (!districtMap.has(court.courtId)) {
+      districtMap.set(court.courtId, {
+        courtId: court.courtId,
+        courtName: court.courtName,
+        state: court.state,
+      });
+    }
+  }
+
+  // Convert to array and sort by state then court name
+  const districts = Array.from(districtMap.values());
+
+  return districts.sort((a, b) => {
+    // Sort by state name (mapped from code to full name)
+    const stateA = getStateNameFromCode(a.state || '');
+    const stateB = getStateNameFromCode(b.state || '');
+    const stateComparison = stateA.localeCompare(stateB);
+    if (stateComparison !== 0) return stateComparison;
+
+    // Sort by court name within state
+    return a.courtName.localeCompare(b.courtName);
+  });
+}
+
+/**
+ * Gets all divisions for a specific district (court).
+ * Returns divisions sorted alphabetically by division name.
+ *
+ * @param courts - Flat array of court division details
+ * @param courtId - The court ID to filter by
+ * @returns Array of divisions for the specified court, sorted alphabetically
+ *
+ * @example
+ * getDivisionsForDistrict(courts, '097');
+ * // Returns: [
+ * //   { courtDivisionCode: '710', courtDivisionName: 'Juneau' },
+ * //   { courtDivisionCode: '711', courtDivisionName: 'Nome' }
+ * // ]
+ */
+export function getDivisionsForDistrict(
+  courts: CourtDivisionDetails[],
+  courtId: string,
+): DivisionOption[] {
+  const divisions = courts
+    .filter((court) => court.courtId === courtId)
+    .map((court) => ({
+      courtDivisionCode: court.courtDivisionCode,
+      courtDivisionName: court.courtDivisionName,
+    }));
+
+  // Sort alphabetically by division name
+  return divisions.sort((a, b) => a.courtDivisionName.localeCompare(b.courtDivisionName));
+}

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -298,7 +298,7 @@ export function sortTrusteeAppointments(appointments: TrusteeAppointment[]): Tru
 /**
  * Represents a unique district (court) for selection in a dropdown.
  */
-export interface DistrictOption {
+interface DistrictOption {
   courtId: string;
   courtName: string;
   state?: string;
@@ -307,7 +307,7 @@ export interface DistrictOption {
 /**
  * Represents a division within a district for selection in a dropdown.
  */
-export interface DivisionOption {
+interface DivisionOption {
   courtDivisionCode: string;
   courtDivisionName: string;
 }
@@ -379,4 +379,64 @@ export function getDivisionsForDistrict(
 
   // Sort alphabetically by division name
   return divisions.sort((a, b) => a.courtDivisionName.localeCompare(b.courtDivisionName));
+}
+
+/**
+ * Build a human-readable display string for an appointment's divisions.
+ *
+ * Handles multiple data shapes:
+ * - New format: divisionCodes array → looks up names, shows "All" if every division selected
+ * - Legacy format with enriched name: courtDivisionName already provided by backend
+ * - Legacy format with code only: looks up name from courts data, falls back to raw code
+ *
+ * @param appointment - Object containing division fields from the appointment
+ * @param allCourts - Full courts dataset for name lookups (may be empty if not yet loaded)
+ * @returns Display string such as "All", "Springfield, St. Louis", or "Not specified"
+ */
+export function buildDivisionsDisplay(
+  appointment: {
+    courtId?: string;
+    divisionCode?: string;
+    divisionCodes?: string[];
+    courtDivisionName?: string;
+  },
+  allCourts: CourtDivisionDetails[],
+): string {
+  if (appointment.divisionCodes && appointment.divisionCodes.length > 0) {
+    if (appointment.courtId && allCourts.length > 0) {
+      const divisions = getDivisionsForDistrict(allCourts, appointment.courtId);
+      const allDivisionCodes = divisions.map((d) => d.courtDivisionCode);
+
+      const hasAllDivisions =
+        appointment.divisionCodes.length === allDivisionCodes.length &&
+        appointment.divisionCodes.every((code) => allDivisionCodes.includes(code));
+
+      if (hasAllDivisions) return 'All';
+
+      return appointment.divisionCodes
+        .map((code) => {
+          const division = divisions.find((d) => d.courtDivisionCode === code);
+          return division?.courtDivisionName || code;
+        })
+        .sort()
+        .join(', ');
+    }
+    return appointment.divisionCodes.join(', ');
+  }
+
+  if (appointment.courtDivisionName) {
+    return appointment.courtDivisionName;
+  }
+
+  if (appointment.divisionCode && appointment.courtId && allCourts.length > 0) {
+    const divisions = getDivisionsForDistrict(allCourts, appointment.courtId);
+    const division = divisions.find((d) => d.courtDivisionCode === appointment.divisionCode);
+    return division?.courtDivisionName || appointment.divisionCode;
+  }
+
+  if (appointment.divisionCode) {
+    return appointment.divisionCode;
+  }
+
+  return 'Not specified';
 }

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.helpers.test.ts
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.helpers.test.ts
@@ -1,55 +1,6 @@
 import { describe, test, expect } from 'vitest';
 import { CourtDivisionDetails } from '@common/cams/courts';
-
-// Re-export the helper for testing
-// Since extractCourtAndDivisions is defined inside the component, we'll test it via the component's behavior
-// For now, let's write tests that validate the logic conceptually
-
-const ALL_DIVISIONS_VALUE = '__ALL__';
-
-type FormData = {
-  courtId: string;
-  divisionCodes: string[];
-  districtKey: string;
-};
-
-/**
- * Extracted helper logic for testing
- */
-function extractCourtAndDivisions(
-  formData: Pick<FormData, 'courtId' | 'divisionCodes' | 'districtKey'>,
-  useSeparateFields: boolean,
-  allCourts: CourtDivisionDetails[],
-): { courtId: string; divisionCodes: string[] } | null {
-  if (useSeparateFields) {
-    if (!formData.courtId || formData.divisionCodes.length === 0) {
-      return null;
-    }
-
-    let divisionCodes = formData.divisionCodes;
-
-    if (divisionCodes.includes(ALL_DIVISIONS_VALUE)) {
-      divisionCodes = allCourts
-        .filter((c) => c.courtId === formData.courtId)
-        .map((d) => d.courtDivisionCode);
-    }
-
-    return {
-      courtId: formData.courtId,
-      divisionCodes,
-    };
-  } else {
-    if (!formData.districtKey) {
-      return null;
-    }
-
-    const [courtId, divisionCode] = formData.districtKey.split('|');
-    return {
-      courtId,
-      divisionCodes: [divisionCode],
-    };
-  }
-}
+import { extractCourtAndDivisions, ALL_DIVISIONS_VALUE } from './TrusteeAppointmentForm';
 
 describe('TrusteeAppointmentForm Helper Functions', () => {
   const mockCourts: CourtDivisionDetails[] = [
@@ -159,7 +110,7 @@ describe('TrusteeAppointmentForm Helper Functions', () => {
         const result = extractCourtAndDivisions(
           {
             courtId: '081-',
-            divisionCodes: ['__ALL__'],
+            divisionCodes: [ALL_DIVISIONS_VALUE],
             districtKey: '',
           },
           true,
@@ -168,8 +119,9 @@ describe('TrusteeAppointmentForm Helper Functions', () => {
 
         expect(result).toEqual({
           courtId: '081-',
-          divisionCodes: ['301', '303', '310'],
+          divisionCodes: expect.arrayContaining(['301', '303', '310']),
         });
+        expect(result!.divisionCodes).toHaveLength(3);
       });
 
       test('should expand "All Divisions" for correct district only', () => {
@@ -192,7 +144,7 @@ describe('TrusteeAppointmentForm Helper Functions', () => {
         const result = extractCourtAndDivisions(
           {
             courtId: '081-',
-            divisionCodes: ['__ALL__'],
+            divisionCodes: [ALL_DIVISIONS_VALUE],
             districtKey: '',
           },
           true,
@@ -202,8 +154,10 @@ describe('TrusteeAppointmentForm Helper Functions', () => {
         // Should only expand to Missouri divisions, not Alaska
         expect(result).toEqual({
           courtId: '081-',
-          divisionCodes: ['301', '303', '310'],
+          divisionCodes: expect.arrayContaining(['301', '303', '310']),
         });
+        expect(result!.divisionCodes).toHaveLength(3);
+        expect(result!.divisionCodes).not.toContain('710');
       });
     });
 

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.helpers.test.ts
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.helpers.test.ts
@@ -1,0 +1,281 @@
+import { describe, test, expect } from 'vitest';
+import { CourtDivisionDetails } from '@common/cams/courts';
+
+// Re-export the helper for testing
+// Since extractCourtAndDivisions is defined inside the component, we'll test it via the component's behavior
+// For now, let's write tests that validate the logic conceptually
+
+const ALL_DIVISIONS_VALUE = '__ALL__';
+
+type FormData = {
+  courtId: string;
+  divisionCodes: string[];
+  districtKey: string;
+};
+
+/**
+ * Extracted helper logic for testing
+ */
+function extractCourtAndDivisions(
+  formData: Pick<FormData, 'courtId' | 'divisionCodes' | 'districtKey'>,
+  useSeparateFields: boolean,
+  allCourts: CourtDivisionDetails[],
+): { courtId: string; divisionCodes: string[] } | null {
+  if (useSeparateFields) {
+    if (!formData.courtId || formData.divisionCodes.length === 0) {
+      return null;
+    }
+
+    let divisionCodes = formData.divisionCodes;
+
+    if (divisionCodes.includes(ALL_DIVISIONS_VALUE)) {
+      divisionCodes = allCourts
+        .filter((c) => c.courtId === formData.courtId)
+        .map((d) => d.courtDivisionCode);
+    }
+
+    return {
+      courtId: formData.courtId,
+      divisionCodes,
+    };
+  } else {
+    if (!formData.districtKey) {
+      return null;
+    }
+
+    const [courtId, divisionCode] = formData.districtKey.split('|');
+    return {
+      courtId,
+      divisionCodes: [divisionCode],
+    };
+  }
+}
+
+describe('TrusteeAppointmentForm Helper Functions', () => {
+  const mockCourts: CourtDivisionDetails[] = [
+    {
+      courtId: '081-',
+      courtName: 'Eastern District of Missouri',
+      courtDivisionCode: '301',
+      courtDivisionName: 'Springfield',
+      regionId: '08',
+      regionName: 'Region 08',
+      officeCode: 'MO',
+      officeName: 'Missouri',
+      groupDesignator: 'EO',
+      state: 'MO',
+    },
+    {
+      courtId: '081-',
+      courtName: 'Eastern District of Missouri',
+      courtDivisionCode: '303',
+      courtDivisionName: 'St. Louis',
+      regionId: '08',
+      regionName: 'Region 08',
+      officeCode: 'MO',
+      officeName: 'Missouri',
+      groupDesignator: 'EO',
+      state: 'MO',
+    },
+    {
+      courtId: '081-',
+      courtName: 'Eastern District of Missouri',
+      courtDivisionCode: '310',
+      courtDivisionName: 'Cape Girardeau',
+      regionId: '08',
+      regionName: 'Region 08',
+      officeCode: 'MO',
+      officeName: 'Missouri',
+      groupDesignator: 'EO',
+      state: 'MO',
+    },
+  ];
+
+  describe('extractCourtAndDivisions', () => {
+    describe('when useSeparateFields is true (new format)', () => {
+      test('should return null when courtId is missing', () => {
+        const result = extractCourtAndDivisions(
+          {
+            courtId: '',
+            divisionCodes: ['301'],
+            districtKey: '',
+          },
+          true,
+          mockCourts,
+        );
+
+        expect(result).toBeNull();
+      });
+
+      test('should return null when divisionCodes is empty', () => {
+        const result = extractCourtAndDivisions(
+          {
+            courtId: '081-',
+            divisionCodes: [],
+            districtKey: '',
+          },
+          true,
+          mockCourts,
+        );
+
+        expect(result).toBeNull();
+      });
+
+      test('should return courtId and specific divisions when single division selected', () => {
+        const result = extractCourtAndDivisions(
+          {
+            courtId: '081-',
+            divisionCodes: ['301'],
+            districtKey: '',
+          },
+          true,
+          mockCourts,
+        );
+
+        expect(result).toEqual({
+          courtId: '081-',
+          divisionCodes: ['301'],
+        });
+      });
+
+      test('should return courtId and multiple divisions when multiple divisions selected', () => {
+        const result = extractCourtAndDivisions(
+          {
+            courtId: '081-',
+            divisionCodes: ['301', '303'],
+            districtKey: '',
+          },
+          true,
+          mockCourts,
+        );
+
+        expect(result).toEqual({
+          courtId: '081-',
+          divisionCodes: ['301', '303'],
+        });
+      });
+
+      test('should expand "All Divisions" to actual division codes', () => {
+        const result = extractCourtAndDivisions(
+          {
+            courtId: '081-',
+            divisionCodes: ['__ALL__'],
+            districtKey: '',
+          },
+          true,
+          mockCourts,
+        );
+
+        expect(result).toEqual({
+          courtId: '081-',
+          divisionCodes: ['301', '303', '310'],
+        });
+      });
+
+      test('should expand "All Divisions" for correct district only', () => {
+        const multiDistrictCourts: CourtDivisionDetails[] = [
+          ...mockCourts,
+          {
+            courtId: '097-',
+            courtName: 'District of Alaska',
+            courtDivisionCode: '710',
+            courtDivisionName: 'Juneau',
+            regionId: '09',
+            regionName: 'Region 09',
+            officeCode: 'AK',
+            officeName: 'Alaska',
+            groupDesignator: 'EO',
+            state: 'AK',
+          },
+        ];
+
+        const result = extractCourtAndDivisions(
+          {
+            courtId: '081-',
+            divisionCodes: ['__ALL__'],
+            districtKey: '',
+          },
+          true,
+          multiDistrictCourts,
+        );
+
+        // Should only expand to Missouri divisions, not Alaska
+        expect(result).toEqual({
+          courtId: '081-',
+          divisionCodes: ['301', '303', '310'],
+        });
+      });
+    });
+
+    describe('when useSeparateFields is false (legacy format)', () => {
+      test('should return null when districtKey is missing', () => {
+        const result = extractCourtAndDivisions(
+          {
+            courtId: '',
+            divisionCodes: [],
+            districtKey: '',
+          },
+          false,
+          mockCourts,
+        );
+
+        expect(result).toBeNull();
+      });
+
+      test('should parse districtKey and return courtId and single divisionCode', () => {
+        const result = extractCourtAndDivisions(
+          {
+            courtId: '',
+            divisionCodes: [],
+            districtKey: '081-|301',
+          },
+          false,
+          mockCourts,
+        );
+
+        expect(result).toEqual({
+          courtId: '081-',
+          divisionCodes: ['301'],
+        });
+      });
+    });
+  });
+
+  describe('Validation overlap logic', () => {
+    test('should detect overlap when "All Divisions" includes existing specific division', () => {
+      const newDivisions = ['301', '303', '310']; // Expanded from "All Divisions"
+      const existingDivisions = ['301']; // Springfield
+
+      const hasOverlap = newDivisions.some((code) => existingDivisions.includes(code));
+
+      expect(hasOverlap).toBe(true);
+    });
+
+    test('should detect overlap when specific division exists in "All Divisions"', () => {
+      const newDivisions = ['303']; // St. Louis
+      const existingDivisions = ['301', '303', '310']; // All divisions
+
+      const hasOverlap = newDivisions.some((code) => existingDivisions.includes(code));
+
+      expect(hasOverlap).toBe(true);
+    });
+
+    test('should NOT detect overlap when divisions are different', () => {
+      const newDivisions = ['301']; // Springfield
+      const existingDivisions = ['303']; // St. Louis
+
+      const hasOverlap = newDivisions.some((code) => existingDivisions.includes(code));
+
+      expect(hasOverlap).toBe(false);
+    });
+
+    test('should detect overlap when multiple divisions share at least one', () => {
+      const newDivisions = ['301', '310']; // Springfield, Cape Girardeau
+      const existingDivisions = ['303', '310']; // St. Louis, Cape Girardeau
+
+      const hasOverlap = newDivisions.some((code) => existingDivisions.includes(code));
+
+      expect(hasOverlap).toBe(true); // Cape Girardeau overlaps
+    });
+  });
+});

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
@@ -13,7 +13,7 @@
   .field-group {
     gap: 0;
   }
-  
+
   .division-field-group {
     margin-bottom: 24px; // Space between pills and next field
 

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
@@ -38,6 +38,14 @@
       max-width: var(--form-field-max-width); // Match form field width
     }
 
+    .division-pill-static {
+      cursor: default;
+
+      .pill-text {
+        max-width: 100%;
+      }
+    }
+
     .division-pill {
       display: inline-flex;
       align-items: center;

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
@@ -1,8 +1,73 @@
 .trustee-form-screen {
+  // CSS variable for consistent field width
+  --form-field-max-width: 385px;
+
   .usa-alert-container {
     margin-left: 0;
   }
   .field-group.appointedDate {
     margin-bottom: 0.5rem;
+  }
+
+  // Ensure division field takes full width and proper spacing
+  .field-group {
+    gap: 0;
+  }
+  
+  .division-field-group {
+    margin-bottom: 24px; // Space between pills and next field
+
+    .division-dropdown-wrapper {
+      display: block;
+      width: 100%;
+      margin-bottom: 0; // Remove any default margin
+
+      .combo-box-form-group {
+        margin-bottom: 0; // Ensure ComboBox has no bottom margin
+      }
+    }
+
+    // Division pills styling - display below the dropdown
+    .division-pills-container {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 16px; // Exactly 16px space between dropdown and pills
+      max-width: var(--form-field-max-width); // Match form field width
+    }
+
+    .division-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      background-color: #005ea2;
+      color: #ffffff;
+      height: 32px; // Figma spec
+      padding: 0 0.75rem;
+      border-radius: 99rem;
+      font-size: 0.875rem;
+      font-weight: 700;
+      text-transform: none;
+
+      .usa-tag__remove-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        margin-left: 0.5rem;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        color: #ffffff;
+        font-size: 1.25rem;
+        line-height: 1;
+        width: 1rem;
+        height: 1rem;
+
+        &:hover {
+          color: #f0f0f0;
+        }
+      }
+    }
   }
 }

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
@@ -1,3 +1,5 @@
+@use 'uswds-core' as *;
+
 .trustee-form-screen {
   // CSS variable for consistent field width
   --form-field-max-width: 385px;
@@ -40,8 +42,8 @@
       display: inline-flex;
       align-items: center;
       gap: 0.25rem;
-      background-color: #005ea2;
-      color: #ffffff;
+      background-color: color('primary');
+      color: color('white');
       height: 32px; // Figma spec
       padding: 0 0.75rem;
       border-radius: 99rem;
@@ -58,14 +60,14 @@
         background: transparent;
         border: none;
         cursor: pointer;
-        color: #ffffff;
+        color: color('white');
         font-size: 1.25rem;
         line-height: 1;
         width: 1rem;
         height: 1rem;
 
         &:hover {
-          color: #f0f0f0;
+          filter: brightness(0.9);
         }
       }
     }

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.test.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.test.tsx
@@ -693,6 +693,67 @@ describe('TrusteeAppointmentForm Tests', () => {
     });
   });
 
+  describe('"All Divisions" Validation Logic', () => {
+    // These tests verify the validation logic works with the new divisionCodes array format
+    // Unit tests for the helper functions are in TrusteeAppointmentForm.helpers.test.ts
+
+    test('should detect conflict when existing appointment has multiple divisions', async () => {
+      const mockMultiDivisionAppointment: TrusteeAppointment = {
+        ...mockActiveAppointment,
+        id: 'appointment-multi',
+        divisionCode: '710', // Backward compat
+        divisionCodes: ['710', '720'], // Multiple divisions
+      };
+
+      renderWithProps({
+        trusteeId: TEST_TRUSTEE_ID,
+        existingAppointments: [mockMultiDivisionAppointment],
+      });
+
+      // Try to create overlapping appointment with same district/chapter/type
+      await setAppointmentTypeOnDefaultCompleteForm(userEvent, 'Panel');
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/An active appointment already exists for Chapter 7 - Panel/i),
+        ).toBeInTheDocument();
+      });
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      expect(submitButton).toBeDisabled();
+    });
+
+    test('should allow appointment when existing has divisionCodes but no overlap', async () => {
+      const mockDifferentDivisionAppointment: TrusteeAppointment = {
+        ...mockActiveAppointment,
+        id: 'appointment-diff',
+        courtId: '097-',
+        divisionCode: '720', // Nome
+        divisionCodes: ['720'], // Single division, different from default
+        courtDivisionName: 'Nome',
+      };
+
+      renderWithProps({
+        trusteeId: TEST_TRUSTEE_ID,
+        existingAppointments: [mockDifferentDivisionAppointment],
+      });
+
+      // Create appointment for Juneau (710) - no overlap with Nome (720)
+      await fillCompleteForm(userEvent, {
+        district: courtDivisionName.alaskaJ, // Juneau - different division
+        chapter: chapter.seven,
+        appointmentType: 'Panel',
+        appointedDate: TEST_APPOINTED_DATE,
+      });
+
+      // No validation error - different divisions
+      expect(screen.queryByText(/An active appointment already exists/i)).not.toBeInTheDocument();
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+
   describe('Dynamic Status Options Tests', () => {
     test('should not show status dropdown in create mode', async () => {
       renderWithProps();

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -3,11 +3,19 @@ import './TrusteeAppointmentForm.scss';
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import DatePicker from '@/lib/components/uswds/DatePicker';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
-import useFeatureFlags, { TRUSTEE_MANAGEMENT } from '@/lib/hooks/UseFeatureFlags';
+import useFeatureFlags, {
+  TRUSTEE_MANAGEMENT,
+  TRUSTEE_DISTRICT_DIVISION,
+} from '@/lib/hooks/UseFeatureFlags';
 import Api2 from '@/lib/models/api2';
 import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import LocalStorage from '@/lib/utils/local-storage';
-import { sortByCourtLocation } from '@/lib/utils/court-utils';
+import {
+  sortByCourtLocation,
+  getUniqueDistricts,
+  getDivisionsForDistrict,
+} from '@/lib/utils/court-utils';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import { CamsRole } from '@common/cams/roles';
 import useCamsNavigator from '@/lib/hooks/UseCamsNavigator';
 import { Stop } from '@/lib/components/Stop';
@@ -27,6 +35,7 @@ import {
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import { FormRequirementsNotice } from '@/lib/components/uswds/FormRequirementsNotice';
 import { useLocation } from 'react-router-dom';
 
 const CHAPTER_OPTIONS: ComboOption<AppointmentChapterType>[] = [
@@ -60,8 +69,13 @@ function getDefaultAppointmentType(
   return types.length === 1 ? types[0] : '';
 }
 
+// Synthetic value for "All Divisions" option
+const ALL_DIVISIONS_VALUE = '__ALL__';
+
 type FormData = {
-  districtKey: string; // Combined key: "{courtId}|{divisionCode}"
+  districtKey: string; // Combined key: "{courtId}|{divisionCode}" (used when flag is OFF)
+  courtId: string; // Separate court ID (used when flag is ON)
+  divisionCodes: string[]; // Multi-select division codes (used when flag is ON)
   chapter: AppointmentChapterType | '';
   appointmentType: AppointmentType | '';
   status: AppointmentStatus | '';
@@ -85,6 +99,9 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   const { trusteeId, existingAppointments: passedAppointments, appointment } = props;
   const isEditMode = !!appointment;
 
+  // Extract flag value to avoid re-render loops (flags object reference changes)
+  const districtDivisionEnabled = !!flags[TRUSTEE_DISTRICT_DIVISION];
+
   const appointmentsFromState = (location.state as { existingAppointments?: TrusteeAppointment[] })
     ?.existingAppointments;
   const appointmentsToUse = passedAppointments ?? appointmentsFromState;
@@ -93,13 +110,16 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   const [isLoadingDistricts, setIsLoadingDistricts] = useState(true);
   const [isLoadingAppointments, setIsLoadingAppointments] = useState(!appointmentsToUse);
   const [districtOptions, setDistrictOptions] = useState<ComboOption[]>([]);
+  const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]); // Store raw courts data
   const [existingAppointments, setExistingAppointments] = useState<TrusteeAppointment[]>(
     appointmentsToUse ?? [],
   );
   const [formData, setFormData] = useState<FormData>(() => {
     if (appointment) {
       return {
-        districtKey: `${appointment.courtId}|${appointment.divisionCode}`,
+        districtKey: `${appointment.courtId}|${appointment.divisionCode ?? ''}`,
+        courtId: appointment.courtId,
+        divisionCodes: appointment.divisionCode ? [appointment.divisionCode] : [],
         chapter: appointment.chapter,
         appointmentType: appointment.appointmentType,
         status: appointment.status,
@@ -109,6 +129,8 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     }
     return {
       districtKey: '',
+      courtId: '',
+      divisionCodes: [], // Start empty, will be set to [ALL_DIVISIONS_VALUE] when district selected
       chapter: '' as AppointmentChapterType,
       appointmentType: '' as AppointmentType,
       status: 'active' as AppointmentStatus,
@@ -118,6 +140,20 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   });
 
   const canManage = !!session?.user?.roles?.includes(CamsRole.TrusteeAdmin);
+
+  const divisionOptions = useMemo<ComboOption[]>(() => {
+    if (!formData.courtId || !allCourts.length) return [];
+
+    const divisions = getDivisionsForDistrict(allCourts, formData.courtId);
+
+    return [
+      { value: ALL_DIVISIONS_VALUE, label: 'All Divisions' },
+      ...divisions.map((div) => ({
+        value: div.courtDivisionCode,
+        label: div.courtDivisionName,
+      })),
+    ];
+  }, [formData.courtId, allCourts]);
 
   const appointmentTypeOptions = useMemo<ComboOption<AppointmentType>[]>(() => {
     if (!formData.chapter) return [];
@@ -147,25 +183,39 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     const loadDistricts = async () => {
       try {
         const response = await Api2.getCourts();
-        const sortedCourts = sortByCourtLocation(response.data);
-        const options = sortedCourts.map((district) => {
-          // Build label with guards for missing data
-          let label: string;
-          if (district.courtName && district.courtDivisionName) {
-            label = `${district.courtName} (${district.courtDivisionName})`;
-          } else if (district.courtName) {
-            label = district.courtName;
-          } else {
-            label = `Court ${district.courtId}`;
-          }
+        const courtsData = response.data;
+        setAllCourts(courtsData); // Store raw data for division filtering
 
-          return {
-            value: `${district.courtId}|${district.courtDivisionCode}`,
-            label,
-          };
-        });
+        // Build district options based on feature flag
+        if (districtDivisionEnabled && !isEditMode) {
+          // When flag is ON: build options from unique districts
+          const uniqueDistricts = getUniqueDistricts(courtsData);
+          const options = uniqueDistricts.map((district) => ({
+            value: district.courtId,
+            label: district.courtName,
+          }));
+          setDistrictOptions(options);
+        } else {
+          // When flag is OFF or edit mode: use existing combined format
+          const sortedCourts = sortByCourtLocation(courtsData);
+          const options = sortedCourts.map((district) => {
+            // Build label with guards for missing data
+            let label: string;
+            if (district.courtName && district.courtDivisionName) {
+              label = `${district.courtName} (${district.courtDivisionName})`;
+            } else if (district.courtName) {
+              label = district.courtName;
+            } else {
+              label = `Court ${district.courtId}`;
+            }
 
-        setDistrictOptions(options);
+            return {
+              value: `${district.courtId}|${district.courtDivisionCode}`,
+              label,
+            };
+          });
+          setDistrictOptions(options);
+        }
       } catch (err) {
         globalAlert?.error('Failed to load districts');
         console.error('Error loading districts:', err);
@@ -175,7 +225,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     };
 
     loadDistricts();
-  }, [globalAlert]);
+  }, [globalAlert, districtDivisionEnabled, isEditMode]);
 
   useEffect(() => {
     if (appointmentsToUse) {
@@ -197,16 +247,48 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     loadAppointments();
   }, [trusteeId, appointmentsToUse, globalAlert]);
 
+  // Auto-select "All Divisions" when district is selected
+  useEffect(() => {
+    if (districtDivisionEnabled && !isEditMode && divisionOptions.length > 0) {
+      // Only auto-select if divisions are currently empty (fresh district selection)
+      if (formData.divisionCodes.length === 0) {
+        setFormData((prev) => ({
+          ...prev,
+          divisionCodes: [ALL_DIVISIONS_VALUE],
+        }));
+      }
+    }
+  }, [divisionOptions, districtDivisionEnabled, isEditMode, formData.divisionCodes.length]);
+
   // Pure validation function
   const getValidationError = (
     data: FormData,
     appointments: TrusteeAppointment[],
     options: ComboOption[],
     currentAppointmentId?: string,
+    useSeparateFields?: boolean,
   ): string | null => {
-    if (!data.districtKey || !data.chapter || !data.appointmentType) return null;
+    // Get courtId and divisionCode based on flag state
+    let courtId: string;
+    let divisionCode: string;
 
-    const [courtId, divisionCode] = data.districtKey.split('|');
+    if (useSeparateFields) {
+      // When flag is ON, use separate fields
+      if (
+        !data.courtId ||
+        data.divisionCodes.length === 0 ||
+        !data.chapter ||
+        !data.appointmentType
+      )
+        return null;
+      courtId = data.courtId;
+      // For validation, use first division code
+      divisionCode = data.divisionCodes[0];
+    } else {
+      // When flag is OFF, use combined districtKey
+      if (!data.districtKey || !data.chapter || !data.appointmentType) return null;
+      [courtId, divisionCode] = data.districtKey.split('|');
+    }
 
     const hasOverlap = appointments.some(
       (appointment) =>
@@ -220,28 +302,52 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
     if (!hasOverlap) return null;
 
-    const district = options.find((opt) => opt.value === data.districtKey);
+    // Build error message
     const chapter = CHAPTER_OPTIONS.find((opt) => opt.value === data.chapter);
     const appointmentTypeLabel = formatAppointmentType(data.appointmentType);
 
-    return `An active appointment already exists for ${chapter?.label} - ${appointmentTypeLabel} in ${district?.label}. Please end the existing appointment before creating a new one.`;
+    let districtLabel: string;
+    if (useSeparateFields) {
+      // Find district name from allCourts
+      const court = allCourts.find((c) => c.courtId === courtId);
+      const division = allCourts.find(
+        (c) => c.courtId === courtId && c.courtDivisionCode === divisionCode,
+      );
+      districtLabel = court && division ? `${court.courtName} (${division.courtDivisionName})` : '';
+    } else {
+      const district = options.find((opt) => opt.value === data.districtKey);
+      districtLabel = district?.label ?? '';
+    }
+
+    return `An active appointment already exists for ${chapter?.label} - ${appointmentTypeLabel} in ${districtLabel}. Please end the existing appointment before creating a new one.`;
   };
+
+  const useSeparateFields = districtDivisionEnabled && !isEditMode;
 
   const validationError = getValidationError(
     formData,
     existingAppointments,
     districtOptions,
     appointment?.id,
+    useSeparateFields,
   );
 
-  const isFormValid =
-    !!formData.districtKey &&
-    !!formData.chapter &&
-    !!formData.appointmentType &&
-    !!formData.status &&
-    (!isEditMode || !!formData.effectiveDate) &&
-    !!formData.appointedDate &&
-    !validationError;
+  const isFormValid = useSeparateFields
+    ? !!formData.courtId &&
+      formData.divisionCodes.length > 0 &&
+      !!formData.chapter &&
+      !!formData.appointmentType &&
+      !!formData.status &&
+      (!isEditMode || !!formData.effectiveDate) &&
+      !!formData.appointedDate &&
+      !validationError
+    : !!formData.districtKey &&
+      !!formData.chapter &&
+      !!formData.appointmentType &&
+      !!formData.status &&
+      (!isEditMode || !!formData.effectiveDate) &&
+      !!formData.appointedDate &&
+      !validationError;
 
   const handleSubmit = async (ev: React.FormEvent): Promise<void> => {
     ev.preventDefault();
@@ -252,7 +358,27 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
     setIsSubmitting(true);
 
-    const [courtId, divisionCode] = formData.districtKey.split('|');
+    // Get courtId and divisionCode(s) based on flag state
+    let courtId: string;
+    let divisionCode: string | undefined;
+
+    if (useSeparateFields) {
+      // When flag is ON, use separate fields and map "All Divisions" to actual codes
+      courtId = formData.courtId;
+
+      // Map "__ALL__" to all actual division codes for this district
+      let divisionCodes = formData.divisionCodes;
+      if (divisionCodes.includes(ALL_DIVISIONS_VALUE)) {
+        divisionCodes = getDivisionsForDistrict(allCourts, courtId).map((d) => d.courtDivisionCode);
+      }
+
+      // For now, send first division code (backend doesn't support array yet)
+      // TODO: Update when backend supports divisionCodes array
+      divisionCode = divisionCodes[0];
+    } else {
+      // When flag is OFF, split the composite key
+      [courtId, divisionCode] = formData.districtKey.split('|');
+    }
 
     const payload: TrusteeAppointmentInput = {
       chapter: formData.chapter as AppointmentChapterType,
@@ -285,6 +411,11 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
   const handleFieldChange = (field: keyof FormData, value: string) => {
     setFormData((prev) => {
+      // When district (courtId) changes, reset divisions to empty (useEffect will set to "All Divisions")
+      if (field === 'courtId' && useSeparateFields) {
+        return { ...prev, courtId: value, divisionCodes: [] };
+      }
+
       // When chapter changes, reset appointmentType and status
       if (field === 'chapter') {
         // Type guard to ensure value is a valid AppointmentChapterType
@@ -319,8 +450,46 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     return selected ? [selected] : undefined;
   };
 
+  const getMultiSelections = (fieldValues: string[], options: ComboOption[]) => {
+    if (!fieldValues || fieldValues.length === 0) return undefined;
+    const selected = options.filter((opt) => fieldValues.includes(opt.value));
+    return selected.length > 0 ? selected : undefined;
+  };
+
   const handleComboBoxUpdate = (field: keyof FormData, options: ComboOption[]) => {
     handleFieldChange(field, options[0]?.value ?? '');
+  };
+
+  // Handle division selection with mutually exclusive "All Divisions" logic
+  const handleDivisionSelection = (selectedOptions: ComboOption[]) => {
+    const selectedValues = selectedOptions.map((opt) => opt.value);
+    const prevValues = formData.divisionCodes;
+
+    // Edge case: User clicked X to clear "All Divisions" - prevent it by re-selecting
+    if (selectedValues.length === 0 && prevValues.includes(ALL_DIVISIONS_VALUE)) {
+      return; // Do nothing, keep "All Divisions" selected
+    }
+
+    // If both "All Divisions" and specific divisions are present
+    if (selectedValues.includes(ALL_DIVISIONS_VALUE) && selectedValues.length > 1) {
+      // Determine what was just added
+      const addedValues = selectedValues.filter((v) => !prevValues.includes(v));
+
+      if (addedValues.includes(ALL_DIVISIONS_VALUE)) {
+        // "All Divisions" was just added - keep only it
+        setFormData((prev) => ({ ...prev, divisionCodes: [ALL_DIVISIONS_VALUE] }));
+      } else {
+        // A specific division was just added - remove "All Divisions"
+        setFormData((prev) => ({
+          ...prev,
+          divisionCodes: selectedValues.filter((v) => v !== ALL_DIVISIONS_VALUE),
+        }));
+      }
+      return;
+    }
+
+    // Normal case: just update to whatever was selected
+    setFormData((prev) => ({ ...prev, divisionCodes: selectedValues }));
   };
 
   const handleDateChange = (field: keyof FormData, e: React.ChangeEvent<HTMLInputElement>) => {
@@ -357,12 +526,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
         data-testid="trustee-appointment-form"
         onSubmit={handleSubmit}
       >
-        <div className="form-header">
-          <span>
-            A red asterisk (<span className="text-secondary-dark">*</span>) indicates a required
-            field.
-          </span>
-        </div>
+        <FormRequirementsNotice />
 
         {validationError && (
           <Alert type={UswdsAlertStyle.Error} inline={true} show={true} message={validationError} />
@@ -370,16 +534,96 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
         <div className="form-container">
           <div className="form-column">
-            <div className="field-group">
-              <ComboBox
-                id="district"
-                label="District"
-                required={true}
-                options={districtOptions}
-                selections={getSelections(formData.districtKey, districtOptions)}
-                onUpdateSelection={(options) => handleComboBoxUpdate('districtKey', options)}
-              />
-            </div>
+            {useSeparateFields ? (
+              <>
+                {/* District dropdown when flag is ON */}
+                <div className="field-group">
+                  <ComboBox
+                    id="district"
+                    label="District"
+                    required={true}
+                    options={districtOptions}
+                    selections={getSelections(formData.courtId, districtOptions)}
+                    onUpdateSelection={(options) => handleComboBoxUpdate('courtId', options)}
+                  />
+                </div>
+
+                {/* Division dropdown when flag is ON */}
+                <div className="field-group division-field-group">
+                  <div className="division-dropdown-wrapper">
+                    <ComboBox
+                      id="division"
+                      label="Assignable Divisions"
+                      required={true}
+                      multiSelect={true}
+                      wrapPills={true}
+                      pluralLabel="divisions"
+                      singularLabel="division"
+                      disabled={!formData.courtId}
+                      options={divisionOptions}
+                      ariaDescription="Divisions where this trustee will be assigned"
+                      selections={getMultiSelections(formData.divisionCodes, divisionOptions)}
+                      onUpdateSelection={handleDivisionSelection}
+                      hideClearAllButton={
+                        formData.divisionCodes.length === 1 &&
+                        formData.divisionCodes[0] === ALL_DIVISIONS_VALUE
+                      }
+                    />
+                  </div>
+
+                  {/* Division pills - display below dropdown */}
+                  {formData.divisionCodes.length > 0 && (
+                    <div className="division-pills-container">
+                      {getMultiSelections(formData.divisionCodes, divisionOptions)?.map(
+                        (division) => {
+                          const showRemoveButton = !(
+                            formData.divisionCodes.length === 1 &&
+                            formData.divisionCodes[0] === ALL_DIVISIONS_VALUE
+                          );
+                          return (
+                            <span key={division.value} className="usa-tag division-pill">
+                              {division.label}
+                              {showRemoveButton && (
+                                <button
+                                  type="button"
+                                  className="usa-tag__remove-button"
+                                  onClick={() => {
+                                    const newCodes = formData.divisionCodes.filter(
+                                      (code) => code !== division.value,
+                                    );
+                                    // If removing last item, default back to "All Divisions"
+                                    setFormData((prev) => ({
+                                      ...prev,
+                                      divisionCodes:
+                                        newCodes.length === 0 ? [ALL_DIVISIONS_VALUE] : newCodes,
+                                    }));
+                                  }}
+                                  aria-label={`Remove ${division.label}`}
+                                >
+                                  ×
+                                </button>
+                              )}
+                            </span>
+                          );
+                        },
+                      )}
+                    </div>
+                  )}
+                </div>
+              </>
+            ) : (
+              /* Combined district dropdown when flag is OFF or edit mode */
+              <div className="field-group">
+                <ComboBox
+                  id="district"
+                  label="District"
+                  required={true}
+                  options={districtOptions}
+                  selections={getSelections(formData.districtKey, districtOptions)}
+                  onUpdateSelection={(options) => handleComboBoxUpdate('districtKey', options)}
+                />
+              </div>
+            )}
 
             <div className="field-group">
               <ComboBox

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -34,6 +34,7 @@ import {
 } from '@common/cams/trustees';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
+import PillBox from '@/lib/components/PillBox';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { FormRequirementsNotice } from '@/lib/components/uswds/FormRequirementsNotice';
 import { useLocation } from 'react-router-dom';
@@ -530,6 +531,16 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     setFormData((prev) => ({ ...prev, divisionCodes: selectedValues }));
   };
 
+  // Handle pill removal from PillBox with "All Divisions" default behavior
+  const handlePillRemoval = (updatedSelections: ComboOption[]) => {
+    const newCodes = updatedSelections.map((opt) => opt.value);
+    // If removing last item, default back to "All Divisions"
+    setFormData((prev) => ({
+      ...prev,
+      divisionCodes: newCodes.length === 0 ? [ALL_DIVISIONS_VALUE] : newCodes,
+    }));
+  };
+
   // Handle when focus leaves the entire division dropdown component
   const handleDivisionBlur = (e: React.FocusEvent) => {
     const currentTarget = e.currentTarget;
@@ -652,43 +663,29 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
                   </div>
 
                   {/* Division pills - display below dropdown */}
-                  {formData.divisionCodes.length > 0 && (
-                    <div className="division-pills-container">
-                      {getMultiSelections(formData.divisionCodes, divisionOptions)?.map(
-                        (division) => {
-                          const showRemoveButton = !(
-                            formData.divisionCodes.length === 1 &&
-                            formData.divisionCodes[0] === ALL_DIVISIONS_VALUE
-                          );
-                          return (
-                            <span key={division.value} className="usa-tag division-pill">
-                              {division.label}
-                              {showRemoveButton && (
-                                <button
-                                  type="button"
-                                  className="usa-tag__remove-button"
-                                  onClick={() => {
-                                    const newCodes = formData.divisionCodes.filter(
-                                      (code) => code !== division.value,
-                                    );
-                                    // If removing last item, default back to "All Divisions"
-                                    setFormData((prev) => ({
-                                      ...prev,
-                                      divisionCodes:
-                                        newCodes.length === 0 ? [ALL_DIVISIONS_VALUE] : newCodes,
-                                    }));
-                                  }}
-                                  aria-label={`Remove ${division.label}`}
-                                >
-                                  ×
-                                </button>
-                              )}
-                            </span>
-                          );
-                        },
-                      )}
-                    </div>
-                  )}
+                  {formData.divisionCodes.length > 0 &&
+                    getMultiSelections(formData.divisionCodes, divisionOptions) &&
+                    (formData.divisionCodes.length === 1 &&
+                    formData.divisionCodes[0] === ALL_DIVISIONS_VALUE ? (
+                      // Show non-interactive badge when only "All Divisions" is selected
+                      <div className="division-pills-container">
+                        <span className="pill usa-button--unstyled" style={{ cursor: 'default' }}>
+                          <div className="pill-text" style={{ maxWidth: '100%' }}>
+                            All Divisions
+                          </div>
+                        </span>
+                      </div>
+                    ) : (
+                      // Use PillBox for removable specific divisions
+                      <PillBox
+                        id="division-pills"
+                        className="division-pills-container"
+                        selections={getMultiSelections(formData.divisionCodes, divisionOptions)!}
+                        wrapPills={true}
+                        ariaLabelPrefix="Division"
+                        onSelectionChange={handlePillRemoval}
+                      />
+                    ))}
                 </div>
               </>
             ) : (

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -361,19 +361,20 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     // Get courtId and divisionCode(s) based on flag state
     let courtId: string;
     let divisionCode: string | undefined;
+    let divisionCodes: string[] | undefined;
 
     if (useSeparateFields) {
       // When flag is ON, use separate fields and map "All Divisions" to actual codes
       courtId = formData.courtId;
 
       // Map "__ALL__" to all actual division codes for this district
-      let divisionCodes = formData.divisionCodes;
+      divisionCodes = formData.divisionCodes;
       if (divisionCodes.includes(ALL_DIVISIONS_VALUE)) {
         divisionCodes = getDivisionsForDistrict(allCourts, courtId).map((d) => d.courtDivisionCode);
       }
 
-      // For now, send first division code (backend doesn't support array yet)
-      // TODO: Update when backend supports divisionCodes array
+      // Send array to backend (backend now supports divisionCodes array)
+      // Also send first as divisionCode for backward compatibility
       divisionCode = divisionCodes[0];
     } else {
       // When flag is OFF, split the composite key
@@ -385,6 +386,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
       appointmentType: formData.appointmentType as AppointmentType,
       courtId,
       divisionCode,
+      divisionCodes, // New: send array of division codes
       appointedDate: formData.appointedDate,
       status: formData.status as AppointmentStatus,
       effectiveDate: isEditMode ? formData.effectiveDate : formData.appointedDate,
@@ -492,6 +494,34 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     setFormData((prev) => ({ ...prev, divisionCodes: selectedValues }));
   };
 
+  // Handle when focus leaves the entire division dropdown component
+  const handleDivisionBlur = (e: React.FocusEvent) => {
+    const currentTarget = e.currentTarget;
+
+    // Check if the new focus target is outside the division dropdown component
+    setTimeout(() => {
+      // If focus moved to an element outside this component
+      if (!currentTarget.contains(document.activeElement)) {
+        if (!formData.courtId || !allCourts.length) return;
+
+        const allAvailableDivisions = getDivisionsForDistrict(allCourts, formData.courtId).map(
+          (d) => d.courtDivisionCode,
+        );
+
+        // If user selected all individual divisions (and not already "All Divisions")
+        if (
+          !formData.divisionCodes.includes(ALL_DIVISIONS_VALUE) &&
+          formData.divisionCodes.length === allAvailableDivisions.length &&
+          formData.divisionCodes.length > 0 &&
+          allAvailableDivisions.every((code) => formData.divisionCodes.includes(code))
+        ) {
+          // Auto-convert to "All Divisions"
+          setFormData((prev) => ({ ...prev, divisionCodes: [ALL_DIVISIONS_VALUE] }));
+        }
+      }
+    }, 100);
+  };
+
   const handleDateChange = (field: keyof FormData, e: React.ChangeEvent<HTMLInputElement>) => {
     handleFieldChange(field, e.target.value);
   };
@@ -550,7 +580,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
                 {/* Division dropdown when flag is ON */}
                 <div className="field-group division-field-group">
-                  <div className="division-dropdown-wrapper">
+                  <div className="division-dropdown-wrapper" onBlur={handleDivisionBlur}>
                     <ComboBox
                       id="division"
                       label="Assignable Divisions"

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -71,7 +71,13 @@ function getDefaultAppointmentType(
 }
 
 // Synthetic value for "All Divisions" option
-const ALL_DIVISIONS_VALUE = '__ALL__';
+export const ALL_DIVISIONS_VALUE = '__ALL__';
+
+export type CourtDivisionInput = {
+  courtId: string;
+  divisionCodes: string[];
+  districtKey: string;
+};
 
 /**
  * Extract court and division information from form data.
@@ -83,8 +89,8 @@ const ALL_DIVISIONS_VALUE = '__ALL__';
  * @param allCourts - All available court divisions (needed for "All Divisions" expansion)
  * @returns {courtId, divisionCodes} or null if required fields are missing
  */
-function extractCourtAndDivisions(
-  formData: Pick<FormData, 'courtId' | 'divisionCodes' | 'districtKey'>,
+export function extractCourtAndDivisions(
+  formData: CourtDivisionInput,
   useSeparateFields: boolean,
   allCourts: CourtDivisionDetails[],
 ): { courtId: string; divisionCodes: string[] } | null {
@@ -340,7 +346,9 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
       }
 
       // Get existing appointment's divisions (could be array or single code for backward compat)
-      const existingDivisions = appointment.divisionCodes || [appointment.divisionCode];
+      const existingDivisions = (appointment.divisionCodes || [appointment.divisionCode]).filter(
+        Boolean,
+      ) as string[];
 
       // Check if ANY of the new divisions overlap with ANY of the existing divisions
       return divisionCodesToCheck.some((code) => existingDivisions.includes(code));

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -73,7 +73,7 @@ function getDefaultAppointmentType(
 // Synthetic value for "All Divisions" option
 export const ALL_DIVISIONS_VALUE = '__ALL__';
 
-export type CourtDivisionInput = {
+type CourtDivisionInput = {
   courtId: string;
   divisionCodes: string[];
   districtKey: string;

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -316,7 +316,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     }
   }, [divisionOptions, districtDivisionEnabled, isEditMode, formData.divisionCodes.length]);
 
-  // Pure validation function
+  // Validation: checks for overlapping active appointments
   const getValidationError = (
     data: FormData,
     appointments: TrusteeAppointment[],
@@ -390,22 +390,15 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     useSeparateFields,
   );
 
-  const isFormValid = useSeparateFields
-    ? !!formData.courtId &&
-      formData.divisionCodes.length > 0 &&
-      !!formData.chapter &&
-      !!formData.appointmentType &&
-      !!formData.status &&
-      (!isEditMode || !!formData.effectiveDate) &&
-      !!formData.appointedDate &&
-      !validationError
-    : !!formData.districtKey &&
-      !!formData.chapter &&
-      !!formData.appointmentType &&
-      !!formData.status &&
-      (!isEditMode || !!formData.effectiveDate) &&
-      !!formData.appointedDate &&
-      !validationError;
+  const hasCourtSelection = !!extractCourtAndDivisions(formData, useSeparateFields, allCourts);
+  const isFormValid =
+    hasCourtSelection &&
+    !!formData.chapter &&
+    !!formData.appointmentType &&
+    !!formData.status &&
+    (!isEditMode || !!formData.effectiveDate) &&
+    !!formData.appointedDate &&
+    !validationError;
 
   const handleSubmit = async (ev: React.FormEvent): Promise<void> => {
     ev.preventDefault();
@@ -677,10 +670,8 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
                     formData.divisionCodes[0] === ALL_DIVISIONS_VALUE ? (
                       // Show non-interactive badge when only "All Divisions" is selected
                       <div className="division-pills-container">
-                        <span className="pill usa-button--unstyled" style={{ cursor: 'default' }}>
-                          <div className="pill-text" style={{ maxWidth: '100%' }}>
-                            All Divisions
-                          </div>
+                        <span className="pill usa-button--unstyled division-pill-static">
+                          <div className="pill-text">All Divisions</div>
                         </span>
                       </div>
                     ) : (

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -409,7 +409,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     // Extract court and divisions using shared helper
     const courtInfo = extractCourtAndDivisions(formData, useSeparateFields, allCourts);
     if (!courtInfo) {
-      setGlobalAlertWarning('Missing required court or division information');
+      globalAlert?.warning('Missing required court or division information');
       setIsSubmitting(false);
       return;
     }

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -72,6 +72,54 @@ function getDefaultAppointmentType(
 // Synthetic value for "All Divisions" option
 const ALL_DIVISIONS_VALUE = '__ALL__';
 
+/**
+ * Extract court and division information from form data.
+ * Handles both legacy (combined districtKey) and new (separate courtId/divisionCodes) formats.
+ * Expands "All Divisions" synthetic value to actual division codes.
+ *
+ * @param formData - The form data
+ * @param useSeparateFields - Whether district-division flag is enabled (separate fields)
+ * @param allCourts - All available court divisions (needed for "All Divisions" expansion)
+ * @returns {courtId, divisionCodes} or null if required fields are missing
+ */
+function extractCourtAndDivisions(
+  formData: Pick<FormData, 'courtId' | 'divisionCodes' | 'districtKey'>,
+  useSeparateFields: boolean,
+  allCourts: CourtDivisionDetails[],
+): { courtId: string; divisionCodes: string[] } | null {
+  if (useSeparateFields) {
+    // New format: separate courtId and divisionCodes fields
+    if (!formData.courtId || formData.divisionCodes.length === 0) {
+      return null;
+    }
+
+    let divisionCodes = formData.divisionCodes;
+
+    // Expand "All Divisions" synthetic value to actual division codes
+    if (divisionCodes.includes(ALL_DIVISIONS_VALUE)) {
+      divisionCodes = getDivisionsForDistrict(allCourts, formData.courtId).map(
+        (d) => d.courtDivisionCode,
+      );
+    }
+
+    return {
+      courtId: formData.courtId,
+      divisionCodes,
+    };
+  } else {
+    // Legacy format: combined districtKey (courtId|divisionCode)
+    if (!formData.districtKey) {
+      return null;
+    }
+
+    const [courtId, divisionCode] = formData.districtKey.split('|');
+    return {
+      courtId,
+      divisionCodes: [divisionCode],
+    };
+  }
+}
+
 type FormData = {
   districtKey: string; // Combined key: "{courtId}|{divisionCode}" (used when flag is OFF)
   courtId: string; // Separate court ID (used when flag is ON)
@@ -268,39 +316,35 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     currentAppointmentId?: string,
     useSeparateFields?: boolean,
   ): string | null => {
-    // Get courtId and divisionCode based on flag state
-    let courtId: string;
-    let divisionCode: string;
+    // Validate required fields
+    if (!data.chapter || !data.appointmentType) return null;
 
-    if (useSeparateFields) {
-      // When flag is ON, use separate fields
+    // Extract court and divisions using shared helper
+    const courtInfo = extractCourtAndDivisions(data, !!useSeparateFields, allCourts);
+    if (!courtInfo) return null;
+
+    const { courtId, divisionCodes: divisionCodesToCheck } = courtInfo;
+
+    // Check for overlap: any of the new divisions overlap with any existing appointment's divisions
+    const conflictingAppointment = appointments.find((appointment) => {
       if (
-        !data.courtId ||
-        data.divisionCodes.length === 0 ||
-        !data.chapter ||
-        !data.appointmentType
-      )
-        return null;
-      courtId = data.courtId;
-      // For validation, use first division code
-      divisionCode = data.divisionCodes[0];
-    } else {
-      // When flag is OFF, use combined districtKey
-      if (!data.districtKey || !data.chapter || !data.appointmentType) return null;
-      [courtId, divisionCode] = data.districtKey.split('|');
-    }
+        appointment.id === currentAppointmentId ||
+        appointment.courtId !== courtId ||
+        appointment.chapter !== data.chapter ||
+        appointment.appointmentType !== data.appointmentType ||
+        appointment.status !== 'active'
+      ) {
+        return false;
+      }
 
-    const hasOverlap = appointments.some(
-      (appointment) =>
-        appointment.id !== currentAppointmentId &&
-        appointment.courtId === courtId &&
-        appointment.divisionCode === divisionCode &&
-        appointment.chapter === data.chapter &&
-        appointment.appointmentType === data.appointmentType &&
-        appointment.status === 'active',
-    );
+      // Get existing appointment's divisions (could be array or single code for backward compat)
+      const existingDivisions = appointment.divisionCodes || [appointment.divisionCode];
 
-    if (!hasOverlap) return null;
+      // Check if ANY of the new divisions overlap with ANY of the existing divisions
+      return divisionCodesToCheck.some((code) => existingDivisions.includes(code));
+    });
+
+    if (!conflictingAppointment) return null;
 
     // Build error message
     const chapter = CHAPTER_OPTIONS.find((opt) => opt.value === data.chapter);
@@ -310,12 +354,16 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     if (useSeparateFields) {
       // Find district name from allCourts
       const court = allCourts.find((c) => c.courtId === courtId);
+      // Show the first conflicting division in the error message
+      const conflictingDivisionCode =
+        conflictingAppointment.divisionCodes?.[0] || conflictingAppointment.divisionCode;
       const division = allCourts.find(
-        (c) => c.courtId === courtId && c.courtDivisionCode === divisionCode,
+        (c) => c.courtId === courtId && c.courtDivisionCode === conflictingDivisionCode,
       );
       districtLabel = court && division ? `${court.courtName} (${division.courtDivisionName})` : '';
     } else {
-      const district = options.find((opt) => opt.value === data.districtKey);
+      const districtKey = `${courtId}|${conflictingAppointment.divisionCode}`;
+      const district = options.find((opt) => opt.value === districtKey);
       districtLabel = district?.label ?? '';
     }
 
@@ -358,35 +406,22 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
     setIsSubmitting(true);
 
-    // Get courtId and divisionCode(s) based on flag state
-    let courtId: string;
-    let divisionCode: string | undefined;
-    let divisionCodes: string[] | undefined;
-
-    if (useSeparateFields) {
-      // When flag is ON, use separate fields and map "All Divisions" to actual codes
-      courtId = formData.courtId;
-
-      // Map "__ALL__" to all actual division codes for this district
-      divisionCodes = formData.divisionCodes;
-      if (divisionCodes.includes(ALL_DIVISIONS_VALUE)) {
-        divisionCodes = getDivisionsForDistrict(allCourts, courtId).map((d) => d.courtDivisionCode);
-      }
-
-      // Send array to backend (backend now supports divisionCodes array)
-      // Also send first as divisionCode for backward compatibility
-      divisionCode = divisionCodes[0];
-    } else {
-      // When flag is OFF, split the composite key
-      [courtId, divisionCode] = formData.districtKey.split('|');
+    // Extract court and divisions using shared helper
+    const courtInfo = extractCourtAndDivisions(formData, useSeparateFields, allCourts);
+    if (!courtInfo) {
+      setGlobalAlertWarning('Missing required court or division information');
+      setIsSubmitting(false);
+      return;
     }
+
+    const { courtId, divisionCodes } = courtInfo;
 
     const payload: TrusteeAppointmentInput = {
       chapter: formData.chapter as AppointmentChapterType,
       appointmentType: formData.appointmentType as AppointmentType,
       courtId,
-      divisionCode,
-      divisionCodes, // New: send array of division codes
+      divisionCode: divisionCodes[0], // Send first for backward compatibility
+      divisionCodes, // Send array of division codes
       appointedDate: formData.appointedDate,
       status: formData.status as AppointmentStatus,
       effectiveDate: isEditMode ? formData.effectiveDate : formData.appointedDate,

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -1,6 +1,6 @@
 import './TrusteeContactForm.scss';
 import './TrusteeAppointmentForm.scss';
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import DatePicker from '@/lib/components/uswds/DatePicker';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import useFeatureFlags, {
@@ -162,6 +162,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   const [existingAppointments, setExistingAppointments] = useState<TrusteeAppointment[]>(
     appointmentsToUse ?? [],
   );
+  const divisionBlurTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [formData, setFormData] = useState<FormData>(() => {
     if (appointment) {
       return {
@@ -533,8 +534,13 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   const handleDivisionBlur = (e: React.FocusEvent) => {
     const currentTarget = e.currentTarget;
 
+    // Clear any pending timeout
+    if (divisionBlurTimeoutRef.current) {
+      clearTimeout(divisionBlurTimeoutRef.current);
+    }
+
     // Check if the new focus target is outside the division dropdown component
-    setTimeout(() => {
+    divisionBlurTimeoutRef.current = setTimeout(() => {
       // If focus moved to an element outside this component
       if (!currentTarget.contains(document.activeElement)) {
         if (!formData.courtId || !allCourts.length) return;
@@ -556,6 +562,15 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
       }
     }, 100);
   };
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (divisionBlurTimeoutRef.current) {
+        clearTimeout(divisionBlurTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleDateChange = (field: keyof FormData, e: React.ChangeEvent<HTMLInputElement>) => {
     handleFieldChange(field, e.target.value);

--- a/user-interface/src/trustees/panels/AppointmentCard.tsx
+++ b/user-interface/src/trustees/panels/AppointmentCard.tsx
@@ -11,9 +11,7 @@ import { CamsRole } from '@common/cams/roles';
 import useFeatureFlags, {
   DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES,
 } from '@/lib/hooks/UseFeatureFlags';
-import { useState, useEffect } from 'react';
-import Api2 from '@/lib/models/api2';
-import { CourtDivisionDetails } from '@common/cams/courts';
+import useCourts from '@/lib/hooks/UseCourts';
 import { getDivisionsForDistrict } from '@/lib/utils/court-utils';
 
 export interface AppointmentCardProps {
@@ -46,21 +44,12 @@ export default function AppointmentCard(props: Readonly<AppointmentCardProps>) {
   const formattedChapter = formatChapterType(chapter);
   const formattedAppointmentType = formatAppointmentType(appointmentType);
 
-  const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]);
+  // Use shared courts hook to avoid redundant API calls
+  const { courts: allCourts, error: courtsError } = useCourts();
 
-  // Load courts data for division name lookup
-  useEffect(() => {
-    const loadCourts = async () => {
-      try {
-        const response = await Api2.getCourts();
-        setAllCourts(response.data);
-      } catch (err) {
-        console.error('Error loading courts:', err);
-      }
-    };
-
-    loadCourts();
-  }, []);
+  if (courtsError) {
+    console.error('Error loading courts:', courtsError);
+  }
 
   // Build district display with guards for missing data
   // Use court name (e.g., "Eastern District of Missouri") populated by backend enrichment

--- a/user-interface/src/trustees/panels/AppointmentCard.tsx
+++ b/user-interface/src/trustees/panels/AppointmentCard.tsx
@@ -76,20 +76,47 @@ export default function AppointmentCard(props: Readonly<AppointmentCardProps>) {
   }
 
   // Build divisions display
-  // Backend returns divisionCode but not courtDivisionName (yet)
-  // Enrich on frontend by looking up the division name from the code
+  // Backend may return divisionCodes array or legacy single divisionCode
+  // Enrich on frontend by looking up division names from codes
   let divisionsDisplay = 'Not specified';
 
-  if (props.appointment.courtDivisionName) {
-    // Backend provided the enriched name
+  if (props.appointment.divisionCodes && props.appointment.divisionCodes.length > 0) {
+    // New format: array of division codes
+    if (props.appointment.courtId && allCourts.length > 0) {
+      const divisions = getDivisionsForDistrict(allCourts, props.appointment.courtId);
+      const allDivisionCodes = divisions.map((d) => d.courtDivisionCode);
+
+      // Check if all divisions are selected
+      const hasAllDivisions =
+        props.appointment.divisionCodes.length === allDivisionCodes.length &&
+        props.appointment.divisionCodes.every((code) => allDivisionCodes.includes(code));
+
+      if (hasAllDivisions) {
+        divisionsDisplay = 'All';
+      } else {
+        // Look up names for each code
+        const divisionNames = props.appointment.divisionCodes
+          .map((code) => {
+            const division = divisions.find((d) => d.courtDivisionCode === code);
+            return division?.courtDivisionName || code;
+          })
+          .sort();
+        divisionsDisplay = divisionNames.join(', ');
+      }
+    } else {
+      // Can't look up names - show codes
+      divisionsDisplay = props.appointment.divisionCodes.join(', ');
+    }
+  } else if (props.appointment.courtDivisionName) {
+    // Backend provided the enriched name (legacy single division)
     divisionsDisplay = props.appointment.courtDivisionName;
   } else if (props.appointment.divisionCode && props.appointment.courtId && allCourts.length > 0) {
-    // Look up the division name from the code
+    // Look up the division name from the code (legacy single division)
     const divisions = getDivisionsForDistrict(allCourts, props.appointment.courtId);
     const division = divisions.find((d) => d.courtDivisionCode === props.appointment.divisionCode);
     divisionsDisplay = division?.courtDivisionName || props.appointment.divisionCode;
   } else if (props.appointment.divisionCode) {
-    // Have code but can't look up name - show code
+    // Have code but can't look up name - show code (legacy single division)
     divisionsDisplay = props.appointment.divisionCode;
   }
 

--- a/user-interface/src/trustees/panels/AppointmentCard.tsx
+++ b/user-interface/src/trustees/panels/AppointmentCard.tsx
@@ -12,7 +12,7 @@ import useFeatureFlags, {
   DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES,
 } from '@/lib/hooks/UseFeatureFlags';
 import useCourts from '@/lib/hooks/UseCourts';
-import { getDivisionsForDistrict } from '@/lib/utils/court-utils';
+import { buildDivisionsDisplay } from '@/lib/utils/court-utils';
 
 export interface AppointmentCardProps {
   appointment: TrusteeAppointment;
@@ -64,50 +64,7 @@ export default function AppointmentCard(props: Readonly<AppointmentCardProps>) {
     districtDisplay = 'Court information not available';
   }
 
-  // Build divisions display
-  // Backend may return divisionCodes array or legacy single divisionCode
-  // Enrich on frontend by looking up division names from codes
-  let divisionsDisplay = 'Not specified';
-
-  if (props.appointment.divisionCodes && props.appointment.divisionCodes.length > 0) {
-    // New format: array of division codes
-    if (props.appointment.courtId && allCourts.length > 0) {
-      const divisions = getDivisionsForDistrict(allCourts, props.appointment.courtId);
-      const allDivisionCodes = divisions.map((d) => d.courtDivisionCode);
-
-      // Check if all divisions are selected
-      const hasAllDivisions =
-        props.appointment.divisionCodes.length === allDivisionCodes.length &&
-        props.appointment.divisionCodes.every((code) => allDivisionCodes.includes(code));
-
-      if (hasAllDivisions) {
-        divisionsDisplay = 'All';
-      } else {
-        // Look up names for each code
-        const divisionNames = props.appointment.divisionCodes
-          .map((code) => {
-            const division = divisions.find((d) => d.courtDivisionCode === code);
-            return division?.courtDivisionName || code;
-          })
-          .sort();
-        divisionsDisplay = divisionNames.join(', ');
-      }
-    } else {
-      // Can't look up names - show codes
-      divisionsDisplay = props.appointment.divisionCodes.join(', ');
-    }
-  } else if (props.appointment.courtDivisionName) {
-    // Backend provided the enriched name (legacy single division)
-    divisionsDisplay = props.appointment.courtDivisionName;
-  } else if (props.appointment.divisionCode && props.appointment.courtId && allCourts.length > 0) {
-    // Look up the division name from the code (legacy single division)
-    const divisions = getDivisionsForDistrict(allCourts, props.appointment.courtId);
-    const division = divisions.find((d) => d.courtDivisionCode === props.appointment.divisionCode);
-    divisionsDisplay = division?.courtDivisionName || props.appointment.divisionCode;
-  } else if (props.appointment.divisionCode) {
-    // Have code but can't look up name - show code (legacy single division)
-    divisionsDisplay = props.appointment.divisionCode;
-  }
+  const divisionsDisplay = buildDivisionsDisplay(props.appointment, allCourts);
 
   const formattedEffectiveDate = formatAppointmentDate(props.appointment.effectiveDate);
   const formattedAppointedDate = formatAppointmentDate(props.appointment.appointedDate);

--- a/user-interface/src/trustees/panels/AppointmentCard.tsx
+++ b/user-interface/src/trustees/panels/AppointmentCard.tsx
@@ -11,6 +11,10 @@ import { CamsRole } from '@common/cams/roles';
 import useFeatureFlags, {
   DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES,
 } from '@/lib/hooks/UseFeatureFlags';
+import { useState, useEffect } from 'react';
+import Api2 from '@/lib/models/api2';
+import { CourtDivisionDetails } from '@common/cams/courts';
+import { getDivisionsForDistrict } from '@/lib/utils/court-utils';
 
 export interface AppointmentCardProps {
   appointment: TrusteeAppointment;
@@ -42,6 +46,22 @@ export default function AppointmentCard(props: Readonly<AppointmentCardProps>) {
   const formattedChapter = formatChapterType(chapter);
   const formattedAppointmentType = formatAppointmentType(appointmentType);
 
+  const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]);
+
+  // Load courts data for division name lookup
+  useEffect(() => {
+    const loadCourts = async () => {
+      try {
+        const response = await Api2.getCourts();
+        setAllCourts(response.data);
+      } catch (err) {
+        console.error('Error loading courts:', err);
+      }
+    };
+
+    loadCourts();
+  }, []);
+
   // Build district display with guards for missing data
   // Use court name (e.g., "Eastern District of Missouri") populated by backend enrichment
   // Only fallback to court ID if court name is not available
@@ -53,6 +73,24 @@ export default function AppointmentCard(props: Readonly<AppointmentCardProps>) {
     districtDisplay = `Court ${props.appointment.courtId}`;
   } else {
     districtDisplay = 'Court information not available';
+  }
+
+  // Build divisions display
+  // Backend returns divisionCode but not courtDivisionName (yet)
+  // Enrich on frontend by looking up the division name from the code
+  let divisionsDisplay = 'Not specified';
+
+  if (props.appointment.courtDivisionName) {
+    // Backend provided the enriched name
+    divisionsDisplay = props.appointment.courtDivisionName;
+  } else if (props.appointment.divisionCode && props.appointment.courtId && allCourts.length > 0) {
+    // Look up the division name from the code
+    const divisions = getDivisionsForDistrict(allCourts, props.appointment.courtId);
+    const division = divisions.find((d) => d.courtDivisionCode === props.appointment.divisionCode);
+    divisionsDisplay = division?.courtDivisionName || props.appointment.divisionCode;
+  } else if (props.appointment.divisionCode) {
+    // Have code but can't look up name - show code
+    divisionsDisplay = props.appointment.divisionCode;
   }
 
   const formattedEffectiveDate = formatAppointmentDate(props.appointment.effectiveDate);
@@ -86,6 +124,7 @@ export default function AppointmentCard(props: Readonly<AppointmentCardProps>) {
           editTitle="Edit trustee appointment"
           fields={[
             { label: 'District', value: districtDisplay },
+            { label: 'Divisions', value: divisionsDisplay },
             { label: 'Chapter', value: formattedChapter },
             { label: 'Type', value: formattedAppointmentType },
             { label: 'Appointed', value: formattedAppointedDate },

--- a/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tsx
@@ -4,6 +4,7 @@ import LoadingIndicator from '@/lib/components/LoadingIndicator';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { useEffect, useState } from 'react';
 import Api2 from '@/lib/models/api2';
+import { CourtDivisionDetails } from '@common/cams/courts';
 import {
   TrusteeHistory,
   TrusteeNameHistory,
@@ -255,10 +256,11 @@ function ShowTrusteeOversightHistory(props: ShowTrusteeOversightHistoryProps) {
 type ShowTrusteeAppointmentHistoryProps = Readonly<{
   history: TrusteeAppointmentHistory;
   idx: number;
+  allCourts: CourtDivisionDetails[];
 }>;
 
 function ShowTrusteeAppointmentHistory(props: ShowTrusteeAppointmentHistoryProps) {
-  const { history, idx } = props;
+  const { history, idx, allCourts } = props;
 
   const formatAppointmentData = (data: typeof history.before | typeof history.after) => {
     if (!data) return '(none)';
@@ -278,12 +280,39 @@ function ShowTrusteeAppointmentHistory(props: ShowTrusteeAppointmentHistoryProps
       districtDisplay = 'Court information not available';
     }
 
+    // Format divisions display (new multi-division feature)
+    let divisionsDisplay: string | null = null;
+    if (data.divisionCodes && data.divisionCodes.length > 0) {
+      // Look up division names from allCourts
+      const divisionNames = data.divisionCodes
+        .map((code) => {
+          const court = allCourts.find(
+            (c) => c.courtId === data.courtId && c.courtDivisionCode === code,
+          );
+          return court?.courtDivisionName || code;
+        })
+        .join(', ');
+      divisionsDisplay = divisionNames;
+    } else if (data.divisionCode) {
+      // Legacy single division - look up name
+      const court = allCourts.find(
+        (c) => c.courtId === data.courtId && c.courtDivisionCode === data.divisionCode,
+      );
+      divisionsDisplay = court?.courtDivisionName || data.divisionCode;
+    }
+
     return (
       <>
         Chapter: {getAppointmentDetails(chapter, appointmentType)}
         <br />
         District: {districtDisplay}
         <br />
+        {divisionsDisplay && (
+          <>
+            Divisions: {divisionsDisplay}
+            <br />
+          </>
+        )}
         Appointed: {formatDate(data.appointedDate)}
         <br />
         Status: {data.status.charAt(0).toUpperCase() + data.status.slice(1)}{' '}
@@ -459,8 +488,10 @@ function ShowTrusteeUpcomingKeyDatesHistory(props: ShowTrusteeUpcomingKeyDatesHi
   );
 }
 
-function RenderTrusteeHistory(props: Readonly<{ trusteeHistory: TrusteeHistory[] }>) {
-  const { trusteeHistory } = props;
+function RenderTrusteeHistory(
+  props: Readonly<{ trusteeHistory: TrusteeHistory[]; allCourts: CourtDivisionDetails[] }>,
+) {
+  const { trusteeHistory, allCourts } = props;
   return (
     <>
       {trusteeHistory.map((history, idx: number) => {
@@ -502,6 +533,7 @@ function RenderTrusteeHistory(props: Readonly<{ trusteeHistory: TrusteeHistory[]
                 key={`${history.trusteeId}-${idx}`}
                 history={history}
                 idx={idx}
+                allCourts={allCourts}
               />
             );
           case 'AUDIT_ASSISTANT':
@@ -529,26 +561,36 @@ function RenderTrusteeHistory(props: Readonly<{ trusteeHistory: TrusteeHistory[]
 export default function TrusteeDetailAuditHistory(props: Readonly<TrusteeDetailAuditHistoryProps>) {
   const [trusteeHistory, setTrusteeHistory] = useState<TrusteeHistory[]>([]);
   const [isAuditHistoryLoading, setIsAuditHistoryLoading] = useState<boolean>(false);
+  const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]);
 
   useEffect(() => {
-    const fetchTrusteeHistory = async () => {
+    const fetchData = async () => {
       setIsAuditHistoryLoading(true);
       try {
-        const response = await Api2.getTrusteeHistory(props.trusteeId);
-        if (response) {
+        const [historyResponse, courtsResponse] = await Promise.all([
+          Api2.getTrusteeHistory(props.trusteeId),
+          Api2.getCourts(),
+        ]);
+
+        if (historyResponse) {
           setTrusteeHistory(
-            response.data.sort((a: Auditable, b: Auditable) =>
+            historyResponse.data.sort((a: Auditable, b: Auditable) =>
               sortByDateReverse(a.updatedOn, b.updatedOn),
             ),
           );
         }
+
+        if (courtsResponse) {
+          setAllCourts(courtsResponse.data);
+        }
       } catch {
         setTrusteeHistory([]);
+        setAllCourts([]);
       } finally {
         setIsAuditHistoryLoading(false);
       }
     };
-    fetchTrusteeHistory();
+    fetchData();
   }, [props.trusteeId]);
 
   return (
@@ -582,7 +624,7 @@ export default function TrusteeDetailAuditHistory(props: Readonly<TrusteeDetailA
                 </tr>
               </thead>
               <tbody>
-                <RenderTrusteeHistory trusteeHistory={trusteeHistory} />
+                <RenderTrusteeHistory trusteeHistory={trusteeHistory} allCourts={allCourts} />
               </tbody>
             </table>
           )}

--- a/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.tsx
@@ -5,6 +5,8 @@ import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { useEffect, useState } from 'react';
 import Api2 from '@/lib/models/api2';
 import { CourtDivisionDetails } from '@common/cams/courts';
+import { buildDivisionsDisplay } from '@/lib/utils/court-utils';
+import useCourts from '@/lib/hooks/UseCourts';
 import {
   TrusteeHistory,
   TrusteeNameHistory,
@@ -280,26 +282,9 @@ function ShowTrusteeAppointmentHistory(props: ShowTrusteeAppointmentHistoryProps
       districtDisplay = 'Court information not available';
     }
 
-    // Format divisions display (new multi-division feature)
-    let divisionsDisplay: string | null = null;
-    if (data.divisionCodes && data.divisionCodes.length > 0) {
-      // Look up division names from allCourts
-      const divisionNames = data.divisionCodes
-        .map((code) => {
-          const court = allCourts.find(
-            (c) => c.courtId === data.courtId && c.courtDivisionCode === code,
-          );
-          return court?.courtDivisionName || code;
-        })
-        .join(', ');
-      divisionsDisplay = divisionNames;
-    } else if (data.divisionCode) {
-      // Legacy single division - look up name
-      const court = allCourts.find(
-        (c) => c.courtId === data.courtId && c.courtDivisionCode === data.divisionCode,
-      );
-      divisionsDisplay = court?.courtDivisionName || data.divisionCode;
-    }
+    // Format divisions display using shared helper
+    const divisionsResult = buildDivisionsDisplay(data, allCourts);
+    const divisionsDisplay = divisionsResult !== 'Not specified' ? divisionsResult : null;
 
     return (
       <>
@@ -561,36 +546,27 @@ function RenderTrusteeHistory(
 export default function TrusteeDetailAuditHistory(props: Readonly<TrusteeDetailAuditHistoryProps>) {
   const [trusteeHistory, setTrusteeHistory] = useState<TrusteeHistory[]>([]);
   const [isAuditHistoryLoading, setIsAuditHistoryLoading] = useState<boolean>(false);
-  const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]);
+  const { courts: allCourts } = useCourts();
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchTrusteeHistory = async () => {
       setIsAuditHistoryLoading(true);
       try {
-        const [historyResponse, courtsResponse] = await Promise.all([
-          Api2.getTrusteeHistory(props.trusteeId),
-          Api2.getCourts(),
-        ]);
-
-        if (historyResponse) {
+        const response = await Api2.getTrusteeHistory(props.trusteeId);
+        if (response) {
           setTrusteeHistory(
-            historyResponse.data.sort((a: Auditable, b: Auditable) =>
+            response.data.sort((a: Auditable, b: Auditable) =>
               sortByDateReverse(a.updatedOn, b.updatedOn),
             ),
           );
         }
-
-        if (courtsResponse) {
-          setAllCourts(courtsResponse.data);
-        }
       } catch {
         setTrusteeHistory([]);
-        setAllCourts([]);
       } finally {
         setIsAuditHistoryLoading(false);
       }
     };
-    fetchData();
+    fetchTrusteeHistory();
   }, [props.trusteeId]);
 
   return (


### PR DESCRIPTION
## Purpose

Add multi-division support for trustee appointments behind a feature flag. Replace the single combined district dropdown with separate District (single-select) and Divisions (multi-select) fields, enabling trustees to be appointed across multiple divisions within a district.

## Major Changes

- **Multi-select divisions with pill UI**: Divisions appear as removable pill badges below the dropdown
- **"All Divisions" option**: First option and default selection; mutually exclusive with specific divisions
- **Backend normalization**: Accept `divisionCodes` array in `TrusteeAppointmentInput`, normalize between old (`divisionCode`) and new (`divisionCodes`) formats
- **Division validation**: `validateDivisionCodes` ensures at least one division is specified
- **Frontend enrichment**: `buildDivisionsDisplay` utility resolves division codes to human-readable names in appointment cards and audit history
- **Shared court data caching**: `useCourts` hook prevents redundant API calls across components
- **Overlap detection**: Validation detects conflicting active appointments across division arrays

## Testing/Validation

1. Enable the district-division feature flag
2. Create a new trustee appointment — verify separate District and Divisions dropdowns appear
3. Select a district — verify "All Divisions" auto-selected, pill appears below dropdown
4. Select specific divisions — verify "All Divisions" deselects, individual pills appear with remove buttons
5. Verify appointment card shows "All" or comma-separated division names
6. Verify audit history shows division changes
7. Verify overlap validation blocks duplicate active appointments for overlapping divisions
8. Disable feature flag — verify legacy single dropdown still works

## Notes

- Feature flag `DISTRICT_DIVISION_ENABLED` controls new UI; legacy single dropdown preserved when flag is off
- Backend integration for storing `divisionCodes` array is included in this PR
- 13 new tests for `buildDivisionsDisplay`, covering all display branches
- PR review feedback addressed: guard against undefined divisions, deduplicate helpers, use USWDS tokens, simplify validation logic

## Definition of Done:

- [x] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed: More important code doesn't directly depend on less important code
- [x] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application