### PR TITLE
CAMS-740: Edit flow and smart merge for divisions (Slice 2)

### DIFF
--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -732,6 +732,265 @@ describe('TrusteeAppointmentsUseCase tests', () => {
     });
   });
 
+  describe('hasAppointmentChanged with divisionCodes', () => {
+    beforeEach(async () => {
+      context = await createMockApplicationContext();
+      trusteeAppointmentsUseCase = new TrusteeAppointmentsUseCase(context);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    test('should detect division addition as change', async () => {
+      const appointmentId = 'appointment-123';
+      const trusteeId = 'trustee-123';
+      const mockExisting = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        divisionCodes: ['710'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+      const mockUpdated = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        divisionCodes: ['710', '711'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+
+      const historyCreateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
+        .mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockExisting);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(mockUpdated);
+      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '097',
+        divisionCode: '710',
+        divisionCodes: ['710', '711'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+
+      expect(historyCreateSpy).toHaveBeenCalled();
+    });
+
+    test('should detect division removal as change', async () => {
+      const appointmentId = 'appointment-123';
+      const trusteeId = 'trustee-123';
+      const mockExisting = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        divisionCodes: ['710', '711'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+      const mockUpdated = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '711',
+        divisionCodes: ['711'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+
+      const historyCreateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
+        .mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockExisting);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(mockUpdated);
+      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '097',
+        divisionCode: '711',
+        divisionCodes: ['711'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+
+      expect(historyCreateSpy).toHaveBeenCalled();
+    });
+
+    test('should not detect division reordering as change', async () => {
+      const appointmentId = 'appointment-123';
+      const trusteeId = 'trustee-123';
+      const mockExisting = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        divisionCodes: ['710', '711'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+      const mockUpdated = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        divisionCodes: ['711', '710'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+
+      const historyCreateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
+        .mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockExisting);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(mockUpdated);
+      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '097',
+        divisionCode: '710',
+        divisionCodes: ['711', '710'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+
+      expect(historyCreateSpy).not.toHaveBeenCalled();
+    });
+
+    test('should not detect format-only change (single to array with same value) as change', async () => {
+      const appointmentId = 'appointment-123';
+      const trusteeId = 'trustee-123';
+      // Legacy appointment: has divisionCode but no divisionCodes
+      const mockExisting = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+      // Clear divisionCodes to simulate legacy record
+      delete (mockExisting as Record<string, unknown>).divisionCodes;
+
+      const mockUpdated = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        divisionCodes: ['710'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+
+      const historyCreateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
+        .mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockExisting);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(mockUpdated);
+      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '097',
+        divisionCode: '710',
+        divisionCodes: ['710'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+
+      expect(historyCreateSpy).not.toHaveBeenCalled();
+    });
+
+    test('should detect combined changes (divisions + status) as change', async () => {
+      const appointmentId = 'appointment-123';
+      const trusteeId = 'trustee-123';
+      const mockExisting = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        divisionCodes: ['710'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15T00:00:00.000Z',
+      });
+      const mockUpdated = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        courtId: '097',
+        chapter: '7',
+        appointmentType: 'panel',
+        divisionCode: '710',
+        divisionCodes: ['710', '711'],
+        appointedDate: '2024-01-15',
+        status: 'voluntarily-suspended',
+        effectiveDate: '2024-02-01T00:00:00.000Z',
+      });
+
+      const historyCreateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
+        .mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockExisting);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(mockUpdated);
+      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '097',
+        divisionCode: '710',
+        divisionCodes: ['710', '711'],
+        appointedDate: '2024-01-15',
+        status: 'voluntarily-suspended',
+        effectiveDate: '2024-02-01T00:00:00.000Z',
+      });
+
+      expect(historyCreateSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('multi-division support', () => {
     beforeEach(async () => {
       context = await createMockApplicationContext();

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -1112,5 +1112,29 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       expect(actualError.isCamsError).toBe(true);
       expect(actualError.message).toContain('At least one division must be specified');
     });
+
+    test('should reject appointment with only empty strings in divisionCodes', async () => {
+      const trusteeId = 'trustee-123';
+      const mockTrustee = MockData.getTrustee({ trusteeId });
+
+      const appointmentInput: TrusteeAppointmentInput = {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['', ' '],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+
+      const actualError = await getTheThrownError(() =>
+        trusteeAppointmentsUseCase.createAppointment(context, trusteeId, appointmentInput),
+      );
+
+      expect(actualError.isCamsError).toBe(true);
+      expect(actualError.message).toContain('At least one division must be specified');
+    });
   });
 });

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -98,12 +98,22 @@ export class TrusteeAppointmentsUseCase {
     }
   }
 
+  private divisionsChanged(before: TrusteeAppointment, after: TrusteeAppointment): boolean {
+    const beforeSet = new Set(before.divisionCodes ?? [before.divisionCode].filter(Boolean));
+    const afterSet = new Set(after.divisionCodes ?? [after.divisionCode].filter(Boolean));
+    if (beforeSet.size !== afterSet.size) return true;
+    for (const code of beforeSet) {
+      if (!afterSet.has(code)) return true;
+    }
+    return false;
+  }
+
   private hasAppointmentChanged(before: TrusteeAppointment, after: TrusteeAppointment): boolean {
     return (
       before.chapter !== after.chapter ||
       before.appointmentType !== after.appointmentType ||
       before.courtId !== after.courtId ||
-      before.divisionCode !== after.divisionCode ||
+      this.divisionsChanged(before, after) ||
       before.appointedDate !== after.appointedDate ||
       before.status !== after.status ||
       before.effectiveDate !== after.effectiveDate

--- a/common/src/cams/trustee-appointments.ts
+++ b/common/src/cams/trustee-appointments.ts
@@ -152,8 +152,14 @@ const validateDivisionCodes: ValidatorFunction = (obj: unknown): ValidatorResult
   const appointment = obj as TrusteeAppointmentInput;
   const { divisionCode, divisionCodes } = appointment;
 
-  // At least one division must be specified (either old or new format)
-  if (!divisionCode && (!divisionCodes || divisionCodes.length === 0)) {
+  // Filter out empty/falsy entries from divisionCodes
+  const validDivisionCodes = divisionCodes?.filter((code) => !!code?.trim()) ?? [];
+
+  const hasLegacyDivision = typeof divisionCode === 'string' && divisionCode.trim().length > 0;
+  const hasNewDivision = validDivisionCodes.length > 0;
+
+  // At least one non-empty division must be specified (either old or new format)
+  if (!hasLegacyDivision && !hasNewDivision) {
     return {
       reasonMap: {
         $: {

--- a/common/src/string-helper.ts
+++ b/common/src/string-helper.ts
@@ -1,0 +1,11 @@
+/**
+ * Case-insensitive string comparison for sorting.
+ * Uses locale-aware comparison with base sensitivity.
+ *
+ * @param a - First string to compare
+ * @param b - Second string to compare
+ * @returns Negative if a < b, positive if a > b, 0 if equal
+ */
+export function caseInsensitiveCompare(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { sensitivity: 'base' });
+}

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -1,6 +1,7 @@
 import { usStates } from '@common/cams/us-states';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import { TrusteeAppointment } from '@common/cams/trustee-appointments';
+import { caseInsensitiveCompare } from '@common/string-helper';
 
 /**
  * Maps a 2-letter state code to its full state name for sorting purposes.
@@ -29,18 +30,6 @@ export function getStateNameFromCode(stateCode: string): string {
 function getChapterNumber(chapter: string): number {
   const match = chapter.match(/^(\d+)/);
   return match ? parseInt(match[1], 10) : 0;
-}
-
-/**
- * Case-insensitive string comparison for sorting.
- * Uses locale-aware comparison with base sensitivity.
- *
- * @param a - First string to compare
- * @param b - Second string to compare
- * @returns Negative if a < b, positive if a > b, 0 if equal
- */
-function caseInsensitiveCompare(a: string, b: string): number {
-  return a.localeCompare(b, undefined, { sensitivity: 'base' });
 }
 
 /**

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.helpers.test.ts
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import { CourtDivisionDetails } from '@common/cams/courts';
-import { extractCourtAndDivisions, ALL_DIVISIONS_VALUE } from './TrusteeAppointmentForm';
+import { extractCourtAndDivisions } from './TrusteeAppointmentForm';
+import { ALL_DIVISIONS_VALUE } from './useDivisionSelection';
 
 describe('TrusteeAppointmentForm Helper Functions', () => {
   const mockCourts: CourtDivisionDetails[] = [

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -315,13 +315,13 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     appointments: TrusteeAppointment[],
     options: ComboOption[],
     currentAppointmentId?: string,
-    useSeparateFields?: boolean,
+    doUseSeparateFields?: boolean,
   ): string | null => {
     // Validate required fields
     if (!data.chapter || !data.appointmentType) return null;
 
     // Extract court and divisions using shared helper
-    const courtInfo = extractCourtAndDivisions(data, !!useSeparateFields, allCourts);
+    const courtInfo = extractCourtAndDivisions(data, !!doUseSeparateFields, allCourts);
     if (!courtInfo) return null;
 
     const { courtId, divisionCodes: divisionCodesToCheck } = courtInfo;
@@ -354,7 +354,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     const appointmentTypeLabel = formatAppointmentType(data.appointmentType);
 
     let districtLabel: string;
-    if (useSeparateFields) {
+    if (doUseSeparateFields) {
       // Find district name from allCourts
       const court = allCourts.find((c) => c.courtId === courtId);
       // Show the first conflicting division in the error message
@@ -373,17 +373,17 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     return `An active appointment already exists for ${chapter?.label} - ${appointmentTypeLabel} in ${districtLabel}. Please end the existing appointment before creating a new one.`;
   };
 
-  const useSeparateFields = districtDivisionEnabled;
+  const doUseSeparateFields = districtDivisionEnabled;
 
   const validationError = getValidationError(
     formData,
     existingAppointments,
     districtOptions,
     appointment?.id,
-    useSeparateFields,
+    doUseSeparateFields,
   );
 
-  const hasCourtSelection = !!extractCourtAndDivisions(formData, useSeparateFields, allCourts);
+  const hasCourtSelection = !!extractCourtAndDivisions(formData, doUseSeparateFields, allCourts);
   const isFormValid =
     hasCourtSelection &&
     !!formData.chapter &&
@@ -403,7 +403,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     setIsSubmitting(true);
 
     // Extract court and divisions using shared helper
-    const courtInfo = extractCourtAndDivisions(formData, useSeparateFields, allCourts);
+    const courtInfo = extractCourtAndDivisions(formData, doUseSeparateFields, allCourts);
     if (!courtInfo) {
       globalAlert?.warning('Missing required court or division information');
       setIsSubmitting(false);
@@ -462,7 +462,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   const handleFieldChange = (field: keyof FormData, value: string) => {
     setFormData((prev) => {
       // When district (courtId) changes, reset divisions to empty (useEffect will set to "All Divisions")
-      if (field === 'courtId' && useSeparateFields) {
+      if (field === 'courtId' && doUseSeparateFields) {
         return { ...prev, courtId: value, divisionCodes: [] };
       }
 
@@ -546,7 +546,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
         <div className="form-container">
           <div className="form-column">
-            {useSeparateFields ? (
+            {doUseSeparateFields ? (
               <>
                 {/* District dropdown when flag is ON */}
                 <div className="field-group">

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -40,8 +40,6 @@ import { FormRequirementsNotice } from '@/lib/components/uswds/FormRequirementsN
 import { useLocation } from 'react-router-dom';
 import { useDivisionSelection, ALL_DIVISIONS_VALUE } from './useDivisionSelection';
 import { findMergeTarget, buildMergeResult } from './appointmentMergeHelpers';
-// Re-export for backward compatibility with existing test imports
-export { ALL_DIVISIONS_VALUE } from './useDivisionSelection';
 
 const CHAPTER_OPTIONS: ComboOption<AppointmentChapterType>[] = [
   { value: '7', label: 'Chapter 7' },

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -253,7 +253,6 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
         // Build district options based on feature flag
         if (districtDivisionEnabled) {
-          // When flag is ON: build options from unique districts
           const uniqueDistricts = getUniqueDistricts(courtsData);
           const options = uniqueDistricts.map((district) => ({
             value: district.courtId,
@@ -261,10 +260,8 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
           }));
           setDistrictOptions(options);
         } else {
-          // When flag is OFF: use existing combined format
           const sortedCourts = sortByCourtLocation(courtsData);
           const options = sortedCourts.map((district) => {
-            // Build label with guards for missing data
             let label: string;
             if (district.courtName && district.courtDivisionName) {
               label = `${district.courtName} (${district.courtDivisionName})`;

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -175,7 +175,11 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
       return {
         districtKey: `${appointment.courtId}|${appointment.divisionCode ?? ''}`,
         courtId: appointment.courtId,
-        divisionCodes: appointment.divisionCode ? [appointment.divisionCode] : [],
+        divisionCodes: appointment.divisionCodes?.length
+          ? appointment.divisionCodes
+          : appointment.divisionCode
+            ? [appointment.divisionCode]
+            : [],
         chapter: appointment.chapter,
         appointmentType: appointment.appointmentType,
         status: appointment.status,
@@ -243,7 +247,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
         setAllCourts(courtsData); // Store raw data for division filtering
 
         // Build district options based on feature flag
-        if (districtDivisionEnabled && !isEditMode) {
+        if (districtDivisionEnabled) {
           // When flag is ON: build options from unique districts
           const uniqueDistricts = getUniqueDistricts(courtsData);
           const options = uniqueDistricts.map((district) => ({
@@ -252,7 +256,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
           }));
           setDistrictOptions(options);
         } else {
-          // When flag is OFF or edit mode: use existing combined format
+          // When flag is OFF: use existing combined format
           const sortedCourts = sortByCourtLocation(courtsData);
           const options = sortedCourts.map((district) => {
             // Build label with guards for missing data
@@ -281,7 +285,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     };
 
     loadDistricts();
-  }, [globalAlert, districtDivisionEnabled, isEditMode]);
+  }, [globalAlert, districtDivisionEnabled]);
 
   useEffect(() => {
     if (appointmentsToUse) {
@@ -305,7 +309,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
   // Auto-select "All Divisions" when district is selected
   useEffect(() => {
-    if (districtDivisionEnabled && !isEditMode && divisionOptions.length > 0) {
+    if (districtDivisionEnabled && divisionOptions.length > 0) {
       // Only auto-select if divisions are currently empty (fresh district selection)
       if (formData.divisionCodes.length === 0) {
         setFormData((prev) => ({
@@ -314,7 +318,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
         }));
       }
     }
-  }, [divisionOptions, districtDivisionEnabled, isEditMode, formData.divisionCodes.length]);
+  }, [divisionOptions, districtDivisionEnabled, formData.divisionCodes.length]);
 
   // Validation: checks for overlapping active appointments
   const getValidationError = (
@@ -380,7 +384,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     return `An active appointment already exists for ${chapter?.label} - ${appointmentTypeLabel} in ${districtLabel}. Please end the existing appointment before creating a new one.`;
   };
 
-  const useSeparateFields = districtDivisionEnabled && !isEditMode;
+  const useSeparateFields = districtDivisionEnabled;
 
   const validationError = getValidationError(
     formData,
@@ -434,6 +438,40 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
       if (isEditMode && appointment) {
         await Api2.putTrusteeAppointment(trusteeId, appointment.id, payload);
       } else {
+        // Check for mergeable appointment (same courtId/chapter/type, complementary divisions)
+        const mergeTarget = existingAppointments.find(
+          (appt) =>
+            appt.courtId === courtId &&
+            appt.chapter === formData.chapter &&
+            appt.appointmentType === formData.appointmentType &&
+            appt.status === 'active',
+        );
+
+        if (mergeTarget) {
+          const existingDivisions = (
+            mergeTarget.divisionCodes ?? [mergeTarget.divisionCode]
+          ).filter(Boolean) as string[];
+          const mergedDivisions = [...new Set([...existingDivisions, ...divisionCodes])];
+          const addedDivisions = divisionCodes.filter((code) => !existingDivisions.includes(code));
+
+          const mergePayload: TrusteeAppointmentInput = {
+            ...payload,
+            divisionCodes: mergedDivisions,
+            divisionCode: mergedDivisions[0],
+          };
+
+          await Api2.putTrusteeAppointment(trusteeId, mergeTarget.id, mergePayload);
+
+          const addedNames = addedDivisions.map((code) => {
+            const divisions = getDivisionsForDistrict(allCourts, courtId);
+            const div = divisions.find((d) => d.courtDivisionCode === code);
+            return div?.courtDivisionName ?? code;
+          });
+          globalAlert?.success(`Updated existing appointment to include ${addedNames.join(', ')}`);
+          navigateToAppointments(trusteeId, navigate);
+          return;
+        }
+
         await Api2.postTrusteeAppointment(trusteeId, payload);
       }
       navigateToAppointments(trusteeId, navigate);
@@ -688,7 +726,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
                 </div>
               </>
             ) : (
-              /* Combined district dropdown when flag is OFF or edit mode */
+              /* Combined district dropdown when flag is OFF */
               <div className="field-group">
                 <ComboBox
                   id="district"

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -1,6 +1,6 @@
 import './TrusteeContactForm.scss';
 import './TrusteeAppointmentForm.scss';
-import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import DatePicker from '@/lib/components/uswds/DatePicker';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import useFeatureFlags, {
@@ -38,6 +38,10 @@ import PillBox from '@/lib/components/PillBox';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { FormRequirementsNotice } from '@/lib/components/uswds/FormRequirementsNotice';
 import { useLocation } from 'react-router-dom';
+import { useDivisionSelection, ALL_DIVISIONS_VALUE } from './useDivisionSelection';
+import { findMergeTarget, buildMergeResult } from './appointmentMergeHelpers';
+// Re-export for backward compatibility with existing test imports
+export { ALL_DIVISIONS_VALUE } from './useDivisionSelection';
 
 const CHAPTER_OPTIONS: ComboOption<AppointmentChapterType>[] = [
   { value: '7', label: 'Chapter 7' },
@@ -69,9 +73,6 @@ function getDefaultAppointmentType(
   const types = getAvailableAppointmentTypes(chapter, isEditMode);
   return types.length === 1 ? types[0] : '';
 }
-
-// Synthetic value for "All Divisions" option
-export const ALL_DIVISIONS_VALUE = '__ALL__';
 
 type CourtDivisionInput = {
   courtId: string;
@@ -169,7 +170,6 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   const [existingAppointments, setExistingAppointments] = useState<TrusteeAppointment[]>(
     appointmentsToUse ?? [],
   );
-  const divisionBlurTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [formData, setFormData] = useState<FormData>(() => {
     if (appointment) {
       return {
@@ -201,19 +201,26 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
   const canManage = !!session?.user?.roles?.includes(CamsRole.TrusteeAdmin);
 
-  const divisionOptions = useMemo<ComboOption[]>(() => {
-    if (!formData.courtId || !allCourts.length) return [];
+  const handleDivisionCodesChange = useCallback(
+    (codes: string[]) => {
+      setFormData((prev) => ({ ...prev, divisionCodes: codes }));
+    },
+    [setFormData],
+  );
 
-    const divisions = getDivisionsForDistrict(allCourts, formData.courtId);
-
-    return [
-      { value: ALL_DIVISIONS_VALUE, label: 'All Divisions' },
-      ...divisions.map((div) => ({
-        value: div.courtDivisionCode,
-        label: div.courtDivisionName,
-      })),
-    ];
-  }, [formData.courtId, allCourts]);
+  const {
+    divisionOptions,
+    divisionSelections,
+    handleDivisionSelection,
+    handlePillRemoval,
+    handleDivisionBlur,
+  } = useDivisionSelection({
+    courtId: formData.courtId,
+    allCourts,
+    divisionCodes: formData.divisionCodes,
+    enabled: districtDivisionEnabled,
+    onDivisionCodesChange: handleDivisionCodesChange,
+  });
 
   const appointmentTypeOptions = useMemo<ComboOption<AppointmentType>[]>(() => {
     if (!formData.chapter) return [];
@@ -306,19 +313,6 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
     loadAppointments();
   }, [trusteeId, appointmentsToUse, globalAlert]);
-
-  // Auto-select "All Divisions" when district is selected
-  useEffect(() => {
-    if (districtDivisionEnabled && divisionOptions.length > 0) {
-      // Only auto-select if divisions are currently empty (fresh district selection)
-      if (formData.divisionCodes.length === 0) {
-        setFormData((prev) => ({
-          ...prev,
-          divisionCodes: [ALL_DIVISIONS_VALUE],
-        }));
-      }
-    }
-  }, [divisionOptions, districtDivisionEnabled, formData.divisionCodes.length]);
 
   // Validation: checks for overlapping active appointments
   const getValidationError = (
@@ -438,36 +432,19 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
       if (isEditMode && appointment) {
         await Api2.putTrusteeAppointment(trusteeId, appointment.id, payload);
       } else {
-        // Check for mergeable appointment (same courtId/chapter/type, complementary divisions)
-        const mergeTarget = existingAppointments.find(
-          (appt) =>
-            appt.courtId === courtId &&
-            appt.chapter === formData.chapter &&
-            appt.appointmentType === formData.appointmentType &&
-            appt.status === 'active',
+        const mergeTarget = findMergeTarget(
+          courtId,
+          formData.chapter,
+          formData.appointmentType,
+          existingAppointments,
         );
+        const mergeResult = buildMergeResult(mergeTarget, payload, allCourts);
 
-        if (mergeTarget) {
-          const existingDivisions = (
-            mergeTarget.divisionCodes ?? [mergeTarget.divisionCode]
-          ).filter(Boolean) as string[];
-          const mergedDivisions = [...new Set([...existingDivisions, ...divisionCodes])];
-          const addedDivisions = divisionCodes.filter((code) => !existingDivisions.includes(code));
-
-          const mergePayload: TrusteeAppointmentInput = {
-            ...payload,
-            divisionCodes: mergedDivisions,
-            divisionCode: mergedDivisions[0],
-          };
-
-          await Api2.putTrusteeAppointment(trusteeId, mergeTarget.id, mergePayload);
-
-          const addedNames = addedDivisions.map((code) => {
-            const divisions = getDivisionsForDistrict(allCourts, courtId);
-            const div = divisions.find((d) => d.courtDivisionCode === code);
-            return div?.courtDivisionName ?? code;
-          });
-          globalAlert?.success(`Updated existing appointment to include ${addedNames.join(', ')}`);
+        if (mergeResult.type === 'merged') {
+          await Api2.putTrusteeAppointment(trusteeId, mergeResult.targetId, mergeResult.payload);
+          globalAlert?.success(
+            `Updated existing appointment to include ${mergeResult.addedNames.join(', ')}`,
+          );
           navigateToAppointments(trusteeId, navigate);
           return;
         }
@@ -528,99 +505,9 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     return selected ? [selected] : undefined;
   };
 
-  const getMultiSelections = (fieldValues: string[], options: ComboOption[]) => {
-    if (!fieldValues || fieldValues.length === 0) return undefined;
-    const selected = options.filter((opt) => fieldValues.includes(opt.value));
-    return selected.length > 0 ? selected : undefined;
-  };
-
   const handleComboBoxUpdate = (field: keyof FormData, options: ComboOption[]) => {
     handleFieldChange(field, options[0]?.value ?? '');
   };
-
-  // Handle division selection with mutually exclusive "All Divisions" logic
-  const handleDivisionSelection = (selectedOptions: ComboOption[]) => {
-    const selectedValues = selectedOptions.map((opt) => opt.value);
-    const prevValues = formData.divisionCodes;
-
-    // Edge case: User clicked X to clear "All Divisions" - prevent it by re-selecting
-    if (selectedValues.length === 0 && prevValues.includes(ALL_DIVISIONS_VALUE)) {
-      return; // Do nothing, keep "All Divisions" selected
-    }
-
-    // If both "All Divisions" and specific divisions are present
-    if (selectedValues.includes(ALL_DIVISIONS_VALUE) && selectedValues.length > 1) {
-      // Determine what was just added
-      const addedValues = selectedValues.filter((v) => !prevValues.includes(v));
-
-      if (addedValues.includes(ALL_DIVISIONS_VALUE)) {
-        // "All Divisions" was just added - keep only it
-        setFormData((prev) => ({ ...prev, divisionCodes: [ALL_DIVISIONS_VALUE] }));
-      } else {
-        // A specific division was just added - remove "All Divisions"
-        setFormData((prev) => ({
-          ...prev,
-          divisionCodes: selectedValues.filter((v) => v !== ALL_DIVISIONS_VALUE),
-        }));
-      }
-      return;
-    }
-
-    // Normal case: just update to whatever was selected
-    setFormData((prev) => ({ ...prev, divisionCodes: selectedValues }));
-  };
-
-  // Handle pill removal from PillBox with "All Divisions" default behavior
-  const handlePillRemoval = (updatedSelections: ComboOption[]) => {
-    const newCodes = updatedSelections.map((opt) => opt.value);
-    // If removing last item, default back to "All Divisions"
-    setFormData((prev) => ({
-      ...prev,
-      divisionCodes: newCodes.length === 0 ? [ALL_DIVISIONS_VALUE] : newCodes,
-    }));
-  };
-
-  // Handle when focus leaves the entire division dropdown component
-  const handleDivisionBlur = (e: React.FocusEvent) => {
-    const currentTarget = e.currentTarget;
-
-    // Clear any pending timeout
-    if (divisionBlurTimeoutRef.current) {
-      clearTimeout(divisionBlurTimeoutRef.current);
-    }
-
-    // Check if the new focus target is outside the division dropdown component
-    divisionBlurTimeoutRef.current = setTimeout(() => {
-      // If focus moved to an element outside this component
-      if (!currentTarget.contains(document.activeElement)) {
-        if (!formData.courtId || !allCourts.length) return;
-
-        const allAvailableDivisions = getDivisionsForDistrict(allCourts, formData.courtId).map(
-          (d) => d.courtDivisionCode,
-        );
-
-        // If user selected all individual divisions (and not already "All Divisions")
-        if (
-          !formData.divisionCodes.includes(ALL_DIVISIONS_VALUE) &&
-          formData.divisionCodes.length === allAvailableDivisions.length &&
-          formData.divisionCodes.length > 0 &&
-          allAvailableDivisions.every((code) => formData.divisionCodes.includes(code))
-        ) {
-          // Auto-convert to "All Divisions"
-          setFormData((prev) => ({ ...prev, divisionCodes: [ALL_DIVISIONS_VALUE] }));
-        }
-      }
-    }, 100);
-  };
-
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (divisionBlurTimeoutRef.current) {
-        clearTimeout(divisionBlurTimeoutRef.current);
-      }
-    };
-  }, []);
 
   const handleDateChange = (field: keyof FormData, e: React.ChangeEvent<HTMLInputElement>) => {
     handleFieldChange(field, e.target.value);
@@ -692,7 +579,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
                       disabled={!formData.courtId}
                       options={divisionOptions}
                       ariaDescription="Divisions where this trustee will be assigned"
-                      selections={getMultiSelections(formData.divisionCodes, divisionOptions)}
+                      selections={divisionSelections}
                       onUpdateSelection={handleDivisionSelection}
                       hideClearAllButton={
                         formData.divisionCodes.length === 1 &&
@@ -703,7 +590,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
 
                   {/* Division pills - display below dropdown */}
                   {formData.divisionCodes.length > 0 &&
-                    getMultiSelections(formData.divisionCodes, divisionOptions) &&
+                    divisionSelections &&
                     (formData.divisionCodes.length === 1 &&
                     formData.divisionCodes[0] === ALL_DIVISIONS_VALUE ? (
                       // Show non-interactive badge when only "All Divisions" is selected
@@ -717,7 +604,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
                       <PillBox
                         id="division-pills"
                         className="division-pills-container"
-                        selections={getMultiSelections(formData.divisionCodes, divisionOptions)!}
+                        selections={divisionSelections!}
                         wrapPills={true}
                         ariaLabelPrefix="Division"
                         onSelectionChange={handlePillRemoval}

--- a/user-interface/src/trustees/forms/appointmentMergeHelpers.ts
+++ b/user-interface/src/trustees/forms/appointmentMergeHelpers.ts
@@ -1,0 +1,71 @@
+import { getDivisionsForDistrict } from '@/lib/utils/court-utils';
+import { CourtDivisionDetails } from '@common/cams/courts';
+import { TrusteeAppointment, TrusteeAppointmentInput } from '@common/cams/trustee-appointments';
+import { AppointmentChapterType, AppointmentType } from '@common/cams/trustees';
+
+type MergeResult =
+  | {
+      type: 'merged';
+      targetId: string;
+      payload: TrusteeAppointmentInput;
+      addedNames: string[];
+    }
+  | {
+      type: 'created';
+    };
+
+/**
+ * Find a merge target among existing appointments.
+ * A merge target is an active appointment with the same courtId, chapter, and appointmentType.
+ */
+export function findMergeTarget(
+  courtId: string,
+  chapter: AppointmentChapterType | string,
+  appointmentType: AppointmentType | string,
+  existingAppointments: TrusteeAppointment[],
+): TrusteeAppointment | undefined {
+  return existingAppointments.find(
+    (appt) =>
+      appt.courtId === courtId &&
+      appt.chapter === chapter &&
+      appt.appointmentType === appointmentType &&
+      appt.status === 'active',
+  );
+}
+
+/**
+ * Determine whether to merge into an existing appointment or create a new one.
+ * If a merge target exists, builds a merged payload with deduplicated division codes.
+ */
+export function buildMergeResult(
+  mergeTarget: TrusteeAppointment | undefined,
+  payload: TrusteeAppointmentInput,
+  allCourts: CourtDivisionDetails[],
+): MergeResult {
+  if (!mergeTarget) {
+    return { type: 'created' };
+  }
+
+  const existingDivisions = (mergeTarget.divisionCodes ?? [mergeTarget.divisionCode]).filter(
+    Boolean,
+  ) as string[];
+  const mergedDivisions = [...new Set([...existingDivisions, ...payload.divisionCodes!])];
+  const addedDivisions = payload.divisionCodes!.filter((code) => !existingDivisions.includes(code));
+
+  const divisions = getDivisionsForDistrict(allCourts, payload.courtId);
+  const addedNames = addedDivisions.map((code) => {
+    const div = divisions.find((d) => d.courtDivisionCode === code);
+    return div?.courtDivisionName ?? code;
+  });
+
+  return {
+    type: 'merged',
+    targetId: mergeTarget.id,
+    payload: {
+      ...payload,
+      divisionCodes: mergedDivisions,
+      divisionCode: mergedDivisions[0],
+    },
+    addedNames,
+  };
+}

--- a/user-interface/src/trustees/forms/useDivisionSelection.ts
+++ b/user-interface/src/trustees/forms/useDivisionSelection.ts
@@ -1,0 +1,120 @@
+import { useMemo, useEffect, useRef } from 'react';
+import { getDivisionsForDistrict } from '@/lib/utils/court-utils';
+import { CourtDivisionDetails } from '@common/cams/courts';
+import { ComboOption } from '@/lib/components/combobox/ComboBox';
+
+export const ALL_DIVISIONS_VALUE = '__ALL__';
+
+type UseDivisionSelectionParams = {
+  courtId: string;
+  allCourts: CourtDivisionDetails[];
+  divisionCodes: string[];
+  enabled: boolean;
+  onDivisionCodesChange: (codes: string[]) => void;
+};
+
+export function useDivisionSelection(params: UseDivisionSelectionParams) {
+  const { courtId, allCourts, divisionCodes, enabled, onDivisionCodesChange } = params;
+  const blurTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const divisionOptions = useMemo<ComboOption[]>(() => {
+    if (!courtId || !allCourts.length) return [];
+
+    const divisions = getDivisionsForDistrict(allCourts, courtId);
+
+    return [
+      { value: ALL_DIVISIONS_VALUE, label: 'All Divisions' },
+      ...divisions.map((div) => ({
+        value: div.courtDivisionCode,
+        label: div.courtDivisionName,
+      })),
+    ];
+  }, [courtId, allCourts]);
+
+  // Auto-select "All Divisions" when district is selected and divisions are empty
+  useEffect(() => {
+    if (enabled && divisionOptions.length > 0) {
+      if (divisionCodes.length === 0) {
+        onDivisionCodesChange([ALL_DIVISIONS_VALUE]);
+      }
+    }
+  }, [divisionOptions, enabled, divisionCodes.length, onDivisionCodesChange]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (blurTimeoutRef.current) {
+        clearTimeout(blurTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const getMultiSelections = (fieldValues: string[]) => {
+    if (!fieldValues || fieldValues.length === 0) return undefined;
+    const selected = divisionOptions.filter((opt) => fieldValues.includes(opt.value));
+    return selected.length > 0 ? selected : undefined;
+  };
+
+  const handleDivisionSelection = (selectedOptions: ComboOption[]) => {
+    const selectedValues = selectedOptions.map((opt) => opt.value);
+
+    // Edge case: User clicked X to clear "All Divisions" - prevent it
+    if (selectedValues.length === 0 && divisionCodes.includes(ALL_DIVISIONS_VALUE)) {
+      return;
+    }
+
+    // If both "All Divisions" and specific divisions are present
+    if (selectedValues.includes(ALL_DIVISIONS_VALUE) && selectedValues.length > 1) {
+      const addedValues = selectedValues.filter((v) => !divisionCodes.includes(v));
+
+      if (addedValues.includes(ALL_DIVISIONS_VALUE)) {
+        onDivisionCodesChange([ALL_DIVISIONS_VALUE]);
+      } else {
+        onDivisionCodesChange(selectedValues.filter((v) => v !== ALL_DIVISIONS_VALUE));
+      }
+      return;
+    }
+
+    onDivisionCodesChange(selectedValues);
+  };
+
+  const handlePillRemoval = (updatedSelections: ComboOption[]) => {
+    const newCodes = updatedSelections.map((opt) => opt.value);
+    onDivisionCodesChange(newCodes.length === 0 ? [ALL_DIVISIONS_VALUE] : newCodes);
+  };
+
+  const handleDivisionBlur = (e: React.FocusEvent) => {
+    const currentTarget = e.currentTarget;
+
+    if (blurTimeoutRef.current) {
+      clearTimeout(blurTimeoutRef.current);
+    }
+
+    blurTimeoutRef.current = setTimeout(() => {
+      if (!currentTarget.contains(document.activeElement)) {
+        if (!courtId || !allCourts.length) return;
+
+        const allAvailableDivisions = getDivisionsForDistrict(allCourts, courtId).map(
+          (d) => d.courtDivisionCode,
+        );
+
+        if (
+          !divisionCodes.includes(ALL_DIVISIONS_VALUE) &&
+          divisionCodes.length === allAvailableDivisions.length &&
+          divisionCodes.length > 0 &&
+          allAvailableDivisions.every((code) => divisionCodes.includes(code))
+        ) {
+          onDivisionCodesChange([ALL_DIVISIONS_VALUE]);
+        }
+      }
+    }, 100);
+  };
+
+  return {
+    divisionOptions,
+    divisionSelections: getMultiSelections(divisionCodes),
+    handleDivisionSelection,
+    handlePillRemoval,
+    handleDivisionBlur,
+  };
+}


### PR DESCRIPTION
## Summary
- Enable separate district/division dropdowns in edit mode (behind `trustee-district-division` feature flag)
- Handle legacy appointment pre-population: prefer `divisionCodes` array over single `divisionCode`, with graceful fallback
- Fix audit history to use set-based division comparison so array additions/removals are detected (order-insensitive)
- Add smart duplicate merge: when creating an appointment that matches an existing active appointment with complementary (non-overlapping) divisions, auto-merge via PUT instead of creating a duplicate

## Test plan
- [ ] Backend: 5 new tests for `hasAppointmentChanged` with `divisionCodes` (addition, removal, reorder, format migration, combined changes) — all passing
- [ ] Frontend: existing helper and court-utils tests pass (56 + 31 = 87 total)
- [ ] TypeScript compiles without errors
- [ ] Linting passes across all workspaces
- [ ] Edit mode with flag ON shows separate District and Division dropdowns
- [ ] Edit mode with flag OFF still shows legacy combined dropdown
- [ ] Add mode behavior unchanged
- [ ] Legacy appointments with single `divisionCode` pre-populate correctly in edit
- [ ] Smart merge: complementary divisions merge into existing appointment via PUT
- [ ] Smart merge: overlapping divisions still show validation error
- [ ] Audit history records division array changes

## Notes
- Depends on Slice 1 (PR #2325, branch `CAMS-740-district-division-selection`)
- Design doc: `.ustp-cams-fdp/ai/specs/CAMS-740_district-division-selection/district-division-selection.slice-2-design.md`

## Summary by Sourcery

Introduce multi-division trustee appointments with smarter district/division selection, validation, and auditing across frontend and backend.

New Features:
- Support selection of multiple court divisions per trustee appointment, including an "All Divisions" option, when the district-division feature flag is enabled.
- Add smart merge behavior to combine complementary division selections into an existing active appointment instead of creating duplicates.
- Provide shared courts fetching hook and utilities for deriving unique districts, divisions, and human-readable division labels for UI display and history.

Bug Fixes:
- Ensure trustee appointment audit history correctly detects and records changes to division assignments using set-based comparison, including multi-division updates.
- Fix validation to detect overlapping appointments when existing records use single or multiple division codes and to allow non-overlapping multi-division combinations.

Enhancements:
- Normalize trustee appointment data on the backend to maintain backward compatibility between legacy single-division and new multi-division formats while enforcing that at least one division is specified.
- Refine trustee appointment sorting and court/appointment string comparisons to use centralized, case-insensitive helpers.
- Update appointment cards and audit history views to consistently display division information based on new multi-division support.
- Improve trustee appointment form UX with dedicated district/division fields, pill-based division display, and a standardized form requirements notice.

Tests:
- Add backend tests covering division normalization, validation of required divisions, audit-change detection for division arrays, and behavior of multi-division appointments.
- Extend frontend tests for court utilities, district/division helpers, and validation of overlapping multi-division appointments.