### PR TITLE
Pin mongoose to 8.22.1 to address injection vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13523,9 +13523,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.21.0.tgz",
-      "integrity": "sha512-dW2U01gN8EVQT5KAO5AkzjbqWc8A/CsEq15jOzq/M9ISpy8jw3iq7W9ZP135h9zykFOMt3AMxq4+anvt2YNJgw==",
+      "version": "8.22.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.22.1.tgz",
+      "integrity": "sha512-c0bzt7ElI1CwWiyFSgg9bfhlFcblAoPwr+gmDcLCryClyKaeixWhP9KDGnr13kRPE8KPAuUN3ZZ3jSDxSPvoTg==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",


### PR DESCRIPTION
# Bug

Snyk SCA scan was failing on `main` due to a High severity injection vulnerability in `mongoose@8.21.0` (SNYK-JS-MONGOOSE-16425765). The vulnerable version was hoisted to the root `node_modules` as a transitive dependency via `name-match → natural@6.12.0`.

# Purpose

Resolve the Snyk SCA CI failure blocking deployments by pinning the vulnerable transitive mongoose dependency to the patched version.

# Major Changes

* Updated `package-lock.json` to pin `node_modules/mongoose` from `8.21.0` to `8.22.1`

# Testing/Validation

Verified `npm audit` no longer reports the mongoose vulnerability after the lock file change. The change is compatible with `npm ci` — `8.22.1` satisfies the `^8.2.0` range declared by the transitive dependency.

# Notes

The vulnerable package is not a direct dependency — it is pulled in transiently via `name-match@1.0.4 → natural@6.12.0 → mongoose@^8.2.0`. An npm `overrides` entry in `package.json` was attempted but silently ignored due to workspace hoisting behavior, so the lock file was updated directly with the correct version, resolved URL, and integrity hash from the npm registry.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Build:
- Update package-lock.json to lock mongoose to version 8.22.1 instead of 8.21.0 as a transitive dependency.