### PR TITLE
Add CamsTable component, migrate search/assignment tables, fix a11y

### DIFF
--- a/user-interface/src/App.scss
+++ b/user-interface/src/App.scss
@@ -5,6 +5,7 @@
 @use 'uswds/index' as uswds;
 @use 'styles/theme';
 @use 'styles/abstracts/colors';
+@use 'styles/abstracts/general' as general;
 @use 'styles/abstracts/tables';
 
 /* Overriding USWDS Grid row large gap negative margins because they force
@@ -48,14 +49,7 @@ body {
     Use this class anywhere you need screen readers to get more context, such as with aria-describedby sections.
   */
   .screen-reader-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    white-space: nowrap;
-    border: 0;
+    @include general.visually-hidden;
   }
 
   .cams-content {

--- a/user-interface/src/lib/components/cams/CamsTable/CamsTable.scss
+++ b/user-interface/src/lib/components/cams/CamsTable/CamsTable.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/general' as general;
+
 // Base responsive styles applied automatically to every CamsTable.
 // To override breakpoint behavior in a screen, use the mixins in _cams-table-mixins.scss:
 //   @use '@/lib/components/cams/CamsTable/cams-table-mixins' as cams-table;
@@ -14,9 +16,10 @@
     margin-bottom: 0.5rem;
   }
 
-  // Header hidden on mobile — column labels shown via data-cell ::before
+  // Header visually hidden on mobile so AT retains column context,
+  // while data-cell ::before labels provide the visible inline labels.
   .cams-table__header-group {
-    display: none;
+    @include general.visually-hidden;
   }
 
   .cams-table__header-row,
@@ -50,6 +53,7 @@
   // Tablet (641px+): flex row, equal columns, show header
   @media screen and (min-width: 641px) {
     .cams-table__header-group {
+      @include general.visually-shown;
       display: block;
       font-weight: bold;
       border-bottom: 1px solid #1b1b1b;

--- a/user-interface/src/lib/components/cams/CamsTable/CamsTable.tsx
+++ b/user-interface/src/lib/components/cams/CamsTable/CamsTable.tsx
@@ -1,13 +1,14 @@
-import { type JSX, type PropsWithChildren } from 'react';
+import { type JSX, type PropsWithChildren, useId } from 'react';
 import './CamsTable.scss';
 
-type CamsTableProps = PropsWithChildren<{
-  id?: string;
-  className?: string;
-  'data-testid'?: string;
-  'aria-label'?: string;
-  caption?: string;
-}>;
+type CamsTableProps = PropsWithChildren<
+  {
+    id?: string;
+    className?: string;
+    'data-testid'?: string;
+    caption?: string;
+  } & ({ 'aria-label': string; caption?: string } | { 'aria-label'?: string; caption: string })
+>;
 
 export function CamsTable({
   children,
@@ -16,13 +17,18 @@ export function CamsTable({
   caption,
   ...rest
 }: CamsTableProps): JSX.Element {
+  const captionId = useId();
   const wrapperClasses = ['cams-table', 'cams-table--responsive', className]
     .filter(Boolean)
     .join(' ');
   return (
     <div id={id} className={wrapperClasses}>
-      {caption && <div className="cams-table__caption">{caption}</div>}
-      <div role="table" {...rest}>
+      <div role="table" aria-labelledby={caption ? captionId : undefined} {...rest}>
+        {caption && (
+          <div id={captionId} className="cams-table__caption">
+            {caption}
+          </div>
+        )}
         {children}
       </div>
     </div>

--- a/user-interface/src/lib/components/cams/CamsTable/_cams-table-mixins.scss
+++ b/user-interface/src/lib/components/cams/CamsTable/_cams-table-mixins.scss
@@ -1,7 +1,9 @@
+@use 'styles/abstracts/general' as general;
+
 // Use when a screen needs to override CamsTable's tablet flex-row layout back to stacked,
 // e.g. when a side panel leaves insufficient width for columns at that breakpoint.
 @mixin cams-table-stacked {
-  .cams-table__header-group { display: none; }
+  .cams-table__header-group { @include general.visually-hidden; }
   .cams-table__header-row,
   .cams-table__row { display: block; }
   .cams-table__cell { display: block; width: 100%; padding: 0.25rem 0; }
@@ -11,7 +13,7 @@
 
 // Use when a screen is ready to enable the flex-row column layout.
 @mixin cams-table-flex-row {
-  .cams-table__header-group { display: block; font-weight: bold; border-bottom: 1px solid #1b1b1b; padding-bottom: 0.5rem; margin-bottom: 0; }
+  .cams-table__header-group { @include general.visually-shown; display: block; font-weight: bold; border-bottom: 1px solid #1b1b1b; padding-bottom: 0.5rem; margin-bottom: 0; }
   .cams-table__header-row,
   .cams-table__row { display: flex; flex-direction: row; gap: 1rem; align-items: baseline; }
   .cams-table__cell { flex: 1 1 0; min-width: 0; padding: 0.5rem 1rem; width: auto; }

--- a/user-interface/src/styles/abstracts/_general.scss
+++ b/user-interface/src/styles/abstracts/_general.scss
@@ -1,1 +1,27 @@
 $borderRadius: 5px;
+
+// Visually hidden but accessible to screen readers.
+// Use anywhere an element needs to be hidden from sighted users
+// while remaining in the accessibility tree.
+@mixin visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// Reverses visually-hidden — restores an element to normal flow.
+// Use in media queries to un-hide an element that was hidden with visually-hidden.
+@mixin visually-shown {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}


### PR DESCRIPTION
# Purpose

Introduce a reusable, accessible `CamsTable` component built on ARIA roles instead of native HTML table elements, enabling a responsive mobile-first stacked layout that transitions to a flex-row column layout at wider breakpoints. Migrate Search, My Cases, and Staff Assignment tables to the new component, and centralize closed-case hint logic in `SearchScreen`.

# Major Changes

* **CamsTable component library** — New `CamsTable`, `CamsTableHeader`, `CamsTableHeaderCell`, `CamsTableBody`, `CamsTableRow`, and `CamsTableCell` primitives using `role="table/rowgroup/row/columnheader/cell"` with a responsive stacked-to-flex-row layout driven by screen-specific SCSS overrides
* **GenericTable removed** — Replaced by CamsTable across all consumer screens
* **Search, My Cases, Staff Assignment** — All tables migrated to CamsTable; column flex values defined per-screen via `.col-*` CSS classes
* **Closed-case hint centralized** — `ClosedCasesHintMessage` extracted to `lib/components/cams/` as a shared component; hint rendering moved from `SearchResults` into `SearchScreen` with named boolean flags and count-aware messaging
* **SCSS mixins** — `visually-hidden`/`visually-shown` added to `styles/abstracts/_general`; `cams-table-stacked`/`cams-table-flex-row` mixins in `_cams-table-mixins.scss` allow screen-specific breakpoint overrides without duplicating property blocks
* **Accessibility fixes** — Caption moved inside `role="table"` with `aria-labelledby`; mobile header now uses `visually-hidden` instead of `display:none` so screen readers retain column context; TypeScript enforces that either `aria-label` or `caption` is required
* **hasResults alignment** — Both `SearchScreen` and `MyCasesScreen` now use `boolean | null` sentinel pattern
* **MyCasesScreen error handling tests** — Added coverage for generic failure, 504 timeout, no-results, and error-clears-on-success paths

# Testing/Validation

* Implemented with TDD throughout — unit tests updated for CamsTable structure (`cams-table`, `cams-table__body`, `cams-table__row`, `cams-table__cell` selectors)
* Playwright accessibility tests updated for new DOM structure
* New SearchScreen tests cover all closed-case hint variants (generic, count, singular/plural, no-results with count)
* New MyCasesScreen tests cover `handleSearchError` and `handleResultsChanged` paths
* Manually tested in browser with VoiceOver — column headers announced correctly on mobile and desktop

# Notes

* Screen-specific breakpoint overrides are intentional — each screen has a unique layout context (`SearchScreen` has a side-by-side filter+results pane; `StaffAssignment` stays stacked longer). Sharing breakpoints would force unrelated layouts to couple.
* The `::before` pseudo-content mobile labels are supplementary — screen readers get authoritative column context from the visually-hidden `role="columnheader"` elements.
* `Table.tsx` (USWDS wrapper) retained intentionally despite Knip warning — it is a building block for future USWDS component coverage.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve accessibility and responsiveness of the reusable CamsTable component and shared styles.

New Features:
- Require either an aria-label or caption for CamsTable via strengthened TypeScript props.
- Add reusable visually-hidden and visually-shown SCSS mixins for accessible, toggleable visibility states.

Bug Fixes:
- Keep CamsTable headers available to assistive technologies on mobile by replacing display:none with visually hidden styles and moving captions inside the table role with aria-labelledby.

Enhancements:
- Refactor existing screen-reader-only styles and CamsTable breakpoint mixins to use shared visually-hidden/visually-shown mixins for consistent behavior across views.