### PR TITLE
CAMS-738 add trustee chapter filter

### DIFF
--- a/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
+++ b/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
@@ -325,7 +325,7 @@
         "version": "KqlItem/1.0",
         "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Chapter Filter Changed\"\n| extend selectedCount = toint(customMeasurements.selectedCount)\n| summarize FilterApplications = count() by selectedCount\n| order by selectedCount asc",
         "size": 3,
-        "title": "Chapter Selections per Filter Application",
+        "title": "Count of # of Chapters Selected",
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.insights/components",
@@ -451,7 +451,9 @@
         "visualization": "barchart",
         "chartSettings": {
           "xAxis": "ChapterLabel",
-          "yAxis": ["PctOfVisits"],
+          "yAxis": [
+            "PctOfVisits"
+          ],
           "seriesLabelSettings": [
             {
               "seriesName": "PctOfVisits",
@@ -569,7 +571,7 @@
     }
   ],
   "fallbackResourceIds": [
-    "/subscriptions/729f9083-9edf-4269-919f-3f05f7a0ab20/resourceGroups/rg-cams-app-dev-5d5564/providers/Microsoft.Insights/components/appi-ustp-cams-dev-5d5564-webapp"
+    "/subscriptions/729f9083-9edf-4269-919f-3f05f7a0ab20/resourceGroups/rg-cams-app-dev-b2abcd/providers/Microsoft.Insights/components/appi-ustp-cams-dev-b2abcd-webapp"
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
+++ b/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
@@ -434,6 +434,91 @@
     {
       "type": 1,
       "content": {
+        "json": "---\n## Chapter Filter Popularity\nHow often each chapter is selected, based on `selectedChapterValues` in the `Trustee Chapter Filter Changed` event."
+      },
+      "name": "chapter-popularity-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Chapter Filter Changed\"\n| extend selectedChapterValues = tostring(customDimensions.selectedChapterValues)\n| where isnotempty(selectedChapterValues)\n| mv-expand Chapter = split(selectedChapterValues, \",\")\n| extend ChapterLabel = case(\n    Chapter == \"7\", \"7\",\n    Chapter == \"11\", \"11\",\n    Chapter == \"11-subchapter-v\", \"11 Subchapter V\",\n    Chapter == \"12\", \"12\",\n    Chapter == \"13\", \"13\",\n    tostring(Chapter)\n  )\n| summarize SelectionCount = count() by ChapterLabel\n| order by SelectionCount desc",
+        "size": 0,
+        "title": "Chapter Filter Selection Frequency",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "chartSettings": {
+          "xAxis": "ChapterLabel",
+          "yAxis": ["SelectionCount"],
+          "seriesLabelSettings": [
+            {
+              "seriesName": "SelectionCount",
+              "label": "Times Selected",
+              "color": "blue"
+            }
+          ],
+          "ySettings": {
+            "numberFormatSettings": {
+              "unit": 0,
+              "options": {
+                "style": "decimal",
+                "useGrouping": true
+              }
+            }
+          }
+        }
+      },
+      "customWidth": "50",
+      "name": "chapter-selection-frequency"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n## Combined Filter Usage\nHow often users apply both district and chapter filters at the same time. Incremented on each filter change event where both `selectedCount` (district) and `chapterCount`/`districtCount` > 0."
+      },
+      "name": "combined-filter-usage-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let DistrictWithChapter =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee District Filter Changed\"\n    | where tostring(customDimensions.isDefault) != \"true\"\n    | extend districtCount = toint(customDimensions.selectedCount)\n    | extend chapterCount = toint(customDimensions.chapterCount)\n    | where districtCount > 0 and chapterCount > 0\n    | count;\nlet ChapterWithDistrict =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Chapter Filter Changed\"\n    | extend chapterCount = toint(customDimensions.selectedCount)\n    | extend districtCount = toint(customDimensions.districtCount)\n    | where chapterCount > 0 and districtCount > 0\n    | count;\nlet DistrictOnly =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee District Filter Changed\"\n    | where tostring(customDimensions.isDefault) != \"true\"\n    | extend districtCount = toint(customDimensions.selectedCount)\n    | extend chapterCount = toint(customDimensions.chapterCount)\n    | where districtCount > 0 and (isnull(chapterCount) or chapterCount == 0)\n    | count;\nlet ChapterOnly =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Chapter Filter Changed\"\n    | extend chapterCount = toint(customDimensions.selectedCount)\n    | extend districtCount = toint(customDimensions.districtCount)\n    | where chapterCount > 0 and (isnull(districtCount) or districtCount == 0)\n    | count;\nprint\n    DistrictOnly = toscalar(DistrictOnly),\n    ChapterOnly = toscalar(ChapterOnly),\n    BothFilters = toscalar(DistrictWithChapter) + toscalar(ChapterWithDistrict)",
+        "size": 3,
+        "title": "Filter Combination Usage",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {},
+          "leftContent": {
+            "columnMatch": "BothFilters",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal"
+              }
+            }
+          },
+          "secondaryContent": {
+            "columnMatch": "DistrictOnly",
+            "formatter": 1
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "50",
+      "name": "combined-filter-usage-kpi"
+    },
+    {
+      "type": 1,
+      "content": {
         "json": "---\n## Performance Tracking\nFilter response time and page load time for the trustee list."
       },
       "name": "performance-header"

--- a/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
+++ b/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
@@ -4,7 +4,7 @@
     {
       "type": 1,
       "content": {
-        "json": "# Trustee District Filter Metrics\n\nSuccess metrics for CAMS-691: district filter usage and performance on the Trustee Management page.\n\n**Instrumented events:**\n- `Trustee District Filter Changed` — fired on any selection change; dimensions: `isDefault`, `selectedCount`, `resultCount`\n- `Trustee District Filter Cleared` — fired when user clicks Clear (restores defaults)\n- `Trustee List Loaded` — fired when trustee data first renders; dimensions: `trusteeCount`; measurement: `loadMs`"
+        "json": "# Trustee Filter Metrics\n\nSuccess metrics for trustee filter usage and performance on the Trustee Management page.\n\n**Instrumented events:**\n- `Trustee District Filter Changed` — fired on any selection change; dimensions: `isDefault`, `selectedCount`, `resultCount`\n- `Trustee District Filter Cleared` — fired when user clicks Clear (restores defaults)\n- `Trustee Chapter Filter Changed` — fired on any chapter selection change; dimensions: `selectedCount`, `resultCount`\n- `Trustee List Loaded` — fired when trustee data first renders; dimensions: `trusteeCount`; measurement: `loadMs`"
       },
       "name": "header"
     },
@@ -238,12 +238,162 @@
       "name": "trustee-count-distribution-kpi"
     },
     {
+      "type": 1,
+      "content": {
+        "json": "---\n## Chapter Filter Usage\nHow frequently users apply the chapter filter and what results they see."
+      },
+      "name": "chapter-filter-header"
+    },
+    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee District Filter Changed\" or name == \"Trustee District Filter Cleared\"\n| summarize\n    FilterModifications = countif(name == \"Trustee District Filter Changed\" and tostring(customDimensions.isDefault) != \"true\"),\n    DefaultClears = countif(name == \"Trustee District Filter Cleared\")\n    by Day = bin(timestamp, 1d)\n| order by Day asc",
+        "query": "let TrusteePageVisits =\n    pageViews\n    | where timestamp {TimeRange}\n    | where url contains \"/trustees\"\n    | project operation_Id;\nlet ChapterFilterVisits =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Chapter Filter Changed\"\n    | project operation_Id;\nlet TotalVisits = toscalar(TrusteePageVisits | count);\nlet ChapterFilteredVisits = toscalar(\n    ChapterFilterVisits\n    | join kind=inner TrusteePageVisits on operation_Id\n    | summarize by operation_Id\n    | count\n);\nprint\n    TotalVisits = TotalVisits,\n    ChapterFilteredVisits = ChapterFilteredVisits,\n    ChapterFilterRate = round(iif(TotalVisits > 0, todouble(ChapterFilteredVisits) / todouble(TotalVisits) * 100, 0.0), 1)",
+        "size": 3,
+        "title": "% of Page Visits Where Chapter Filter Was Used",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {},
+          "leftContent": {
+            "columnMatch": "ChapterFilterRate",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 1,
+              "options": {
+                "style": "decimal",
+                "minimumFractionDigits": 1,
+                "maximumFractionDigits": 1
+              }
+            }
+          },
+          "secondaryContent": {
+            "columnMatch": "TotalVisits",
+            "formatter": 1
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "25",
+      "name": "chapter-filter-usage-rate-kpi"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let TrusteePageSessions =\n    pageViews\n    | where timestamp {TimeRange}\n    | where url contains \"/trustees\"\n    | project operation_Id;\nlet ChapterFilterChanges =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Chapter Filter Changed\"\n    | project operation_Id;\nlet TotalVisits = toscalar(TrusteePageSessions | count);\nlet TotalChanges = toscalar(ChapterFilterChanges | count);\nprint\n    TotalVisits = TotalVisits,\n    TotalChanges = TotalChanges,\n    AvgChangesPerVisit = round(iif(TotalVisits > 0, todouble(TotalChanges) / todouble(TotalVisits), 0.0), 2)",
+        "size": 3,
+        "title": "Avg Chapter Filter Changes per Page Visit",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {},
+          "leftContent": {
+            "columnMatch": "AvgChangesPerVisit",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal",
+                "minimumFractionDigits": 2,
+                "maximumFractionDigits": 2
+              }
+            }
+          },
+          "secondaryContent": {
+            "columnMatch": "TotalVisits"
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "25",
+      "name": "chapter-filter-avg-changes-kpi"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Chapter Filter Changed\"\n| extend selectedCount = toint(customMeasurements.selectedCount)\n| summarize FilterApplications = count() by selectedCount\n| order by selectedCount asc",
+        "size": 3,
+        "title": "Chapter Selections per Filter Application",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {
+            "columnMatch": "selectedCount"
+          },
+          "leftContent": {
+            "columnMatch": "FilterApplications",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal"
+              }
+            }
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "25",
+      "name": "chapter-filter-selection-count-kpi"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Chapter Filter Changed\"\n| extend resultCount = toint(customMeasurements.resultCount)\n| extend ResultBucket = case(\n    resultCount == 0, \"0 trustees\",\n    resultCount <= 5, \"1–5 trustees\",\n    resultCount <= 10, \"6–10 trustees\",\n    resultCount <= 20, \"11–20 trustees\",\n    resultCount <= 50, \"21–50 trustees\",\n    \"51+ trustees\"\n  )\n| summarize FilterApplications = count() by ResultBucket\n| order by ResultBucket asc",
+        "size": 3,
+        "title": "Trustee Count Distribution After Chapter Filtering",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {
+            "columnMatch": "ResultBucket"
+          },
+          "leftContent": {
+            "columnMatch": "FilterApplications",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal"
+              }
+            }
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "25",
+      "name": "chapter-filter-count-distribution-kpi"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where timestamp {TimeRange}\n| where name in (\"Trustee District Filter Changed\", \"Trustee District Filter Cleared\", \"Trustee Chapter Filter Changed\")\n| summarize\n    DistrictModifications = countif(name == \"Trustee District Filter Changed\" and tostring(customDimensions.isDefault) != \"true\"),\n    DefaultClears = countif(name == \"Trustee District Filter Cleared\"),\n    ChapterModifications = countif(name == \"Trustee Chapter Filter Changed\")\n    by Day = bin(timestamp, 1d)\n| order by Day asc",
         "size": 0,
-        "title": "Filter Activity Over Time",
+        "title": "Filter Activity Over Time (District + Chapter)",
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.insights/components",
@@ -253,14 +403,19 @@
           "showDataPoints": true,
           "seriesLabelSettings": [
             {
-              "seriesName": "FilterModifications",
-              "label": "Filter Modified Beyond Defaults",
+              "seriesName": "DistrictModifications",
+              "label": "District Filter Modified",
               "color": "blue"
             },
             {
               "seriesName": "DefaultClears",
-              "label": "Default Selection Cleared",
+              "label": "District Default Cleared",
               "color": "orange"
+            },
+            {
+              "seriesName": "ChapterModifications",
+              "label": "Chapter Filter Modified",
+              "color": "green"
             }
           ],
           "ySettings": {
@@ -274,7 +429,7 @@
           }
         }
       },
-      "name": "filter-activity-trend"
+      "name": "combined-filter-activity-trend"
     },
     {
       "type": 1,

--- a/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
+++ b/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
@@ -4,7 +4,7 @@
     {
       "type": 1,
       "content": {
-        "json": "# Trustee Filter Metrics\n\nSuccess metrics for trustee filter usage and performance on the Trustee Management page.\n\n**Instrumented events:**\n- `Trustee District Filter Changed` — fired on any selection change; dimensions: `isDefault`, `selectedCount`, `resultCount`\n- `Trustee District Filter Cleared` — fired when user clicks Clear (restores defaults)\n- `Trustee Chapter Filter Changed` — fired on any chapter selection change; dimensions: `selectedCount`, `resultCount`\n- `Trustee List Loaded` — fired when trustee data first renders; dimensions: `trusteeCount`; measurement: `loadMs`"
+        "json": "# Trustee Filter Metrics\n\nSuccess metrics for trustee filter usage and performance on the Trustee Management page.\n\n**Instrumented events:**\n- `Trustee District Filter Changed` — fired on any selection change; dimensions: `isDefault`; measurements: `selectedCount`, `resultCount`, `chapterCount`\n- `Trustee District Filter Cleared` — fired when user clicks Clear (restores defaults)\n- `Trustee Chapter Filter Changed` — fired on any chapter selection change; dimensions: `selectedChapterValues`; measurements: `selectedCount`, `resultCount`, `districtCount`\n- `Trustee List Loaded` — fired when trustee data first renders; measurements: `trusteeCount`, `loadMs`"
       },
       "name": "header"
     },
@@ -434,7 +434,7 @@
     {
       "type": 1,
       "content": {
-        "json": "---\n## Chapter Filter Popularity\nHow often each chapter is selected, based on `selectedChapterValues` in the `Trustee Chapter Filter Changed` event."
+        "json": "---\n## Chapter Filter Popularity\n% of trustee page visits where each chapter was selected, based on `selectedChapterValues` in the `Trustee Chapter Filter Changed` event."
       },
       "name": "chapter-popularity-header"
     },
@@ -442,29 +442,30 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Chapter Filter Changed\"\n| extend selectedChapterValues = tostring(customDimensions.selectedChapterValues)\n| where isnotempty(selectedChapterValues)\n| mv-expand Chapter = split(selectedChapterValues, \",\")\n| extend ChapterLabel = case(\n    Chapter == \"7\", \"7\",\n    Chapter == \"11\", \"11\",\n    Chapter == \"11-subchapter-v\", \"11 Subchapter V\",\n    Chapter == \"12\", \"12\",\n    Chapter == \"13\", \"13\",\n    tostring(Chapter)\n  )\n| summarize SelectionCount = count() by ChapterLabel\n| order by SelectionCount desc",
+        "query": "let TotalVisits = toscalar(\n    pageViews\n    | where timestamp {TimeRange}\n    | where url contains \"/trustees\"\n    | summarize by operation_Id\n    | count\n);\ncustomEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Chapter Filter Changed\"\n| extend selectedChapterValues = tostring(customDimensions.selectedChapterValues)\n| where isnotempty(selectedChapterValues)\n| mv-expand Chapter = split(selectedChapterValues, \",\")\n| extend ChapterLabel = case(\n    Chapter == \"7\", \"Chapter 7\",\n    Chapter == \"11\", \"Chapter 11\",\n    Chapter == \"11-subchapter-v\", \"Chapter 11 Subchapter V\",\n    Chapter == \"12\", \"Chapter 12\",\n    Chapter == \"13\", \"Chapter 13\",\n    tostring(Chapter)\n  )\n| summarize VisitCount = dcount(operation_Id) by ChapterLabel\n| extend PctOfVisits = round(todouble(VisitCount) / todouble(TotalVisits) * 100, 1)\n| order by PctOfVisits desc",
         "size": 0,
-        "title": "Chapter Filter Selection Frequency",
+        "title": "% of Page Visits by Chapter Selected",
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.insights/components",
         "visualization": "barchart",
         "chartSettings": {
           "xAxis": "ChapterLabel",
-          "yAxis": ["SelectionCount"],
+          "yAxis": ["PctOfVisits"],
           "seriesLabelSettings": [
             {
-              "seriesName": "SelectionCount",
-              "label": "Times Selected",
+              "seriesName": "PctOfVisits",
+              "label": "% of Visits",
               "color": "blue"
             }
           ],
           "ySettings": {
             "numberFormatSettings": {
-              "unit": 0,
+              "unit": 1,
               "options": {
                 "style": "decimal",
-                "useGrouping": true
+                "minimumFractionDigits": 1,
+                "maximumFractionDigits": 1
               }
             }
           }
@@ -476,7 +477,7 @@
     {
       "type": 1,
       "content": {
-        "json": "---\n## Combined Filter Usage\nHow often users apply both district and chapter filters at the same time. Incremented on each filter change event where both `selectedCount` (district) and `chapterCount`/`districtCount` > 0."
+        "json": "---\n## Combined Filter Usage\n% of trustee page visits where both district and chapter filters were active at the same time, and the average number of combined-filter events per visit."
       },
       "name": "combined-filter-usage-header"
     },
@@ -484,9 +485,9 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let DistrictWithChapter =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee District Filter Changed\"\n    | where tostring(customDimensions.isDefault) != \"true\"\n    | extend districtCount = toint(customDimensions.selectedCount)\n    | extend chapterCount = toint(customDimensions.chapterCount)\n    | where districtCount > 0 and chapterCount > 0\n    | count;\nlet ChapterWithDistrict =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Chapter Filter Changed\"\n    | extend chapterCount = toint(customDimensions.selectedCount)\n    | extend districtCount = toint(customDimensions.districtCount)\n    | where chapterCount > 0 and districtCount > 0\n    | count;\nlet DistrictOnly =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee District Filter Changed\"\n    | where tostring(customDimensions.isDefault) != \"true\"\n    | extend districtCount = toint(customDimensions.selectedCount)\n    | extend chapterCount = toint(customDimensions.chapterCount)\n    | where districtCount > 0 and (isnull(chapterCount) or chapterCount == 0)\n    | count;\nlet ChapterOnly =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Chapter Filter Changed\"\n    | extend chapterCount = toint(customDimensions.selectedCount)\n    | extend districtCount = toint(customDimensions.districtCount)\n    | where chapterCount > 0 and (isnull(districtCount) or districtCount == 0)\n    | count;\nprint\n    DistrictOnly = toscalar(DistrictOnly),\n    ChapterOnly = toscalar(ChapterOnly),\n    BothFilters = toscalar(DistrictWithChapter) + toscalar(ChapterWithDistrict)",
+        "query": "let TrusteePageVisits =\n    pageViews\n    | where timestamp {TimeRange}\n    | where url contains \"/trustees\"\n    | summarize by operation_Id;\nlet TotalVisits = toscalar(TrusteePageVisits | count);\nlet CombinedEvents =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Chapter Filter Changed\"\n    | extend chapterCount = toint(customMeasurements.selectedCount)\n    | extend districtCount = toint(customMeasurements.districtCount)\n    | where chapterCount > 0 and districtCount > 0\n    | project operation_Id;\nlet CombinedVisits = toscalar(\n    CombinedEvents\n    | join kind=inner TrusteePageVisits on operation_Id\n    | summarize by operation_Id\n    | count\n);\nlet TotalCombinedEvents = toscalar(CombinedEvents | count);\nprint\n    TotalVisits = TotalVisits,\n    CombinedVisits = CombinedVisits,\n    PctCombinedVisits = round(iif(TotalVisits > 0, todouble(CombinedVisits) / todouble(TotalVisits) * 100, 0.0), 1),\n    AvgCombinedEventsPerVisit = round(iif(TotalVisits > 0, todouble(TotalCombinedEvents) / todouble(TotalVisits), 0.0), 2)",
         "size": 3,
-        "title": "Filter Combination Usage",
+        "title": "Combined Filter Usage (District + Chapter)",
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.insights/components",
@@ -494,20 +495,22 @@
         "tileSettings": {
           "titleContent": {},
           "leftContent": {
-            "columnMatch": "BothFilters",
+            "columnMatch": "PctCombinedVisits",
             "formatter": 12,
             "formatOptions": {
               "palette": "blue"
             },
             "numberFormat": {
-              "unit": 0,
+              "unit": 1,
               "options": {
-                "style": "decimal"
+                "style": "decimal",
+                "minimumFractionDigits": 1,
+                "maximumFractionDigits": 1
               }
             }
           },
           "secondaryContent": {
-            "columnMatch": "DistrictOnly",
+            "columnMatch": "AvgCombinedEventsPerVisit",
             "formatter": 1
           },
           "showBorder": true

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -494,7 +494,7 @@ describe('TrusteesList Component', () => {
 
       const { container } = renderWithRouter(<TrusteesList />);
 
-      await waitFor(() => expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
+      expect(await screen.findByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
 
       const toggleButton = screen.getByRole('button', { name: /filters/i });
       await userEvent.setup().click(toggleButton);
@@ -504,7 +504,7 @@ describe('TrusteesList Component', () => {
       const chapterCombobox = screen.getByLabelText('Chapter');
       await userEvent.setup().click(chapterCombobox);
 
-      await waitFor(() => expect(screen.getByRole('option', { name: /option: 13/ })).toBeInTheDocument());
+      expect(await screen.findByRole('option', { name: /option: 13/ })).toBeInTheDocument();
       await userEvent.setup().click(screen.getByRole('option', { name: /option: 13/ }));
 
       await waitFor(() => {
@@ -597,7 +597,7 @@ describe('TrusteesList Component', () => {
       renderWithRouter(<TrusteesList />);
 
       // Wait for default district filter (Manhattan) to be applied — shows A and B
-      await waitFor(() => expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
+      expect(await screen.findByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
 
       // Now select chapter 7
       const toggleButton = screen.getByRole('button', { name: /filters/i });
@@ -605,7 +605,7 @@ describe('TrusteesList Component', () => {
       expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
       const chapterCombobox = screen.getByLabelText('Chapter');
       await userEvent.setup().click(chapterCombobox);
-      await waitFor(() => expect(screen.getByRole('option', { name: /option: 7/ })).toBeInTheDocument());
+      expect(await screen.findByRole('option', { name: /option: 7/ })).toBeInTheDocument();
       await userEvent.setup().click(screen.getByRole('option', { name: /option: 7/ }));
 
       // Only Trustee A (ch7 + Manhattan) should remain
@@ -639,7 +639,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderWithRouter(<TrusteesList />);
-      await waitFor(() => expect(screen.getByText('3 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
+      expect(await screen.findByText('3 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
 
       const user = userEvent.setup();
       const toggleButton = screen.getByRole('button', { name: /filters/i });
@@ -648,9 +648,9 @@ describe('TrusteesList Component', () => {
 
       const chapterCombobox = screen.getByLabelText('Chapter');
       await user.click(chapterCombobox);
-      await waitFor(() => expect(screen.getByRole('option', { name: /option: 7/ })).toBeInTheDocument());
+      expect(await screen.findByRole('option', { name: /option: 7/ })).toBeInTheDocument();
       await user.click(screen.getByRole('option', { name: /option: 7/ }));
-      await waitFor(() => expect(screen.getByRole('option', { name: /option: 13/ })).toBeInTheDocument());
+      expect(await screen.findByRole('option', { name: /option: 13/ })).toBeInTheDocument();
       await user.click(screen.getByRole('option', { name: /option: 13/ }));
 
       await waitFor(() => {
@@ -678,7 +678,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderWithRouter(<TrusteesList />);
-      await waitFor(() => expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
+      expect(await screen.findByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
 
       const liveRegion = screen.getByRole('status');
       expect(liveRegion).toHaveTextContent('2 Trustee(s)');
@@ -689,7 +689,7 @@ describe('TrusteesList Component', () => {
       expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
       const chapterCombobox = screen.getByLabelText('Chapter');
       await user.click(chapterCombobox);
-      await waitFor(() => expect(screen.getByRole('option', { name: /option: 7/ })).toBeInTheDocument());
+      expect(await screen.findByRole('option', { name: /option: 7/ })).toBeInTheDocument();
       await user.click(screen.getByRole('option', { name: /option: 7/ }));
 
       await waitFor(() => {
@@ -711,7 +711,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderWithRouter(<TrusteesList />);
-      await waitFor(() => expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
 
       const user = userEvent.setup();
       const toggleButton = screen.getByRole('button', { name: /filters/i });
@@ -719,7 +719,7 @@ describe('TrusteesList Component', () => {
       expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
       const chapterCombobox = screen.getByLabelText('Chapter');
       await user.click(chapterCombobox);
-      await waitFor(() => expect(screen.getByRole('option', { name: /option: 7/ })).toBeInTheDocument());
+      expect(await screen.findByRole('option', { name: /option: 7/ })).toBeInTheDocument();
       await user.click(screen.getByRole('option', { name: /option: 7/ }));
 
       await waitFor(() => {

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -67,7 +67,7 @@ describe('TrusteesList Component', () => {
     renderWithRouter(<TrusteesList />);
 
     await waitFor(() => {
-      expect(screen.getByText('2 Trustee(s)')).toBeInTheDocument();
+      expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
     });
   });
 
@@ -293,7 +293,7 @@ describe('TrusteesList Component', () => {
     renderWithRouter(<TrusteesList />);
 
     await waitFor(() => {
-      expect(screen.getByText('11 Subchapter V')).toBeInTheDocument();
+      expect(screen.getAllByText('11 Subchapter V').length).toBeGreaterThan(0);
     });
 
     expect(screen.getByText('Pool')).toBeInTheDocument();
@@ -472,6 +472,265 @@ describe('TrusteesList Component', () => {
     });
   });
 
+  describe('Chapter Filtering', () => {
+    test('should filter trustees by selected chapter', async () => {
+      const ch7Appt = makeAppointment({ chapter: '7', divisionCode: '081' });
+      const ch13Appt = makeAppointment({ chapter: '13', divisionCode: '088' });
+      const trustee7 = makeListItem({
+        trusteeId: 't7',
+        name: 'Chapter 7 Trustee',
+        appointments: [ch7Appt],
+      });
+      const trustee13 = makeListItem({
+        trusteeId: 't13',
+        name: 'Chapter 13 Trustee',
+        appointments: [ch13Appt],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee7, trustee13] });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      const { container } = renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument());
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
+
+      const chapterCombobox = screen.getByLabelText('Chapter');
+      await userEvent.setup().click(chapterCombobox);
+
+      await waitFor(() => expect(screen.getAllByText('13').length).toBeGreaterThan(0));
+      await userEvent.setup().click(screen.getAllByText('13')[0]);
+
+      await waitFor(() => {
+        expect(screen.getAllByText('1 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
+        expect(screen.queryByText('Chapter 7 Trustee')).not.toBeInTheDocument();
+      });
+
+      // Suppress unused variable warning
+      void container;
+    });
+
+    test('should show all trustees when no chapter is selected', async () => {
+      const trustee7 = makeListItem({
+        trusteeId: 't7',
+        name: 'Chapter 7 Trustee',
+        appointments: [makeAppointment({ chapter: '7' })],
+      });
+      const trustee13 = makeListItem({
+        trusteeId: 't13',
+        name: 'Chapter 13 Trustee',
+        appointments: [makeAppointment({ chapter: '13' })],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee7, trustee13] });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('Chapter 7 Trustee')).toBeInTheDocument();
+        expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
+      });
+    });
+
+    test('should AND-filter when both district and chapter filters are active', async () => {
+      const apptA = makeAppointment({ chapter: '7', divisionCode: '081' });
+      const apptB = makeAppointment({ chapter: '13', divisionCode: '081' });
+      const apptC = makeAppointment({ chapter: '7', divisionCode: '088' });
+      const trusteeA = makeListItem({ trusteeId: 'a', name: 'Trustee A', appointments: [apptA] });
+      const trusteeB = makeListItem({ trusteeId: 'b', name: 'Trustee B', appointments: [apptB] });
+      const trusteeC = makeListItem({ trusteeId: 'c', name: 'Trustee C', appointments: [apptC] });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trusteeA, trusteeB, trusteeC] });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({
+        data: [
+          {
+            courtId: 'NYSB',
+            courtName: 'Southern District of New York',
+            officeCode: '081',
+            officeName: 'Manhattan',
+            courtDivisionCode: '081',
+            courtDivisionName: 'Manhattan',
+            groupDesignator: 'NY',
+            regionId: '02',
+            regionName: 'New York',
+          },
+        ],
+      });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue({
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '081',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '081',
+                      court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      // Wait for default district filter (Manhattan) to be applied — shows A and B
+      await waitFor(() => expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument());
+
+      // Now select chapter 7
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+      expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
+      const chapterCombobox = screen.getByLabelText('Chapter');
+      await userEvent.setup().click(chapterCombobox);
+      await waitFor(() => expect(screen.getAllByText('7').length).toBeGreaterThan(0));
+      await userEvent.setup().click(screen.getAllByText('7')[0]);
+
+      // Only Trustee A (ch7 + Manhattan) should remain
+      await waitFor(() => {
+        expect(screen.getAllByText('1 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('Trustee A')).toBeInTheDocument();
+        expect(screen.queryByText('Trustee B')).not.toBeInTheDocument();
+        expect(screen.queryByText('Trustee C')).not.toBeInTheDocument();
+      });
+    });
+
+    test('should use OR logic within chapter filter', async () => {
+      const trustee7 = makeListItem({
+        trusteeId: 't7',
+        name: 'Chapter 7 Trustee',
+        appointments: [makeAppointment({ chapter: '7' })],
+      });
+      const trustee11 = makeListItem({
+        trusteeId: 't11',
+        name: 'Chapter 11 Trustee',
+        appointments: [makeAppointment({ chapter: '11' })],
+      });
+      const trustee13 = makeListItem({
+        trusteeId: 't13',
+        name: 'Chapter 13 Trustee',
+        appointments: [makeAppointment({ chapter: '13' })],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee7, trustee11, trustee13] });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      renderWithRouter(<TrusteesList />);
+      await waitFor(() => expect(screen.getAllByText('3 Trustee(s)')[0]).toBeInTheDocument());
+
+      const user = userEvent.setup();
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+      expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
+
+      const chapterCombobox = screen.getByLabelText('Chapter');
+      await user.click(chapterCombobox);
+      await waitFor(() => expect(screen.getAllByText('7').length).toBeGreaterThan(0));
+      await user.click(screen.getAllByText('7')[0]);
+      await user.click(chapterCombobox);
+      await waitFor(() => expect(screen.getAllByText('13').length).toBeGreaterThan(0));
+      await user.click(screen.getAllByText('13')[0]);
+
+      await waitFor(() => {
+        expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('Chapter 7 Trustee')).toBeInTheDocument();
+        expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
+        expect(screen.queryByText('Chapter 11 Trustee')).not.toBeInTheDocument();
+      });
+    });
+
+    test('should announce updated count in live region when chapter filter changes', async () => {
+      const trustee7 = makeListItem({
+        trusteeId: 't7',
+        name: 'Chapter 7 Trustee',
+        appointments: [makeAppointment({ chapter: '7' })],
+      });
+      const trustee13 = makeListItem({
+        trusteeId: 't13',
+        name: 'Chapter 13 Trustee',
+        appointments: [makeAppointment({ chapter: '13' })],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee7, trustee13] });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      renderWithRouter(<TrusteesList />);
+      await waitFor(() => expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument());
+
+      const liveRegion = screen.getByRole('status');
+      expect(liveRegion).toHaveTextContent('2 Trustee(s)');
+
+      const user = userEvent.setup();
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+      expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
+      const chapterCombobox = screen.getByLabelText('Chapter');
+      await user.click(chapterCombobox);
+      await waitFor(() => expect(screen.getAllByText('7').length).toBeGreaterThan(0));
+      await user.click(screen.getAllByText('7')[0]);
+
+      await waitFor(() => {
+        expect(liveRegion).toHaveTextContent('1 Trustee(s)');
+      });
+    });
+  });
+
+  describe('Chapter Filter Telemetry', () => {
+    test('should track Trustee Chapter Filter Changed with selectedCount and resultCount', async () => {
+      const trustee7 = makeListItem({
+        trusteeId: 't7',
+        name: 'Chapter 7 Trustee',
+        appointments: [makeAppointment({ chapter: '7' })],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee7] });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      renderWithRouter(<TrusteesList />);
+      await waitFor(() => expect(screen.getAllByText('1 Trustee(s)')[0]).toBeInTheDocument());
+
+      const user = userEvent.setup();
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+      expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
+      const chapterCombobox = screen.getByLabelText('Chapter');
+      await user.click(chapterCombobox);
+      await waitFor(() => expect(screen.getAllByText('7').length).toBeGreaterThan(0));
+      await user.click(screen.getAllByText('7')[0]);
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          { name: 'Trustee Chapter Filter Changed' },
+          expect.objectContaining({ selectedCount: 1, resultCount: 1 }),
+        );
+      });
+    });
+  });
+
   describe('District Filtering', () => {
     test('should render district filter component with ARIA live region', async () => {
       const trustee = makeListItem({
@@ -503,21 +762,18 @@ describe('TrusteesList Component', () => {
       vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-      const { container } = renderWithRouter(<TrusteesList />);
+      renderWithRouter(<TrusteesList />);
 
       await waitFor(() => {
-        expect(screen.getByText('2 Trustee(s)')).toBeInTheDocument();
+        expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
       });
 
       // Check live region for filter announcements
-      const liveRegion = container.querySelector(
-        '[role="status"][aria-live="polite"][aria-atomic="true"]',
-      );
+      const liveRegion = screen.getByRole('status');
       expect(liveRegion).toBeInTheDocument();
 
       // Check filter section
-      const filterSection = container.querySelector('[aria-label="District filter controls"]');
-      expect(filterSection).toBeInTheDocument();
+      expect(screen.getByRole('region', { name: 'Trustee filter controls' })).toBeInTheDocument();
 
       // Check table
       const table = screen.getByTestId('trustees-table');
@@ -645,7 +901,7 @@ describe('TrusteesList Component', () => {
         expect(screen.getByText('Trustee, Vermont')).toBeInTheDocument();
         expect(screen.queryByText('Trustee, California')).not.toBeInTheDocument();
       });
-      expect(screen.getByText('2 Trustee(s)')).toBeInTheDocument();
+      expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
     });
 
     test('should show all trustees when no district filter is active, including unassigned ones', async () => {
@@ -679,7 +935,7 @@ describe('TrusteesList Component', () => {
       renderWithRouter(<TrusteesList />);
 
       await waitFor(() => {
-        expect(screen.getByText('3 Trustee(s)')).toBeInTheDocument();
+        expect(screen.getAllByText('3 Trustee(s)')[0]).toBeInTheDocument();
       });
 
       expect(screen.getByText('Trustee, Appointed')).toBeInTheDocument();
@@ -867,7 +1123,7 @@ describe('TrusteesList Component', () => {
 
       // Should remove the filter and show all trustees
       await waitFor(() => {
-        expect(screen.getByText('1 Trustee(s)')).toBeInTheDocument();
+        expect(screen.getAllByText('1 Trustee(s)')[0]).toBeInTheDocument();
       });
     });
   });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import TrusteesList from './TrusteesList';
@@ -67,7 +67,7 @@ describe('TrusteesList Component', () => {
     renderWithRouter(<TrusteesList />);
 
     await waitFor(() => {
-      expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
+      expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
     });
   });
 
@@ -293,7 +293,8 @@ describe('TrusteesList Component', () => {
     renderWithRouter(<TrusteesList />);
 
     await waitFor(() => {
-      expect(screen.getAllByText('11 Subchapter V').length).toBeGreaterThan(0);
+      const chapterCell = document.querySelector('[data-cell="Chapter"]') as HTMLElement;
+      expect(within(chapterCell).getByText('11 Subchapter V')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Pool')).toBeInTheDocument();
@@ -493,7 +494,7 @@ describe('TrusteesList Component', () => {
 
       const { container } = renderWithRouter(<TrusteesList />);
 
-      await waitFor(() => expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
 
       const toggleButton = screen.getByRole('button', { name: /filters/i });
       await userEvent.setup().click(toggleButton);
@@ -503,11 +504,11 @@ describe('TrusteesList Component', () => {
       const chapterCombobox = screen.getByLabelText('Chapter');
       await userEvent.setup().click(chapterCombobox);
 
-      await waitFor(() => expect(screen.getAllByText('13').length).toBeGreaterThan(0));
-      await userEvent.setup().click(screen.getAllByText('13')[0]);
+      await waitFor(() => expect(screen.getByRole('option', { name: /option: 13/ })).toBeInTheDocument());
+      await userEvent.setup().click(screen.getByRole('option', { name: /option: 13/ }));
 
       await waitFor(() => {
-        expect(screen.getAllByText('1 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
         expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
         expect(screen.queryByText('Chapter 7 Trustee')).not.toBeInTheDocument();
       });
@@ -535,7 +536,7 @@ describe('TrusteesList Component', () => {
       renderWithRouter(<TrusteesList />);
 
       await waitFor(() => {
-        expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
         expect(screen.getByText('Chapter 7 Trustee')).toBeInTheDocument();
         expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
       });
@@ -596,7 +597,7 @@ describe('TrusteesList Component', () => {
       renderWithRouter(<TrusteesList />);
 
       // Wait for default district filter (Manhattan) to be applied — shows A and B
-      await waitFor(() => expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
 
       // Now select chapter 7
       const toggleButton = screen.getByRole('button', { name: /filters/i });
@@ -604,12 +605,12 @@ describe('TrusteesList Component', () => {
       expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
       const chapterCombobox = screen.getByLabelText('Chapter');
       await userEvent.setup().click(chapterCombobox);
-      await waitFor(() => expect(screen.getAllByText('7').length).toBeGreaterThan(0));
-      await userEvent.setup().click(screen.getAllByText('7')[0]);
+      await waitFor(() => expect(screen.getByRole('option', { name: /option: 7/ })).toBeInTheDocument());
+      await userEvent.setup().click(screen.getByRole('option', { name: /option: 7/ }));
 
       // Only Trustee A (ch7 + Manhattan) should remain
       await waitFor(() => {
-        expect(screen.getAllByText('1 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
         expect(screen.getByText('Trustee A')).toBeInTheDocument();
         expect(screen.queryByText('Trustee B')).not.toBeInTheDocument();
         expect(screen.queryByText('Trustee C')).not.toBeInTheDocument();
@@ -638,7 +639,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderWithRouter(<TrusteesList />);
-      await waitFor(() => expect(screen.getAllByText('3 Trustee(s)')[0]).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('3 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
 
       const user = userEvent.setup();
       const toggleButton = screen.getByRole('button', { name: /filters/i });
@@ -647,14 +648,13 @@ describe('TrusteesList Component', () => {
 
       const chapterCombobox = screen.getByLabelText('Chapter');
       await user.click(chapterCombobox);
-      await waitFor(() => expect(screen.getAllByText('7').length).toBeGreaterThan(0));
-      await user.click(screen.getAllByText('7')[0]);
-      await user.click(chapterCombobox);
-      await waitFor(() => expect(screen.getAllByText('13').length).toBeGreaterThan(0));
-      await user.click(screen.getAllByText('13')[0]);
+      await waitFor(() => expect(screen.getByRole('option', { name: /option: 7/ })).toBeInTheDocument());
+      await user.click(screen.getByRole('option', { name: /option: 7/ }));
+      await waitFor(() => expect(screen.getByRole('option', { name: /option: 13/ })).toBeInTheDocument());
+      await user.click(screen.getByRole('option', { name: /option: 13/ }));
 
       await waitFor(() => {
-        expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
         expect(screen.getByText('Chapter 7 Trustee')).toBeInTheDocument();
         expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
         expect(screen.queryByText('Chapter 11 Trustee')).not.toBeInTheDocument();
@@ -678,7 +678,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderWithRouter(<TrusteesList />);
-      await waitFor(() => expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
 
       const liveRegion = screen.getByRole('status');
       expect(liveRegion).toHaveTextContent('2 Trustee(s)');
@@ -689,8 +689,8 @@ describe('TrusteesList Component', () => {
       expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
       const chapterCombobox = screen.getByLabelText('Chapter');
       await user.click(chapterCombobox);
-      await waitFor(() => expect(screen.getAllByText('7').length).toBeGreaterThan(0));
-      await user.click(screen.getAllByText('7')[0]);
+      await waitFor(() => expect(screen.getByRole('option', { name: /option: 7/ })).toBeInTheDocument());
+      await user.click(screen.getByRole('option', { name: /option: 7/ }));
 
       await waitFor(() => {
         expect(liveRegion).toHaveTextContent('1 Trustee(s)');
@@ -711,7 +711,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderWithRouter(<TrusteesList />);
-      await waitFor(() => expect(screen.getAllByText('1 Trustee(s)')[0]).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument());
 
       const user = userEvent.setup();
       const toggleButton = screen.getByRole('button', { name: /filters/i });
@@ -719,8 +719,8 @@ describe('TrusteesList Component', () => {
       expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
       const chapterCombobox = screen.getByLabelText('Chapter');
       await user.click(chapterCombobox);
-      await waitFor(() => expect(screen.getAllByText('7').length).toBeGreaterThan(0));
-      await user.click(screen.getAllByText('7')[0]);
+      await waitFor(() => expect(screen.getByRole('option', { name: /option: 7/ })).toBeInTheDocument());
+      await user.click(screen.getByRole('option', { name: /option: 7/ }));
 
       await waitFor(() => {
         expect(mockTrackEvent).toHaveBeenCalledWith(
@@ -765,7 +765,7 @@ describe('TrusteesList Component', () => {
       renderWithRouter(<TrusteesList />);
 
       await waitFor(() => {
-        expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
       });
 
       // Check live region for filter announcements
@@ -901,7 +901,7 @@ describe('TrusteesList Component', () => {
         expect(screen.getByText('Trustee, Vermont')).toBeInTheDocument();
         expect(screen.queryByText('Trustee, California')).not.toBeInTheDocument();
       });
-      expect(screen.getAllByText('2 Trustee(s)')[0]).toBeInTheDocument();
+      expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
     });
 
     test('should show all trustees when no district filter is active, including unassigned ones', async () => {
@@ -935,7 +935,7 @@ describe('TrusteesList Component', () => {
       renderWithRouter(<TrusteesList />);
 
       await waitFor(() => {
-        expect(screen.getAllByText('3 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('3 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
       });
 
       expect(screen.getByText('Trustee, Appointed')).toBeInTheDocument();
@@ -1123,7 +1123,7 @@ describe('TrusteesList Component', () => {
 
       // Should remove the filter and show all trustees
       await waitFor(() => {
-        expect(screen.getAllByText('1 Trustee(s)')[0]).toBeInTheDocument();
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
       });
     });
   });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -547,9 +547,24 @@ describe('TrusteesList Component', () => {
       const apptA = makeAppointment({ chapter: '7', divisionCode: '081' });
       const apptB = makeAppointment({ chapter: '13', divisionCode: '081' });
       const apptC = makeAppointment({ chapter: '7', divisionCode: '088' });
-      const trusteeA = makeListItem({ trusteeId: 'a', firstName: 'Alice', lastName: 'Alpha', appointments: [apptA] });
-      const trusteeB = makeListItem({ trusteeId: 'b', firstName: 'Bob', lastName: 'Beta', appointments: [apptB] });
-      const trusteeC = makeListItem({ trusteeId: 'c', firstName: 'Carol', lastName: 'Gamma', appointments: [apptC] });
+      const trusteeA = makeListItem({
+        trusteeId: 'a',
+        firstName: 'Alice',
+        lastName: 'Alpha',
+        appointments: [apptA],
+      });
+      const trusteeB = makeListItem({
+        trusteeId: 'b',
+        firstName: 'Bob',
+        lastName: 'Beta',
+        appointments: [apptB],
+      });
+      const trusteeC = makeListItem({
+        trusteeId: 'c',
+        firstName: 'Carol',
+        lastName: 'Gamma',
+        appointments: [apptC],
+      });
 
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trusteeA, trusteeB, trusteeC] });
       vi.spyOn(Api2, 'getCourts').mockResolvedValue({
@@ -703,10 +718,11 @@ describe('TrusteesList Component', () => {
   });
 
   describe('Chapter Filter Telemetry', () => {
-    test('should track Trustee Chapter Filter Changed with selectedCount and resultCount', async () => {
+    test('should track Trustee Chapter Filter Changed with selectedCount, resultCount, districtCount, and selectedChapterValues', async () => {
       const trustee7 = makeListItem({
         trusteeId: 't7',
-        name: 'Chapter 7 Trustee',
+        firstName: 'Alice',
+        lastName: 'Seven',
         appointments: [makeAppointment({ chapter: '7' })],
       });
 
@@ -729,7 +745,89 @@ describe('TrusteesList Component', () => {
       await waitFor(() => {
         expect(mockTrackEvent).toHaveBeenCalledWith(
           { name: 'Trustee Chapter Filter Changed' },
-          expect.objectContaining({ selectedCount: 1, resultCount: 1 }),
+          expect.objectContaining({
+            selectedCount: 1,
+            resultCount: 1,
+            districtCount: 0,
+            selectedChapterValues: '7',
+          }),
+        );
+      });
+    });
+
+    test('should include districtCount when district filter is also active', async () => {
+      const appt = makeAppointment({ chapter: '7', divisionCode: '081' });
+      const trustee = makeListItem({
+        trusteeId: 't1',
+        firstName: 'Alice',
+        lastName: 'Seven',
+        appointments: [appt],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee] });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({
+        data: [
+          {
+            courtId: 'NYSB',
+            courtName: 'Southern District of New York',
+            officeCode: '081',
+            officeName: 'Manhattan',
+            courtDivisionCode: '081',
+            courtDivisionName: 'Manhattan',
+            groupDesignator: 'NY',
+            regionId: '02',
+            regionName: 'New York',
+          },
+        ],
+      });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue({
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '081',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '081',
+                      court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      const user = userEvent.setup();
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+      expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
+      const chapterCombobox = screen.getByLabelText('Chapter');
+      await user.click(chapterCombobox);
+      expect(await screen.findByRole('option', { name: /option: 7/ })).toBeInTheDocument();
+      await user.click(screen.getByRole('option', { name: /option: 7/ }));
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          { name: 'Trustee Chapter Filter Changed' },
+          expect.objectContaining({
+            selectedCount: 1,
+            districtCount: 1,
+            selectedChapterValues: '7',
+          }),
         );
       });
     });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -479,12 +479,14 @@ describe('TrusteesList Component', () => {
       const ch13Appt = makeAppointment({ chapter: '13', divisionCode: '088' });
       const trustee7 = makeListItem({
         trusteeId: 't7',
-        name: 'Chapter 7 Trustee',
+        firstName: 'Alice',
+        lastName: 'Seven',
         appointments: [ch7Appt],
       });
       const trustee13 = makeListItem({
         trusteeId: 't13',
-        name: 'Chapter 13 Trustee',
+        firstName: 'Bob',
+        lastName: 'Thirteen',
         appointments: [ch13Appt],
       });
 
@@ -492,7 +494,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-      const { container } = renderWithRouter(<TrusteesList />);
+      renderWithRouter(<TrusteesList />);
 
       expect(await screen.findByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
 
@@ -509,23 +511,22 @@ describe('TrusteesList Component', () => {
 
       await waitFor(() => {
         expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
-        expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
-        expect(screen.queryByText('Chapter 7 Trustee')).not.toBeInTheDocument();
+        expect(screen.getByText('Thirteen, Bob')).toBeInTheDocument();
+        expect(screen.queryByText('Seven, Alice')).not.toBeInTheDocument();
       });
-
-      // Suppress unused variable warning
-      void container;
     });
 
     test('should show all trustees when no chapter is selected', async () => {
       const trustee7 = makeListItem({
         trusteeId: 't7',
-        name: 'Chapter 7 Trustee',
+        firstName: 'Alice',
+        lastName: 'Seven',
         appointments: [makeAppointment({ chapter: '7' })],
       });
       const trustee13 = makeListItem({
         trusteeId: 't13',
-        name: 'Chapter 13 Trustee',
+        firstName: 'Bob',
+        lastName: 'Thirteen',
         appointments: [makeAppointment({ chapter: '13' })],
       });
 
@@ -537,8 +538,8 @@ describe('TrusteesList Component', () => {
 
       await waitFor(() => {
         expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
-        expect(screen.getByText('Chapter 7 Trustee')).toBeInTheDocument();
-        expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
+        expect(screen.getByText('Seven, Alice')).toBeInTheDocument();
+        expect(screen.getByText('Thirteen, Bob')).toBeInTheDocument();
       });
     });
 
@@ -546,9 +547,9 @@ describe('TrusteesList Component', () => {
       const apptA = makeAppointment({ chapter: '7', divisionCode: '081' });
       const apptB = makeAppointment({ chapter: '13', divisionCode: '081' });
       const apptC = makeAppointment({ chapter: '7', divisionCode: '088' });
-      const trusteeA = makeListItem({ trusteeId: 'a', name: 'Trustee A', appointments: [apptA] });
-      const trusteeB = makeListItem({ trusteeId: 'b', name: 'Trustee B', appointments: [apptB] });
-      const trusteeC = makeListItem({ trusteeId: 'c', name: 'Trustee C', appointments: [apptC] });
+      const trusteeA = makeListItem({ trusteeId: 'a', firstName: 'Alice', lastName: 'Alpha', appointments: [apptA] });
+      const trusteeB = makeListItem({ trusteeId: 'b', firstName: 'Bob', lastName: 'Beta', appointments: [apptB] });
+      const trusteeC = makeListItem({ trusteeId: 'c', firstName: 'Carol', lastName: 'Gamma', appointments: [apptC] });
 
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trusteeA, trusteeB, trusteeC] });
       vi.spyOn(Api2, 'getCourts').mockResolvedValue({
@@ -611,26 +612,29 @@ describe('TrusteesList Component', () => {
       // Only Trustee A (ch7 + Manhattan) should remain
       await waitFor(() => {
         expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
-        expect(screen.getByText('Trustee A')).toBeInTheDocument();
-        expect(screen.queryByText('Trustee B')).not.toBeInTheDocument();
-        expect(screen.queryByText('Trustee C')).not.toBeInTheDocument();
+        expect(screen.getByText('Alpha, Alice')).toBeInTheDocument();
+        expect(screen.queryByText('Beta, Bob')).not.toBeInTheDocument();
+        expect(screen.queryByText('Gamma, Carol')).not.toBeInTheDocument();
       });
     });
 
     test('should use OR logic within chapter filter', async () => {
       const trustee7 = makeListItem({
         trusteeId: 't7',
-        name: 'Chapter 7 Trustee',
+        firstName: 'Alice',
+        lastName: 'Seven',
         appointments: [makeAppointment({ chapter: '7' })],
       });
       const trustee11 = makeListItem({
         trusteeId: 't11',
-        name: 'Chapter 11 Trustee',
+        firstName: 'Bob',
+        lastName: 'Eleven',
         appointments: [makeAppointment({ chapter: '11' })],
       });
       const trustee13 = makeListItem({
         trusteeId: 't13',
-        name: 'Chapter 13 Trustee',
+        firstName: 'Carol',
+        lastName: 'Thirteen',
         appointments: [makeAppointment({ chapter: '13' })],
       });
 
@@ -655,9 +659,9 @@ describe('TrusteesList Component', () => {
 
       await waitFor(() => {
         expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
-        expect(screen.getByText('Chapter 7 Trustee')).toBeInTheDocument();
-        expect(screen.getByText('Chapter 13 Trustee')).toBeInTheDocument();
-        expect(screen.queryByText('Chapter 11 Trustee')).not.toBeInTheDocument();
+        expect(screen.getByText('Seven, Alice')).toBeInTheDocument();
+        expect(screen.getByText('Thirteen, Carol')).toBeInTheDocument();
+        expect(screen.queryByText('Eleven, Bob')).not.toBeInTheDocument();
       });
     });
 

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -683,12 +683,14 @@ describe('TrusteesList Component', () => {
     test('should announce updated count in live region when chapter filter changes', async () => {
       const trustee7 = makeListItem({
         trusteeId: 't7',
-        name: 'Chapter 7 Trustee',
+        firstName: 'Alice',
+        lastName: 'Seven',
         appointments: [makeAppointment({ chapter: '7' })],
       });
       const trustee13 = makeListItem({
         trusteeId: 't13',
-        name: 'Chapter 13 Trustee',
+        firstName: 'Bob',
+        lastName: 'Thirteen',
         appointments: [makeAppointment({ chapter: '13' })],
       });
 
@@ -700,7 +702,8 @@ describe('TrusteesList Component', () => {
       expect(await screen.findByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
 
       const liveRegion = screen.getByRole('status');
-      expect(liveRegion).toHaveTextContent('2 Trustee(s)');
+      // live region starts empty — only populated after chapter interaction
+      expect(liveRegion).toHaveTextContent('');
 
       const user = userEvent.setup();
       const toggleButton = screen.getByRole('button', { name: /filters/i });
@@ -712,7 +715,7 @@ describe('TrusteesList Component', () => {
       await user.click(screen.getByRole('option', { name: /option: 7/ }));
 
       await waitFor(() => {
-        expect(liveRegion).toHaveTextContent('1 Trustee(s)');
+        expect(liveRegion).toHaveTextContent('1 Trustees');
       });
     });
   });

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -142,7 +142,12 @@ export default function TrusteesList() {
 
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee District Filter Changed' },
-      { isDefault, selectedCount: selectedDistricts.length, resultCount },
+      {
+        isDefault,
+        selectedCount: selectedDistricts.length,
+        resultCount,
+        chapterCount: selectedChapters.length,
+      },
     );
   }, [selectedDistricts, selectedChapters, trustees]);
 
@@ -153,7 +158,12 @@ export default function TrusteesList() {
 
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee Chapter Filter Changed' },
-      { selectedCount: selectedChapters.length, resultCount },
+      {
+        selectedCount: selectedChapters.length,
+        resultCount,
+        districtCount: selectedDistricts.length,
+        selectedChapterValues: selectedChapters.map((c) => c.value).join(','),
+      },
     );
   }, [selectedChapters, selectedDistricts, trustees]);
 

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -129,7 +129,7 @@ export default function TrusteesList() {
       filteredTrustees: sorted,
       announcement: `${filtered.length} Trustee(s)`,
     };
-  }, [trustees, selectedDistricts, selectedChapters]);
+  }, [trustees, selectedDistricts, selectedChapters, sortDirection]);
 
   useEffect(() => {
     if (!isDefaultApplied.current) return;

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -41,6 +41,7 @@ export default function TrusteesList() {
   const [error, setError] = useState<string | null>(null);
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
   const filterRef = useRef<TrusteeDistrictFilterRef>(null);
   const pageLoadStart = useRef(performance.now());
 
@@ -72,6 +73,7 @@ export default function TrusteesList() {
 
   const defaultDistrictsRef = useRef<ComboOption[]>([]);
   const isDefaultApplied = useRef(false);
+  const isChapterFilterInteracted = useRef(false);
 
   const handleFilterDistrict = (districts: ComboOption[]) => {
     if (!isDefaultApplied.current) {
@@ -81,18 +83,31 @@ export default function TrusteesList() {
     setSelectedDistricts(districts);
   };
 
+  const handleFilterChapter = (chapters: ComboOption[]) => {
+    isChapterFilterInteracted.current = true;
+    setSelectedChapters(chapters);
+  };
+
   const { filteredTrustees, announcement } = useMemo(() => {
     const selectedDivisionCodes = selectedDistricts.map((d) => d.value);
-    const base =
-      selectedDistricts.length === 0
-        ? trustees
-        : trustees.filter((t) =>
-            t.appointments.some(
-              (appt) => appt.divisionCode && selectedDivisionCodes.includes(appt.divisionCode),
-            ),
-          );
+    const selectedChapterValues = selectedChapters.map((c) => c.value);
 
-    const sorted = [...base].sort((a, b) => {
+    const filtered =
+      selectedDistricts.length === 0 && selectedChapters.length === 0
+        ? trustees
+        : trustees.filter((trustee) => {
+            const districtMatch =
+              selectedDistricts.length === 0 ||
+              trustee.appointments.some(
+                (appt) => appt.divisionCode && selectedDivisionCodes.includes(appt.divisionCode),
+              );
+            const chapterMatch =
+              selectedChapters.length === 0 ||
+              trustee.appointments.some((appt) => selectedChapterValues.includes(appt.chapter));
+            return districtMatch && chapterMatch;
+          });
+
+    const sorted = [...filtered].sort((a, b) => {
       const lastCmp = (a.lastName ?? '').localeCompare(b.lastName ?? '', undefined, {
         sensitivity: 'base',
       });
@@ -105,13 +120,11 @@ export default function TrusteesList() {
       return sortDirection === 'asc' ? cmp : -cmp;
     });
 
-    const announcement =
-      selectedDistricts.length === 0
-        ? `Showing all ${trustees.length} trustee(s)`
-        : `Showing ${base.length} trustee(s) in ${selectedDistricts.map((d) => d.label).join(', ')}`;
-
-    return { filteredTrustees: sorted, announcement };
-  }, [trustees, selectedDistricts, sortDirection]);
+    return {
+      filteredTrustees: sorted,
+      announcement: `${filtered.length} Trustee(s)`,
+    };
+  }, [trustees, selectedDistricts, selectedChapters]);
 
   useEffect(() => {
     if (!isDefaultApplied.current) return;
@@ -120,22 +133,54 @@ export default function TrusteesList() {
       selectedDistricts.length === defaults.length &&
       selectedDistricts.every((d) => defaults.some((def) => def.value === d.value));
 
-    // Calculate result count inline to avoid dependency on filteredTrustees
     const selectedDivisionCodes = selectedDistricts.map((d) => d.value);
+    const selectedChapterValues = selectedChapters.map((c) => c.value);
     const resultCount =
-      selectedDistricts.length === 0
+      selectedDistricts.length === 0 && selectedChapters.length === 0
         ? trustees.length
-        : trustees.filter((trustee) =>
-            trustee.appointments.some(
-              (appt) => appt.divisionCode && selectedDivisionCodes.includes(appt.divisionCode),
-            ),
-          ).length;
+        : trustees.filter((trustee) => {
+            const districtMatch =
+              selectedDistricts.length === 0 ||
+              trustee.appointments.some(
+                (appt) => appt.divisionCode && selectedDivisionCodes.includes(appt.divisionCode),
+              );
+            const chapterMatch =
+              selectedChapters.length === 0 ||
+              trustee.appointments.some((appt) => selectedChapterValues.includes(appt.chapter));
+            return districtMatch && chapterMatch;
+          }).length;
 
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee District Filter Changed' },
       { isDefault, selectedCount: selectedDistricts.length, resultCount },
     );
-  }, [selectedDistricts, trustees]);
+  }, [selectedDistricts, selectedChapters, trustees]);
+
+  useEffect(() => {
+    if (!isChapterFilterInteracted.current) return;
+
+    const selectedDivisionCodes = selectedDistricts.map((d) => d.value);
+    const selectedChapterValues = selectedChapters.map((c) => c.value);
+    const resultCount =
+      selectedDistricts.length === 0 && selectedChapters.length === 0
+        ? trustees.length
+        : trustees.filter((trustee) => {
+            const districtMatch =
+              selectedDistricts.length === 0 ||
+              trustee.appointments.some(
+                (appt) => appt.divisionCode && selectedDivisionCodes.includes(appt.divisionCode),
+              );
+            const chapterMatch =
+              selectedChapters.length === 0 ||
+              trustee.appointments.some((appt) => selectedChapterValues.includes(appt.chapter));
+            return districtMatch && chapterMatch;
+          }).length;
+
+    getAppInsights().appInsights.trackEvent(
+      { name: 'Trustee Chapter Filter Changed' },
+      { selectedCount: selectedChapters.length, resultCount },
+    );
+  }, [selectedChapters, selectedDistricts, trustees]);
 
   if (loading) {
     return <LoadingSpinner caption="Loading trustees..." />;
@@ -168,7 +213,11 @@ export default function TrusteesList() {
 
   return (
     <div className="trustees-list">
-      <TrusteeDistrictFilter ref={filterRef} handleFilterDistrict={handleFilterDistrict} />
+      <TrusteeDistrictFilter
+        ref={filterRef}
+        handleFilterDistrict={handleFilterDistrict}
+        handleFilterChapter={handleFilterChapter}
+      />
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">
         {announcement}
       </div>

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -18,6 +18,27 @@ import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 const COLUMN_HEADERS = ['Name', 'District (Division)', 'Chapter', 'Type', 'Status'];
 
+function filterTrustees(
+  trustees: TrusteeListItem[],
+  selectedDistricts: ComboOption[],
+  selectedChapters: ComboOption[],
+): TrusteeListItem[] {
+  if (selectedDistricts.length === 0 && selectedChapters.length === 0) return trustees;
+  const selectedDivisionCodes = new Set(selectedDistricts.map((d) => d.value));
+  const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
+  return trustees.filter((trustee) => {
+    const districtMatch =
+      selectedDistricts.length === 0 ||
+      trustee.appointments.some(
+        (appt) => appt.divisionCode && selectedDivisionCodes.has(appt.divisionCode),
+      );
+    const chapterMatch =
+      selectedChapters.length === 0 ||
+      trustee.appointments.some((appt) => selectedChapterValues.has(appt.chapter));
+    return districtMatch && chapterMatch;
+  });
+}
+
 function toColClass(header: string): string {
   return (
     'col-' +
@@ -89,23 +110,7 @@ export default function TrusteesList() {
   };
 
   const { filteredTrustees, announcement } = useMemo(() => {
-    const selectedDivisionCodes = selectedDistricts.map((d) => d.value);
-    const selectedChapterValues = selectedChapters.map((c) => c.value);
-
-    const filtered =
-      selectedDistricts.length === 0 && selectedChapters.length === 0
-        ? trustees
-        : trustees.filter((trustee) => {
-            const districtMatch =
-              selectedDistricts.length === 0 ||
-              trustee.appointments.some(
-                (appt) => appt.divisionCode && selectedDivisionCodes.includes(appt.divisionCode),
-              );
-            const chapterMatch =
-              selectedChapters.length === 0 ||
-              trustee.appointments.some((appt) => selectedChapterValues.includes(appt.chapter));
-            return districtMatch && chapterMatch;
-          });
+    const filtered = filterTrustees(trustees, selectedDistricts, selectedChapters);
 
     const sorted = [...filtered].sort((a, b) => {
       const lastCmp = (a.lastName ?? '').localeCompare(b.lastName ?? '', undefined, {
@@ -133,22 +138,7 @@ export default function TrusteesList() {
       selectedDistricts.length === defaults.length &&
       selectedDistricts.every((d) => defaults.some((def) => def.value === d.value));
 
-    const selectedDivisionCodes = selectedDistricts.map((d) => d.value);
-    const selectedChapterValues = selectedChapters.map((c) => c.value);
-    const resultCount =
-      selectedDistricts.length === 0 && selectedChapters.length === 0
-        ? trustees.length
-        : trustees.filter((trustee) => {
-            const districtMatch =
-              selectedDistricts.length === 0 ||
-              trustee.appointments.some(
-                (appt) => appt.divisionCode && selectedDivisionCodes.includes(appt.divisionCode),
-              );
-            const chapterMatch =
-              selectedChapters.length === 0 ||
-              trustee.appointments.some((appt) => selectedChapterValues.includes(appt.chapter));
-            return districtMatch && chapterMatch;
-          }).length;
+    const resultCount = filterTrustees(trustees, selectedDistricts, selectedChapters).length;
 
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee District Filter Changed' },
@@ -159,22 +149,7 @@ export default function TrusteesList() {
   useEffect(() => {
     if (!isChapterFilterInteracted.current) return;
 
-    const selectedDivisionCodes = selectedDistricts.map((d) => d.value);
-    const selectedChapterValues = selectedChapters.map((c) => c.value);
-    const resultCount =
-      selectedDistricts.length === 0 && selectedChapters.length === 0
-        ? trustees.length
-        : trustees.filter((trustee) => {
-            const districtMatch =
-              selectedDistricts.length === 0 ||
-              trustee.appointments.some(
-                (appt) => appt.divisionCode && selectedDivisionCodes.includes(appt.divisionCode),
-              );
-            const chapterMatch =
-              selectedChapters.length === 0 ||
-              trustee.appointments.some((appt) => selectedChapterValues.includes(appt.chapter));
-            return districtMatch && chapterMatch;
-          }).length;
+    const resultCount = filterTrustees(trustees, selectedDistricts, selectedChapters).length;
 
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee Chapter Filter Changed' },

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -111,7 +111,7 @@ export default function TrusteesList() {
     setLiveAnnouncement('');
   };
 
-  const { filteredTrustees, announcement } = useMemo(() => {
+  const { filteredTrustees } = useMemo(() => {
     const filtered = filterTrustees(trustees, selectedDistricts, selectedChapters);
 
     const sorted = [...filtered].sort((a, b) => {
@@ -129,7 +129,6 @@ export default function TrusteesList() {
 
     return {
       filteredTrustees: sorted,
-      announcement: `${filtered.length} Trustees`,
     };
   }, [trustees, selectedDistricts, selectedChapters, sortDirection]);
 

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -63,6 +63,7 @@ export default function TrusteesList() {
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
+  const [liveAnnouncement, setLiveAnnouncement] = useState<string>('');
   const filterRef = useRef<TrusteeDistrictFilterRef>(null);
   const pageLoadStart = useRef(performance.now());
 
@@ -107,6 +108,7 @@ export default function TrusteesList() {
   const handleFilterChapter = (chapters: ComboOption[]) => {
     isChapterFilterInteracted.current = true;
     setSelectedChapters(chapters);
+    setLiveAnnouncement('');
   };
 
   const { filteredTrustees, announcement } = useMemo(() => {
@@ -127,7 +129,7 @@ export default function TrusteesList() {
 
     return {
       filteredTrustees: sorted,
-      announcement: `${filtered.length} Trustee(s)`,
+      announcement: `${filtered.length} Trustees`,
     };
   }, [trustees, selectedDistricts, selectedChapters, sortDirection]);
 
@@ -150,6 +152,11 @@ export default function TrusteesList() {
       },
     );
   }, [selectedDistricts, selectedChapters, trustees]);
+
+  useEffect(() => {
+    if (!isChapterFilterInteracted.current) return;
+    setLiveAnnouncement(`${filteredTrustees.length} Trustees`);
+  }, [filteredTrustees]);
 
   useEffect(() => {
     if (!isChapterFilterInteracted.current) return;
@@ -204,7 +211,7 @@ export default function TrusteesList() {
         handleFilterChapter={handleFilterChapter}
       />
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">
-        {announcement}
+        {liveAnnouncement}
       </div>
       <p className="trustees-list-count">{filteredTrustees.length} Trustee(s)</p>
       <div

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
@@ -67,7 +67,7 @@
         margin-top: 0;
 
         .combo-box-label .usa-label {
-          display: none;
+          @extend .usa-sr-only;
         }
       }
     }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
@@ -52,11 +52,49 @@
     margin-top: 1rem;
     animation: slideDown 0.2s ease-out;
 
+    .filter-controls-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+    }
+
     .filter-control {
+      flex: 1 1 20rem;
+      min-width: 16rem;
       max-width: 30rem;
 
       .combo-box-form-group {
-        max-width: 30rem;
+        margin-top: 0;
+
+        .combo-box-label .usa-label {
+          display: none;
+        }
+      }
+    }
+
+    .filter-control-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      margin-bottom: 0.25rem;
+    }
+
+    .filter-control-label {
+      font-weight: 700;
+      font-size: 1rem;
+    }
+
+    .filter-clear-link {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: 0.875rem;
+      color: #005ea2;
+      cursor: pointer;
+      text-decoration: underline;
+
+      &:hover {
+        color: #1a4480;
       }
     }
   }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
@@ -67,7 +67,15 @@
         margin-top: 0;
 
         .combo-box-label .usa-label {
-          @extend .usa-sr-only;
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
         }
       }
     }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -47,6 +47,7 @@ const mockDistricts: CourtDivisionDetails[] = [
 
 describe('TrusteeDistrictFilter Component', () => {
   const mockHandleFilterDistrict = vi.fn();
+  const mockHandleFilterChapter = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -62,7 +63,12 @@ describe('TrusteeDistrictFilter Component', () => {
     const user = userEvent.setup();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(<TrusteeDistrictFilter handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -85,7 +91,12 @@ describe('TrusteeDistrictFilter Component', () => {
     const user = userEvent.setup();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(<TrusteeDistrictFilter handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -147,7 +158,12 @@ describe('TrusteeDistrictFilter Component', () => {
     };
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
 
-    render(<TrusteeDistrictFilter handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     // Wait for component to render
     await waitFor(() => {
@@ -171,7 +187,12 @@ describe('TrusteeDistrictFilter Component', () => {
     const user = userEvent.setup();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(<TrusteeDistrictFilter handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -206,7 +227,12 @@ describe('TrusteeDistrictFilter Component', () => {
     const user = userEvent.setup();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(<TrusteeDistrictFilter handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -278,7 +304,12 @@ describe('TrusteeDistrictFilter Component', () => {
     };
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
 
-    render(<TrusteeDistrictFilter handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -311,7 +342,12 @@ describe('TrusteeDistrictFilter Component', () => {
     vi.spyOn(Api2, 'getCourts').mockRejectedValue(new Error('API Error'));
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(<TrusteeDistrictFilter handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -331,7 +367,12 @@ describe('TrusteeDistrictFilter Component', () => {
   test('should handle empty user session gracefully', async () => {
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(<TrusteeDistrictFilter handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -415,7 +456,13 @@ describe('TrusteeDistrictFilter Component', () => {
     };
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
 
-    render(<TrusteeDistrictFilter ref={ref} handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        ref={ref}
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -477,7 +524,13 @@ describe('TrusteeDistrictFilter Component', () => {
     };
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
 
-    render(<TrusteeDistrictFilter ref={ref} handleFilterDistrict={mockHandleFilterDistrict} />);
+    render(
+      <TrusteeDistrictFilter
+        ref={ref}
+        handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -523,6 +576,94 @@ describe('TrusteeDistrictFilter Component', () => {
           { value: '081', label: 'Southern District of New York (Manhattan)' },
         ]),
       );
+    });
+  });
+
+  describe('Chapter Filter', () => {
+    test('should render chapter combobox when accordion is expanded', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      render(
+        <TrusteeDistrictFilter
+          handleFilterDistrict={mockHandleFilterDistrict}
+          handleFilterChapter={mockHandleFilterChapter}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Chapter')).toBeInTheDocument();
+      });
+    });
+
+    test('should call handleFilterChapter when a chapter is selected', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      render(
+        <TrusteeDistrictFilter
+          handleFilterDistrict={mockHandleFilterDistrict}
+          handleFilterChapter={mockHandleFilterChapter}
+        />,
+      );
+
+      expect(await screen.findByText('Filters')).toBeInTheDocument();
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
+
+      const chapterCombobox = screen.getByLabelText('Chapter');
+      await user.click(chapterCombobox);
+
+      expect(await screen.findByText('11 Subchapter V')).toBeInTheDocument();
+
+      await user.click(screen.getByText('11 Subchapter V'));
+
+      await waitFor(() => {
+        expect(mockHandleFilterChapter).toHaveBeenCalledWith(
+          expect.arrayContaining([{ value: '11-subchapter-v', label: '11 Subchapter V' }]),
+        );
+      });
+    });
+
+    test('should render chapter pill when chapter is selected and accordion is collapsed', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      render(
+        <TrusteeDistrictFilter
+          handleFilterDistrict={mockHandleFilterDistrict}
+          handleFilterChapter={mockHandleFilterChapter}
+        />,
+      );
+
+      expect(await screen.findByText('Filters')).toBeInTheDocument();
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
+
+      const chapterCombobox = screen.getByLabelText('Chapter');
+      await user.click(chapterCombobox);
+
+      expect(await screen.findByText('7')).toBeInTheDocument();
+      await user.click(screen.getByText('7'));
+
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /remove 7 filter/i })).toBeInTheDocument();
+      });
     });
   });
 });

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -8,6 +8,7 @@ import { vi } from 'vitest';
 import LocalStorage from '@/lib/utils/local-storage';
 import MockData from '@common/cams/test-utilities/mock-data';
 import { TrusteeDistrictFilterRef } from './trusteeDistrictFilter.types';
+import React from 'react';
 
 const mockDistricts: CourtDivisionDetails[] = [
   {
@@ -45,10 +46,26 @@ const mockDistricts: CourtDivisionDetails[] = [
   },
 ];
 
-describe('TrusteeDistrictFilter Component', () => {
+function renderFilter(
+  overrides: Partial<{
+    ref: React.RefObject<TrusteeDistrictFilterRef>;
+    onExpandedChange: (expanded: boolean) => void;
+  }> = {},
+) {
   const mockHandleFilterDistrict = vi.fn();
   const mockHandleFilterChapter = vi.fn();
+  render(
+    <TrusteeDistrictFilter
+      ref={overrides.ref}
+      handleFilterDistrict={mockHandleFilterDistrict}
+      handleFilterChapter={mockHandleFilterChapter}
+      onExpandedChange={overrides.onExpandedChange}
+    />,
+  );
+  return { mockHandleFilterDistrict, mockHandleFilterChapter };
+}
 
+describe('TrusteeDistrictFilter Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     const mockResponse: ResponseBody<CourtDivisionDetails[]> = { data: mockDistricts };
@@ -63,12 +80,7 @@ describe('TrusteeDistrictFilter Component', () => {
     const user = userEvent.setup();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    renderFilter();
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -91,12 +103,7 @@ describe('TrusteeDistrictFilter Component', () => {
     const user = userEvent.setup();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    renderFilter();
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -158,12 +165,7 @@ describe('TrusteeDistrictFilter Component', () => {
     };
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    renderFilter();
 
     // Wait for component to render
     await waitFor(() => {
@@ -187,12 +189,7 @@ describe('TrusteeDistrictFilter Component', () => {
     const user = userEvent.setup();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    const { mockHandleFilterDistrict } = renderFilter();
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -227,12 +224,7 @@ describe('TrusteeDistrictFilter Component', () => {
     const user = userEvent.setup();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    renderFilter();
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -304,12 +296,7 @@ describe('TrusteeDistrictFilter Component', () => {
     };
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    const { mockHandleFilterDistrict } = renderFilter();
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -342,12 +329,7 @@ describe('TrusteeDistrictFilter Component', () => {
     vi.spyOn(Api2, 'getCourts').mockRejectedValue(new Error('API Error'));
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    renderFilter();
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -367,12 +349,7 @@ describe('TrusteeDistrictFilter Component', () => {
   test('should handle empty user session gracefully', async () => {
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    const { mockHandleFilterDistrict } = renderFilter();
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -387,13 +364,7 @@ describe('TrusteeDistrictFilter Component', () => {
     const mockOnExpandedChange = vi.fn();
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-    render(
-      <TrusteeDistrictFilter
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-        onExpandedChange={mockOnExpandedChange}
-      />,
-    );
+    renderFilter({ onExpandedChange: mockOnExpandedChange });
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -457,13 +428,7 @@ describe('TrusteeDistrictFilter Component', () => {
     };
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
 
-    render(
-      <TrusteeDistrictFilter
-        ref={ref}
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    const { mockHandleFilterDistrict } = renderFilter({ ref });
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -525,13 +490,7 @@ describe('TrusteeDistrictFilter Component', () => {
     };
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
 
-    render(
-      <TrusteeDistrictFilter
-        ref={ref}
-        handleFilterDistrict={mockHandleFilterDistrict}
-        handleFilterChapter={mockHandleFilterChapter}
-      />,
-    );
+    const { mockHandleFilterDistrict } = renderFilter({ ref });
 
     await waitFor(() => {
       expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -585,12 +544,7 @@ describe('TrusteeDistrictFilter Component', () => {
       const user = userEvent.setup();
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-      render(
-        <TrusteeDistrictFilter
-          handleFilterDistrict={mockHandleFilterDistrict}
-          handleFilterChapter={mockHandleFilterChapter}
-        />,
-      );
+      renderFilter();
 
       await waitFor(() => {
         expect(screen.getByText('Filters')).toBeInTheDocument();
@@ -608,12 +562,7 @@ describe('TrusteeDistrictFilter Component', () => {
       const user = userEvent.setup();
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-      render(
-        <TrusteeDistrictFilter
-          handleFilterDistrict={mockHandleFilterDistrict}
-          handleFilterChapter={mockHandleFilterChapter}
-        />,
-      );
+      const { mockHandleFilterChapter } = renderFilter();
 
       expect(await screen.findByText('Filters')).toBeInTheDocument();
 
@@ -640,12 +589,7 @@ describe('TrusteeDistrictFilter Component', () => {
       const user = userEvent.setup();
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
-      render(
-        <TrusteeDistrictFilter
-          handleFilterDistrict={mockHandleFilterDistrict}
-          handleFilterChapter={mockHandleFilterChapter}
-        />,
-      );
+      renderFilter();
 
       expect(await screen.findByText('Filters')).toBeInTheDocument();
 

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -390,6 +390,7 @@ describe('TrusteeDistrictFilter Component', () => {
     render(
       <TrusteeDistrictFilter
         handleFilterDistrict={mockHandleFilterDistrict}
+        handleFilterChapter={mockHandleFilterChapter}
         onExpandedChange={mockOnExpandedChange}
       />,
     );

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -20,11 +20,14 @@ const TrusteeDistrictFilter_ = (
   const store: TrusteeDistrictFilterStore = useTrusteeDistrictFilterStoreReact();
   const controls: TrusteeDistrictFilterControls = useTrusteeDistrictFilterControlsReact();
   const previousDistrictsRef = useRef<ComboOption[] | undefined>(undefined);
+  const previousChaptersRef = useRef<ComboOption[] | undefined>(undefined);
   const useCase = trusteeDistrictFilterUseCase(
     store,
     controls,
     props.handleFilterDistrict,
     previousDistrictsRef,
+    props.handleFilterChapter,
+    previousChaptersRef,
   );
   const globalAlert = useGlobalAlert();
 
@@ -61,13 +64,19 @@ const TrusteeDistrictFilter_ = (
     districts: store.districts,
     districtsError: store.districtsError,
     selectedDistricts: store.selectedDistricts,
+    selectedChapters: store.selectedChapters,
     isExpanded: store.isExpanded,
     districtFilterRef: controls.districtFilterRef,
+    chapterFilterRef: controls.chapterFilterRef,
     districtsToComboOptions: useCase.districtsToComboOptions,
+    chaptersToComboOptions: useCase.chaptersToComboOptions,
     handleFilterChange: useCase.handleFilterChange,
     handleClearAll: useCase.handleClearAll,
     handleToggleExpanded: useCase.handleToggleExpanded,
     handleRemovePill: useCase.handleRemovePill,
+    handleFilterChapter: useCase.handleFilterChapter,
+    handleClearAllChapters: useCase.handleClearAllChapters,
+    handleRemoveChapterPill: useCase.handleRemoveChapterPill,
   };
 
   return <TrusteeDistrictFilterView viewModel={viewModel}></TrusteeDistrictFilterView>;
@@ -81,6 +90,7 @@ function useTrusteeDistrictFilterStoreReact() {
   const [districtsError, setDistrictsError] = useState<boolean>(false);
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
   const [defaultDistricts, setDefaultDistricts] = useState<ComboOption[]>([]);
+  const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   return {
@@ -92,6 +102,8 @@ function useTrusteeDistrictFilterStoreReact() {
     setSelectedDistricts,
     defaultDistricts,
     setDefaultDistricts,
+    selectedChapters,
+    setSelectedChapters,
     isExpanded,
     setIsExpanded,
   };
@@ -99,8 +111,10 @@ function useTrusteeDistrictFilterStoreReact() {
 
 function useTrusteeDistrictFilterControlsReact() {
   const districtFilterRef = useRef<ComboBoxRef>(null);
+  const chapterFilterRef = useRef<ComboBoxRef>(null);
 
   return {
     districtFilterRef,
+    chapterFilterRef,
   };
 }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -8,29 +8,11 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
   const { viewModel } = props;
 
   return (
-    <section className="trustee-district-filter" aria-label="District filter controls">
+    <section className="trustee-district-filter" aria-label="Trustee filter controls">
       <AccordionGroup>
         <Accordion id="district-filter" onExpand={() => viewModel.handleToggleExpanded()}>
           <span>Filters</span>
           <div id="district-filter-content" className="filter-content">
-            {viewModel.districts.length > 0 && !viewModel.districtsError && (
-              <div className="filter-control">
-                <ComboBox
-                  id="district-combobox"
-                  label="District (Division)"
-                  options={viewModel.districtsToComboOptions(viewModel.districts)}
-                  selections={viewModel.selectedDistricts}
-                  onUpdateSelection={viewModel.handleFilterChange}
-                  multiSelect={true}
-                  wrapPills={true}
-                  pluralLabel="districts"
-                  singularLabel="district"
-                  placeholder="- Select one or more -"
-                  ref={viewModel.districtFilterRef}
-                />
-              </div>
-            )}
-
             {viewModel.districtsError && (
               <div className="usa-alert usa-alert--error usa-alert--slim" role="alert">
                 <div className="usa-alert__body">
@@ -40,11 +22,73 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                 </div>
               </div>
             )}
+
+            <div className="filter-controls-row">
+              {viewModel.districts.length > 0 && !viewModel.districtsError && (
+                <div className="filter-control">
+                  <div className="filter-control-header">
+                    <span className="filter-control-label">District (Division)</span>
+                    {viewModel.selectedDistricts.length > 0 && (
+                      <button
+                        type="button"
+                        className="filter-clear-link"
+                        onClick={viewModel.handleClearAll}
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
+                  <ComboBox
+                    id="district-combobox"
+                    label="District (Division)"
+                    options={viewModel.districtsToComboOptions(viewModel.districts)}
+                    selections={viewModel.selectedDistricts}
+                    onUpdateSelection={viewModel.handleFilterChange}
+                    multiSelect={true}
+                    wrapPills={true}
+                    pluralLabel="districts"
+                    singularLabel="district"
+                    placeholder="- Select one or more -"
+                    ref={viewModel.districtFilterRef}
+                    hideClearAllButton={true}
+                  />
+                </div>
+              )}
+
+              <div className="filter-control">
+                <div className="filter-control-header">
+                  <span className="filter-control-label">Chapter</span>
+                  {viewModel.selectedChapters.length > 0 && (
+                    <button
+                      type="button"
+                      className="filter-clear-link"
+                      onClick={viewModel.handleClearAllChapters}
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+                <ComboBox
+                  id="chapter-combobox"
+                  label="Chapter"
+                  options={viewModel.chaptersToComboOptions()}
+                  selections={viewModel.selectedChapters}
+                  onUpdateSelection={viewModel.handleFilterChapter}
+                  multiSelect={true}
+                  wrapPills={true}
+                  pluralLabel="chapters"
+                  singularLabel="chapter"
+                  placeholder="- Select one or more -"
+                  ref={viewModel.chapterFilterRef}
+                  hideClearAllButton={true}
+                />
+              </div>
+            </div>
           </div>
         </Accordion>
       </AccordionGroup>
 
-      {viewModel.selectedDistricts.length > 0 && (
+      {(viewModel.selectedDistricts.length > 0 || viewModel.selectedChapters.length > 0) && (
         <div className="filter-pills-container">
           {viewModel.selectedDistricts.map((district) => (
             <span key={district.value} className="usa-tag filter-pill">
@@ -54,6 +98,19 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                 className="usa-tag__remove-button"
                 onClick={() => viewModel.handleRemovePill(district)}
                 aria-label={`Remove ${district.label} filter`}
+              >
+                <Icon name="close" />
+              </button>
+            </span>
+          ))}
+          {viewModel.selectedChapters.map((chapter) => (
+            <span key={chapter.value} className="usa-tag filter-pill">
+              {chapter.label}
+              <button
+                type="button"
+                className="usa-tag__remove-button"
+                onClick={() => viewModel.handleRemoveChapterPill(chapter)}
+                aria-label={`Remove ${chapter.label} filter`}
               >
                 <Icon name="close" />
               </button>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -4,8 +4,27 @@ import Icon from '@/lib/components/uswds/Icon';
 import { Accordion, AccordionGroup } from '@/lib/components/uswds/Accordion';
 import { TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
 
+function FilterPill({ label, onRemove }: { label: string; onRemove: () => void }) {
+  return (
+    <span className="usa-tag filter-pill">
+      {label}
+      <button
+        type="button"
+        className="usa-tag__remove-button"
+        onClick={onRemove}
+        aria-label={`Remove ${label} filter`}
+      >
+        <Icon name="close" />
+      </button>
+    </span>
+  );
+}
+
 function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
   const { viewModel } = props;
+
+  const showDistrictFilter = viewModel.districts.length > 0 && !viewModel.districtsError;
+  const hasPills = viewModel.selectedDistricts.length > 0 || viewModel.selectedChapters.length > 0;
 
   return (
     <section className="trustee-district-filter" aria-label="Trustee filter controls">
@@ -24,7 +43,7 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
             )}
 
             <div className="filter-controls-row">
-              {viewModel.districts.length > 0 && !viewModel.districtsError && (
+              {showDistrictFilter && (
                 <div className="filter-control">
                   <div className="filter-control-header">
                     <span className="filter-control-label">District (Division)</span>
@@ -88,33 +107,21 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
         </Accordion>
       </AccordionGroup>
 
-      {(viewModel.selectedDistricts.length > 0 || viewModel.selectedChapters.length > 0) && (
+      {hasPills && (
         <div className="filter-pills-container">
           {viewModel.selectedDistricts.map((district) => (
-            <span key={district.value} className="usa-tag filter-pill">
-              {district.label}
-              <button
-                type="button"
-                className="usa-tag__remove-button"
-                onClick={() => viewModel.handleRemovePill(district)}
-                aria-label={`Remove ${district.label} filter`}
-              >
-                <Icon name="close" />
-              </button>
-            </span>
+            <FilterPill
+              key={district.value}
+              label={district.label}
+              onRemove={() => viewModel.handleRemovePill(district)}
+            />
           ))}
           {viewModel.selectedChapters.map((chapter) => (
-            <span key={chapter.value} className="usa-tag filter-pill">
-              {chapter.label}
-              <button
-                type="button"
-                className="usa-tag__remove-button"
-                onClick={() => viewModel.handleRemoveChapterPill(chapter)}
-                aria-label={`Remove ${chapter.label} filter`}
-              >
-                <Icon name="close" />
-              </button>
-            </span>
+            <FilterPill
+              key={chapter.value}
+              label={chapter.label}
+              onRemove={() => viewModel.handleRemoveChapterPill(chapter)}
+            />
           ))}
         </div>
       )}

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -12,12 +12,15 @@ export interface TrusteeDistrictFilterStore {
   setSelectedDistricts(val: ComboOption[]): void;
   defaultDistricts: ComboOption[];
   setDefaultDistricts(val: ComboOption[]): void;
+  selectedChapters: ComboOption[];
+  setSelectedChapters(val: ComboOption[]): void;
   isExpanded: boolean;
   setIsExpanded(val: boolean): void;
 }
 
 export interface TrusteeDistrictFilterControls {
   districtFilterRef: React.RefObject<ComboBoxRef | null>;
+  chapterFilterRef: React.RefObject<ComboBoxRef | null>;
 }
 
 export type TrusteeDistrictFilterViewProps = {
@@ -28,14 +31,20 @@ export interface TrusteeDistrictFilterViewModel {
   districts: CourtDivisionDetails[];
   districtsError: boolean;
   selectedDistricts: ComboOption[];
+  selectedChapters: ComboOption[];
   isExpanded: boolean;
   districtFilterRef: React.RefObject<ComboBoxRef | null>;
+  chapterFilterRef: React.RefObject<ComboBoxRef | null>;
 
   districtsToComboOptions(districts: CourtDivisionDetails[]): ComboOption[];
+  chaptersToComboOptions(): ComboOption[];
   handleFilterChange(districts: ComboOption[]): void;
   handleClearAll(): void;
   handleToggleExpanded(): void;
   handleRemovePill(district: ComboOption): void;
+  handleFilterChapter(chapters: ComboOption[]): void;
+  handleClearAllChapters(): void;
+  handleRemoveChapterPill(chapter: ComboOption): void;
 }
 
 export interface TrusteeDistrictFilterRef {
@@ -47,11 +56,13 @@ export interface TrusteeDistrictFilterRef {
 
 export type TrusteeDistrictFilterProps = {
   handleFilterDistrict(districts: ComboOption[]): void;
+  handleFilterChapter(chapters: ComboOption[]): void;
   onExpandedChange?: (isExpanded: boolean) => void;
 };
 
 export interface TrusteeDistrictFilterUseCase {
   districtsToComboOptions(districts: CourtDivisionDetails[]): ComboOption[];
+  chaptersToComboOptions(): ComboOption[];
   fetchDistricts(): Promise<void>;
   focusOnDistrictFilter(): void;
   getDefaultDistrictsFromSession(
@@ -62,4 +73,7 @@ export interface TrusteeDistrictFilterUseCase {
   handleClearAll(): void;
   handleToggleExpanded(): void;
   handleRemovePill(district: ComboOption): void;
+  handleFilterChapter(chapters: ComboOption[]): void;
+  handleClearAllChapters(): void;
+  handleRemoveChapterPill(chapter: ComboOption): void;
 }

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -58,6 +58,7 @@ describe('trustee district filter use case tests', () => {
   ];
 
   const mockOnFilterDistrict = vi.fn();
+  const mockOnFilterChapter = vi.fn();
 
   const mockStore: TrusteeDistrictFilterStore = {
     districts: mockDistricts,
@@ -68,6 +69,8 @@ describe('trustee district filter use case tests', () => {
     setSelectedDistricts: vi.fn(),
     defaultDistricts: [],
     setDefaultDistricts: vi.fn(),
+    selectedChapters: [],
+    setSelectedChapters: vi.fn(),
     isExpanded: false,
     setIsExpanded: vi.fn(),
   };
@@ -85,23 +88,30 @@ describe('trustee district filter use case tests', () => {
 
   const mockControls: TrusteeDistrictFilterControls = {
     districtFilterRef: comboBoxRef,
+    chapterFilterRef: comboBoxRef,
   };
 
   const previousDistrictsRef = { current: undefined as ComboOption[] | undefined };
+  const previousChaptersRef = { current: undefined as ComboOption[] | undefined };
 
   const useCase = trusteeDistrictFilterUseCase(
     mockStore,
     mockControls,
     mockOnFilterDistrict,
     previousDistrictsRef,
+    mockOnFilterChapter,
+    previousChaptersRef,
   );
 
   beforeEach(() => {
     mockStore.setSelectedDistricts = vi.fn();
+    mockStore.setSelectedChapters = vi.fn();
     setSelectedDistrictsSpy = vi.spyOn(mockStore, 'setSelectedDistricts');
     mockOnFilterDistrict.mockReset();
+    mockOnFilterChapter.mockReset();
     mockTrackEvent.mockReset();
-    previousDistrictsRef.current = undefined; // Reset ref state between tests
+    previousDistrictsRef.current = undefined;
+    previousChaptersRef.current = undefined;
   });
 
   afterEach(() => {
@@ -449,6 +459,73 @@ describe('trustee district filter use case tests', () => {
       useCase.focusOnDistrictFilter();
 
       expect(focusInputSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('chaptersToComboOptions', () => {
+    test('should return all 5 chapter options with correct labels', () => {
+      const options = useCase.chaptersToComboOptions();
+
+      expect(options).toHaveLength(5);
+      expect(options).toEqual([
+        { value: '7', label: '7' },
+        { value: '11', label: '11' },
+        { value: '11-subchapter-v', label: '11 Subchapter V' },
+        { value: '12', label: '12' },
+        { value: '13', label: '13' },
+      ]);
+    });
+  });
+
+  describe('handleFilterChapter', () => {
+    test('should update selected chapters and trigger callback', () => {
+      const setSelectedChaptersSpy = vi.spyOn(mockStore, 'setSelectedChapters');
+      const chapters: ComboOption[] = [{ value: '7', label: '7' }];
+
+      useCase.handleFilterChapter(chapters);
+
+      expect(setSelectedChaptersSpy).toHaveBeenCalledWith(chapters);
+      expect(mockOnFilterChapter).toHaveBeenCalledWith(chapters);
+    });
+
+    test('should fire Trustee Chapter Filter Cleared only when transitioning non-empty to empty', () => {
+      useCase.handleFilterChapter([{ value: '7', label: '7' }]);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+
+      useCase.handleFilterChapter([]);
+      expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'Trustee Chapter Filter Cleared' });
+    });
+
+    test('should not fire Trustee Chapter Filter Cleared on initial empty call', () => {
+      useCase.handleFilterChapter([]);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleClearAllChapters', () => {
+    test('should clear selected chapters and notify', () => {
+      const setSelectedChaptersSpy = vi.spyOn(mockStore, 'setSelectedChapters');
+
+      useCase.handleClearAllChapters();
+
+      expect(setSelectedChaptersSpy).toHaveBeenCalledWith([]);
+      expect(mockOnFilterChapter).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('handleRemoveChapterPill', () => {
+    test('should remove the specified chapter from selection and notify', () => {
+      const chapters: ComboOption[] = [
+        { value: '7', label: '7' },
+        { value: '13', label: '13' },
+      ];
+      mockStore.selectedChapters = chapters;
+      const setSelectedChaptersSpy = vi.spyOn(mockStore, 'setSelectedChapters');
+
+      useCase.handleRemoveChapterPill(chapters[0]);
+
+      expect(setSelectedChaptersSpy).toHaveBeenCalledWith([chapters[1]]);
+      expect(mockOnFilterChapter).toHaveBeenCalledWith([chapters[1]]);
     });
   });
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -9,6 +9,7 @@ import Api2 from '@/lib/models/api2';
 import LocalStorage from '@/lib/utils/local-storage';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
+import { AppointmentChapterType, formatChapterType } from '@common/cams/trustees';
 
 const districtsToComboOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
   // Show all divisions with format: District (Division)
@@ -58,11 +59,18 @@ const getDefaultDistrictsFromSession = (
     .sort((a, b) => a.label.localeCompare(b.label));
 };
 
+const CHAPTER_OPTIONS: AppointmentChapterType[] = ['7', '11', '11-subchapter-v', '12', '13'];
+
+const chaptersToComboOptions = (): ComboOption[] =>
+  CHAPTER_OPTIONS.map((chapter) => ({ value: chapter, label: formatChapterType(chapter) }));
+
 const trusteeDistrictFilterUseCase = (
   store: TrusteeDistrictFilterStore,
   controls: TrusteeDistrictFilterControls,
   onFilterDistrict: (districts: ComboOption[]) => void,
   previousDistrictsRef: { current: ComboOption[] | undefined },
+  onFilterChapter: (chapters: ComboOption[]) => void,
+  previousChaptersRef: { current: ComboOption[] | undefined },
 ): TrusteeDistrictFilterUseCase => {
   const notifySelectionChange = (districts: ComboOption[]) => {
     onFilterDistrict(districts);
@@ -120,7 +128,30 @@ const trusteeDistrictFilterUseCase = (
     handleFilterChange(updatedDistricts);
   };
 
+  const handleFilterChapter = (chapters: ComboOption[]) => {
+    const wasNonEmpty = previousChaptersRef.current && previousChaptersRef.current.length > 0;
+    const isNowEmpty = chapters.length === 0;
+
+    if (wasNonEmpty && isNowEmpty) {
+      getAppInsights().appInsights.trackEvent({ name: 'Trustee Chapter Filter Cleared' });
+    }
+
+    previousChaptersRef.current = chapters;
+    store.setSelectedChapters(chapters);
+    onFilterChapter(chapters);
+  };
+
+  const handleClearAllChapters = () => {
+    handleFilterChapter([]);
+  };
+
+  const handleRemoveChapterPill = (chapter: ComboOption) => {
+    const updated = store.selectedChapters.filter((c) => c.value !== chapter.value);
+    handleFilterChapter(updated);
+  };
+
   return {
+    chaptersToComboOptions,
     districtsToComboOptions,
     fetchDistricts,
     focusOnDistrictFilter,
@@ -129,6 +160,9 @@ const trusteeDistrictFilterUseCase = (
     handleClearAll,
     handleToggleExpanded,
     handleRemovePill,
+    handleFilterChapter,
+    handleClearAllChapters,
+    handleRemoveChapterPill,
   };
 };
 


### PR DESCRIPTION
# Purpose

Add chapter filter to trustee search.

<img width="1373" height="535" alt="Screenshot 2026-04-29 at 10 53 40 AM" src="https://github.com/user-attachments/assets/f7efd1c9-fd47-4150-8a52-3bb7e7b09d64" />

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add chapter-based filtering to the trustees list alongside the existing district filter and update the UI and telemetry to support the new filter.

New Features:
- Introduce a chapter multi-select filter for trustees, including support for standard chapters and 11 Subchapter V.
- Allow combined district and chapter filtering of trustees with AND logic between filters and OR logic within each filter type.

Enhancements:
- Update the trustee filter panel layout and labeling to accommodate both district and chapter filters with clear actions for each.
- Expose selected district and chapter filters as removable pills and simplify the status announcement text for screen readers.
- Extend trustee filtering use case and state to manage chapter options, selection, and clear/remove interactions, including tracking cleared events.
- Track analytics for chapter filter usage and result counts alongside existing district filter telemetry.

Tests:
- Add comprehensive tests for chapter filtering behavior, including no-filter, AND-combination with district filters, OR behavior within chapters, accessibility announcements, and telemetry events.
- Update existing trustee list and district filter tests to account for the new chapter filter and revised accessibility roles and labels.