### PR TITLE
CAMS-691: Refine trustee district filter dropdown

### DIFF
--- a/user-interface/src/lib/components/Pill.scss
+++ b/user-interface/src/lib/components/Pill.scss
@@ -1,3 +1,5 @@
+@use 'uswds-core' as *;
+
 .pill-container {
   display: flex;
   flex-wrap: wrap;
@@ -6,18 +8,21 @@
 
 .pill.usa-button--unstyled {
   position: relative;
+  background-color: color('primary');
+  color: color('white');
   display: flex;
   justify-content: space-between;
   align-items: center;
   text-decoration: none;
   height: 1.5rem;
-  border: 2px solid #949494;
-  border-radius: calc(1.5rem / 4);
+  border-radius: calc(1.5rem / 2);
   max-width: 100%;
   min-width: 4rem;
-  padding: 0 0.25rem 0 0.6rem;
+  padding: 0.25rem 0.75rem;
   margin: 0.25rem;
   cursor: pointer;
+  font-weight: 700;
+  font-size: 0.875rem;
 
   .pill-text {
     display: inline-block;
@@ -25,6 +30,12 @@
     text-overflow: ellipsis;
     overflow: hidden;
     max-width: calc(100% - 1em);
+  }
+
+  svg {
+    margin-left: 0.5rem;
+    width: 1rem;
+    height: 1rem;
   }
 }
 
@@ -45,5 +56,5 @@
 }
 
 .pill:hover {
-  filter: brightness(0.85);
+  filter: brightness(0.9);
 }

--- a/user-interface/src/lib/components/Pill.tsx
+++ b/user-interface/src/lib/components/Pill.tsx
@@ -2,13 +2,8 @@ import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import './Pill.scss';
 import Icon from './uswds/Icon';
 
-const defaultColor = 'black';
-const defaultBackgroundColor = '#d0d0d0';
-
 type PillProps = {
   id: string;
-  color?: string;
-  backgroundColor?: string;
   label: string;
   ariaLabelPrefix?: string;
   value: string;
@@ -19,8 +14,6 @@ type PillProps = {
 };
 
 function Pill_(props: PillProps, ref: React.Ref<Partial<HTMLButtonElement>>) {
-  const color = props.color ?? defaultColor;
-  const backgroundColor = props.backgroundColor ?? defaultBackgroundColor;
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   function handleKeyDown(ev: React.KeyboardEvent<HTMLButtonElement>) {
@@ -49,7 +42,6 @@ function Pill_(props: PillProps, ref: React.Ref<Partial<HTMLButtonElement>>) {
       id={props.id}
       data-testid={`pill-${props.id}`}
       className={`pill usa-button--unstyled ${wrapTextClass}`}
-      style={{ backgroundColor, color }}
       onClick={() => props.onClick(props.value)}
       onKeyDown={(ev) => handleKeyDown(ev)}
       tabIndex={0}

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -458,7 +458,7 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
           ) as HTMLElement;
 
           if (selectedElement && typeof selectedElement.scrollIntoView === 'function') {
-            selectedElement.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            selectedElement.scrollIntoView({ block: 'nearest', behavior: 'instant' });
           }
         });
       }

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -458,7 +458,7 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
           ) as HTMLElement;
 
           if (selectedElement && typeof selectedElement.scrollIntoView === 'function') {
-            selectedElement.scrollIntoView({ block: 'nearest', behavior: 'instant' });
+            selectedElement.scrollIntoView({ block: 'nearest', behavior: 'auto' });
           }
         });
       }

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -49,6 +49,7 @@ export interface ComboBoxProps extends Omit<InputProps, 'onChange' | 'onFocus' |
   errorMessage?: string;
   hideClearAllButton?: boolean;
   placeholder?: string;
+  scrollToSelected?: boolean;
 }
 
 function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
@@ -71,6 +72,7 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
     errorMessage,
     hideClearAllButton,
     placeholder,
+    scrollToSelected,
     ...otherProps
   } = props;
 
@@ -446,7 +448,7 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
       focusInput();
 
       // Scroll to first selected item if there are selections (only on open, not on selection changes)
-      if (selectedMap.size > 0 && comboBoxListRef.current) {
+      if (scrollToSelected && selectedMap.size > 0 && comboBoxListRef.current) {
         requestAnimationFrame(() => {
           const firstSelected = Array.from(selectedMap.values())[0];
           if (!firstSelected) return;

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -132,3 +132,50 @@ export function groupDivisionsByDistrict(
   });
   return districtMap;
 }
+
+/**
+ * Separates ComboBox options into defaults and non-defaults with proper accessibility markup.
+ *
+ * User default options are placed first in the list, marked with `isAriaDefault: true` for
+ * screen readers, and separated from other options with a visual divider on the last default.
+ *
+ * @param allOptions - All available ComboBox options
+ * @param defaultValues - Set of values that should be treated as defaults
+ * @returns Ordered array with defaults first (marked and divided), then non-defaults
+ *
+ * @example
+ * const options = [
+ *   { value: "081", label: "Southern District of NY" },
+ *   { value: "088", label: "District of Vermont" },
+ *   { value: "089", label: "Eastern District of CA" }
+ * ];
+ * const defaults = new Set(["081", "088"]);
+ * const result = separateDefaultOptions(options, defaults);
+ * // [
+ * //   { value: "081", label: "...", isAriaDefault: true, divider: false },
+ * //   { value: "088", label: "...", isAriaDefault: true, divider: true },  ← divider
+ * //   { value: "089", label: "..." }
+ * // ]
+ */
+export function separateDefaultOptions(
+  allOptions: { value: string; label: string; [key: string]: unknown }[],
+  defaultValues: Set<string>,
+): {
+  value: string;
+  label: string;
+  isAriaDefault?: boolean;
+  divider?: boolean;
+  [key: string]: unknown;
+}[] {
+  const defaults = allOptions.filter((opt) => defaultValues.has(opt.value));
+  const nonDefaults = allOptions.filter((opt) => !defaultValues.has(opt.value));
+
+  // Mark defaults and add divider to last one if non-defaults exist
+  const markedDefaults = defaults.map((opt, i) => ({
+    ...opt,
+    isAriaDefault: true,
+    divider: i === defaults.length - 1 && nonDefaults.length > 0,
+  }));
+
+  return [...markedDefaults, ...nonDefaults];
+}

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -1,4 +1,5 @@
 import { usStates } from '@common/cams/us-states';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
 /**
  * Maps a 2-letter state code to its full state name for sorting purposes.
@@ -94,4 +95,40 @@ export function sortByCourtLocation<T extends CourtLocationSortable>(
 
     return 0;
   });
+}
+
+/**
+ * Groups divisions by district (court name).
+ *
+ * Multiple divisions can belong to the same district court. For example,
+ * "Southern District of New York" has Manhattan (081) and White Plains (087) divisions.
+ * This function groups all divisions under their parent district.
+ *
+ * @param divisions - Array of court division details
+ * @returns Map where key is courtName and value is array of all divisions in that district
+ *
+ * @example
+ * const divisions = [
+ *   { courtName: "Southern District of New York", courtDivisionCode: "081", ... },
+ *   { courtName: "Southern District of New York", courtDivisionCode: "087", ... },
+ *   { courtName: "District of Vermont", courtDivisionCode: "088", ... }
+ * ];
+ * const grouped = groupDivisionsByDistrict(divisions);
+ * // Map {
+ * //   "Southern District of New York" => [{ code: "081", ... }, { code: "087", ... }],
+ * //   "District of Vermont" => [{ code: "088", ... }]
+ * // }
+ */
+export function groupDivisionsByDistrict(
+  divisions: CourtDivisionDetails[],
+): Map<string, CourtDivisionDetails[]> {
+  const districtMap = new Map<string, CourtDivisionDetails[]>();
+  divisions.forEach((division) => {
+    const key = division.courtName;
+    if (!districtMap.has(key)) {
+      districtMap.set(key, []);
+    }
+    districtMap.get(key)!.push(division);
+  });
+  return districtMap;
 }

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -1,5 +1,6 @@
 import { usStates } from '@common/cams/us-states';
 import { CourtDivisionDetails } from '@common/cams/courts';
+import { TrusteeAppointment } from '@common/cams/trustee-appointments';
 
 /**
  * Maps a 2-letter state code to its full state name for sorting purposes.
@@ -167,8 +168,14 @@ export function separateDefaultOptions(
   divider?: boolean;
   [key: string]: unknown;
 }[] {
-  const defaults = allOptions.filter((opt) => defaultValues.has(opt.value));
-  const nonDefaults = allOptions.filter((opt) => !defaultValues.has(opt.value));
+  // Check if option's value (which may be comma-separated codes) contains any default code
+  const isDefault = (opt: { value: string; [key: string]: unknown }) => {
+    const codes = opt.value.split(',');
+    return codes.some((code) => defaultValues.has(code));
+  };
+
+  const defaults = allOptions.filter(isDefault);
+  const nonDefaults = allOptions.filter((opt) => !isDefault(opt));
 
   // Mark defaults and add divider to last one if non-defaults exist
   const markedDefaults = defaults.map((opt, i) => ({
@@ -178,4 +185,86 @@ export function separateDefaultOptions(
   }));
 
   return [...markedDefaults, ...nonDefaults];
+}
+
+/**
+ * Parses state and region from district court name.
+ *
+ * @param courtName - Full district court name
+ * @returns Object with state and region components
+ *
+ * @example
+ * parseDistrictName("Southern District of New York")
+ * // { state: "New York", region: "Southern" }
+ *
+ * parseDistrictName("District of Vermont")
+ * // { state: "Vermont", region: "" }
+ */
+function parseDistrictName(courtName: string): { state: string; region: string } {
+  // Extract state: everything after "District of " or use entire name as fallback
+  const districtOfMatch = courtName.match(/District of (.+)$/i);
+  const state = districtOfMatch ? districtOfMatch[1] : courtName;
+
+  // Extract region: everything before "District of" (e.g., "Southern", "Eastern", "Western", "Northern")
+  const regionMatch = courtName.match(/^(.+?)\s+District of/i);
+  const region = regionMatch ? regionMatch[1] : '';
+
+  return { state, region };
+}
+
+/**
+ * Sorts trustee appointments by state, region, chapter, and appointment type.
+ *
+ * Since TrusteeAppointment doesn't include a state field, this function parses
+ * the state and region from the courtName before sorting.
+ *
+ * Sort order:
+ * 1. State name - alphabetically (parsed from courtName)
+ * 2. Region - alphabetically (Eastern, Northern, Southern, Western, etc.)
+ * 3. Chapter number - ascending (7, 11, 13, etc.)
+ * 4. Appointment type - alphabetically
+ *
+ * @param appointments - Array of trustee appointments to sort
+ * @returns New sorted array (does not mutate original)
+ *
+ * @example
+ * const sorted = sortTrusteeAppointments([
+ *   { courtName: "Southern District of New York", chapter: "13", ... },
+ *   { courtName: "Western District of Kentucky", chapter: "7", ... }
+ * ]);
+ * // Kentucky comes before New York, then sorted by chapter within each district
+ */
+export function sortTrusteeAppointments(appointments: TrusteeAppointment[]): TrusteeAppointment[] {
+  return [...appointments]
+    .map((appt) => {
+      const parsed = parseDistrictName(appt.courtName ?? appt.courtId ?? '');
+      return {
+        appointment: appt,
+        state: parsed.state,
+        region: parsed.region,
+      };
+    })
+    .sort((a, b) => {
+      // 1. Sort by state name alphabetically
+      const stateComparison = a.state.localeCompare(b.state, undefined, { sensitivity: 'base' });
+      if (stateComparison !== 0) return stateComparison;
+
+      // 2. Sort by region (Eastern, Northern, Southern, Western, etc.)
+      const regionComparison = a.region.localeCompare(b.region, undefined, {
+        sensitivity: 'base',
+      });
+      if (regionComparison !== 0) return regionComparison;
+
+      // 3. Sort by chapter number
+      const chapterA = a.appointment.chapter ?? '';
+      const chapterB = b.appointment.chapter ?? '';
+      const chapterComparison = getChapterNumber(chapterA) - getChapterNumber(chapterB);
+      if (chapterComparison !== 0) return chapterComparison;
+
+      // 4. Sort by appointment type
+      const typeA = a.appointment.appointmentType ?? '';
+      const typeB = b.appointment.appointmentType ?? '';
+      return typeA.localeCompare(typeB, undefined, { sensitivity: 'base' });
+    })
+    .map((wrapper) => wrapper.appointment);
 }

--- a/user-interface/src/search/SearchScreen.tsx
+++ b/user-interface/src/search/SearchScreen.tsx
@@ -10,7 +10,7 @@ import Input from '@/lib/components/uswds/Input';
 import Api2 from '@/lib/models/api2';
 import { ComboBoxRef, InputRef } from '@/lib/type-declarations/input-fields';
 import { getDivisionComboOptions } from '@/data-verification/dataVerificationHelper';
-import { sortByCourtLocation } from '@/lib/utils/court-utils';
+import { sortByCourtLocation, separateDefaultOptions } from '@/lib/utils/court-utils';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import SearchResults, { isValidSearchPredicate } from '@/search-results/SearchResults';
 import { SearchResultsHeader } from './SearchResultsHeader';
@@ -147,24 +147,20 @@ export default function SearchScreen() {
     Api2.getCourts()
       .then((response) => {
         const newOfficesList = sortByCourtLocation(response.data);
-        const officeComboOptions = getDivisionComboOptions(newOfficesList);
-        const filteredDivisionCodes = getDivisionComboOptions(
-          newOfficesList.filter((office) =>
-            defaultDivisionCodes?.includes(office.courtDivisionCode),
-          ),
+        const allOfficeComboOptions = getDivisionComboOptions(newOfficesList);
+
+        // Separate defaults from non-defaults using utility
+        const defaultCodesSet = new Set(defaultDivisionCodes || []);
+        const finalOfficeComboOptions = separateDefaultOptions(
+          allOfficeComboOptions,
+          defaultCodesSet,
         );
-        if (filteredDivisionCodes.length) {
-          filteredDivisionCodes[filteredDivisionCodes.length - 1].divider = true;
-          filteredDivisionCodes.forEach((option: ComboOption) => {
-            option.isAriaDefault = true;
-          });
-        }
-        const filteredOfficeComboOptions = officeComboOptions.filter((officeComboOption) => {
-          return !defaultDivisionCodes?.includes(officeComboOption.value);
-        });
-        const finalOfficeComboOptions = [...filteredDivisionCodes, ...filteredOfficeComboOptions];
+
+        // Get default options for initial selection
+        const defaultOptions = finalOfficeComboOptions.filter((opt) => opt.isAriaDefault);
+
         setOfficesList(finalOfficeComboOptions);
-        courtSelectionRef.current?.setSelections(filteredDivisionCodes);
+        courtSelectionRef.current?.setSelections(defaultOptions);
       })
       .catch(() => {
         globalAlert?.error('Cannot load office list');

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -134,7 +134,7 @@
       white-space: normal;
     }
 
-    .col-district-division {
+    .col-district {
       flex: 2 1 0;
       min-width: 0;
       max-width: none;
@@ -149,7 +149,7 @@
       min-width: 160px;
     }
 
-    .col-district-division {
+    .col-district {
       flex: 3 1 0;
       min-width: 300px;
     }

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -859,11 +859,11 @@ describe('TrusteesList Component', () => {
         expect(pills.length).toBeGreaterThan(1);
       });
 
-      // Click remove button on one of the pills
-      const removeButtons = screen.getAllByRole('button', {
-        name: /remove southern district of new york filter/i,
+      // Click remove button on one of the pills (PillBox component)
+      const pillButton = screen.getByRole('button', {
+        name: /southern district of new york selected.*click to deselect/i,
       });
-      await user.click(removeButtons[0]);
+      await user.click(pillButton);
 
       // Should remove the filter and show all trustees
       await waitFor(() => {

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -158,15 +158,15 @@ describe('TrusteesList Component', () => {
       expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Southern District of New York (Manhattan)')).toBeInTheDocument();
-    expect(screen.getByText('District of Vermont (Burlington)')).toBeInTheDocument();
+    expect(screen.getByText('Southern District of New York')).toBeInTheDocument();
+    expect(screen.getByText('District of Vermont')).toBeInTheDocument();
     expect(screen.getByText('Panel')).toBeInTheDocument();
     expect(screen.getByText('Case by Case')).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
     expect(screen.getByText('Inactive')).toBeInTheDocument();
   });
 
-  test('should format District (Division) correctly using courtName and courtDivisionName', async () => {
+  test('should format District correctly using courtName only', async () => {
     const trusteeId = 'trustee-district';
     const appt = makeAppointment({
       trusteeId,
@@ -182,11 +182,11 @@ describe('TrusteesList Component', () => {
     renderWithRouter(<TrusteesList />);
 
     await waitFor(() => {
-      expect(screen.getByText('Eastern District of California (Sacramento)')).toBeInTheDocument();
+      expect(screen.getByText('Eastern District of California')).toBeInTheDocument();
     });
   });
 
-  test('should fall back to courtId and divisionCode when court name fields are absent', async () => {
+  test('should fall back to courtId when courtName is absent', async () => {
     const trusteeId = 'trustee-fallback';
     const appt = makeAppointment({
       trusteeId,
@@ -203,7 +203,7 @@ describe('TrusteesList Component', () => {
     renderWithRouter(<TrusteesList />);
 
     await waitFor(() => {
-      expect(screen.getByText('court-xyz (042)')).toBeInTheDocument();
+      expect(screen.getByText('court-xyz')).toBeInTheDocument();
     });
   });
 

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -761,7 +761,7 @@ describe('TrusteesList Component', () => {
 
       // Initially collapsed - pills should be in filter component
       await waitFor(() => {
-        const pills = screen.getAllByText('Southern District of New York (Manhattan)');
+        const pills = screen.getAllByText('Southern District of New York');
         expect(pills.length).toBeGreaterThan(0);
       });
 
@@ -771,7 +771,7 @@ describe('TrusteesList Component', () => {
 
       // When expanded, pills should appear above trustee count (in TrusteesList)
       await waitFor(() => {
-        const pills = screen.getAllByText('Southern District of New York (Manhattan)');
+        const pills = screen.getAllByText('Southern District of New York');
         // Should have pills both in dropdown AND in list area
         expect(pills.length).toBeGreaterThan(1);
       });
@@ -855,13 +855,13 @@ describe('TrusteesList Component', () => {
 
       // Wait for pills to appear
       await waitFor(() => {
-        const pills = screen.getAllByText('Southern District of New York (Manhattan)');
+        const pills = screen.getAllByText('Southern District of New York');
         expect(pills.length).toBeGreaterThan(1);
       });
 
       // Click remove button on one of the pills
       const removeButtons = screen.getAllByRole('button', {
-        name: /remove southern district of new york \(manhattan\) filter/i,
+        name: /remove southern district of new york filter/i,
       });
       await user.click(removeButtons[0]);
 

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -15,7 +15,7 @@ import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types';
 import Icon from '@/lib/components/uswds/Icon';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
-import { sortByCourtLocation } from '@/lib/utils/court-utils';
+import { sortTrusteeAppointments } from '@/lib/utils/court-utils';
 
 const COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
 
@@ -105,10 +105,10 @@ export default function TrusteesList() {
       return sortDirection === 'asc' ? cmp : -cmp;
     });
 
-    // Sort appointments within each trustee by state, court, division, chapter, and appointment type
+    // Sort appointments within each trustee by state, region, chapter, and appointment type
     const sortedWithAppointments = sorted.map((trustee) => ({
       ...trustee,
-      appointments: sortByCourtLocation(trustee.appointments, { includeAppointmentDetails: true }),
+      appointments: sortTrusteeAppointments(trustee.appointments),
     }));
 
     const announcement =

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -16,7 +16,7 @@ import { TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types'
 import Icon from '@/lib/components/uswds/Icon';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
-const COLUMN_HEADERS = ['Name', 'District (Division)', 'Chapter', 'Type', 'Status'];
+const COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
 
 function toColClass(header: string): string {
   return (
@@ -30,9 +30,19 @@ function toColClass(header: string): string {
 }
 
 function formatDistrict(appointment: TrusteeListItem['appointments'][number]): string {
-  const name = appointment.courtName ?? appointment.courtId;
-  const division = appointment.courtDivisionName ?? appointment.divisionCode;
-  return division ? `${name} (${division})` : name;
+  return appointment.courtName ?? appointment.courtId;
+}
+
+function parseDistrictName(courtName: string): { state: string; region: string } {
+  // Extract state: everything after "District of " or use entire name as fallback
+  const districtOfMatch = courtName.match(/District of (.+)$/i);
+  const state = districtOfMatch ? districtOfMatch[1] : courtName;
+
+  // Extract region: everything before "District of" (e.g., "Southern", "Eastern", "Western", "Northern")
+  const regionMatch = courtName.match(/^(.+?)\s+District of/i);
+  const region = regionMatch ? regionMatch[1] : '';
+
+  return { state, region };
 }
 
 export default function TrusteesList() {
@@ -82,7 +92,7 @@ export default function TrusteesList() {
   };
 
   const { filteredTrustees, announcement } = useMemo(() => {
-    const selectedDivisionCodes = selectedDistricts.map((d) => d.value);
+    const selectedDivisionCodes = selectedDistricts.flatMap((d) => d.value.split(','));
     const base =
       selectedDistricts.length === 0
         ? trustees
@@ -92,6 +102,7 @@ export default function TrusteesList() {
             ),
           );
 
+    // Sort trustees by last name
     const sorted = [...base].sort((a, b) => {
       const lastCmp = (a.lastName ?? '').localeCompare(b.lastName ?? '', undefined, {
         sensitivity: 'base',
@@ -105,12 +116,37 @@ export default function TrusteesList() {
       return sortDirection === 'asc' ? cmp : -cmp;
     });
 
+    // Sort appointments within each trustee by state, then region, then chapter
+    const sortedWithAppointments = sorted.map((trustee) => ({
+      ...trustee,
+      appointments: [...trustee.appointments].sort((a, b) => {
+        const districtA = a.courtName ?? a.courtId ?? '';
+        const districtB = b.courtName ?? b.courtId ?? '';
+
+        const { state: stateA, region: regionA } = parseDistrictName(districtA);
+        const { state: stateB, region: regionB } = parseDistrictName(districtB);
+
+        // First sort by state
+        const stateCmp = stateA.localeCompare(stateB, undefined, { sensitivity: 'base' });
+        if (stateCmp !== 0) return stateCmp;
+
+        // Then sort by region (Western, Southern, Eastern, Northern, etc.)
+        const regionCmp = regionA.localeCompare(regionB, undefined, { sensitivity: 'base' });
+        if (regionCmp !== 0) return regionCmp;
+
+        // Finally sort by chapter
+        const chapterA = a.chapter ?? '';
+        const chapterB = b.chapter ?? '';
+        return chapterA.localeCompare(chapterB, undefined, { sensitivity: 'base' });
+      }),
+    }));
+
     const announcement =
       selectedDistricts.length === 0
         ? `Showing all ${trustees.length} trustee(s)`
         : `Showing ${base.length} trustee(s) in ${selectedDistricts.map((d) => d.label).join(', ')}`;
 
-    return { filteredTrustees: sorted, announcement };
+    return { filteredTrustees: sortedWithAppointments, announcement };
   }, [trustees, selectedDistricts, sortDirection]);
 
   useEffect(() => {

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -15,6 +15,7 @@ import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types';
 import Icon from '@/lib/components/uswds/Icon';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
+import { sortByCourtLocation } from '@/lib/utils/court-utils';
 
 const COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
 
@@ -31,18 +32,6 @@ function toColClass(header: string): string {
 
 function formatDistrict(appointment: TrusteeListItem['appointments'][number]): string {
   return appointment.courtName ?? appointment.courtId;
-}
-
-function parseDistrictName(courtName: string): { state: string; region: string } {
-  // Extract state: everything after "District of " or use entire name as fallback
-  const districtOfMatch = courtName.match(/District of (.+)$/i);
-  const state = districtOfMatch ? districtOfMatch[1] : courtName;
-
-  // Extract region: everything before "District of" (e.g., "Southern", "Eastern", "Western", "Northern")
-  const regionMatch = courtName.match(/^(.+?)\s+District of/i);
-  const region = regionMatch ? regionMatch[1] : '';
-
-  return { state, region };
 }
 
 export default function TrusteesList() {
@@ -116,29 +105,10 @@ export default function TrusteesList() {
       return sortDirection === 'asc' ? cmp : -cmp;
     });
 
-    // Sort appointments within each trustee by state, then region, then chapter
+    // Sort appointments within each trustee by state, court, division, chapter, and appointment type
     const sortedWithAppointments = sorted.map((trustee) => ({
       ...trustee,
-      appointments: [...trustee.appointments].sort((a, b) => {
-        const districtA = a.courtName ?? a.courtId ?? '';
-        const districtB = b.courtName ?? b.courtId ?? '';
-
-        const { state: stateA, region: regionA } = parseDistrictName(districtA);
-        const { state: stateB, region: regionB } = parseDistrictName(districtB);
-
-        // First sort by state
-        const stateCmp = stateA.localeCompare(stateB, undefined, { sensitivity: 'base' });
-        if (stateCmp !== 0) return stateCmp;
-
-        // Then sort by region (Western, Southern, Eastern, Northern, etc.)
-        const regionCmp = regionA.localeCompare(regionB, undefined, { sensitivity: 'base' });
-        if (regionCmp !== 0) return regionCmp;
-
-        // Finally sort by chapter
-        const chapterA = a.chapter ?? '';
-        const chapterB = b.chapter ?? '';
-        return chapterA.localeCompare(chapterB, undefined, { sensitivity: 'base' });
-      }),
+      appointments: sortByCourtLocation(trustee.appointments, { includeAppointmentDetails: true }),
     }));
 
     const announcement =

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
@@ -62,45 +62,8 @@
   }
 
   .filter-pills-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
     margin-bottom: 1rem;
     padding-left: 1rem;
-
-    .filter-pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-      background-color: #005ea2;
-      color: #ffffff;
-      padding: 0.25rem 0.75rem;
-      border-radius: 99rem;
-      font-size: 0.875rem;
-      font-weight: 700;
-      text-transform: none;
-
-      .usa-tag__remove-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0;
-        margin: 0 0 0 0.25rem;
-        background: transparent;
-        border: none;
-        cursor: pointer;
-        color: #ffffff;
-
-        &:hover {
-          color: #f0f0f0;
-        }
-
-        .usa-icon {
-          width: 1rem;
-          height: 1rem;
-        }
-      }
-    }
   }
 
   @keyframes slideDown {
@@ -121,11 +84,5 @@
       }
     }
 
-    .filter-pills-container {
-      .filter-pill {
-        font-size: 0.8rem;
-        padding: 0.25rem 0.5rem;
-      }
-    }
   }
 }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -380,65 +380,6 @@ describe('TrusteeDistrictFilter Component', () => {
     });
   });
 
-  test('should expose removePill method via ref', async () => {
-    const ref = { current: null } as unknown as React.RefObject<TrusteeDistrictFilterRef>;
-    const session = {
-      ...MockData.getCamsSession(),
-      user: {
-        ...MockData.getCamsSession().user,
-        offices: [
-          {
-            officeCode: '081',
-            officeName: 'Manhattan',
-            idpGroupName: 'Manhattan',
-            regionId: '02',
-            regionName: 'New York Region',
-            groups: [
-              {
-                groupDesignator: 'NY',
-                divisions: [
-                  {
-                    divisionCode: '081',
-                    court: {
-                      courtId: 'NYSB',
-                      courtName: 'Southern District of New York',
-                    },
-                    courtOffice: {
-                      courtOfficeCode: '081',
-                      courtOfficeName: 'Manhattan',
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    };
-    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
-
-    render(<TrusteeDistrictFilter ref={ref} handleFilterDistrict={mockHandleFilterDistrict} />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Filters')).toBeInTheDocument();
-    });
-
-    // Wait for pre-populated district
-    await waitFor(() => {
-      expect(mockHandleFilterDistrict).toHaveBeenCalledWith(
-        expect.arrayContaining([{ value: '081', label: 'Southern District of New York' }]),
-      );
-    });
-
-    // Call removePill via ref
-    ref.current?.removePill({ value: '081', label: 'Southern District of New York' });
-
-    // Should update selection to empty
-    await waitFor(() => {
-      expect(mockHandleFilterDistrict).toHaveBeenCalledWith([]);
-    });
-  });
-
   test('should expose clearAll method via ref', async () => {
     const user = userEvent.setup();
     const ref = { current: null } as unknown as React.RefObject<TrusteeDistrictFilterRef>;
@@ -486,7 +427,7 @@ describe('TrusteeDistrictFilter Component', () => {
     // Wait for pre-populated district
     await waitFor(() => {
       expect(mockHandleFilterDistrict).toHaveBeenCalledWith(
-        expect.arrayContaining([{ value: '081', label: 'Southern District of New York' }]),
+        expect.arrayContaining([{ value: '081,087', label: 'Southern District of New York' }]),
       );
     });
 
@@ -517,7 +458,7 @@ describe('TrusteeDistrictFilter Component', () => {
 
     await waitFor(() => {
       expect(mockHandleFilterDistrict).toHaveBeenCalledWith(
-        expect.arrayContaining([{ value: '081', label: 'Southern District of New York' }]),
+        expect.arrayContaining([{ value: '081,087', label: 'Southern District of New York' }]),
       );
     });
   });

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -105,10 +105,10 @@ describe('TrusteeDistrictFilter Component', () => {
     const combobox = screen.getByLabelText('District');
     await user.click(combobox);
 
-    // Should show all 3 divisions (2 NYSB + 1 VTB)
+    // Should show 2 unique districts (NYSB and VTB)
     await waitFor(() => {
       expect(screen.getByText('District of Vermont')).toBeInTheDocument();
-      expect(screen.getAllByText('Southern District of New York')).toHaveLength(2);
+      expect(screen.getByText('Southern District of New York')).toBeInTheDocument();
     });
   });
 

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -20,6 +20,7 @@ const mockDistricts: CourtDivisionDetails[] = [
     groupDesignator: 'NY',
     regionId: '02',
     regionName: 'New York Region',
+    state: 'NY',
   },
   {
     officeName: 'White Plains',
@@ -31,6 +32,7 @@ const mockDistricts: CourtDivisionDetails[] = [
     groupDesignator: 'NY',
     regionId: '02',
     regionName: 'New York Region',
+    state: 'NY',
   },
   {
     officeName: 'Rutland',
@@ -42,6 +44,7 @@ const mockDistricts: CourtDivisionDetails[] = [
     groupDesignator: 'VT',
     regionId: '01',
     regionName: 'Boston Region',
+    state: 'VT',
   },
 ];
 
@@ -76,7 +79,7 @@ describe('TrusteeDistrictFilter Component', () => {
 
     expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
     await waitFor(() => {
-      expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      expect(screen.getByLabelText('District')).toBeInTheDocument();
       expect(Api2.getCourts).toHaveBeenCalled();
     });
   });
@@ -96,17 +99,16 @@ describe('TrusteeDistrictFilter Component', () => {
     await user.click(toggleButton);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      expect(screen.getByLabelText('District')).toBeInTheDocument();
     });
 
-    const combobox = screen.getByLabelText('District (Division)');
+    const combobox = screen.getByLabelText('District');
     await user.click(combobox);
 
-    // Should show 2 unique districts (NYSB and VTB), not 3 divisions
+    // Should show all 3 divisions (2 NYSB + 1 VTB)
     await waitFor(() => {
-      expect(screen.getByText('District of Vermont (Rutland)')).toBeInTheDocument();
-      expect(screen.getByText('Southern District of New York (Manhattan)')).toBeInTheDocument();
-      expect(screen.getByText('Southern District of New York (White Plains)')).toBeInTheDocument();
+      expect(screen.getByText('District of Vermont')).toBeInTheDocument();
+      expect(screen.getAllByText('Southern District of New York')).toHaveLength(2);
     });
   });
 
@@ -182,22 +184,22 @@ describe('TrusteeDistrictFilter Component', () => {
     await user.click(toggleButton);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      expect(screen.getByLabelText('District')).toBeInTheDocument();
     });
 
-    const combobox = screen.getByLabelText('District (Division)');
+    const combobox = screen.getByLabelText('District');
     await user.click(combobox);
 
     await waitFor(() => {
-      expect(screen.getByText('District of Vermont (Rutland)')).toBeInTheDocument();
+      expect(screen.getByText('District of Vermont')).toBeInTheDocument();
     });
 
-    const vermontOption = screen.getByText('District of Vermont (Rutland)');
+    const vermontOption = screen.getByText('District of Vermont');
     await user.click(vermontOption);
 
     await waitFor(() => {
       expect(mockHandleFilterDistrict).toHaveBeenCalledWith(
-        expect.arrayContaining([{ value: '088', label: 'District of Vermont (Rutland)' }]),
+        expect.arrayContaining([{ value: '088', label: 'District of Vermont' }]),
       );
     });
   });
@@ -217,18 +219,18 @@ describe('TrusteeDistrictFilter Component', () => {
     await user.click(toggleButton);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      expect(screen.getByLabelText('District')).toBeInTheDocument();
     });
 
     // Select a district
-    const combobox = screen.getByLabelText('District (Division)');
+    const combobox = screen.getByLabelText('District');
     await user.click(combobox);
 
     await waitFor(() => {
-      expect(screen.getByText('District of Vermont (Rutland)')).toBeInTheDocument();
+      expect(screen.getByText('District of Vermont')).toBeInTheDocument();
     });
 
-    const vermontOption = screen.getByText('District of Vermont (Rutland)');
+    const vermontOption = screen.getByText('District of Vermont');
     await user.click(vermontOption);
 
     // Collapse the filter again
@@ -236,7 +238,7 @@ describe('TrusteeDistrictFilter Component', () => {
 
     // Pills should be visible when collapsed
     await waitFor(() => {
-      const pills = screen.getAllByText('District of Vermont (Rutland)');
+      const pills = screen.getAllByText('District of Vermont');
       expect(pills.length).toBeGreaterThan(0);
     });
   });
@@ -289,14 +291,14 @@ describe('TrusteeDistrictFilter Component', () => {
     await waitFor(() => {
       expect(
         screen.getByRole('button', {
-          name: /remove southern district of new york \(manhattan\) filter/i,
+          name: /remove southern district of new york filter/i,
         }),
       ).toBeInTheDocument();
     });
 
     // Click remove button on pill
     const removeButton = screen.getByRole('button', {
-      name: /remove southern district of new york \(manhattan\) filter/i,
+      name: /remove southern district of new york filter/i,
     });
     await user.click(removeButton);
 
@@ -367,7 +369,7 @@ describe('TrusteeDistrictFilter Component', () => {
     await waitFor(() => {
       expect(mockOnExpandedChange).toHaveBeenCalledWith(true);
       expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
-      expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      expect(screen.getByLabelText('District')).toBeInTheDocument();
     });
 
     // Collapse
@@ -424,14 +426,12 @@ describe('TrusteeDistrictFilter Component', () => {
     // Wait for pre-populated district
     await waitFor(() => {
       expect(mockHandleFilterDistrict).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          { value: '081', label: 'Southern District of New York (Manhattan)' },
-        ]),
+        expect.arrayContaining([{ value: '081', label: 'Southern District of New York' }]),
       );
     });
 
     // Call removePill via ref
-    ref.current?.removePill({ value: '081', label: 'Southern District of New York (Manhattan)' });
+    ref.current?.removePill({ value: '081', label: 'Southern District of New York' });
 
     // Should update selection to empty
     await waitFor(() => {
@@ -486,9 +486,7 @@ describe('TrusteeDistrictFilter Component', () => {
     // Wait for pre-populated district
     await waitFor(() => {
       expect(mockHandleFilterDistrict).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          { value: '081', label: 'Southern District of New York (Manhattan)' },
-        ]),
+        expect.arrayContaining([{ value: '081', label: 'Southern District of New York' }]),
       );
     });
 
@@ -499,17 +497,17 @@ describe('TrusteeDistrictFilter Component', () => {
     await user.click(toggleButton);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      expect(screen.getByLabelText('District')).toBeInTheDocument();
     });
 
-    const combobox = screen.getByLabelText('District (Division)');
+    const combobox = screen.getByLabelText('District');
     await user.click(combobox);
 
     await waitFor(() => {
-      expect(screen.getByText('District of Vermont (Rutland)')).toBeInTheDocument();
+      expect(screen.getByText('District of Vermont')).toBeInTheDocument();
     });
 
-    const vermontOption = screen.getByText('District of Vermont (Rutland)');
+    const vermontOption = screen.getByText('District of Vermont');
     await user.click(vermontOption);
 
     mockHandleFilterDistrict.mockClear();
@@ -519,9 +517,7 @@ describe('TrusteeDistrictFilter Component', () => {
 
     await waitFor(() => {
       expect(mockHandleFilterDistrict).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          { value: '081', label: 'Southern District of New York (Manhattan)' },
-        ]),
+        expect.arrayContaining([{ value: '081', label: 'Southern District of New York' }]),
       );
     });
   });

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -466,13 +466,11 @@ describe('TrusteeDistrictFilter Component', () => {
 
     mockHandleFilterDistrict.mockClear();
 
-    // Call clearAll via ref - should restore defaults (NYSB)
+    // Call clearAll via ref - should clear to empty array
     ref.current?.clearAll();
 
     await waitFor(() => {
-      expect(mockHandleFilterDistrict).toHaveBeenCalledWith(
-        expect.arrayContaining([{ value: '081,087', label: 'Southern District of New York' }]),
-      );
+      expect(mockHandleFilterDistrict).toHaveBeenCalledWith([]);
     });
   });
 
@@ -544,7 +542,9 @@ describe('TrusteeDistrictFilter Component', () => {
       await user.click(toggleButton);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /remove 7 filter/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /7 selected.*click to deselect/i }),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -291,14 +291,14 @@ describe('TrusteeDistrictFilter Component', () => {
     await waitFor(() => {
       expect(
         screen.getByRole('button', {
-          name: /remove southern district of new york filter/i,
+          name: /southern district of new york selected\. click to deselect\./i,
         }),
       ).toBeInTheDocument();
     });
 
     // Click remove button on pill
     const removeButton = screen.getByRole('button', {
-      name: /remove southern district of new york filter/i,
+      name: /southern district of new york selected\. click to deselect\./i,
     });
     await user.click(removeButton);
 

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -32,7 +32,6 @@ const TrusteeDistrictFilter_ = (
     return {
       refresh: useCase.fetchDistricts,
       focus: useCase.focusOnDistrictFilter,
-      removePill: useCase.handleRemovePill,
       clearAll: useCase.handleClearAll,
     };
   });
@@ -67,7 +66,6 @@ const TrusteeDistrictFilter_ = (
     handleFilterChange: useCase.handleFilterChange,
     handleClearAll: useCase.handleClearAll,
     handleToggleExpanded: useCase.handleToggleExpanded,
-    handleRemovePill: useCase.handleRemovePill,
   };
 
   return <TrusteeDistrictFilterView viewModel={viewModel}></TrusteeDistrictFilterView>;

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -26,6 +26,7 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                   pluralLabel="districts"
                   singularLabel="district"
                   placeholder="- Select one or more -"
+                  scrollToSelected={true}
                   ref={viewModel.districtFilterRef}
                 />
               </div>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -93,22 +93,27 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
       </AccordionGroup>
 
       {hasPills && (
-        <div className="filter-pills-container">
-          {viewModel.selectedDistricts.length > 0 && (
-            <PillBox
-              id="district-filter-pills"
-              selections={viewModel.selectedDistricts}
-              onSelectionChange={viewModel.handleFilterChange}
-            />
-          )}
-          {viewModel.selectedChapters.length > 0 && (
-            <PillBox
-              id="chapter-filter-pills"
-              selections={viewModel.selectedChapters}
-              onSelectionChange={viewModel.handleFilterChapter}
-            />
-          )}
-        </div>
+        <PillBox
+          id="filter-pills"
+          className="filter-pills-container"
+          selections={[...viewModel.selectedDistricts, ...viewModel.selectedChapters]}
+          onSelectionChange={(updatedPills) => {
+            // Separate district and chapter pills
+            const districtValues = new Set(viewModel.selectedDistricts.map((d) => d.value));
+            const chapterValues = new Set(viewModel.selectedChapters.map((c) => c.value));
+
+            const updatedDistricts = updatedPills.filter((p) => districtValues.has(p.value));
+            const updatedChapters = updatedPills.filter((p) => chapterValues.has(p.value));
+
+            // Update both filters
+            if (updatedDistricts.length !== viewModel.selectedDistricts.length) {
+              viewModel.handleFilterChange(updatedDistricts);
+            }
+            if (updatedChapters.length !== viewModel.selectedChapters.length) {
+              viewModel.handleFilterChapter(updatedChapters);
+            }
+          }}
+        />
       )}
     </section>
   );

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -1,6 +1,6 @@
 import './TrusteeDistrictFilter.scss';
 import ComboBox from '@/lib/components/combobox/ComboBox';
-import Icon from '@/lib/components/uswds/Icon';
+import PillBox from '@/lib/components/PillBox';
 import { Accordion, AccordionGroup } from '@/lib/components/uswds/Accordion';
 import { TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
 
@@ -46,21 +46,12 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
       </AccordionGroup>
 
       {viewModel.selectedDistricts.length > 0 && (
-        <div className="filter-pills-container">
-          {viewModel.selectedDistricts.map((district) => (
-            <span key={district.value} className="usa-tag filter-pill">
-              {district.label}
-              <button
-                type="button"
-                className="usa-tag__remove-button"
-                onClick={() => viewModel.handleRemovePill(district)}
-                aria-label={`Remove ${district.label} filter`}
-              >
-                <Icon name="close" />
-              </button>
-            </span>
-          ))}
-        </div>
+        <PillBox
+          id="district-filter-pills"
+          className="filter-pills-container"
+          selections={viewModel.selectedDistricts}
+          onSelectionChange={viewModel.handleFilterChange}
+        />
       )}
     </section>
   );

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -17,7 +17,7 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
               <div className="filter-control">
                 <ComboBox
                   id="district-combobox"
-                  label="District (Division)"
+                  label="District"
                   options={viewModel.districtsToComboOptions(viewModel.districts)}
                   selections={viewModel.selectedDistricts}
                   onUpdateSelection={viewModel.handleFilterChange}

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -40,7 +40,6 @@ export interface TrusteeDistrictFilterViewModel {
 export interface TrusteeDistrictFilterRef {
   refresh: () => void;
   focus: () => void;
-  removePill: (district: ComboOption) => void;
   clearAll: () => void;
 }
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -35,7 +35,6 @@ export interface TrusteeDistrictFilterViewModel {
   handleFilterChange(districts: ComboOption[]): void;
   handleClearAll(): void;
   handleToggleExpanded(): void;
-  handleRemovePill(district: ComboOption): void;
 }
 
 export interface TrusteeDistrictFilterRef {
@@ -61,5 +60,4 @@ export interface TrusteeDistrictFilterUseCase {
   handleFilterChange(districts: ComboOption[]): void;
   handleClearAll(): void;
   handleToggleExpanded(): void;
-  handleRemovePill(district: ComboOption): void;
 }

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -382,16 +382,13 @@ describe('trustee district filter use case tests', () => {
   });
 
   describe('handleClearAll', () => {
-    test('should reset selected districts to default districts and notify', () => {
-      const defaultDistricts: ComboOption[] = [
-        { value: 'NYSB', label: 'Southern District of New York' },
-      ];
-      mockStore.defaultDistricts = defaultDistricts;
+    test('should clear all selected districts and notify', () => {
+      mockStore.selectedDistricts = [{ value: 'NYSB', label: 'Southern District of New York' }];
 
       useCase.handleClearAll();
 
-      expect(setSelectedDistrictsSpy).toHaveBeenCalledWith(defaultDistricts);
-      expect(mockOnFilterDistrict).toHaveBeenCalledWith(defaultDistricts);
+      expect(setSelectedDistrictsSpy).toHaveBeenCalledWith([]);
+      expect(mockOnFilterDistrict).toHaveBeenCalledWith([]);
     });
   });
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -32,6 +32,7 @@ describe('trustee district filter use case tests', () => {
       groupDesignator: 'NY',
       regionId: '02',
       regionName: 'New York Region',
+      state: 'NY',
     },
     {
       officeName: 'Rutland',
@@ -43,6 +44,7 @@ describe('trustee district filter use case tests', () => {
       groupDesignator: 'VT',
       regionId: '01',
       regionName: 'Boston Region',
+      state: 'VT',
     },
     {
       officeName: 'White Plains',
@@ -54,6 +56,7 @@ describe('trustee district filter use case tests', () => {
       groupDesignator: 'NY',
       regionId: '02',
       regionName: 'New York Region',
+      state: 'NY',
     },
   ];
 
@@ -97,6 +100,7 @@ describe('trustee district filter use case tests', () => {
   );
 
   beforeEach(() => {
+    mockStore.defaultDistricts = [];
     mockStore.setSelectedDistricts = vi.fn();
     setSelectedDistrictsSpy = vi.spyOn(mockStore, 'setSelectedDistricts');
     mockOnFilterDistrict.mockReset();
@@ -109,21 +113,46 @@ describe('trustee district filter use case tests', () => {
   });
 
   describe('districtsToComboOptions', () => {
-    test('should return all divisions with District (Division) format sorted alphabetically', () => {
+    test('should return all divisions sorted by state then court name', () => {
       const comboOptions = useCase.districtsToComboOptions(mockDistricts);
 
       expect(comboOptions).toHaveLength(3);
+      // NY sorts before VT
       expect(comboOptions[0]).toEqual({
-        value: '088',
-        label: 'District of Vermont (Rutland)',
+        value: '081',
+        label: 'Southern District of New York',
       });
       expect(comboOptions[1]).toEqual({
+        value: '087',
+        label: 'Southern District of New York',
+      });
+      expect(comboOptions[2]).toEqual({
+        value: '088',
+        label: 'District of Vermont',
+      });
+    });
+
+    test('should place default districts at the top with divider', () => {
+      mockStore.defaultDistricts = [{ value: '088', label: 'District of Vermont' }];
+
+      const comboOptions = useCase.districtsToComboOptions(mockDistricts);
+
+      expect(comboOptions).toHaveLength(3);
+      // Default appears first with divider and isAriaDefault
+      expect(comboOptions[0]).toEqual({
+        value: '088',
+        label: 'District of Vermont',
+        isAriaDefault: true,
+        divider: true,
+      });
+      // Non-defaults follow, sorted by state
+      expect(comboOptions[1]).toEqual({
         value: '081',
-        label: 'Southern District of New York (Manhattan)',
+        label: 'Southern District of New York',
       });
       expect(comboOptions[2]).toEqual({
         value: '087',
-        label: 'Southern District of New York (White Plains)',
+        label: 'Southern District of New York',
       });
     });
 
@@ -212,7 +241,7 @@ describe('trustee district filter use case tests', () => {
       expect(defaultDistricts).toHaveLength(1);
       expect(defaultDistricts[0]).toEqual({
         value: '081',
-        label: 'Southern District of New York (Manhattan)',
+        label: 'Southern District of New York',
       });
     });
 
@@ -281,13 +310,13 @@ describe('trustee district filter use case tests', () => {
       expect(defaultDistricts).toHaveLength(2);
       expect(defaultDistricts).toEqual(
         expect.arrayContaining([
-          { value: '081', label: 'Southern District of New York (Manhattan)' },
-          { value: '088', label: 'District of Vermont (Rutland)' },
+          { value: '081', label: 'Southern District of New York' },
+          { value: '088', label: 'District of Vermont' },
         ]),
       );
     });
 
-    test('should sort default districts alphabetically and return empty for groups with no divisions', () => {
+    test('should sort default districts by state and return empty for groups with no divisions', () => {
       const sessionWithDivisions: CamsSession = {
         ...MockData.getCamsSession(),
         user: {
@@ -322,8 +351,9 @@ describe('trustee district filter use case tests', () => {
       };
 
       const sorted = useCase.getDefaultDistrictsFromSession(sessionWithDivisions, mockDistricts);
-      expect(sorted[0].label).toBe('District of Vermont (Rutland)');
-      expect(sorted[1].label).toBe('Southern District of New York (Manhattan)');
+      // Sorted by state: NY before VT
+      expect(sorted[0].label).toBe('Southern District of New York');
+      expect(sorted[1].label).toBe('District of Vermont');
 
       const sessionNoDivisions: CamsSession = {
         ...MockData.getCamsSession(),
@@ -503,7 +533,7 @@ describe('trustee district filter use case tests', () => {
       await useCase.fetchDistricts();
 
       expect(mockOnFilterDistrict).toHaveBeenCalledWith([
-        { value: '081', label: 'Southern District of New York (Manhattan)' },
+        { value: '081', label: 'Southern District of New York' },
       ]);
     });
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -385,35 +385,6 @@ describe('trustee district filter use case tests', () => {
     });
   });
 
-  describe('handleRemovePill', () => {
-    test('should remove the specified district from selection', () => {
-      const districts: ComboOption[] = [
-        { value: 'NYSB', label: 'Southern District of New York' },
-        { value: 'VTB', label: 'District of Vermont' },
-      ];
-      mockStore.selectedDistricts = districts;
-
-      const districtToRemove = districts[0];
-      useCase.handleRemovePill(districtToRemove);
-
-      expect(setSelectedDistrictsSpy).toHaveBeenCalledWith([districts[1]]);
-      expect(mockOnFilterDistrict).toHaveBeenCalledWith([districts[1]]);
-    });
-
-    test('should clear selection entirely when removing last district', () => {
-      const districts: ComboOption[] = [{ value: 'NYSB', label: 'Southern District of New York' }];
-      const defaultDistricts: ComboOption[] = [{ value: 'VTB', label: 'District of Vermont' }];
-      mockStore.selectedDistricts = districts;
-      mockStore.defaultDistricts = defaultDistricts;
-
-      useCase.handleRemovePill(districts[0]);
-
-      // Should clear to empty (show all trustees), not restore defaults
-      expect(setSelectedDistrictsSpy).toHaveBeenCalledWith([]);
-      expect(mockOnFilterDistrict).toHaveBeenCalledWith([]);
-    });
-  });
-
   describe('handleToggleExpanded', () => {
     test('should toggle isExpanded state between true and false', () => {
       const setIsExpandedSpy = vi.spyOn(mockStore, 'setIsExpanded');

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -234,7 +234,7 @@ describe('trustee district filter use case tests', () => {
 
       expect(defaultDistricts).toHaveLength(1);
       expect(defaultDistricts[0]).toEqual({
-        value: '081',
+        value: '081,087',
         label: 'Southern District of New York',
       });
     });
@@ -304,7 +304,7 @@ describe('trustee district filter use case tests', () => {
       expect(defaultDistricts).toHaveLength(2);
       expect(defaultDistricts).toEqual(
         expect.arrayContaining([
-          { value: '081', label: 'Southern District of New York' },
+          { value: '081,087', label: 'Southern District of New York' },
           { value: '088', label: 'District of Vermont' },
         ]),
       );
@@ -498,7 +498,7 @@ describe('trustee district filter use case tests', () => {
       await useCase.fetchDistricts();
 
       expect(mockOnFilterDistrict).toHaveBeenCalledWith([
-        { value: '081', label: 'Southern District of New York' },
+        { value: '081,087', label: 'Southern District of New York' },
       ]);
     });
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -508,22 +508,6 @@ describe('trustee district filter use case tests', () => {
     });
   });
 
-  describe('handleRemoveChapterPill', () => {
-    test('should remove the specified chapter from selection and notify', () => {
-      const chapters: ComboOption[] = [
-        { value: '7', label: '7' },
-        { value: '13', label: '13' },
-      ];
-      mockStore.selectedChapters = chapters;
-      const setSelectedChaptersSpy = vi.spyOn(mockStore, 'setSelectedChapters');
-
-      useCase.handleRemoveChapterPill(chapters[0]);
-
-      expect(setSelectedChaptersSpy).toHaveBeenCalledWith([chapters[1]]);
-      expect(mockOnFilterChapter).toHaveBeenCalledWith([chapters[1]]);
-    });
-  });
-
   describe('fetchDistricts', () => {
     beforeEach(() => {
       mockStore.setDistricts = vi.fn();

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -113,20 +113,16 @@ describe('trustee district filter use case tests', () => {
   });
 
   describe('districtsToComboOptions', () => {
-    test('should return all divisions sorted by state then court name', () => {
+    test('should return unique districts with all division codes, sorted by state then court name', () => {
       const comboOptions = useCase.districtsToComboOptions(mockDistricts);
 
-      expect(comboOptions).toHaveLength(3);
-      // NY sorts before VT
+      expect(comboOptions).toHaveLength(2);
+      // NY sorts before VT, and Southern District of NY includes both division codes
       expect(comboOptions[0]).toEqual({
-        value: '081',
+        value: '081,087',
         label: 'Southern District of New York',
       });
       expect(comboOptions[1]).toEqual({
-        value: '087',
-        label: 'Southern District of New York',
-      });
-      expect(comboOptions[2]).toEqual({
         value: '088',
         label: 'District of Vermont',
       });
@@ -137,7 +133,7 @@ describe('trustee district filter use case tests', () => {
 
       const comboOptions = useCase.districtsToComboOptions(mockDistricts);
 
-      expect(comboOptions).toHaveLength(3);
+      expect(comboOptions).toHaveLength(2);
       // Default appears first with divider and isAriaDefault
       expect(comboOptions[0]).toEqual({
         value: '088',
@@ -145,13 +141,9 @@ describe('trustee district filter use case tests', () => {
         isAriaDefault: true,
         divider: true,
       });
-      // Non-defaults follow, sorted by state
+      // Non-defaults follow, sorted by state (Southern District of NY with both divisions)
       expect(comboOptions[1]).toEqual({
-        value: '081',
-        label: 'Southern District of New York',
-      });
-      expect(comboOptions[2]).toEqual({
-        value: '087',
+        value: '081,087',
         label: 'Southern District of New York',
       });
     });
@@ -162,7 +154,7 @@ describe('trustee district filter use case tests', () => {
       expect(comboOptions).toEqual([]);
     });
 
-    test('should show all divisions even if they share the same district', () => {
+    test('should deduplicate districts and include all division codes in value', () => {
       const multiDivisionDistricts: CourtDivisionDetails[] = [
         ...mockDistricts,
         {
@@ -174,9 +166,11 @@ describe('trustee district filter use case tests', () => {
 
       const comboOptions = useCase.districtsToComboOptions(multiDivisionDistricts);
 
-      // Should have 4 divisions now (3 original + 1 new)
-      expect(comboOptions).toHaveLength(4);
-      expect(comboOptions.some((o) => o.value === '999')).toBe(true);
+      // Should have 2 unique districts (Southern District of NY and District of VT)
+      expect(comboOptions).toHaveLength(2);
+      // Southern District of NY should now include 3 division codes
+      expect(comboOptions[0].value).toBe('081,087,999');
+      expect(comboOptions[0].label).toBe('Southern District of New York');
     });
   });
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -42,13 +42,19 @@ const getDefaultDistrictsFromSession = (
     });
   });
 
-  // Group divisions by district (courtName)
-  const filteredDistricts = allDistricts.filter((district) =>
+  // Find which districts contain the user's divisions
+  const userDistricts = allDistricts.filter((district) =>
     userDivisionCodes.has(district.courtDivisionCode),
   );
-  const districtMap = groupDivisionsByDistrict(filteredDistricts);
+  const userDistrictNames = new Set(userDistricts.map((d) => d.courtName));
 
-  // Convert to ComboOptions, one per unique district
+  // Group ALL divisions for those districts (not just user's divisions)
+  const allDistrictsForUser = allDistricts.filter((district) =>
+    userDistrictNames.has(district.courtName),
+  );
+  const districtMap = groupDivisionsByDistrict(allDistrictsForUser);
+
+  // Convert to ComboOptions, one per unique district with ALL division codes
   const sortedDistricts = sortByCourtLocation(
     Array.from(districtMap.values()).map((divisions) => divisions[0]),
   );

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -23,6 +23,22 @@ const toDistrictOption = (
   label: district.courtName,
 });
 
+const buildDistrictOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
+  const districtMap = groupDivisionsByDistrict(districts);
+
+  const sortedDistricts = sortByCourtLocation(
+    Array.from(districtMap.values()).map((divisions) => divisions[0]),
+  );
+
+  return sortedDistricts.map((district) => {
+    const divisions = districtMap.get(district.courtName)!;
+    return toDistrictOption(
+      district,
+      divisions.map((d) => d.courtDivisionCode),
+    );
+  });
+};
+
 const getDefaultDistrictsFromSession = (
   session: CamsSession | null,
   allDistricts: CourtDivisionDetails[],
@@ -52,20 +68,9 @@ const getDefaultDistrictsFromSession = (
   const allDistrictsForUser = allDistricts.filter((district) =>
     userDistrictNames.has(district.courtName),
   );
-  const districtMap = groupDivisionsByDistrict(allDistrictsForUser);
 
   // Convert to ComboOptions, one per unique district with ALL division codes
-  const sortedDistricts = sortByCourtLocation(
-    Array.from(districtMap.values()).map((divisions) => divisions[0]),
-  );
-
-  return sortedDistricts.map((district) => {
-    const divisions = districtMap.get(district.courtName)!;
-    return toDistrictOption(
-      district,
-      divisions.map((d) => d.courtDivisionCode),
-    );
-  });
+  return buildDistrictOptions(allDistrictsForUser);
 };
 
 const trusteeDistrictFilterUseCase = (
@@ -75,26 +80,12 @@ const trusteeDistrictFilterUseCase = (
   previousDistrictsRef: { current: ComboOption[] | undefined },
 ): TrusteeDistrictFilterUseCase => {
   const districtsToComboOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
-    // Group divisions by district (courtName)
-    const districtMap = groupDivisionsByDistrict(districts);
-
-    // Convert to unique districts and sort by court location
-    const sortedRepresentatives = sortByCourtLocation(
-      Array.from(districtMap.values()).map((divisions) => divisions[0]),
-    );
-
-    // Convert to ComboOptions
-    const allOptions = sortedRepresentatives.map((representative) => {
-      const divisions = districtMap.get(representative.courtName)!;
-      return toDistrictOption(
-        representative,
-        divisions.map((d) => d.courtDivisionCode),
-      );
-    });
+    // Build base options (grouped by district, sorted by court location)
+    const allOptions = buildDistrictOptions(districts);
 
     // Separate defaults from non-defaults and mark them
     const defaultCodesFlat = new Set(
-      (store.defaultDistricts || []).flatMap((d) => d.value.split(',')),
+      (store.defaultDistricts ?? []).flatMap((d) => d.value.split(',')),
     );
     return separateDefaultOptions(allOptions, defaultCodesFlat);
   };

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -9,7 +9,11 @@ import Api2 from '@/lib/models/api2';
 import LocalStorage from '@/lib/utils/local-storage';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
-import { sortByCourtLocation, groupDivisionsByDistrict } from '@/lib/utils/court-utils';
+import {
+  sortByCourtLocation,
+  groupDivisionsByDistrict,
+  separateDefaultOptions,
+} from '@/lib/utils/court-utils';
 
 const toDistrictOption = (
   district: CourtDivisionDetails,
@@ -73,35 +77,20 @@ const trusteeDistrictFilterUseCase = (
       Array.from(districtMap.values()).map((divisions) => divisions[0]),
     );
 
-    const uniqueDistricts = sortedRepresentatives.map((representative) => ({
-      representative,
-      divisionCodes: districtMap.get(representative.courtName)!.map((d) => d.courtDivisionCode),
-    }));
+    // Convert to ComboOptions
+    const allOptions = sortedRepresentatives.map((representative) => {
+      const divisions = districtMap.get(representative.courtName)!;
+      return toDistrictOption(
+        representative,
+        divisions.map((d) => d.courtDivisionCode),
+      );
+    });
 
-    // Separate defaults from non-defaults
+    // Separate defaults from non-defaults and mark them
     const defaultCodesFlat = new Set(
       (store.defaultDistricts || []).flatMap((d) => d.value.split(',')),
     );
-    const defaults = uniqueDistricts.filter((d) =>
-      d.divisionCodes.some((code) => defaultCodesFlat.has(code)),
-    );
-    const nonDefaults = uniqueDistricts.filter(
-      (d) => !d.divisionCodes.some((code) => defaultCodesFlat.has(code)),
-    );
-
-    const result: ComboOption[] = [];
-    defaults.forEach((district, i) => {
-      result.push({
-        ...toDistrictOption(district.representative, district.divisionCodes),
-        isAriaDefault: true,
-        divider: i === defaults.length - 1 && nonDefaults.length > 0,
-      });
-    });
-    nonDefaults.forEach((district) => {
-      result.push(toDistrictOption(district.representative, district.divisionCodes));
-    });
-
-    return result;
+    return separateDefaultOptions(allOptions, defaultCodesFlat);
   };
 
   const notifySelectionChange = (districts: ComboOption[]) => {

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -9,7 +9,7 @@ import Api2 from '@/lib/models/api2';
 import LocalStorage from '@/lib/utils/local-storage';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
-import { sortByCourtLocation } from '@/lib/utils/court-utils';
+import { sortByCourtLocation, groupDivisionsByDistrict } from '@/lib/utils/court-utils';
 
 const toDistrictOption = (
   district: CourtDivisionDetails,
@@ -39,16 +39,10 @@ const getDefaultDistrictsFromSession = (
   });
 
   // Group divisions by district (courtName)
-  const districtMap = new Map<string, CourtDivisionDetails[]>();
-  allDistricts
-    .filter((district) => userDivisionCodes.has(district.courtDivisionCode))
-    .forEach((district) => {
-      const key = district.courtName;
-      if (!districtMap.has(key)) {
-        districtMap.set(key, []);
-      }
-      districtMap.get(key)!.push(district);
-    });
+  const filteredDistricts = allDistricts.filter((district) =>
+    userDivisionCodes.has(district.courtDivisionCode),
+  );
+  const districtMap = groupDivisionsByDistrict(filteredDistricts);
 
   // Convert to ComboOptions, one per unique district
   const sortedDistricts = sortByCourtLocation(
@@ -72,14 +66,7 @@ const trusteeDistrictFilterUseCase = (
 ): TrusteeDistrictFilterUseCase => {
   const districtsToComboOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
     // Group divisions by district (courtName)
-    const districtMap = new Map<string, CourtDivisionDetails[]>();
-    districts.forEach((district) => {
-      const key = district.courtName;
-      if (!districtMap.has(key)) {
-        districtMap.set(key, []);
-      }
-      districtMap.get(key)!.push(district);
-    });
+    const districtMap = groupDivisionsByDistrict(districts);
 
     // Convert to unique districts and sort by court location
     const sortedRepresentatives = sortByCourtLocation(

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -9,11 +9,7 @@ import Api2 from '@/lib/models/api2';
 import LocalStorage from '@/lib/utils/local-storage';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
-
-const sortByState = (a: CourtDivisionDetails, b: CourtDivisionDetails) =>
-  (a.state || '').localeCompare(b.state || '') ||
-  a.courtName.localeCompare(b.courtName) ||
-  a.courtDivisionCode.localeCompare(b.courtDivisionCode);
+import { sortByCourtLocation } from '@/lib/utils/court-utils';
 
 const toDistrictOption = (
   district: CourtDivisionDetails,
@@ -55,14 +51,17 @@ const getDefaultDistrictsFromSession = (
     });
 
   // Convert to ComboOptions, one per unique district
-  return Array.from(districtMap.values())
-    .sort((a, b) => sortByState(a[0], b[0]))
-    .map((divisions) =>
-      toDistrictOption(
-        divisions[0],
-        divisions.map((d) => d.courtDivisionCode),
-      ),
+  const sortedDistricts = sortByCourtLocation(
+    Array.from(districtMap.values()).map((divisions) => divisions[0]),
+  );
+
+  return sortedDistricts.map((district) => {
+    const divisions = districtMap.get(district.courtName)!;
+    return toDistrictOption(
+      district,
+      divisions.map((d) => d.courtDivisionCode),
     );
+  });
 };
 
 const trusteeDistrictFilterUseCase = (
@@ -82,13 +81,15 @@ const trusteeDistrictFilterUseCase = (
       districtMap.get(key)!.push(district);
     });
 
-    // Convert to unique districts
-    const uniqueDistricts = Array.from(districtMap.values())
-      .map((divisions) => ({
-        representative: divisions[0],
-        divisionCodes: divisions.map((d) => d.courtDivisionCode),
-      }))
-      .sort((a, b) => sortByState(a.representative, b.representative));
+    // Convert to unique districts and sort by court location
+    const sortedRepresentatives = sortByCourtLocation(
+      Array.from(districtMap.values()).map((divisions) => divisions[0]),
+    );
+
+    const uniqueDistricts = sortedRepresentatives.map((representative) => ({
+      representative,
+      divisionCodes: districtMap.get(representative.courtName)!.map((d) => d.courtDivisionCode),
+    }));
 
     // Separate defaults from non-defaults
     const defaultCodesFlat = new Set(
@@ -167,11 +168,6 @@ const trusteeDistrictFilterUseCase = (
     store.setIsExpanded(!store.isExpanded);
   };
 
-  const handleRemovePill = (district: ComboOption) => {
-    const updatedDistricts = store.selectedDistricts.filter((d) => d.value !== district.value);
-    handleFilterChange(updatedDistricts);
-  };
-
   return {
     districtsToComboOptions,
     fetchDistricts,
@@ -180,7 +176,6 @@ const trusteeDistrictFilterUseCase = (
     handleFilterChange,
     handleClearAll,
     handleToggleExpanded,
-    handleRemovePill,
   };
 };
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -11,7 +11,17 @@ import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 const sortByState = (a: CourtDivisionDetails, b: CourtDivisionDetails) =>
-  (a.state || '').localeCompare(b.state || '') || a.courtName.localeCompare(b.courtName);
+  (a.state || '').localeCompare(b.state || '') ||
+  a.courtName.localeCompare(b.courtName) ||
+  a.courtDivisionCode.localeCompare(b.courtDivisionCode);
+
+const toDistrictOption = (
+  district: CourtDivisionDetails,
+  divisionCodes: string[],
+): ComboOption => ({
+  value: divisionCodes.join(','),
+  label: district.courtName,
+});
 
 const getDefaultDistrictsFromSession = (
   session: CamsSession | null,
@@ -32,13 +42,27 @@ const getDefaultDistrictsFromSession = (
     });
   });
 
-  return allDistricts
+  // Group divisions by district (courtName)
+  const districtMap = new Map<string, CourtDivisionDetails[]>();
+  allDistricts
     .filter((district) => userDivisionCodes.has(district.courtDivisionCode))
-    .sort(sortByState)
-    .map((district) => ({
-      value: district.courtDivisionCode,
-      label: district.courtName,
-    }));
+    .forEach((district) => {
+      const key = district.courtName;
+      if (!districtMap.has(key)) {
+        districtMap.set(key, []);
+      }
+      districtMap.get(key)!.push(district);
+    });
+
+  // Convert to ComboOptions, one per unique district
+  return Array.from(districtMap.values())
+    .sort((a, b) => sortByState(a[0], b[0]))
+    .map((divisions) =>
+      toDistrictOption(
+        divisions[0],
+        divisions.map((d) => d.courtDivisionCode),
+      ),
+    );
 };
 
 const trusteeDistrictFilterUseCase = (
@@ -48,26 +72,45 @@ const trusteeDistrictFilterUseCase = (
   previousDistrictsRef: { current: ComboOption[] | undefined },
 ): TrusteeDistrictFilterUseCase => {
   const districtsToComboOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
-    const defaultCodes = new Set(store.defaultDistricts.map((d) => d.value));
-    const sorted = [...districts].sort(sortByState);
+    // Group divisions by district (courtName)
+    const districtMap = new Map<string, CourtDivisionDetails[]>();
+    districts.forEach((district) => {
+      const key = district.courtName;
+      if (!districtMap.has(key)) {
+        districtMap.set(key, []);
+      }
+      districtMap.get(key)!.push(district);
+    });
 
-    const defaults = sorted.filter((d) => defaultCodes.has(d.courtDivisionCode));
-    const nonDefaults = sorted.filter((d) => !defaultCodes.has(d.courtDivisionCode));
+    // Convert to unique districts
+    const uniqueDistricts = Array.from(districtMap.values())
+      .map((divisions) => ({
+        representative: divisions[0],
+        divisionCodes: divisions.map((d) => d.courtDivisionCode),
+      }))
+      .sort((a, b) => sortByState(a.representative, b.representative));
+
+    // Separate defaults from non-defaults
+    const defaultCodesFlat = new Set(
+      (store.defaultDistricts || []).flatMap((d) => d.value.split(',')),
+    );
+    const defaults = uniqueDistricts.filter((d) =>
+      d.divisionCodes.some((code) => defaultCodesFlat.has(code)),
+    );
+    const nonDefaults = uniqueDistricts.filter(
+      (d) => !d.divisionCodes.some((code) => defaultCodesFlat.has(code)),
+    );
 
     const result: ComboOption[] = [];
     defaults.forEach((district, i) => {
       result.push({
-        value: district.courtDivisionCode,
-        label: district.courtName,
+        ...toDistrictOption(district.representative, district.divisionCodes),
         isAriaDefault: true,
         divider: i === defaults.length - 1 && nonDefaults.length > 0,
       });
     });
     nonDefaults.forEach((district) => {
-      result.push({
-        value: district.courtDivisionCode,
-        label: district.courtName,
-      });
+      result.push(toDistrictOption(district.representative, district.divisionCodes));
     });
 
     return result;

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -10,20 +10,8 @@ import LocalStorage from '@/lib/utils/local-storage';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
-const districtsToComboOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
-  // Show all divisions with format: District (Division)
-  return districts
-    .map((district) => {
-      const divisionName = district.courtDivisionName || district.courtDivisionCode;
-      const label = divisionName ? `${district.courtName} (${divisionName})` : district.courtName;
-
-      return {
-        value: district.courtDivisionCode,
-        label: label,
-      };
-    })
-    .sort((a, b) => a.label.localeCompare(b.label));
-};
+const sortByState = (a: CourtDivisionDetails, b: CourtDivisionDetails) =>
+  (a.state || '').localeCompare(b.state || '') || a.courtName.localeCompare(b.courtName);
 
 const getDefaultDistrictsFromSession = (
   session: CamsSession | null,
@@ -46,16 +34,11 @@ const getDefaultDistrictsFromSession = (
 
   return allDistricts
     .filter((district) => userDivisionCodes.has(district.courtDivisionCode))
-    .map((district) => {
-      const divisionName = district.courtDivisionName || district.courtDivisionCode;
-      const label = divisionName ? `${district.courtName} (${divisionName})` : district.courtName;
-
-      return {
-        value: district.courtDivisionCode,
-        label: label,
-      };
-    })
-    .sort((a, b) => a.label.localeCompare(b.label));
+    .sort(sortByState)
+    .map((district) => ({
+      value: district.courtDivisionCode,
+      label: district.courtName,
+    }));
 };
 
 const trusteeDistrictFilterUseCase = (
@@ -64,6 +47,32 @@ const trusteeDistrictFilterUseCase = (
   onFilterDistrict: (districts: ComboOption[]) => void,
   previousDistrictsRef: { current: ComboOption[] | undefined },
 ): TrusteeDistrictFilterUseCase => {
+  const districtsToComboOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
+    const defaultCodes = new Set(store.defaultDistricts.map((d) => d.value));
+    const sorted = [...districts].sort(sortByState);
+
+    const defaults = sorted.filter((d) => defaultCodes.has(d.courtDivisionCode));
+    const nonDefaults = sorted.filter((d) => !defaultCodes.has(d.courtDivisionCode));
+
+    const result: ComboOption[] = [];
+    defaults.forEach((district, i) => {
+      result.push({
+        value: district.courtDivisionCode,
+        label: district.courtName,
+        isAriaDefault: true,
+        divider: i === defaults.length - 1 && nonDefaults.length > 0,
+      });
+    });
+    nonDefaults.forEach((district) => {
+      result.push({
+        value: district.courtDivisionCode,
+        label: district.courtName,
+      });
+    });
+
+    return result;
+  };
+
   const notifySelectionChange = (districts: ComboOption[]) => {
     onFilterDistrict(districts);
   };


### PR DESCRIPTION
Remove division from filter dropdown labels, sort options by state, place user defaults at top with divider, and make scroll-to-selected opt-in with instant (non-animated) behavior. ComboBox scroll behavior is now opt-in via scrollToSelected prop. Table column format unchanged.

Jira ticket: CAMS-691

# Purpose

Improve trustee district filter UX by:
- Grouping divisions under districts (reduce clutter)
- Prioritizing user's default districts at the top
- Sorting by state name for better discoverability
- Making scroll behavior configurable and instant

# Major Changes

**1. District Grouping**
- Multiple divisions now grouped under single district option (e.g., "Southern District of NY" includes both Manhattan and White Plains)
- Division codes stored as comma-separated values in option.value

**2. Default Districts Priority**
- User's default districts appear at top of dropdown
- Visual divider separates defaults from other options
- Marked with `isAriaDefault` for screen reader accessibility

**3. Sorting by State**
- Districts sorted by full state name (not state code)
- Then by court name within each state
- Extracted `sortByCourtLocation` utility to `court-utils.ts`

**4. ComboBox Scroll Behavior**
- Added `scrollToSelected` prop (opt-in)
- Changed from 'smooth' to 'auto' (instant, standards-compliant)
- Trustee filter opts in; other ComboBoxes opt out

**5. Shared Utilities**
- Extracted `groupDivisionsByDistrict` helper
- Extracted `separateDefaultOptions` for default handling
- Extracted `buildDistrictOptions` to eliminate duplication

**6. Pill Component Refactor**
- Replaced custom pill markup with shared `PillBox` component
- Moved styling to CSS with USWDS color tokens
- Removed inline color props

# Testing/Validation

## Manual Testing
1. Navigate to Trustees page
2. Verify your default districts appear at top with divider
3. Verify districts are sorted by state
4. Select a multi-division district (e.g., "Southern District of NY")
5. Verify trustees from all divisions in that district appear
6. Verify dropdown scrolls instantly (no animation) to selected items when reopened
7. Verify pill removal works correctly

## Automated Testing
- All existing tests updated and passing
- New test added for default district ordering with divider

# Notes

**Code Review Fixes Applied:**
- Fixed scroll behavior: Changed `'instant'` to `'auto'` (standards-compliant)
- Extracted `buildDistrictOptions` helper to eliminate duplication
- Improved null handling: Changed `||` to `??` for safer defaults

**Future Enhancements (deferred):**
- Add explicit `codes` field to ComboOption type (currently comma-separated in value)

# Definition of Done:

- [x] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed: More important code doesn't directly depend on less important code
- [x] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [x] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Refine trustee district filtering and display by grouping divisions into districts, simplifying labels, and improving default selection behavior across filters and search.

Enhancements:
- Group court divisions by district and sort trustee appointments by state, region, chapter, and appointment type for more consistent ordering.
- Update trustee district filter and search office comboboxes to deduplicate districts, place user default districts/options first with accessibility-friendly markings, and make scroll-to-selected behavior opt-in.
- Simplify trustee district labels and table columns to show district-only names, updating pills and list styling accordingly, and standardize pill visual design.
- Remove bespoke pill-removal logic from the trustee district filter in favor of the shared PillBox component and supporting utilities.

Tests:
- Adjust and extend trustee filter and trustees list tests to cover new district grouping, default ordering, labeling, and interaction behaviors.