### PR TITLE
Fix TypeError crash when case has no debtor in CaseDetailHeader

### DIFF
--- a/user-interface/src/case-detail/caseDetailHelper.test.ts
+++ b/user-interface/src/case-detail/caseDetailHelper.test.ts
@@ -9,6 +9,12 @@ describe('caseDetailHelper', () => {
       expect(result).toBe('');
     });
 
+    test('should return empty string when caseDetail has no debtor', () => {
+      const caseDetail = MockData.getCaseDetail({ override: { debtor: undefined as never } });
+      const result = composeCaseTitle(caseDetail);
+      expect(result).toBe('');
+    });
+
     test('should return debtor name when there is no joint debtor', () => {
       const caseDetail = MockData.getCaseDetail({
         override: {

--- a/user-interface/src/case-detail/caseDetailHelper.ts
+++ b/user-interface/src/case-detail/caseDetailHelper.ts
@@ -1,7 +1,7 @@
 import { CaseDetail } from '@common/cams/cases';
 
 export function composeCaseTitle(caseDetail?: CaseDetail): string {
-  if (!caseDetail) return '';
+  if (!caseDetail?.debtor) return '';
   if (caseDetail.jointDebtor?.name) {
     return `${caseDetail.debtor.name} & ${caseDetail.jointDebtor.name}`;
   }


### PR DESCRIPTION
# Bug

`CaseDetailHeader` crashes with `TypeError: Cannot read properties of undefined (reading 'name')` when a case's `debtor` field is missing or undefined. This causes React to unmount the entire case detail view via the error boundary.

# Purpose

Prevent a crash when navigating to a case detail page for cases with incomplete data (missing debtor).

# Major Changes

- Extended the null guard in `composeCaseTitle` to also handle `caseDetail.debtor` being undefined
- Added a unit test covering the missing-debtor case

# Testing/Validation

Added a unit test for `composeCaseTitle` with a case detail that has no debtor. All 5 tests in `caseDetailHelper.test.ts` pass.

# Notes

The crash was observed against case `081-98-00007` in the local environment. The existing guard only checked for `!caseDetail` (the whole object), not for a missing `debtor` within it. The fix collapses both checks into `!caseDetail?.debtor`.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Handle missing debtor data in case detail titles to prevent runtime crashes.

Bug Fixes:
- Avoid TypeError in composeCaseTitle when caseDetail.debtor is undefined by returning an empty title string in that case.

Tests:
- Add a unit test verifying composeCaseTitle returns an empty string when caseDetail has no debtor.