### PR TITLE
CAMS-737 Add trustee name search filter

### DIFF
--- a/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
+++ b/ops/cloud-deployment/lib/workbooks/trustee-district-filter-metrics.json
@@ -4,7 +4,7 @@
     {
       "type": 1,
       "content": {
-        "json": "# Trustee Filter Metrics\n\nSuccess metrics for trustee filter usage and performance on the Trustee Management page.\n\n**Instrumented events:**\n- `Trustee District Filter Changed` — fired on any selection change; dimensions: `isDefault`; measurements: `selectedCount`, `resultCount`, `chapterCount`\n- `Trustee District Filter Cleared` — fired when user clicks Clear (restores defaults)\n- `Trustee Chapter Filter Changed` — fired on any chapter selection change; dimensions: `selectedChapterValues`; measurements: `selectedCount`, `resultCount`, `districtCount`\n- `Trustee List Loaded` — fired when trustee data first renders; measurements: `trusteeCount`, `loadMs`"
+        "json": "# Trustee Filter Metrics\n\nSuccess metrics for trustee filter usage and performance on the Trustee Management page.\n\n**Instrumented events:**\n- `Trustee District Filter Changed` — fired on any selection change; dimensions: `isDefault`; measurements: `selectedCount`, `resultCount`, `chapterCount`\n- `Trustee District Filter Cleared` — fired when user clicks Clear (restores defaults)\n- `Trustee Chapter Filter Changed` — fired on any chapter selection change; dimensions: `selectedChapterValues`; measurements: `selectedCount`, `resultCount`, `districtCount`\n- `Trustee Name Filter Changed` — fired after each debounced search API call (2+ chars); dimensions: `hasDistrictFilter`; measurements: `queryLength`, `resultCount`, `districtCount`, `chapterCount`, `searchResponseMs`, `sessionSearchCount`\n- `Trustee Name Filter Cleared` — fired when user clears the name input; measurements: `queryLength`, `sessionSearchCount`\n- `Trustee List Loaded` — fired when trustee data first renders; measurements: `trusteeCount`, `loadMs`"
       },
       "name": "header"
     },
@@ -391,9 +391,9 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customEvents\n| where timestamp {TimeRange}\n| where name in (\"Trustee District Filter Changed\", \"Trustee District Filter Cleared\", \"Trustee Chapter Filter Changed\")\n| summarize\n    DistrictModifications = countif(name == \"Trustee District Filter Changed\" and tostring(customDimensions.isDefault) != \"true\"),\n    DefaultClears = countif(name == \"Trustee District Filter Cleared\"),\n    ChapterModifications = countif(name == \"Trustee Chapter Filter Changed\")\n    by Day = bin(timestamp, 1d)\n| order by Day asc",
+        "query": "customEvents\n| where timestamp {TimeRange}\n| where name in (\"Trustee District Filter Changed\", \"Trustee District Filter Cleared\", \"Trustee Chapter Filter Changed\", \"Trustee Name Filter Changed\", \"Trustee Name Filter Cleared\")\n| summarize\n    DistrictModifications = countif(name == \"Trustee District Filter Changed\" and tostring(customDimensions.isDefault) != \"true\"),\n    DefaultClears = countif(name == \"Trustee District Filter Cleared\"),\n    ChapterModifications = countif(name == \"Trustee Chapter Filter Changed\"),\n    NameSearches = countif(name == \"Trustee Name Filter Changed\"),\n    NameSearchClears = countif(name == \"Trustee Name Filter Cleared\")\n    by Day = bin(timestamp, 1d)\n| order by Day asc",
         "size": 0,
-        "title": "Filter Activity Over Time (District + Chapter)",
+        "title": "Filter Activity Over Time (District + Chapter + Name)",
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.insights/components",
@@ -416,6 +416,16 @@
               "seriesName": "ChapterModifications",
               "label": "Chapter Filter Modified",
               "color": "green"
+            },
+            {
+              "seriesName": "NameSearches",
+              "label": "Name Searches",
+              "color": "purple"
+            },
+            {
+              "seriesName": "NameSearchClears",
+              "label": "Name Search Cleared",
+              "color": "pink"
             }
           ],
           "ySettings": {
@@ -520,6 +530,243 @@
       },
       "customWidth": "50",
       "name": "combined-filter-usage-kpi"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n## Name Search Usage\nHow frequently users search by name, average query length, and combination with district filter."
+      },
+      "name": "name-search-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let TrusteePageVisits =\n    pageViews\n    | where timestamp {TimeRange}\n    | where url contains \"/trustees\"\n    | project operation_Id;\nlet NameSearchVisits =\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Name Filter Changed\"\n    | project operation_Id;\nlet TotalVisits = toscalar(TrusteePageVisits | count);\nlet SearchedVisits = toscalar(\n    NameSearchVisits\n    | join kind=inner TrusteePageVisits on operation_Id\n    | summarize by operation_Id\n    | count\n);\nprint\n    TotalVisits = TotalVisits,\n    SearchedVisits = SearchedVisits,\n    SearchUsageRate = round(iif(TotalVisits > 0, todouble(SearchedVisits) / todouble(TotalVisits) * 100, 0.0), 1)",
+        "size": 3,
+        "title": "% of Page Visits Where Name Search Was Used",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {},
+          "leftContent": {
+            "columnMatch": "SearchUsageRate",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 1,
+              "options": {
+                "style": "decimal",
+                "minimumFractionDigits": 1,
+                "maximumFractionDigits": 1
+              }
+            }
+          },
+          "secondaryContent": {
+            "columnMatch": "TotalVisits",
+            "formatter": 1
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "25",
+      "name": "name-search-usage-rate-kpi"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let TrusteePageVisits =\n    pageViews\n    | where timestamp {TimeRange}\n    | where url contains \"/trustees\"\n    | project operation_Id;\nlet TotalVisits = toscalar(TrusteePageVisits | count);\nlet TotalSearches = toscalar(\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Name Filter Changed\"\n    | count\n);\nprint\n    TotalVisits = TotalVisits,\n    TotalSearches = TotalSearches,\n    AvgSearchesPerVisit = round(iif(TotalVisits > 0, todouble(TotalSearches) / todouble(TotalVisits), 0.0), 2)",
+        "size": 3,
+        "title": "Avg Name Searches per Page Visit",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {},
+          "leftContent": {
+            "columnMatch": "AvgSearchesPerVisit",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal",
+                "minimumFractionDigits": 2,
+                "maximumFractionDigits": 2
+              }
+            }
+          },
+          "secondaryContent": {
+            "columnMatch": "TotalVisits"
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "25",
+      "name": "name-search-avg-per-visit-kpi"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Name Filter Changed\"\n| extend queryLength = toint(customMeasurements.queryLength)\n| where isnotnull(queryLength)\n| summarize\n    AvgQueryLength = round(avg(queryLength), 1),\n    P50QueryLength = round(todouble(percentile(queryLength, 50)), 0),\n    P95QueryLength = round(todouble(percentile(queryLength, 95)), 0),\n    SampleCount = count()\n| project\n    ['Avg Length'] = AvgQueryLength,\n    ['P50 Length'] = P50QueryLength,\n    ['P95 Length'] = P95QueryLength,\n    ['Sample Count'] = SampleCount",
+        "size": 3,
+        "title": "Search Query Length (chars)",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {},
+          "leftContent": {
+            "columnMatch": "Avg Length",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal",
+                "minimumFractionDigits": 1,
+                "maximumFractionDigits": 1
+              }
+            }
+          },
+          "secondaryContent": {
+            "columnMatch": "P50 Length",
+            "formatter": 1
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "25",
+      "name": "name-search-query-length-kpi"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let TotalSearches = toscalar(\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Name Filter Changed\"\n    | count\n);\nlet CombinedSearches = toscalar(\n    customEvents\n    | where timestamp {TimeRange}\n    | where name == \"Trustee Name Filter Changed\"\n    | where tostring(customDimensions.hasDistrictFilter) == \"true\"\n    | count\n);\nprint\n    TotalSearches = TotalSearches,\n    CombinedSearches = CombinedSearches,\n    CombinedRate = round(iif(TotalSearches > 0, todouble(CombinedSearches) / todouble(TotalSearches) * 100, 0.0), 1)",
+        "size": 3,
+        "title": "% of Name Searches with District Filter Active",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {},
+          "leftContent": {
+            "columnMatch": "CombinedRate",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 1,
+              "options": {
+                "style": "decimal",
+                "minimumFractionDigits": 1,
+                "maximumFractionDigits": 1
+              }
+            }
+          },
+          "secondaryContent": {
+            "columnMatch": "CombinedSearches",
+            "formatter": 1
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "25",
+      "name": "name-search-combined-rate-kpi"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Name Filter Changed\"\n| extend resultCount = toint(customMeasurements.resultCount)\n| extend ResultBucket = case(\n    resultCount == 0, \"0 trustees\",\n    resultCount <= 5, \"1–5 trustees\",\n    resultCount <= 10, \"6–10 trustees\",\n    resultCount <= 20, \"11–20 trustees\",\n    resultCount <= 50, \"21–50 trustees\",\n    \"51+ trustees\"\n  )\n| summarize SearchCount = count() by ResultBucket\n| order by ResultBucket asc",
+        "size": 3,
+        "title": "Trustee Count Distribution After Name Search",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {
+            "columnMatch": "ResultBucket"
+          },
+          "leftContent": {
+            "columnMatch": "SearchCount",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal"
+              }
+            }
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "50",
+      "name": "name-search-result-distribution-kpi"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n## Name Search Performance\nSearch API response time as measured from the client (debounce-fire to response received)."
+      },
+      "name": "name-search-performance-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customEvents\n| where timestamp {TimeRange}\n| where name == \"Trustee Name Filter Changed\"\n| extend searchResponseMs = todouble(customMeasurements.searchResponseMs)\n| where isnotnull(searchResponseMs)\n| summarize\n    P50Ms = round(percentile(searchResponseMs, 50), 0),\n    P95Ms = round(percentile(searchResponseMs, 95), 0),\n    SampleCount = count()\n| project\n    ['P50 Response (ms)'] = P50Ms,\n    ['P95 Response (ms)'] = P95Ms,\n    ['Sample Count'] = SampleCount",
+        "size": 3,
+        "title": "Name Search API Response Time",
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {},
+          "leftContent": {
+            "columnMatch": "P50 Response (ms)",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "greenRed"
+            },
+            "numberFormat": {
+              "unit": 23,
+              "options": {
+                "style": "decimal",
+                "minimumFractionDigits": 0,
+                "maximumFractionDigits": 0
+              }
+            }
+          },
+          "secondaryContent": {
+            "columnMatch": "P95 Response (ms)",
+            "formatter": 1
+          },
+          "showBorder": true
+        }
+      },
+      "customWidth": "50",
+      "name": "name-search-response-time-kpi"
     },
     {
       "type": 1,

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1022,7 +1022,13 @@ describe('TrusteesList Component', () => {
       await waitFor(() => {
         expect(mockTrackEvent).toHaveBeenCalledWith(
           { name: 'Trustee Name Filter Changed' },
-          expect.objectContaining({ queryLength: 2, districtCount: 0, chapterCount: 0 }),
+          expect.objectContaining({
+            queryLength: 2,
+            districtCount: 0,
+            chapterCount: 0,
+            hasDistrictFilter: false,
+            sessionSearchCount: 1,
+          }),
         );
       });
     });
@@ -1047,7 +1053,10 @@ describe('TrusteesList Component', () => {
       await user.click(screen.getByRole('button', { name: /^clear$/i }));
 
       await waitFor(() => {
-        expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'Trustee Name Filter Cleared' });
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          { name: 'Trustee Name Filter Cleared' },
+          expect.objectContaining({ queryLength: 2, sessionSearchCount: 1 }),
+        );
       });
     });
   });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1090,6 +1090,109 @@ describe('TrusteesList Component', () => {
         );
       });
     });
+
+    test('sessionSearchCount reflects completed API calls, not keystrokes', async () => {
+      // Typing "Smith" (5 chars, each >= 2) should count as 1 search, not 4.
+      // Each keystroke triggers the effect but only the debounced callback fires once.
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({
+        data: [{ ...trustee1, appointments: [], matchType: 'exact' }],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      const user = userEvent.setup({ delay: null });
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Smith');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          { name: 'Trustee Name Filter Changed' },
+          expect.objectContaining({ sessionSearchCount: 1 }),
+        );
+      });
+
+      const changedCalls = mockTrackEvent.mock.calls.filter(
+        ([event]) => event.name === 'Trustee Name Filter Changed',
+      );
+      // sessionSearchCount in the single event should be 1, not 4
+      expect(changedCalls[0][1].sessionSearchCount).toBe(1);
+    });
+
+    test('restores full list when name search API call fails', async () => {
+      // When searchTrustees throws, nameSearchIds is set to empty Set while
+      // nameSearch.length >= 2 stays true — filtering out every trustee.
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });
+      vi.spyOn(Api2, 'searchTrustees').mockRejectedValue(new Error('Network error'));
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      const user = userEvent.setup({ delay: null });
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      // Should NOT silently show "0 Trustee(s)" — either full list restored or error surfaced
+      await waitFor(() => {
+        expect(screen.queryByText('0 Trustee(s)', { selector: 'p' })).not.toBeInTheDocument();
+      });
+    });
+
+    test('searchResponseMs measures only API latency, not the debounce delay', async () => {
+      // searchStart is currently captured before the debounce fires, inflating the metric by ~300ms.
+      // After the fix, the measured duration should be close to the actual API response time, not 300ms+.
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });
+
+      let resolveSearch!: () => void;
+      vi.spyOn(Api2, 'searchTrustees').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSearch = () =>
+              resolve({ data: [{ ...trustee1, appointments: [], matchType: 'exact' }] });
+          }),
+      );
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      const user = userEvent.setup({ delay: null });
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+
+      // Advance past debounce — API call is now in-flight
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      // Resolve the API call immediately (simulates near-zero API latency)
+      await act(async () => {
+        resolveSearch();
+      });
+
+      await waitFor(() => {
+        const changedCalls = mockTrackEvent.mock.calls.filter(
+          ([event]) => event.name === 'Trustee Name Filter Changed',
+        );
+        expect(changedCalls.length).toBeGreaterThan(0);
+        const { searchResponseMs } = changedCalls[0][1];
+        // If searchStart is captured outside the debounce, this will be ~300ms+.
+        // After the fix it should be well under 300ms (near 0 since mock resolves instantly).
+        expect(searchResponseMs).toBeDefined();
+        expect(searchResponseMs).toBeLessThan(300);
+      });
+    });
   });
 
   describe('District Filtering', () => {

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1033,6 +1033,37 @@ describe('TrusteesList Component', () => {
       });
     });
 
+    test('tracks Trustee Name Filter Changed event only once per search', async () => {
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({
+        data: [{ ...trustee1, appointments: [], matchType: 'exact' }],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      await userEvent
+        .setup({ delay: null })
+        .click(screen.getByRole('button', { name: /filters/i }));
+      await userEvent
+        .setup({ delay: null })
+        .type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const changedCalls = mockTrackEvent.mock.calls.filter(
+        ([event]) => event.name === 'Trustee Name Filter Changed',
+      );
+      expect(changedCalls).toHaveLength(1);
+    });
+
     test('tracks Trustee Name Filter Cleared AppInsights event', async () => {
       const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import TrusteesList from './TrusteesList';
@@ -832,6 +832,222 @@ describe('TrusteesList Component', () => {
             selectedChapterValues: '7',
           }),
         );
+      });
+    });
+  });
+
+  describe('Name Filter', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test('renders name filter input inside accordion when expanded', async () => {
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' })],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      await userEvent
+        .setup({ delay: null })
+        .click(screen.getByRole('button', { name: /filters/i }));
+
+      expect(screen.getByRole('textbox', { name: /trustee name/i })).toBeInTheDocument();
+    });
+
+    test('does not call searchTrustees when fewer than 2 characters typed', async () => {
+      const searchSpy = vi.spyOn(Api2, 'searchTrustees');
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' })],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      await userEvent
+        .setup({ delay: null })
+        .click(screen.getByRole('button', { name: /filters/i }));
+      await userEvent
+        .setup({ delay: null })
+        .type(screen.getByRole('textbox', { name: /trustee name/i }), 'S');
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(searchSpy).not.toHaveBeenCalled();
+      expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+    });
+
+    test('filters trustees by name when 2+ characters typed', async () => {
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      const trustee2 = makeListItem({ trusteeId: 't2', firstName: 'Bob', lastName: 'Jones' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1, trustee2] });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({
+        data: [{ ...trustee1, appointments: [], matchType: 'exact' }],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      await userEvent
+        .setup({ delay: null })
+        .click(screen.getByRole('button', { name: /filters/i }));
+      await userEvent
+        .setup({ delay: null })
+        .type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Smith, Alice')).toBeInTheDocument();
+        expect(screen.queryByText('Jones, Bob')).not.toBeInTheDocument();
+      });
+    });
+
+    test('shows zero results when name search returns no matches', async () => {
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' })],
+      });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({ data: [] });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      await userEvent
+        .setup({ delay: null })
+        .click(screen.getByRole('button', { name: /filters/i }));
+      await userEvent
+        .setup({ delay: null })
+        .type(screen.getByRole('textbox', { name: /trustee name/i }), 'xyz');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('0 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.queryByText('Smith, Alice')).not.toBeInTheDocument();
+      });
+    });
+
+    test('clears name filter and restores full list', async () => {
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      const trustee2 = makeListItem({ trusteeId: 't2', firstName: 'Bob', lastName: 'Jones' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1, trustee2] });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({
+        data: [{ ...trustee1, appointments: [], matchType: 'exact' }],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      const user = userEvent.setup({ delay: null });
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /^clear$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Smith, Alice')).toBeInTheDocument();
+        expect(screen.getByText('Jones, Bob')).toBeInTheDocument();
+      });
+    });
+
+    test('live region announces count after name filter interaction', async () => {
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      const trustee2 = makeListItem({ trusteeId: 't2', firstName: 'Bob', lastName: 'Jones' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1, trustee2] });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({
+        data: [{ ...trustee1, appointments: [], matchType: 'exact' }],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      const liveRegion = screen.getByRole('status');
+      expect(liveRegion).toHaveTextContent('');
+
+      await userEvent
+        .setup({ delay: null })
+        .click(screen.getByRole('button', { name: /filters/i }));
+      await userEvent
+        .setup({ delay: null })
+        .type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        expect(liveRegion).toHaveTextContent('1 Trustees');
+      });
+    });
+
+    test('tracks Trustee Name Filter Changed AppInsights event', async () => {
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({
+        data: [{ ...trustee1, appointments: [], matchType: 'exact' }],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      await userEvent
+        .setup({ delay: null })
+        .click(screen.getByRole('button', { name: /filters/i }));
+      await userEvent
+        .setup({ delay: null })
+        .type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          { name: 'Trustee Name Filter Changed' },
+          expect.objectContaining({ queryLength: 2, districtCount: 0, chapterCount: 0 }),
+        );
+      });
+    });
+
+    test('tracks Trustee Name Filter Cleared AppInsights event', async () => {
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({
+        data: [{ ...trustee1, appointments: [], matchType: 'exact' }],
+      });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+
+      const user = userEvent.setup({ delay: null });
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await user.click(screen.getByRole('button', { name: /^clear$/i }));
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'Trustee Name Filter Cleared' });
       });
     });
   });

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -2,6 +2,7 @@ import './TrusteesList.scss';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { TrusteeListItem } from '@common/cams/trustees';
+import useDebounce from '@/lib/hooks/UseDebounce';
 import {
   formatChapterType,
   formatAppointmentType,
@@ -63,8 +64,13 @@ export default function TrusteesList() {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
   const [liveAnnouncement, setLiveAnnouncement] = useState<string>('');
+  const [nameSearch, setNameSearch] = useState('');
+  const [nameSearchIds, setNameSearchIds] = useState<Set<string> | null>(null);
   const filterRef = useRef<TrusteeDistrictFilterRef>(null);
   const pageLoadStart = useRef(performance.now());
+  const isNameFilterInteracted = useRef(false);
+  const previousNameSearchRef = useRef('');
+  const debounce = useDebounce();
 
   useEffect(() => {
     const fetchTrustees = () => {
@@ -110,8 +116,30 @@ export default function TrusteesList() {
     setLiveAnnouncement('');
   };
 
+  const handleFilterName = (name: string) => {
+    isNameFilterInteracted.current = true;
+    setNameSearch(name);
+    if (name.length < 2) {
+      setNameSearchIds(null);
+      return;
+    }
+    debounce(async () => {
+      try {
+        const response = await Api2.searchTrustees(name);
+        const ids = new Set(response.data.map((r) => r.trusteeId));
+        setNameSearchIds(ids);
+      } catch {
+        setNameSearchIds(new Set());
+      }
+    }, 300);
+  };
+
   const { filteredTrustees } = useMemo(() => {
-    const filtered = filterTrustees(trustees, selectedDistricts, selectedChapters);
+    let filtered = filterTrustees(trustees, selectedDistricts, selectedChapters);
+
+    if (nameSearchIds !== null) {
+      filtered = filtered.filter((t) => nameSearchIds.has(t.trusteeId));
+    }
 
     const sorted = [...filtered].sort((a, b) => {
       const lastCmp = (a.lastName ?? '').localeCompare(b.lastName ?? '', undefined, {
@@ -135,7 +163,7 @@ export default function TrusteesList() {
     return {
       filteredTrustees: sortedWithAppointments,
     };
-  }, [trustees, selectedDistricts, selectedChapters, sortDirection]);
+  }, [trustees, selectedDistricts, selectedChapters, nameSearchIds, sortDirection]);
 
   useEffect(() => {
     if (!isDefaultApplied.current) return;
@@ -158,7 +186,7 @@ export default function TrusteesList() {
   }, [selectedDistricts, selectedChapters, trustees]);
 
   useEffect(() => {
-    if (!isChapterFilterInteracted.current) return;
+    if (!isChapterFilterInteracted.current && !isNameFilterInteracted.current) return;
     setLiveAnnouncement(`${filteredTrustees.length} Trustees`);
   }, [filteredTrustees]);
 
@@ -177,6 +205,32 @@ export default function TrusteesList() {
       },
     );
   }, [selectedChapters, selectedDistricts, trustees]);
+
+  useEffect(() => {
+    if (!isNameFilterInteracted.current) return;
+
+    const wasNonEmpty = previousNameSearchRef.current.length > 0;
+    const isNowEmpty = nameSearch.length === 0;
+
+    if (wasNonEmpty && isNowEmpty) {
+      getAppInsights().appInsights.trackEvent({ name: 'Trustee Name Filter Cleared' });
+    }
+
+    previousNameSearchRef.current = nameSearch;
+
+    if (nameSearch.length < 2) return;
+
+    getAppInsights().appInsights.trackEvent(
+      { name: 'Trustee Name Filter Changed' },
+      {
+        queryLength: nameSearch.length,
+        resultCount: filteredTrustees.length,
+        districtCount: selectedDistricts.length,
+        chapterCount: selectedChapters.length,
+      },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nameSearch, nameSearchIds]);
 
   if (loading) {
     return <LoadingSpinner caption="Loading trustees..." />;
@@ -213,6 +267,7 @@ export default function TrusteesList() {
         ref={filterRef}
         handleFilterDistrict={handleFilterDistrict}
         handleFilterChapter={handleFilterChapter}
+        handleFilterName={handleFilterName}
       />
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">
         {liveAnnouncement}

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -126,6 +126,7 @@ export default function TrusteesList() {
 
   useEffect(() => {
     if (nameSearch.length < 2) {
+      nameSearchQueryLengthRef.current = 0;
       setNameSearchIds(new Set());
       return;
     }

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -130,17 +130,18 @@ export default function TrusteesList() {
       setNameSearchIds(new Set());
       return;
     }
-    nameSearchCountRef.current += 1;
     nameSearchQueryLengthRef.current = nameSearch.length;
-    const searchStart = performance.now();
     debounce(async () => {
+      const searchStart = performance.now();
       try {
         const response = await Api2.searchTrustees(nameSearch);
+        nameSearchCountRef.current += 1;
         const ids = new Set(response.data.map((r) => r.trusteeId));
         nameSearchStartRef.current = performance.now() - searchStart;
         setNameSearchIds(ids);
       } catch {
         nameSearchStartRef.current = null;
+        setNameSearch('');
         setNameSearchIds(new Set());
       }
     }, 300);

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -70,6 +70,8 @@ export default function TrusteesList() {
   const pageLoadStart = useRef(performance.now());
   const isNameFilterInteracted = useRef(false);
   const previousNameSearchRef = useRef('');
+  const nameSearchCountRef = useRef(0);
+  const nameSearchStartRef = useRef<number | null>(null);
   const debounce = useDebounce();
 
   useEffect(() => {
@@ -123,12 +125,16 @@ export default function TrusteesList() {
       setNameSearchIds(null);
       return;
     }
+    nameSearchCountRef.current += 1;
+    const searchStart = performance.now();
     debounce(async () => {
       try {
         const response = await Api2.searchTrustees(name);
         const ids = new Set(response.data.map((r) => r.trusteeId));
+        nameSearchStartRef.current = performance.now() - searchStart;
         setNameSearchIds(ids);
       } catch {
+        nameSearchStartRef.current = null;
         setNameSearchIds(new Set());
       }
     }, 300);
@@ -213,7 +219,13 @@ export default function TrusteesList() {
     const isNowEmpty = nameSearch.length === 0;
 
     if (wasNonEmpty && isNowEmpty) {
-      getAppInsights().appInsights.trackEvent({ name: 'Trustee Name Filter Cleared' });
+      getAppInsights().appInsights.trackEvent(
+        { name: 'Trustee Name Filter Cleared' },
+        {
+          queryLength: previousNameSearchRef.current.length,
+          sessionSearchCount: nameSearchCountRef.current,
+        },
+      );
     }
 
     previousNameSearchRef.current = nameSearch;
@@ -227,6 +239,9 @@ export default function TrusteesList() {
         resultCount: filteredTrustees.length,
         districtCount: selectedDistricts.length,
         chapterCount: selectedChapters.length,
+        searchResponseMs: nameSearchStartRef.current ?? undefined,
+        hasDistrictFilter: selectedDistricts.length > 0,
+        sessionSearchCount: nameSearchCountRef.current,
       },
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -65,13 +65,14 @@ export default function TrusteesList() {
   const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
   const [liveAnnouncement, setLiveAnnouncement] = useState<string>('');
   const [nameSearch, setNameSearch] = useState('');
-  const [nameSearchIds, setNameSearchIds] = useState<Set<string> | null>(null);
+  const [nameSearchIds, setNameSearchIds] = useState<Set<string>>(new Set());
   const filterRef = useRef<TrusteeDistrictFilterRef>(null);
   const pageLoadStart = useRef(performance.now());
   const isNameFilterInteracted = useRef(false);
   const previousNameSearchRef = useRef('');
   const nameSearchCountRef = useRef(0);
   const nameSearchStartRef = useRef<number | null>(null);
+  const nameSearchQueryLengthRef = useRef(0);
   const debounce = useDebounce();
 
   useEffect(() => {
@@ -121,15 +122,19 @@ export default function TrusteesList() {
   const handleFilterName = (name: string) => {
     isNameFilterInteracted.current = true;
     setNameSearch(name);
-    if (name.length < 2) {
-      setNameSearchIds(null);
+  };
+
+  useEffect(() => {
+    if (nameSearch.length < 2) {
+      setNameSearchIds(new Set());
       return;
     }
     nameSearchCountRef.current += 1;
+    nameSearchQueryLengthRef.current = nameSearch.length;
     const searchStart = performance.now();
     debounce(async () => {
       try {
-        const response = await Api2.searchTrustees(name);
+        const response = await Api2.searchTrustees(nameSearch);
         const ids = new Set(response.data.map((r) => r.trusteeId));
         nameSearchStartRef.current = performance.now() - searchStart;
         setNameSearchIds(ids);
@@ -138,12 +143,12 @@ export default function TrusteesList() {
         setNameSearchIds(new Set());
       }
     }, 300);
-  };
+  }, [nameSearch, debounce]);
 
   const { filteredTrustees } = useMemo(() => {
     let filtered = filterTrustees(trustees, selectedDistricts, selectedChapters);
 
-    if (nameSearchIds !== null) {
+    if (nameSearch.length >= 2) {
       filtered = filtered.filter((t) => nameSearchIds.has(t.trusteeId));
     }
 
@@ -169,7 +174,7 @@ export default function TrusteesList() {
     return {
       filteredTrustees: sortedWithAppointments,
     };
-  }, [trustees, selectedDistricts, selectedChapters, nameSearchIds, sortDirection]);
+  }, [trustees, selectedDistricts, selectedChapters, nameSearch, nameSearchIds, sortDirection]);
 
   useEffect(() => {
     if (!isDefaultApplied.current) return;
@@ -214,6 +219,25 @@ export default function TrusteesList() {
 
   useEffect(() => {
     if (!isNameFilterInteracted.current) return;
+    if (nameSearchQueryLengthRef.current < 2) return;
+
+    getAppInsights().appInsights.trackEvent(
+      { name: 'Trustee Name Filter Changed' },
+      {
+        queryLength: nameSearchQueryLengthRef.current,
+        resultCount: filteredTrustees.length,
+        districtCount: selectedDistricts.length,
+        chapterCount: selectedChapters.length,
+        searchResponseMs: nameSearchStartRef.current ?? undefined,
+        hasDistrictFilter: selectedDistricts.length > 0,
+        sessionSearchCount: nameSearchCountRef.current,
+      },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nameSearchIds]);
+
+  useEffect(() => {
+    if (!isNameFilterInteracted.current) return;
 
     const wasNonEmpty = previousNameSearchRef.current.length > 0;
     const isNowEmpty = nameSearch.length === 0;
@@ -229,23 +253,7 @@ export default function TrusteesList() {
     }
 
     previousNameSearchRef.current = nameSearch;
-
-    if (nameSearch.length < 2) return;
-
-    getAppInsights().appInsights.trackEvent(
-      { name: 'Trustee Name Filter Changed' },
-      {
-        queryLength: nameSearch.length,
-        resultCount: filteredTrustees.length,
-        districtCount: selectedDistricts.length,
-        chapterCount: selectedChapters.length,
-        searchResponseMs: nameSearchStartRef.current ?? undefined,
-        hasDistrictFilter: selectedDistricts.length > 0,
-        sessionSearchCount: nameSearchCountRef.current,
-      },
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nameSearch, nameSearchIds]);
+  }, [nameSearch]);
 
   if (loading) {
     return <LoadingSpinner caption="Loading trustees..." />;

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -57,15 +57,17 @@ function renderFilter(
 ) {
   const mockHandleFilterDistrict = vi.fn();
   const mockHandleFilterChapter = vi.fn();
+  const mockHandleFilterName = vi.fn();
   render(
     <TrusteeDistrictFilter
       ref={overrides.ref}
       handleFilterDistrict={mockHandleFilterDistrict}
       handleFilterChapter={mockHandleFilterChapter}
+      handleFilterName={mockHandleFilterName}
       onExpandedChange={overrides.onExpandedChange}
     />,
   );
-  return { mockHandleFilterDistrict, mockHandleFilterChapter };
+  return { mockHandleFilterDistrict, mockHandleFilterChapter, mockHandleFilterName };
 }
 
 describe('TrusteeDistrictFilter Component', () => {
@@ -471,6 +473,95 @@ describe('TrusteeDistrictFilter Component', () => {
 
     await waitFor(() => {
       expect(mockHandleFilterDistrict).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('Name Filter', () => {
+    test('renders name input inside accordion when expanded', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      renderFilter();
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /trustee name/i })).toBeInTheDocument();
+      });
+    });
+
+    test('does not show Clear button when name input is empty', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      renderFilter();
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /trustee name/i })).toBeInTheDocument();
+      });
+
+      const clearButtons = screen.queryAllByRole('button', { name: /^clear$/i });
+      expect(clearButtons).toHaveLength(0);
+    });
+
+    test('shows Clear button when name input has text', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      renderFilter();
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /trustee name/i })).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Smith');
+
+      expect(screen.getByRole('button', { name: /^clear$/i })).toBeInTheDocument();
+    });
+
+    test('Clear button click empties input and calls handleFilterName with empty string', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      const { mockHandleFilterName } = renderFilter();
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /trustee name/i })).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Smith');
+      await user.click(screen.getByRole('button', { name: /^clear$/i }));
+
+      expect(screen.getByRole('textbox', { name: /trustee name/i })).toHaveValue('');
+      expect(mockHandleFilterName).toHaveBeenLastCalledWith('');
+    });
+
+    test('typing calls handleFilterName with current value', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      const { mockHandleFilterName } = renderFilter();
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /trustee name/i })).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Smith');
+
+      expect(mockHandleFilterName).toHaveBeenLastCalledWith('Smith');
     });
   });
 

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -8,7 +8,14 @@ import {
 import { CourtDivisionDetails } from '@common/cams/courts';
 import TrusteeDistrictFilterView from './TrusteeDistrictFilterView';
 import trusteeDistrictFilterUseCase from './trusteeDistrictFilterUseCase';
-import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
@@ -17,8 +24,18 @@ const TrusteeDistrictFilter_ = (
   props: TrusteeDistrictFilterProps,
   ref: React.Ref<TrusteeDistrictFilterRef>,
 ) => {
+  const { handleFilterName } = props;
+  const [nameSearch, setNameSearch] = useState('');
   const store: TrusteeDistrictFilterStore = useTrusteeDistrictFilterStoreReact();
   const controls: TrusteeDistrictFilterControls = useTrusteeDistrictFilterControlsReact();
+
+  const handleNameChange = useCallback(
+    (name: string) => {
+      setNameSearch(name);
+      handleFilterName(name);
+    },
+    [handleFilterName],
+  );
   const previousDistrictsRef = useRef<ComboOption[] | undefined>(undefined);
   const previousChaptersRef = useRef<ComboOption[] | undefined>(undefined);
   const useCase = trusteeDistrictFilterUseCase(
@@ -67,6 +84,7 @@ const TrusteeDistrictFilter_ = (
     isExpanded: store.isExpanded,
     districtFilterRef: controls.districtFilterRef,
     chapterFilterRef: controls.chapterFilterRef,
+    nameSearch,
     districtsToComboOptions: useCase.districtsToComboOptions,
     chaptersToComboOptions: useCase.chaptersToComboOptions,
     handleFilterChange: useCase.handleFilterChange,
@@ -74,6 +92,7 @@ const TrusteeDistrictFilter_ = (
     handleToggleExpanded: useCase.handleToggleExpanded,
     handleFilterChapter: useCase.handleFilterChapter,
     handleClearAllChapters: useCase.handleClearAllChapters,
+    handleFilterName: handleNameChange,
   };
 
   return <TrusteeDistrictFilterView viewModel={viewModel}></TrusteeDistrictFilterView>;

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -27,6 +27,31 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
             )}
 
             <div className="filter-controls-row">
+              <div className="filter-control">
+                <div className="filter-control-header">
+                  <span className="filter-control-label">Trustee Name</span>
+                  {viewModel.nameSearch.length > 0 && (
+                    <button
+                      type="button"
+                      className="filter-clear-link"
+                      onClick={() => viewModel.handleFilterName('')}
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+                <input
+                  id="trustee-name-filter"
+                  type="text"
+                  className="usa-input"
+                  aria-label="Trustee Name"
+                  value={viewModel.nameSearch}
+                  onChange={(e) => viewModel.handleFilterName(e.target.value)}
+                  placeholder="Search by name"
+                  autoComplete="off"
+                />
+              </div>
+
               {showDistrictFilter && (
                 <div className="filter-control">
                   <div className="filter-control-header">

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -35,6 +35,7 @@ export interface TrusteeDistrictFilterViewModel {
   isExpanded: boolean;
   districtFilterRef: React.RefObject<ComboBoxRef | null>;
   chapterFilterRef: React.RefObject<ComboBoxRef | null>;
+  nameSearch: string;
 
   districtsToComboOptions(districts: CourtDivisionDetails[]): ComboOption[];
   chaptersToComboOptions(): ComboOption[];
@@ -43,6 +44,7 @@ export interface TrusteeDistrictFilterViewModel {
   handleToggleExpanded(): void;
   handleFilterChapter(chapters: ComboOption[]): void;
   handleClearAllChapters(): void;
+  handleFilterName(name: string): void;
 }
 
 export interface TrusteeDistrictFilterRef {
@@ -54,6 +56,7 @@ export interface TrusteeDistrictFilterRef {
 export type TrusteeDistrictFilterProps = {
   handleFilterDistrict(districts: ComboOption[]): void;
   handleFilterChapter(chapters: ComboOption[]): void;
+  handleFilterName(name: string): void;
   onExpandedChange?: (isExpanded: boolean) => void;
 };
 


### PR DESCRIPTION
# Purpose

Allow users to quickly find a specific trustee on the Trustee Management list by searching by name, without having to scroll through the full list.

# Major Changes

* Added a "Trustee Name" plain text input as the first filter control inside the existing Filters accordion
* Name search calls the existing `GET /api/trustee-search` endpoint (debounced 300ms, 2-character minimum), reusing the same phonetic/fuzzy search used by the Trustee Search Modal
* Search results are intersected client-side with the already-loaded trustee list so district and chapter filters continue to compose correctly
* Clear button follows the same `filter-control-header` / `filter-clear-link` pattern as the existing District and Chapter filters
* Live ARIA announcement fires after first name filter interaction (mirrors chapter filter behavior)
* AppInsights telemetry tracks `Trustee Name Filter Changed` and `Trustee Name Filter Cleared` events

# Testing/Validation

Implemented using TDD. 57 tests pass across the two affected test files (8 new in `TrusteesList.test.tsx`, 5 new in `TrusteeDistrictFilter.test.tsx`). Tests cover: debounce behavior, 2-character minimum, composition with district/chapter filters, Clear button, live region announcement, and AppInsights events.

# Notes

The name filter uses server-side search (same `Api2.searchTrustees` as the Trustee Search Modal) rather than client-side substring matching, giving users phonetic/fuzzy matching for free. The returned `trusteeId`s are intersected with the already-loaded `TrusteeListItem[]` so no additional API call is needed for the list data.

The `filterTrustees` function was intentionally left unchanged — name filtering happens as a post-filter step in the `useMemo`, keeping the existing function pure and its tests unaffected.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add a trustee name text filter to the Trustees list and integrate it with existing filtering, accessibility, and telemetry.

New Features:
- Introduce a trustee name text input filter within the Trustees list filters accordion that narrows results using the existing trustee search API and composes with district and chapter filters.

Enhancements:
- Announce filtered trustee counts via the existing ARIA live region when the name filter is used and track AppInsights events for name filter changes and clears.

Tests:
- Extend TrusteesList and TrusteeDistrictFilter tests to cover name filtering behavior, debounce and minimum length rules, clear button behavior, ARIA announcements, and AppInsights telemetry.