### PR TITLE
CAMS-740 remodel district division appointment

### DIFF
--- a/backend/function-apps/dataflows/migrations/migrate-trustees.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-trustees.ts
@@ -3,10 +3,12 @@ import { app, InvocationContext, output } from '@azure/functions';
 import ApplicationContextCreator from '../../azure/application-context-creator';
 import { ApplicationContext } from '../../../lib/adapters/types/basic';
 import {
+  buildContainerName,
   buildFunctionName,
   buildQueueName,
   buildStartQueueHttpTrigger,
   CursorMessage,
+  ensureContainersExist,
   StartMessage,
 } from '../dataflows-common';
 import * as MigrateTrusteesUseCase from '../../../lib/use-cases/dataflows/migrate-trustees';
@@ -321,6 +323,8 @@ async function handleError(event: QueueError, invocationContext: InvocationConte
 }
 
 function setup() {
+  ensureContainersExist([buildContainerName(MODULE_NAME, 'out')], MODULE_NAME);
+
   app.storageQueue(HANDLE_START, {
     connection: STORAGE_QUEUE_CONNECTION,
     queueName: START.queueName,

--- a/backend/function-apps/dataflows/migrations/migrate-trustees.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-trustees.ts
@@ -84,9 +84,10 @@ async function performDeleteAllIfRequested(
     return false;
   }
 
+  const { deletedTrustees, deletedAppointments, deletedProfessionalIds } = deleteResult.data;
   logger.info(
     MODULE_NAME,
-    `Successfully deleted ${deleteResult.data.deletedTrustees} trustees and ${deleteResult.data.deletedAppointments} appointments.`,
+    `Successfully deleted ${deletedTrustees} trustees, ${deletedAppointments} appointments, and ${deletedProfessionalIds} professional ID mappings.`,
   );
 
   const resetResult = await MigrationStateService.resetMigrationState(context);
@@ -117,7 +118,10 @@ async function handleStart(start: MigrationStartMessage, invocationContext: Invo
     return; // DLQ already populated
   }
 
-  const stateResult = await MigrationStateService.getOrCreateMigrationState(context, !!start.reset);
+  const stateResult = await MigrationStateService.getOrCreateMigrationState(
+    context,
+    !!(start.reset || start.deleteAll),
+  );
 
   if (stateResult.error) {
     invocationContext.extraOutputs.set(

--- a/backend/function-apps/dataflows/migrations/migrate-trustees.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-trustees.ts
@@ -220,7 +220,11 @@ async function handlePage(cursor: CursorMessage, invocationContext: InvocationCo
   );
 
   // Process page with retry logic handled in use case
-  const processResult = await MigrateTrusteesUseCase.processPageOfTrustees(context, trustees);
+  const processResult = await MigrateTrusteesUseCase.processPageOfTrustees(
+    context,
+    trustees,
+    buildContainerName(MODULE_NAME, 'out'),
+  );
 
   if (processResult.error) {
     await MigrationStateService.failMigration(context, currentState, processResult.error.message);

--- a/backend/lib/use-cases/dataflows/migrate-trustees-dedup.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees-dedup.test.ts
@@ -910,7 +910,7 @@ describe('Trustee Deduplication', () => {
         name: 'Test',
       });
 
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       // Should create 2 unique trustees (John Doe merged, Jane Smith separate)
       expect(result.data?.processed).toBe(2);
@@ -959,7 +959,7 @@ describe('Trustee Deduplication', () => {
         },
       });
 
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       // Should create 1 trustee with 4 TOD IDs
       expect(result.data?.processed).toBe(1);

--- a/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
@@ -990,7 +990,7 @@ describe('Migrate Trustees Use Case', () => {
       expect(result.data?.errors).toBe(0);
     });
 
-    test('should expand district appointments to divisions', async () => {
+    test('should enrich district appointments with all division codes', async () => {
       const trustees: AtsTrusteeRecord[] = [
         { ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe', STATE: 'NY' },
       ];
@@ -1089,17 +1089,18 @@ describe('Migrate Trustees Use Case', () => {
       expect(result.data?.processed).toBe(1);
       expect(result.data?.errors).toBe(0);
 
-      // Should have created 2 appointments (one per division)
-      expect(createAppointmentSpy).toHaveBeenCalledTimes(2);
+      // Should have created 1 appointment (district-level, with all division codes)
+      expect(createAppointmentSpy).toHaveBeenCalledTimes(1);
 
-      // Check that appointments have division codes (second argument is the appointment)
-      const calls = createAppointmentSpy.mock.calls;
-      const divisionCodes = calls.map((call) => call[1].divisionCode).sort();
-      expect(divisionCodes).toEqual(['MAH', 'MAN']);
+      // Check that the single appointment has all division codes
+      const call = createAppointmentSpy.mock.calls[0];
+      const appointment = call[1];
+      expect(appointment.divisionCodes).toEqual(expect.arrayContaining(['MAH', 'MAN']));
+      expect(appointment.divisionCodes).toHaveLength(2);
+      expect(appointment.divisionCode).toBeUndefined();
 
-      // Check that appointments have court names
-      const courtNames = calls.map((call) => call[1].courtName);
-      expect(courtNames[0]).toBe(
+      // Check that the appointment has the court name from the first division
+      expect(appointment.courtName).toBe(
         'United States Bankruptcy Court for the Southern District of New York',
       );
     });

--- a/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
@@ -500,7 +500,7 @@ describe('Migrate Trustees Use Case', () => {
       };
 
       const trustees = [malformedTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(0); // Merge failed, so not processed
       expect(result.data?.errors).toBe(1);
@@ -521,7 +521,7 @@ describe('Migrate Trustees Use Case', () => {
       );
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(0); // Failed, so not counted as processed
       expect(result.data?.errors).toBe(1);
@@ -573,7 +573,7 @@ describe('Migrate Trustees Use Case', () => {
       );
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       // Trustee succeeded, so success count = 1
       expect(result.data?.processed).toBe(1);
@@ -600,7 +600,7 @@ describe('Migrate Trustees Use Case', () => {
       );
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       // Trustee is saved successfully despite appointment fetch failure
       expect(result.data?.processed).toBe(1);
@@ -640,7 +640,7 @@ describe('Migrate Trustees Use Case', () => {
       } as unknown as AcmsGateway);
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       // Trustee succeeded despite ACMS failure (non-fatal)
       expect(result.data?.processed).toBe(1);
@@ -674,7 +674,7 @@ describe('Migrate Trustees Use Case', () => {
       });
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(1);
       expect(result.data?.errors).toBe(0);
@@ -708,7 +708,7 @@ describe('Migrate Trustees Use Case', () => {
         },
       });
 
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(2); // John and Bob succeeded
       expect(result.data?.errors).toBe(1); // Only Jane failed
@@ -759,7 +759,7 @@ describe('Migrate Trustees Use Case', () => {
       });
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(1);
       expect(result.data?.errors).toBe(0);
@@ -783,7 +783,7 @@ describe('Migrate Trustees Use Case', () => {
       vi.spyOn(factory, 'getOfficesGateway').mockReturnValue(mockOfficesGateway);
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       // Should return error, not process any trustees
       expect(result.error).toBeDefined();
@@ -851,7 +851,7 @@ describe('Migrate Trustees Use Case', () => {
         .mockResolvedValue(mockTrustee);
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(1);
       expect(result.data?.errors).toBe(0);
@@ -876,7 +876,7 @@ describe('Migrate Trustees Use Case', () => {
         .mockResolvedValue(mockTrustee);
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(1); // Eventually succeeded
       expect(result.data?.errors).toBe(0);
@@ -902,7 +902,7 @@ describe('Migrate Trustees Use Case', () => {
         .mockResolvedValue(mockTrustee);
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(1); // Eventually succeeded
       expect(result.data?.errors).toBe(0);
@@ -923,7 +923,7 @@ describe('Migrate Trustees Use Case', () => {
       );
 
       const trustees = [atsTrustee];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(0); // Failed after all retries
       expect(result.data?.errors).toBe(1);
@@ -944,7 +944,7 @@ describe('Migrate Trustees Use Case', () => {
 
       vi.spyOn(MockMongoRepository.prototype, 'createTrustee').mockResolvedValue(mockTrustee);
 
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(2); // John and Jane succeeded
       expect(result.data?.errors).toBe(1); // Only Bob failed permanently
@@ -984,7 +984,7 @@ describe('Migrate Trustees Use Case', () => {
         },
       });
 
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(2);
       expect(result.data?.errors).toBe(0);
@@ -1084,7 +1084,7 @@ describe('Migrate Trustees Use Case', () => {
 
       vi.spyOn(MockMongoRepository.prototype, 'getTrusteeAppointments').mockResolvedValue([]);
 
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(1);
       expect(result.data?.errors).toBe(0);
@@ -1156,7 +1156,7 @@ describe('Migrate Trustees Use Case', () => {
 
       vi.spyOn(MockMongoRepository.prototype, 'getTrusteeAppointments').mockResolvedValue([]);
 
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(1);
       expect(result.data?.errors).toBe(0);
@@ -1434,12 +1434,12 @@ describe('Migrate Trustees Use Case', () => {
       vi.spyOn(factory, 'getObjectStorageGateway').mockReturnValue(mockObjectStorage);
 
       const trustees = [{ ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe', STATE: 'NY' }];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(result.data?.processed).toBe(1);
       expect(result.data?.failedAppointments).toHaveLength(1);
       expect(mockObjectStorage.writeObject).toHaveBeenCalledWith(
-        expect.stringContaining('migrate-trustees-use-case'),
+        'migrate-trustees-out',
         expect.stringMatching(/^failed-appointments-.*\.jsonl$/),
         expect.stringContaining('"classification":"PROBLEMATIC"'),
       );
@@ -1453,7 +1453,7 @@ describe('Migrate Trustees Use Case', () => {
       vi.spyOn(factory, 'getObjectStorageGateway').mockReturnValue(mockObjectStorage);
 
       const trustees = [{ ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe', STATE: 'NY' }];
-      const result = await processPageOfTrustees(context, trustees);
+      const result = await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       // Migration result is unaffected by blob write failure
       expect(result.data?.processed).toBe(1);
@@ -1483,7 +1483,7 @@ describe('Migrate Trustees Use Case', () => {
       vi.spyOn(factory, 'getObjectStorageGateway').mockReturnValue(mockObjectStorage);
 
       const trustees = [{ ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe', STATE: 'NY' }];
-      await processPageOfTrustees(context, trustees);
+      await processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
       expect(mockObjectStorage.writeObject).not.toHaveBeenCalled();
     });

--- a/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
@@ -21,7 +21,7 @@ import { ApplicationContext } from '../../adapters/types/basic';
 import factory from '../../factory';
 import { AtsTrusteeRecord, FailedAppointment } from '../../adapters/types/ats.types';
 import { TrusteeAppointmentInput } from '@common/cams/trustee-appointments';
-import { AcmsGateway, AtsGateway } from '../../use-cases/gateways.types';
+import { AcmsGateway, AtsGateway, ObjectStorageGateway } from '../../use-cases/gateways.types';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import { UstpOfficeDetails } from '@common/cams/offices';
 
@@ -1364,6 +1364,127 @@ describe('Migrate Trustees Use Case', () => {
       expect(result.error?.message).toContain('Failed to delete all trustees and appointments');
       expect(result.data).toBeUndefined();
       expect(deleteAllSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('writeFailedAppointments (via processPageOfTrustees)', () => {
+    const mockTrustee = {
+      id: 'doc-id',
+      trusteeId: 'trustee-100',
+      firstName: 'Test',
+      lastName: 'Trustee',
+      name: 'Test Trustee',
+      status: 'active' as const,
+      public: {
+        address: { address1: '', city: '', state: '', zipCode: '', countryCode: 'US' as const },
+      },
+      createdOn: '2023-01-01',
+      updatedOn: '2023-01-01',
+      updatedBy: { id: 'SYSTEM', name: 'System' },
+    };
+
+    const failedAppointments: FailedAppointment[] = [
+      {
+        atsAppointment: {
+          TRU_ID: 1,
+          DISTRICT: '053N',
+          STATE: 'NY',
+          CHAPTER: '99',
+          STATUS: 'A',
+          DATE_APPOINTED: new Date('2023-01-15'),
+          EFFECTIVE_DATE: new Date('2023-01-15'),
+        },
+        classification: 'PROBLEMATIC',
+        notes: ['Invalid court ID'],
+        mapType: 'DISTRICT_CHAPTER_TYPE',
+        timestamp: '2023-01-15T00:00:00.000Z',
+      },
+    ];
+
+    beforeEach(() => {
+      vi.spyOn(factory, 'getOfficesGateway').mockReturnValue({
+        getOffices: vi.fn().mockResolvedValue([]),
+        getOfficeName: vi.fn().mockReturnValue(''),
+      });
+      vi.spyOn(factory, 'getAcmsGateway').mockReturnValue({
+        getTrusteeProfessionalIds: vi.fn().mockResolvedValue([]),
+      } as unknown as AcmsGateway);
+      vi.spyOn(MockMongoRepository.prototype, 'findTrusteeByNameAndState').mockResolvedValue(null);
+      vi.spyOn(MockMongoRepository.prototype, 'createTrustee').mockResolvedValue(mockTrustee);
+      vi.spyOn(atsGateway, 'getTrusteeAppointments').mockResolvedValue({
+        cleanAppointments: [],
+        failedAppointments,
+        stats: {
+          total: 1,
+          clean: 0,
+          autoRecoverable: 0,
+          problematic: 1,
+          uncleansable: 0,
+          skipped: 0,
+        },
+      });
+    });
+
+    test('should write failed appointments to blob storage when they exist', async () => {
+      const mockObjectStorage: ObjectStorageGateway = {
+        readObject: vi.fn(),
+        writeObject: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.spyOn(factory, 'getObjectStorageGateway').mockReturnValue(mockObjectStorage);
+
+      const trustees = [{ ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe', STATE: 'NY' }];
+      const result = await processPageOfTrustees(context, trustees);
+
+      expect(result.data?.processed).toBe(1);
+      expect(result.data?.failedAppointments).toHaveLength(1);
+      expect(mockObjectStorage.writeObject).toHaveBeenCalledWith(
+        expect.stringContaining('migrate-trustees-use-case'),
+        expect.stringMatching(/^failed-appointments-.*\.jsonl$/),
+        expect.stringContaining('"classification":"PROBLEMATIC"'),
+      );
+    });
+
+    test('should continue and not throw when blob write fails', async () => {
+      const mockObjectStorage: ObjectStorageGateway = {
+        readObject: vi.fn(),
+        writeObject: vi.fn().mockRejectedValue(new Error('Blob storage unavailable')),
+      };
+      vi.spyOn(factory, 'getObjectStorageGateway').mockReturnValue(mockObjectStorage);
+
+      const trustees = [{ ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe', STATE: 'NY' }];
+      const result = await processPageOfTrustees(context, trustees);
+
+      // Migration result is unaffected by blob write failure
+      expect(result.data?.processed).toBe(1);
+      expect(result.data?.errors).toBe(0);
+      expect(result.data?.failedAppointments).toHaveLength(1);
+      expect(mockObjectStorage.writeObject).toHaveBeenCalled();
+    });
+
+    test('should not call writeObject when there are no failed appointments', async () => {
+      vi.spyOn(atsGateway, 'getTrusteeAppointments').mockResolvedValue({
+        cleanAppointments: [],
+        failedAppointments: [],
+        stats: {
+          total: 0,
+          clean: 0,
+          autoRecoverable: 0,
+          problematic: 0,
+          uncleansable: 0,
+          skipped: 0,
+        },
+      });
+
+      const mockObjectStorage: ObjectStorageGateway = {
+        readObject: vi.fn(),
+        writeObject: vi.fn(),
+      };
+      vi.spyOn(factory, 'getObjectStorageGateway').mockReturnValue(mockObjectStorage);
+
+      const trustees = [{ ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe', STATE: 'NY' }];
+      await processPageOfTrustees(context, trustees);
+
+      expect(mockObjectStorage.writeObject).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/lib/use-cases/dataflows/migrate-trustees.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.ts
@@ -71,12 +71,10 @@ export function buildDistrictToDivisionsMap(
 
 /**
  * Create a unique key for an appointment to prevent duplicates.
- * Key format: trusteeId-courtId-divisionCode-chapter-appointmentType
- * Division is included after courtId if present (DXTR enrichment).
+ * Key format: trusteeId-courtId-chapter-appointmentType (one appointment per district)
  */
 function getAppointmentKey(trusteeId: string, appointment: TrusteeAppointmentInput): string {
-  const divisionPart = appointment.divisionCode ? `-${appointment.divisionCode}` : '';
-  return `${trusteeId}-${appointment.courtId}${divisionPart}-${appointment.chapter}-${appointment.appointmentType}`;
+  return `${trusteeId}-${appointment.courtId}-${appointment.chapter}-${appointment.appointmentType}`;
 }
 
 /**
@@ -336,23 +334,23 @@ export async function getPageOfTrustees(
 }
 
 /**
- * Expand a single district appointment into multiple division-specific appointments.
- * Enriches each appointment with division code, court name, and court division name.
+ * Enrich a district appointment with all division codes for that district.
+ * Collects all division codes into divisionCodes array on a single appointment.
  *
  * @param appointment - Base appointment with courtId (district)
  * @param divisions - Array of divisions for this district
- * @returns Array of enriched appointments (one per division)
+ * @returns Single enriched appointment with all division codes
  */
-function expandAppointmentToDivisions(
+function enrichAppointmentWithDivisions(
   appointment: TrusteeAppointmentInput,
   divisions: DivisionInfo[],
-): TrusteeAppointmentInput[] {
-  return divisions.map((division) => ({
+): TrusteeAppointmentInput {
+  return {
     ...appointment,
-    divisionCode: division.divisionCode,
-    courtName: division.courtName,
-    courtDivisionName: division.courtDivisionName,
-  }));
+    divisionCodes: divisions.map((d) => d.divisionCode),
+    courtName: divisions[0]?.courtName,
+    courtDivisionName: divisions[0]?.courtDivisionName,
+  };
 }
 
 /**
@@ -379,13 +377,11 @@ async function getTrusteeAppointments(
       const divisions = districtToDivisionsMap.get(courtId);
 
       if (divisions && divisions.length > 0) {
-        // Expand into multiple division appointments
-        const divisionAppointments = expandAppointmentToDivisions(appointment, divisions);
-        expandedAppointments.push(...divisionAppointments);
+        expandedAppointments.push(enrichAppointmentWithDivisions(appointment, divisions));
 
         context.logger.debug(
           MODULE_NAME,
-          `Expanded district ${courtId} appointment into ${divisions.length} divisions`,
+          `Enriched district ${courtId} appointment with ${divisions.length} division codes`,
           {
             trusteeId,
             courtId,

--- a/backend/lib/use-cases/dataflows/migrate-trustees.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.ts
@@ -14,6 +14,8 @@ import { CamsUserReference } from '@common/cams/users';
 import { LegacyAddress } from '@common/cams/parties';
 import { normalizeName } from './trustee-match.helpers';
 import { UstpOfficeDetails } from '@common/cams/offices';
+import { ObjectStorageGateway } from '../gateways.types';
+import { buildContainerName } from '../../../function-apps/dataflows/dataflows-common';
 const MODULE_NAME = 'MIGRATE-TRUSTEES-USE-CASE';
 
 /**
@@ -995,6 +997,10 @@ export async function processPageOfTrustees(
     `Page complete: ${processed} unique trustees, ${appointments} appointments, ${failedAppointments.length} failed, ${errors} errors`,
   );
 
+  if (failedAppointments.length > 0) {
+    await writeFailedAppointments(context, failedAppointments);
+  }
+
   return {
     data: {
       processed,
@@ -1003,6 +1009,29 @@ export async function processPageOfTrustees(
       failedAppointments,
     },
   };
+}
+
+async function writeFailedAppointments(
+  context: ApplicationContext,
+  failedAppointments: FailedAppointment[],
+): Promise<void> {
+  const objectStorage: ObjectStorageGateway = factory.getObjectStorageGateway(context);
+  const outputContainer = buildContainerName(MODULE_NAME, 'out');
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const fileName = `failed-appointments-${timestamp}.jsonl`;
+  const content = failedAppointments.map((appt) => JSON.stringify(appt)).join('\n');
+
+  try {
+    await objectStorage.writeObject(outputContainer, fileName, content);
+    context.logger.info(
+      MODULE_NAME,
+      `Wrote ${failedAppointments.length} failed appointments to ${outputContainer}/${fileName}`,
+    );
+  } catch (originalError) {
+    context.logger.warn(MODULE_NAME, `Failed to write failed appointments file — continuing`, {
+      error: getCamsError(originalError, MODULE_NAME).message,
+    });
+  }
 }
 
 /**

--- a/backend/lib/use-cases/dataflows/migrate-trustees.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.ts
@@ -15,7 +15,6 @@ import { LegacyAddress } from '@common/cams/parties';
 import { normalizeName } from './trustee-match.helpers';
 import { UstpOfficeDetails } from '@common/cams/offices';
 import { ObjectStorageGateway } from '../gateways.types';
-import { buildContainerName } from '../../../function-apps/dataflows/dataflows-common';
 const MODULE_NAME = 'MIGRATE-TRUSTEES-USE-CASE';
 
 /**
@@ -913,6 +912,7 @@ async function processTrusteeWithAppointments(
 export async function processPageOfTrustees(
   context: ApplicationContext,
   trustees: AtsTrusteeRecord[],
+  outputContainerName: string,
 ): Promise<
   MaybeData<{
     processed: number;
@@ -994,7 +994,7 @@ export async function processPageOfTrustees(
   );
 
   if (failedAppointments.length > 0) {
-    await writeFailedAppointments(context, failedAppointments);
+    await writeFailedAppointments(context, failedAppointments, outputContainerName);
   }
 
   return {
@@ -1010,9 +1010,10 @@ export async function processPageOfTrustees(
 async function writeFailedAppointments(
   context: ApplicationContext,
   failedAppointments: FailedAppointment[],
+  outputContainerName: string,
 ): Promise<void> {
   const objectStorage: ObjectStorageGateway = factory.getObjectStorageGateway(context);
-  const outputContainer = buildContainerName(MODULE_NAME, 'out');
+  const outputContainer = outputContainerName;
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const fileName = `failed-appointments-${timestamp}.jsonl`;
   const content = failedAppointments.map((appt) => JSON.stringify(appt)).join('\n');


### PR DESCRIPTION
# Purpose

Add district divisions to each district trustee appointment.

## Summary by Sourcery

Remodel trustee district appointments to store all division codes on a single appointment and persist failed appointments to blob storage during migration.

New Features:
- Persist failed trustee appointments discovered during migration to object storage as JSON Lines files for later analysis.
- Initialize required output blob containers for the migrate-trustees dataflow at function startup.

Enhancements:
- Change district-level trustee appointments to a single appointment per district enriched with all division codes instead of one appointment per division.
- Adjust appointment deduplication keys to operate at district level rather than division level.
- Improve migration logging to include deleted professional ID mappings and clarify enrichment of district appointments with division codes.
- Trigger migration state reset when either reset or delete-all options are requested.

Tests:
- Update trustee migration tests to reflect district-level appointments with multiple division codes stored on a single appointment.
- Add tests covering writing failed appointments to blob storage, handling write failures gracefully, and skipping writes when no failures exist.