### PR TITLE
Fix lint errors introduced by eslint-plugin-react-hooks 7.1.0

### DIFF
--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -108,6 +108,107 @@ function OtherMatchesPagination({
   );
 }
 
+type TrusteeCandidateRowProps = {
+  candidate: CandidateScore;
+  onApprove?: (candidate: CandidateScore) => void;
+  isProcessing?: boolean;
+};
+
+function TrusteeCandidateRow({ candidate, onApprove, isProcessing }: TrusteeCandidateRowProps) {
+  const rowAddressLines = candidate.address
+    ? [
+        candidate.address.address1,
+        candidate.address.address2,
+        candidate.address.address3,
+        `${candidate.address.city}, ${candidate.address.state} ${candidate.address.zipCode}`,
+      ].filter(Boolean)
+    : [];
+
+  return (
+    <div className="trustee-data-row grid-row grid-gap-lg">
+      <div
+        className="trustee-data-cell grid-col-2"
+        data-cell="Name"
+        data-testid={`candidate-name-${candidate.trusteeId}`}
+      >
+        <NewTabLink to={`/trustees/${candidate.trusteeId}`} label={candidate.trusteeName} />
+      </div>
+
+      <div className="trustee-data-cell grid-col-2" data-cell="Address">
+        {rowAddressLines.length > 0
+          ? rowAddressLines.map((line, i, arr) => (
+              <span key={i}>
+                {line}
+                {i < arr.length - 1 && <br />}
+              </span>
+            ))
+          : 'Not Provided'}
+      </div>
+      <div className="trustee-data-cell grid-col-1" data-cell="Phone">
+        {candidate.phone
+          ? `${candidate.phone.number}${candidate.phone.extension ? ` x${candidate.phone.extension}` : ''}`
+          : 'Not Provided'}
+      </div>
+      <div className="trustee-data-cell grid-col-2" data-cell="Email">
+        {candidate.email ?? 'Not Provided'}
+      </div>
+      <div className="trustee-data-cell grid-col-3" data-cell="Trustee Appt.">
+        {candidate.appointments?.map((appt, i, arr) => (
+          <span key={i}>
+            {appt.courtName}
+            {appt.courtDivisionName ? ` (${appt.courtDivisionName})` : ''}: Chap{' '}
+            {formatChapterType(appt.chapter)} - {formatAppointmentStatus(appt.status)}
+            {i < arr.length - 1 && <br />}
+          </span>
+        ))}
+      </div>
+      <div className="trustee-data-cell grid-col-2 text-no-wrap" data-cell="Action">
+        {onApprove && (
+          <button
+            type="button"
+            data-testid={`approve-candidate-${candidate.trusteeId}`}
+            onClick={() => onApprove(candidate)}
+            disabled={isProcessing}
+            className="match-trustee-link"
+          >
+            <Icon name="check" />
+            Match Trustee
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type CandidateTableProps = {
+  candidates: CandidateScore[];
+  onApprove?: (candidate: CandidateScore) => void;
+  isProcessing?: boolean;
+};
+
+function CandidateTable({ candidates, onApprove, isProcessing }: CandidateTableProps) {
+  return (
+    <div className="trustee-data-grid trustee-candidates-grid">
+      <div className="trustee-data-header grid-row grid-gap-lg">
+        <div className="trustee-data-cell grid-col-2">Name</div>
+        <div className="trustee-data-cell grid-col-2">Address</div>
+        <div className="trustee-data-cell grid-col-1">Phone</div>
+        <div className="trustee-data-cell grid-col-2">Email</div>
+        <div className="trustee-data-cell grid-col-3">Trustee Appointment</div>
+        <div className="trustee-data-cell grid-col-2">Action</div>
+      </div>
+      {candidates.map((candidate) => (
+        <TrusteeCandidateRow
+          key={candidate.trusteeId}
+          candidate={candidate}
+          onApprove={onApprove}
+          isProcessing={isProcessing}
+        />
+      ))}
+    </div>
+  );
+}
+
 function TrusteeSearchLink({
   linkLabel,
   linkMessage,
@@ -283,108 +384,6 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
       (c) => c.trusteeId === order.resolvedTrusteeId,
     )?.trusteeName;
     return order.resolvedTrusteeName ?? matchedCandidateName ?? order.resolvedTrusteeId ?? '';
-  }
-
-  type TrusteeCandidateRowProps = {
-    candidate: CandidateScore;
-    onApprove?: (candidate: CandidateScore) => void;
-    isProcessing?: boolean;
-  };
-
-  function TrusteeCandidateRow({ candidate, onApprove, isProcessing }: TrusteeCandidateRowProps) {
-    const rowAddressLines = candidate.address
-      ? [
-          candidate.address.address1,
-          candidate.address.address2,
-          candidate.address.address3,
-          `${candidate.address.city}, ${candidate.address.state} ${candidate.address.zipCode}`,
-        ].filter(Boolean)
-      : [];
-
-    return (
-      <div className="trustee-data-row grid-row grid-gap-lg">
-        <div
-          className="trustee-data-cell grid-col-2"
-          data-cell="Name"
-          data-testid={`candidate-name-${candidate.trusteeId}`}
-        >
-          <NewTabLink to={`/trustees/${candidate.trusteeId}`} label={candidate.trusteeName} />
-        </div>
-
-        <div className="trustee-data-cell grid-col-2" data-cell="Address">
-          {rowAddressLines.length > 0
-            ? rowAddressLines.map((line, i, arr) => (
-                <span key={i}>
-                  {line}
-                  {i < arr.length - 1 && <br />}
-                </span>
-              ))
-            : 'Not Provided'}
-        </div>
-        <div className="trustee-data-cell grid-col-1" data-cell="Phone">
-          {candidate.phone
-            ? `${candidate.phone.number}${candidate.phone.extension ? ` x${candidate.phone.extension}` : ''}`
-            : 'Not Provided'}
-        </div>
-        <div className="trustee-data-cell grid-col-2" data-cell="Email">
-          {candidate.email ?? 'Not Provided'}
-        </div>
-        <div className="trustee-data-cell grid-col-3" data-cell="Trustee Appt.">
-          {candidate.appointments?.map((appt, i, arr) => (
-            <span key={i}>
-              {appt.courtName}
-              {appt.courtDivisionName ? ` (${appt.courtDivisionName})` : ''}: Chap{' '}
-              {formatChapterType(appt.chapter)} - {formatAppointmentStatus(appt.status)}
-              {i < arr.length - 1 && <br />}
-            </span>
-          ))}
-        </div>
-        <div className="trustee-data-cell grid-col-2 text-no-wrap" data-cell="Action">
-          {onApprove && (
-            <button
-              type="button"
-              data-testid={`approve-candidate-${candidate.trusteeId}`}
-              onClick={() => onApprove(candidate)}
-              disabled={isProcessing}
-              className="match-trustee-link"
-            >
-              <Icon name="check" />
-              Match Trustee
-            </button>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  type CandidateTableProps = {
-    candidates: CandidateScore[];
-
-    onApprove?: (candidate: CandidateScore) => void;
-    isProcessing?: boolean;
-  };
-
-  function CandidateTable({ candidates, onApprove, isProcessing }: CandidateTableProps) {
-    return (
-      <div className="trustee-data-grid trustee-candidates-grid">
-        <div className="trustee-data-header grid-row grid-gap-lg">
-          <div className="trustee-data-cell grid-col-2">Name</div>
-          <div className="trustee-data-cell grid-col-2">Address</div>
-          <div className="trustee-data-cell grid-col-1">Phone</div>
-          <div className="trustee-data-cell grid-col-2">Email</div>
-          <div className="trustee-data-cell grid-col-3">Trustee Appointment</div>
-          <div className="trustee-data-cell grid-col-2">Action</div>
-        </div>
-        {candidates.map((candidate) => (
-          <TrusteeCandidateRow
-            key={candidate.trusteeId}
-            candidate={candidate}
-            onApprove={onApprove}
-            isProcessing={isProcessing}
-          />
-        ))}
-      </div>
-    );
   }
 
   const caseLink = (

--- a/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
@@ -210,7 +210,7 @@ function TrusteePublicContactForm(props: Readonly<TrusteePublicContactFormProps>
   const handleCancel = useCallback(() => {
     setFieldErrors({});
     navigate.navigateTo(cancelTo);
-  }, [navigate, cancelTo]);
+  }, [navigate, cancelTo, setFieldErrors]);
 
   const validateFormAndUpdateErrors = (formData: TrusteePublicFormData): boolean => {
     const results = validateObject(trusteePublicSpec, formData);


### PR DESCRIPTION
# Purpose

Fix pre-existing lint errors surfaced by the `eslint-plugin-react-hooks` 7.0.1 → 7.1.0 upgrade in PR #2331. Neither file had changed in 7+ months — the errors are entirely due to the stricter rules in the new plugin version.

# Major Changes

* Moved `TrusteeCandidateRow` and `CandidateTable` out of the `TrusteeMatchVerificationAccordion` component body to module level, resolving 6 `react-hooks/static-components` errors. Both components closed over no parent-scope values and are pure prop-driven, making the lift straightforward.
* Added `setFieldErrors` to the `useCallback` dependency array in `TrusteePublicContactForm.handleCancel`, resolving 1 `react-hooks/preserve-manual-memoization` error. `setFieldErrors` is a stable `useState` setter so this has no runtime effect.

# Testing/Validation

No behavior changes — existing test suites cover both components. 101 tests pass in `trustee-verification`, 0 regressions detected.

# Notes

`eslint-plugin-react-hooks` 7.1.0 introduced stricter enforcement of the React Compiler rules `static-components` and `preserve-manual-memoization`. These were not errors under 7.0.1.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Resolve new React Hooks lint violations by refactoring trustee match verification components and adjusting hook dependencies.

Enhancements:
- Lift TrusteeCandidateRow and CandidateTable to module scope in TrusteeMatchVerificationAccordion for static component compliance.
- Update TrusteePublicContactForm cancel handler to include all required dependencies in its useCallback signature.