### PR TITLE
CAMS-741 Separate district/division display with combined filter

### DIFF
--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -302,6 +302,50 @@ interface DivisionOption {
 }
 
 /**
+ * Builds combined "District (Division)" ComboBox options from a flat courts list.
+ *
+ * For each district, prepends an "All [CourtName]" option (value: `${courtId}|ALL`)
+ * followed by individual divisions (value: `${courtId}|${courtDivisionCode}`).
+ * Options are sorted by state then court name; divisions within a court are sorted
+ * alphabetically by division name.
+ *
+ * @param courts - Flat array of court division details
+ * @returns Ordered ComboOption-shaped array for use in a combined district/division combobox
+ */
+export function getDistrictDivisionComboOptions(
+  courts: CourtDivisionDetails[],
+): { value: string; label: string; selectedLabel?: string }[] {
+  const districtMap = groupDivisionsByDistrict(courts);
+  const uniqueDistricts = sortByCourtLocation(
+    Array.from(districtMap.values()).map((divisions) => divisions[0]),
+  );
+
+  const options: { value: string; label: string; selectedLabel?: string }[] = [];
+
+  for (const district of uniqueDistricts) {
+    const divisions = districtMap
+      .get(district.courtName)!
+      .sort((a, b) => a.courtDivisionName.localeCompare(b.courtDivisionName));
+
+    options.push({
+      value: `${district.courtId}|ALL`,
+      label: `${district.courtName} (All)`,
+      selectedLabel: `${district.courtName} (All)`,
+    });
+
+    for (const div of divisions) {
+      options.push({
+        value: `${district.courtId}|${div.courtDivisionCode}`,
+        label: `${district.courtName} (${div.courtDivisionName})`,
+        selectedLabel: `${div.courtDivisionName}`,
+      });
+    }
+  }
+
+  return options;
+}
+
+/**
  * Extracts unique districts from a flat array of CourtDivisionDetails.
  * Deduplicates by courtId and sorts by state name then court name.
  *

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -123,18 +123,18 @@ export function sortByCourtLocation<T extends CourtLocationSortable>(
  * This function groups all divisions under their parent district.
  *
  * @param divisions - Array of court division details
- * @returns Map where key is courtName and value is array of all divisions in that district
+ * @returns Map where key is courtId and value is array of all divisions in that district
  *
  * @example
  * const divisions = [
- *   { courtName: "Southern District of New York", courtDivisionCode: "081", ... },
- *   { courtName: "Southern District of New York", courtDivisionCode: "087", ... },
- *   { courtName: "District of Vermont", courtDivisionCode: "088", ... }
+ *   { courtId: "NYSB", courtName: "Southern District of New York", courtDivisionCode: "081", ... },
+ *   { courtId: "NYSB", courtName: "Southern District of New York", courtDivisionCode: "087", ... },
+ *   { courtId: "VTB", courtName: "District of Vermont", courtDivisionCode: "088", ... }
  * ];
  * const grouped = groupDivisionsByDistrict(divisions);
  * // Map {
- * //   "Southern District of New York" => [{ code: "081", ... }, { code: "087", ... }],
- * //   "District of Vermont" => [{ code: "088", ... }]
+ * //   "NYSB" => [{ code: "081", ... }, { code: "087", ... }],
+ * //   "VTB" => [{ code: "088", ... }]
  * // }
  */
 export function groupDivisionsByDistrict(
@@ -142,7 +142,7 @@ export function groupDivisionsByDistrict(
 ): Map<string, CourtDivisionDetails[]> {
   const districtMap = new Map<string, CourtDivisionDetails[]>();
   divisions.forEach((division) => {
-    const key = division.courtName;
+    const key = division.courtId;
     if (!districtMap.has(key)) {
       districtMap.set(key, []);
     }
@@ -324,7 +324,7 @@ export function getDistrictDivisionComboOptions(
 
   for (const district of uniqueDistricts) {
     const divisions = districtMap
-      .get(district.courtName)!
+      .get(district.courtId)!
       .sort((a, b) => a.courtDivisionName.localeCompare(b.courtDivisionName));
 
     options.push({

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -134,7 +134,8 @@
       white-space: normal;
     }
 
-    .col-district {
+    .col-district,
+    .col-division {
       flex: 2 1 0;
       min-width: 0;
       max-width: none;
@@ -150,8 +151,13 @@
     }
 
     .col-district {
-      flex: 3 1 0;
-      min-width: 300px;
+      flex: 2 1 0;
+      min-width: 200px;
+    }
+
+    .col-division {
+      flex: 2 1 0;
+      min-width: 150px;
     }
 
     .col-chapter,

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -546,9 +546,9 @@ describe('TrusteesList Component', () => {
     });
 
     test('should AND-filter when both district and chapter filters are active', async () => {
-      const apptA = makeAppointment({ chapter: '7', divisionCode: '081' });
-      const apptB = makeAppointment({ chapter: '13', divisionCode: '081' });
-      const apptC = makeAppointment({ chapter: '7', divisionCode: '088' });
+      const apptA = makeAppointment({ chapter: '7', courtId: 'NYSB', divisionCode: '081' });
+      const apptB = makeAppointment({ chapter: '13', courtId: 'NYSB', divisionCode: '081' });
+      const apptC = makeAppointment({ chapter: '7', courtId: 'VTB', divisionCode: '088' });
       const trusteeA = makeListItem({
         trusteeId: 'a',
         firstName: 'Alice',
@@ -1745,6 +1745,271 @@ describe('TrusteesList Component', () => {
 
       // Should remove the filter and show all trustees
       await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('District Filter - courtId matching (flag ON)', () => {
+    beforeEach(() => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': true,
+      } as FeatureFlagSet);
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({
+        data: [
+          {
+            courtId: 'NYSB',
+            courtName: 'Southern District of New York',
+            officeCode: '081',
+            officeName: 'Manhattan',
+            courtDivisionCode: '081',
+            courtDivisionName: 'Manhattan',
+            groupDesignator: 'NY',
+            regionId: '02',
+            regionName: 'New York Region',
+          },
+        ],
+      });
+    });
+
+    test('flag ON: trustee with divisionCodes only (no divisionCode) appears when courtId district is selected', async () => {
+      const appt = makeAppointment({
+        courtId: 'NYSB',
+        divisionCode: undefined,
+        divisionCodes: ['081'],
+      });
+      const trusteeNY = makeListItem({
+        trusteeId: 'ny',
+        firstName: 'New',
+        lastName: 'York',
+        appointments: [appt],
+      });
+      const trusteeOther = makeListItem({
+        trusteeId: 'other',
+        firstName: 'Other',
+        lastName: 'Trustee',
+        appointments: [makeAppointment({ courtId: 'VTB', divisionCodes: ['088'] })],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trusteeNY, trusteeOther] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue({
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '081',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York Region',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '081',
+                      court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('York, New')).toBeInTheDocument();
+        expect(screen.queryByText('Trustee, Other')).not.toBeInTheDocument();
+      });
+    });
+
+    test('flag ON: trustee with empty divisionCodes (all divisions) appears when courtId district is selected', async () => {
+      const appt = makeAppointment({
+        courtId: 'NYSB',
+        divisionCode: undefined,
+        divisionCodes: [],
+      });
+      const trustee = makeListItem({
+        trusteeId: 'ny',
+        firstName: 'All',
+        lastName: 'Divisions',
+        appointments: [appt],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue({
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '081',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York Region',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '081',
+                      court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Divisions, All')).toBeInTheDocument();
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+    });
+
+    test('flag ON: trustee in a different district does NOT appear', async () => {
+      const apptNY = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
+      const apptCA = makeAppointment({ courtId: 'CAB', divisionCodes: ['099'] });
+      const trusteeNY = makeListItem({
+        trusteeId: 'ny',
+        firstName: 'New',
+        lastName: 'York',
+        appointments: [apptNY],
+      });
+      const trusteeCA = makeListItem({
+        trusteeId: 'ca',
+        firstName: 'Cali',
+        lastName: 'Fornia',
+        appointments: [apptCA],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trusteeNY, trusteeCA] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue({
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '081',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York Region',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '081',
+                      court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('York, New')).toBeInTheDocument();
+        expect(screen.queryByText('Fornia, Cali')).not.toBeInTheDocument();
+      });
+    });
+
+    test('flag ON: no district selected — all trustees appear', async () => {
+      const trusteeNY = makeListItem({
+        trusteeId: 'ny',
+        firstName: 'New',
+        lastName: 'York',
+        appointments: [makeAppointment({ courtId: 'NYSB' })],
+      });
+      const trusteeCA = makeListItem({
+        trusteeId: 'ca',
+        firstName: 'Cali',
+        lastName: 'Fornia',
+        appointments: [makeAppointment({ courtId: 'CAB' })],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trusteeNY, trusteeCA] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('York, New')).toBeInTheDocument();
+        expect(screen.getByText('Fornia, Cali')).toBeInTheDocument();
+      });
+    });
+
+    test('flag OFF: filter still uses division code matching (existing behavior)', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': false,
+      } as FeatureFlagSet);
+
+      const appt = makeAppointment({ courtId: 'NYSB', divisionCode: '081' });
+      const trusteeNY = makeListItem({
+        trusteeId: 'ny',
+        firstName: 'New',
+        lastName: 'York',
+        appointments: [appt],
+      });
+      const trusteeOther = makeListItem({
+        trusteeId: 'other',
+        firstName: 'Other',
+        lastName: 'Person',
+        appointments: [makeAppointment({ courtId: 'VTB', divisionCode: '088' })],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trusteeNY, trusteeOther] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue({
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '081',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York Region',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '081',
+                      court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('York, New')).toBeInTheDocument();
+        expect(screen.queryByText('Person, Other')).not.toBeInTheDocument();
         expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
       });
     });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -10,6 +10,8 @@ import { vi } from 'vitest';
 import MockData from '@common/cams/test-utilities/mock-data';
 import LocalStorage from '@/lib/utils/local-storage';
 import React from 'react';
+import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
+import { FeatureFlagSet } from '@common/feature-flags';
 
 const mockTrackEvent = vi.fn();
 vi.mock('@/lib/hooks/UseApplicationInsights', () => ({
@@ -1744,6 +1746,172 @@ describe('TrusteesList Component', () => {
       // Should remove the filter and show all trustees
       await waitFor(() => {
         expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Division Column (Feature Flag)', () => {
+    beforeEach(() => {
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({
+        data: [
+          {
+            courtId: 'NYSB',
+            courtName: 'Southern District of New York',
+            officeCode: '081',
+            officeName: 'Manhattan',
+            courtDivisionCode: '081',
+            courtDivisionName: 'Manhattan',
+            groupDesignator: 'NY',
+            regionId: '02',
+            regionName: 'New York Region',
+          },
+          {
+            courtId: 'NYSB',
+            courtName: 'Southern District of New York',
+            officeCode: '087',
+            officeName: 'White Plains',
+            courtDivisionCode: '087',
+            courtDivisionName: 'White Plains',
+            groupDesignator: 'NY',
+            regionId: '02',
+            regionName: 'New York Region',
+          },
+        ],
+      });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+    });
+
+    test('should display Division column header when feature flag is ON', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': true,
+      } as FeatureFlagSet);
+
+      const trustee = makeListItem({
+        trusteeId: 't1',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        appointments: [makeAppointment({ courtId: 'NYSB', divisionCode: '081' })],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee] });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      const headers = screen.getAllByRole('columnheader');
+      const headerTexts = headers.map((h) => h.textContent);
+      expect(headerTexts).toContain('Division');
+    });
+
+    test('should NOT display Division column header when feature flag is OFF', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': false,
+      } as FeatureFlagSet);
+
+      const trustee = makeListItem({
+        trusteeId: 't1',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        appointments: [makeAppointment({ courtId: 'NYSB', divisionCode: '081' })],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee] });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      const headers = screen.getAllByRole('columnheader');
+      const headerTexts = headers.map((h) => h.textContent);
+      expect(headerTexts).not.toContain('Division');
+    });
+
+    test('should display "All" when appointment covers all divisions in a district', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': true,
+      } as FeatureFlagSet);
+
+      const trustee = makeListItem({
+        trusteeId: 't1',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        appointments: [
+          makeAppointment({
+            courtId: 'NYSB',
+            courtName: 'Southern District of New York',
+            divisionCodes: ['081', '087'],
+          }),
+        ],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee] });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        const divisionCell = document.querySelector('[data-cell="Division"]') as HTMLElement;
+        expect(divisionCell).toBeInTheDocument();
+        expect(within(divisionCell).getByText('All')).toBeInTheDocument();
+      });
+    });
+
+    test('should display specific division names for partial assignments', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': true,
+      } as FeatureFlagSet);
+
+      const trustee = makeListItem({
+        trusteeId: 't1',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        appointments: [
+          makeAppointment({
+            courtId: 'NYSB',
+            courtName: 'Southern District of New York',
+            divisionCodes: ['081'],
+          }),
+        ],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee] });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        const divisionCell = document.querySelector('[data-cell="Division"]') as HTMLElement;
+        expect(divisionCell).toBeInTheDocument();
+        expect(within(divisionCell).getByText('Manhattan')).toBeInTheDocument();
+      });
+    });
+
+    test('should display legacy courtDivisionName when no divisionCodes exist', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': true,
+      } as FeatureFlagSet);
+
+      const trustee = makeListItem({
+        trusteeId: 't1',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        appointments: [
+          makeAppointment({
+            courtId: 'NYSB',
+            courtName: 'Southern District of New York',
+            courtDivisionName: 'Manhattan',
+            divisionCode: '081',
+            divisionCodes: undefined,
+          }),
+        ],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee] });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        const divisionCell = document.querySelector('[data-cell="Division"]') as HTMLElement;
+        expect(divisionCell).toBeInTheDocument();
+        expect(within(divisionCell).getByText('Manhattan')).toBeInTheDocument();
       });
     });
   });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2244,6 +2244,8 @@ describe('TrusteesList Component', () => {
     });
 
     test('filterTrustees: filters by specific division code when flag ON and combined filter selected', async () => {
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
       const apptManhattan = makeAppointment({
         courtId: 'NYSB',
         divisionCodes: ['081'],
@@ -2307,6 +2309,8 @@ describe('TrusteesList Component', () => {
     });
 
     test('filterTrustees: "All Divisions" trustee (empty divisionCodes) always matches any division selection', async () => {
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
       const apptAllDivisions = makeAppointment({
         courtId: 'NYSB',
         divisionCodes: [],
@@ -2434,6 +2438,8 @@ describe('TrusteesList Component', () => {
     });
 
     test('selecting All after specific division shows all trustees in that court', async () => {
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
       const apptManhattan = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
       const apptWhitePlains = makeAppointment({ courtId: 'NYSB', divisionCodes: ['087'] });
       const trusteeManhattan = makeListItem({
@@ -2501,6 +2507,8 @@ describe('TrusteesList Component', () => {
     });
 
     test('clearing all combined selections shows all trustees', async () => {
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
       const apptNY = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
       const trusteeNY = makeListItem({
         trusteeId: 'ny',
@@ -2560,6 +2568,46 @@ describe('TrusteesList Component', () => {
             name: /southern district of new york \(manhattan\) selected.*click to deselect/i,
           }),
         ).not.toBeInTheDocument();
+      });
+    });
+
+    test('defaults to user session divisions when flag is ON', async () => {
+      const apptManhattan = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
+      const apptWhitePlains = makeAppointment({ courtId: 'NYSB', divisionCodes: ['087'] });
+      const trusteeManhattan = makeListItem({
+        trusteeId: 'manhattan',
+        firstName: 'Alice',
+        lastName: 'Manhattan',
+        appointments: [apptManhattan],
+      });
+      const trusteeWhitePlains = makeListItem({
+        trusteeId: 'whiteplains',
+        firstName: 'Bob',
+        lastName: 'WhitePlains',
+        appointments: [apptWhitePlains],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [trusteeManhattan, trusteeWhitePlains],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Manhattan, Alice')).toBeInTheDocument();
+        expect(screen.queryByText('WhitePlains, Bob')).not.toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', {
+            name: /southern district of new york \(manhattan\) selected.*click to deselect/i,
+          }),
+        ).toBeInTheDocument();
       });
     });
 

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2180,4 +2180,297 @@ describe('TrusteesList Component', () => {
       });
     });
   });
+
+  describe('Division Filter (Slice 3, flag ON)', () => {
+    const nysbCourts = [
+      {
+        courtId: 'NYSB',
+        courtName: 'Southern District of New York',
+        officeCode: '081',
+        officeName: 'Manhattan',
+        courtDivisionCode: '081',
+        courtDivisionName: 'Manhattan',
+        groupDesignator: 'NY',
+        regionId: '02',
+        regionName: 'New York Region',
+      },
+      {
+        courtId: 'NYSB',
+        courtName: 'Southern District of New York',
+        officeCode: '087',
+        officeName: 'White Plains',
+        courtDivisionCode: '087',
+        courtDivisionName: 'White Plains',
+        groupDesignator: 'NY',
+        regionId: '02',
+        regionName: 'New York Region',
+      },
+    ];
+
+    const nysbSession = {
+      ...MockData.getCamsSession(),
+      user: {
+        ...MockData.getCamsSession().user,
+        offices: [
+          {
+            officeCode: '081',
+            officeName: 'Manhattan',
+            idpGroupName: 'Manhattan',
+            regionId: '02',
+            regionName: 'New York Region',
+            groups: [
+              {
+                groupDesignator: 'NY',
+                divisions: [
+                  {
+                    divisionCode: '081',
+                    court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                    courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    beforeEach(() => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': true,
+      } as FeatureFlagSet);
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: nysbCourts });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(nysbSession);
+    });
+
+    test('filterTrustees: filters by specific division code when flag ON and division selected', async () => {
+      const apptManhattan = makeAppointment({
+        courtId: 'NYSB',
+        divisionCodes: ['081'],
+      });
+      const apptWhitePlains = makeAppointment({
+        courtId: 'NYSB',
+        divisionCodes: ['087'],
+      });
+      const trusteeManhattan = makeListItem({
+        trusteeId: 'manhattan',
+        firstName: 'Alice',
+        lastName: 'Manhattan',
+        appointments: [apptManhattan],
+      });
+      const trusteeWhitePlains = makeListItem({
+        trusteeId: 'whiteplains',
+        firstName: 'Bob',
+        lastName: 'WhitePlains',
+        appointments: [apptWhitePlains],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [trusteeManhattan, trusteeWhitePlains],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Division')).toBeInTheDocument();
+      });
+
+      const divisionCombobox = screen.getByLabelText('Division');
+      await userEvent.setup().click(divisionCombobox);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: /option: Manhattan/i })).toBeInTheDocument();
+      });
+
+      await userEvent.setup().click(screen.getByRole('option', { name: /option: Manhattan/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Manhattan, Alice')).toBeInTheDocument();
+        expect(screen.queryByText('WhitePlains, Bob')).not.toBeInTheDocument();
+      });
+    });
+
+    test('filterTrustees: "All Divisions" trustee (empty divisionCodes) always matches any division selection', async () => {
+      const apptAllDivisions = makeAppointment({
+        courtId: 'NYSB',
+        divisionCodes: [],
+      });
+      const apptSpecific = makeAppointment({
+        courtId: 'NYSB',
+        divisionCodes: ['087'],
+      });
+      const trusteeAllDivisions = makeListItem({
+        trusteeId: 'alldiv',
+        firstName: 'Alice',
+        lastName: 'AllDivisions',
+        appointments: [apptAllDivisions],
+      });
+      const trusteeSpecific = makeListItem({
+        trusteeId: 'specific',
+        firstName: 'Bob',
+        lastName: 'WhitePlains',
+        appointments: [apptSpecific],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [trusteeAllDivisions, trusteeSpecific],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Division')).toBeInTheDocument();
+      });
+
+      const divisionCombobox = screen.getByLabelText('Division');
+      await userEvent.setup().click(divisionCombobox);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: /option: White Plains/i })).toBeInTheDocument();
+      });
+
+      await userEvent.setup().click(screen.getByRole('option', { name: /option: White Plains/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('AllDivisions, Alice')).toBeInTheDocument();
+        expect(screen.getByText('WhitePlains, Bob')).toBeInTheDocument();
+      });
+    });
+
+    test('division filter hidden when no district is selected', async () => {
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [makeListItem({ trusteeId: 't1' })],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('District')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByLabelText('Division')).not.toBeInTheDocument();
+    });
+
+    test('division filter shown when district is selected', async () => {
+      const appt = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [makeListItem({ trusteeId: 't1', appointments: [appt] })],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Division')).toBeInTheDocument();
+      });
+    });
+
+    test('division selection cleared when district changes', async () => {
+      const apptNY = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
+      const trusteeNY = makeListItem({
+        trusteeId: 'ny',
+        firstName: 'Alice',
+        lastName: 'New York',
+        appointments: [apptNY],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trusteeNY] });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Division')).toBeInTheDocument();
+      });
+
+      const divisionCombobox = screen.getByLabelText('Division');
+      await userEvent.setup().click(divisionCombobox);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: /option: Manhattan/i })).toBeInTheDocument();
+      });
+
+      await userEvent.setup().click(screen.getByRole('option', { name: /option: Manhattan/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /manhattan selected.*click to deselect/i }),
+        ).toBeInTheDocument();
+      });
+
+      // Clear the district filter by clicking the district pill
+      const districtPill = screen.getByRole('button', {
+        name: /southern district of new york selected.*click to deselect/i,
+      });
+      await userEvent.setup().click(districtPill);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', { name: /manhattan selected.*click to deselect/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    test('division filter not shown when feature flag is OFF', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': false,
+      } as FeatureFlagSet);
+
+      const appt = makeAppointment({ courtId: 'NYSB', divisionCode: '081' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [makeListItem({ trusteeId: 't1', appointments: [appt] })],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('District')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByLabelText('Division')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2577,6 +2577,55 @@ describe('TrusteesList Component', () => {
       });
     });
 
+    test('flag ON: clearing all combined filter selections reveals trustees from all districts', async () => {
+      // Regression: with flag ON, selectedDistricts (set by session default) was silently applied
+      // even though the district combo was not accessible in the UI. Clearing selectedDivisions
+      // back to [] must show ALL trustees, not just those in the session's district.
+      const trusteeManhattan = makeListItem({
+        trusteeId: 'manhattan',
+        firstName: 'Alice',
+        lastName: 'Manhattan',
+        appointments: [makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] })],
+      });
+      const trusteeOtherDistrict = makeListItem({
+        trusteeId: 'other',
+        firstName: 'Out',
+        lastName: 'OfDistrict',
+        appointments: [makeAppointment({ courtId: 'CAB', divisionCodes: ['099'] })],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [trusteeManhattan, trusteeOtherDistrict],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      // Session default (NYSB Manhattan) is applied on mount — only Manhattan trustee visible
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Manhattan, Alice')).toBeInTheDocument();
+        expect(screen.queryByText('OfDistrict, Out')).not.toBeInTheDocument();
+      });
+
+      // Expand filters to access pills
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      // Remove the default Manhattan division pill — clears selectedDivisions to []
+      const pill = await screen.findByRole('button', {
+        name: /southern district of new york \(manhattan\) selected.*click to deselect/i,
+      });
+      await userEvent.setup().click(pill);
+
+      // With no active filters, trustees from ALL districts must appear.
+      // The bug would have kept selectedDistricts = [NYSB] active, showing only 1 trustee.
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Manhattan, Alice')).toBeInTheDocument();
+        expect(screen.getByText('OfDistrict, Out')).toBeInTheDocument();
+      });
+    });
+
     test('defaults to user session divisions when flag is ON', async () => {
       const apptManhattan = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
       const apptWhitePlains = makeAppointment({ courtId: 'NYSB', divisionCodes: ['087'] });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2243,7 +2243,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(nysbSession);
     });
 
-    test('filterTrustees: filters by specific division code when flag ON and division selected', async () => {
+    test('filterTrustees: filters by specific division code when flag ON and combined filter selected', async () => {
       const apptManhattan = makeAppointment({
         courtId: 'NYSB',
         divisionCodes: ['081'],
@@ -2279,17 +2279,25 @@ describe('TrusteesList Component', () => {
       await userEvent.setup().click(toggleButton);
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Division')).toBeInTheDocument();
+        expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
       });
 
-      const divisionCombobox = screen.getByLabelText('Division');
-      await userEvent.setup().click(divisionCombobox);
+      const combinedCombobox = screen.getByLabelText('District (Division)');
+      await userEvent.setup().click(combinedCombobox);
 
       await waitFor(() => {
-        expect(screen.getByRole('option', { name: /option: Manhattan/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', {
+            name: /option: Southern District of New York \(Manhattan\)/i,
+          }),
+        ).toBeInTheDocument();
       });
 
-      await userEvent.setup().click(screen.getByRole('option', { name: /option: Manhattan/i }));
+      await userEvent.setup().click(
+        screen.getByRole('option', {
+          name: /option: Southern District of New York \(Manhattan\)/i,
+        }),
+      );
 
       await waitFor(() => {
         expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
@@ -2334,17 +2342,25 @@ describe('TrusteesList Component', () => {
       await userEvent.setup().click(toggleButton);
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Division')).toBeInTheDocument();
+        expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
       });
 
-      const divisionCombobox = screen.getByLabelText('Division');
-      await userEvent.setup().click(divisionCombobox);
+      const combinedCombobox = screen.getByLabelText('District (Division)');
+      await userEvent.setup().click(combinedCombobox);
 
       await waitFor(() => {
-        expect(screen.getByRole('option', { name: /option: White Plains/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', {
+            name: /option: Southern District of New York \(White Plains\)/i,
+          }),
+        ).toBeInTheDocument();
       });
 
-      await userEvent.setup().click(screen.getByRole('option', { name: /option: White Plains/i }));
+      await userEvent.setup().click(
+        screen.getByRole('option', {
+          name: /option: Southern District of New York \(White Plains\)/i,
+        }),
+      );
 
       await waitFor(() => {
         expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
@@ -2353,7 +2369,7 @@ describe('TrusteesList Component', () => {
       });
     });
 
-    test('division filter hidden when no district is selected', async () => {
+    test('combined district/division filter shown when flag is ON', async () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
         data: [makeListItem({ trusteeId: 't1' })],
@@ -2369,13 +2385,14 @@ describe('TrusteesList Component', () => {
       await userEvent.setup().click(toggleButton);
 
       await waitFor(() => {
-        expect(screen.getByLabelText('District')).toBeInTheDocument();
+        expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
       });
 
+      expect(screen.queryByLabelText('District')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('Division')).not.toBeInTheDocument();
     });
 
-    test('division filter shown when district is selected', async () => {
+    test('combined filter shows all district/division options', async () => {
       const appt = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
         data: [makeListItem({ trusteeId: 't1', appointments: [appt] })],
@@ -2391,11 +2408,99 @@ describe('TrusteesList Component', () => {
       await userEvent.setup().click(toggleButton);
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Division')).toBeInTheDocument();
+        expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      });
+
+      const combinedCombobox = screen.getByLabelText('District (Division)');
+      await userEvent.setup().click(combinedCombobox);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('option', {
+            name: /option: Southern District of New York \(All\)/i,
+          }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', {
+            name: /option: Southern District of New York \(Manhattan\)/i,
+          }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', {
+            name: /option: Southern District of New York \(White Plains\)/i,
+          }),
+        ).toBeInTheDocument();
       });
     });
 
-    test('division selection cleared when district changes', async () => {
+    test('selecting All after specific division shows all trustees in that court', async () => {
+      const apptManhattan = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
+      const apptWhitePlains = makeAppointment({ courtId: 'NYSB', divisionCodes: ['087'] });
+      const trusteeManhattan = makeListItem({
+        trusteeId: 'manhattan',
+        firstName: 'Alice',
+        lastName: 'Manhattan',
+        appointments: [apptManhattan],
+      });
+      const trusteeWhitePlains = makeListItem({
+        trusteeId: 'whiteplains',
+        firstName: 'Bob',
+        lastName: 'WhitePlains',
+        appointments: [apptWhitePlains],
+      });
+
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [trusteeManhattan, trusteeWhitePlains],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      });
+
+      const combinedCombobox = screen.getByLabelText('District (Division)');
+      await userEvent.setup().click(combinedCombobox);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('option', {
+            name: /option: Southern District of New York \(Manhattan\)/i,
+          }),
+        ).toBeInTheDocument();
+      });
+      await userEvent.setup().click(
+        screen.getByRole('option', {
+          name: /option: Southern District of New York \(Manhattan\)/i,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Manhattan, Alice')).toBeInTheDocument();
+        expect(screen.queryByText('WhitePlains, Bob')).not.toBeInTheDocument();
+      });
+
+      const manhattanPill = screen.getByRole('button', {
+        name: /southern district of new york \(manhattan\) selected.*click to deselect/i,
+      });
+      await userEvent.setup().click(manhattanPill);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Manhattan, Alice')).toBeInTheDocument();
+        expect(screen.getByText('WhitePlains, Bob')).toBeInTheDocument();
+      });
+    });
+
+    test('clearing all combined selections shows all trustees', async () => {
       const apptNY = makeAppointment({ courtId: 'NYSB', divisionCodes: ['081'] });
       const trusteeNY = makeListItem({
         trusteeId: 'ny',
@@ -2416,33 +2521,44 @@ describe('TrusteesList Component', () => {
       await userEvent.setup().click(toggleButton);
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Division')).toBeInTheDocument();
+        expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
       });
 
-      const divisionCombobox = screen.getByLabelText('Division');
-      await userEvent.setup().click(divisionCombobox);
-
-      await waitFor(() => {
-        expect(screen.getByRole('option', { name: /option: Manhattan/i })).toBeInTheDocument();
-      });
-
-      await userEvent.setup().click(screen.getByRole('option', { name: /option: Manhattan/i }));
+      const combinedCombobox = screen.getByLabelText('District (Division)');
+      await userEvent.setup().click(combinedCombobox);
 
       await waitFor(() => {
         expect(
-          screen.getByRole('button', { name: /manhattan selected.*click to deselect/i }),
+          screen.getByRole('option', {
+            name: /option: Southern District of New York \(Manhattan\)/i,
+          }),
         ).toBeInTheDocument();
       });
 
-      // Clear the district filter by clicking the district pill
-      const districtPill = screen.getByRole('button', {
-        name: /southern district of new york selected.*click to deselect/i,
-      });
-      await userEvent.setup().click(districtPill);
+      await userEvent.setup().click(
+        screen.getByRole('option', {
+          name: /option: Southern District of New York \(Manhattan\)/i,
+        }),
+      );
 
       await waitFor(() => {
         expect(
-          screen.queryByRole('button', { name: /manhattan selected.*click to deselect/i }),
+          screen.getByRole('button', {
+            name: /southern district of new york \(manhattan\) selected.*click to deselect/i,
+          }),
+        ).toBeInTheDocument();
+      });
+
+      const divisionPill = screen.getByRole('button', {
+        name: /southern district of new york \(manhattan\) selected.*click to deselect/i,
+      });
+      await userEvent.setup().click(divisionPill);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('button', {
+            name: /southern district of new york \(manhattan\) selected.*click to deselect/i,
+          }),
         ).not.toBeInTheDocument();
       });
     });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1566,6 +1566,9 @@ describe('TrusteesList Component', () => {
     });
 
     test('should render pills above trustee count when filter is expanded', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': false,
+      } as FeatureFlagSet);
       const user = userEvent.setup();
       const trusteeWithAppt = makeListItem({
         trusteeId: 't1',
@@ -1656,6 +1659,9 @@ describe('TrusteesList Component', () => {
     });
 
     test('should delegate pill removal to filter ref when X clicked on expanded pills', async () => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': false,
+      } as FeatureFlagSet);
       const user = userEvent.setup();
       const trusteeWithAppt = makeListItem({
         trusteeId: 't1',
@@ -2609,6 +2615,49 @@ describe('TrusteesList Component', () => {
           }),
         ).toBeInTheDocument();
       });
+    });
+
+    test('default session divisions appear at top of combined dropdown with divider', async () => {
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [makeListItem({ trusteeId: 't1' })],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee(s)', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      });
+
+      const combinedCombobox = screen.getByLabelText('District (Division)');
+      await userEvent.setup().click(combinedCombobox);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('option', {
+            name: /option: Southern District of New York \(Manhattan\)/i,
+          }),
+        ).toBeInTheDocument();
+      });
+
+      const allOptions = screen.getAllByRole('option');
+      const manhattanIndex = allOptions.findIndex((o) =>
+        o.textContent?.includes('Southern District of New York (Manhattan)'),
+      );
+      const vermontIndex = allOptions.findIndex((o) =>
+        o.textContent?.includes('District of Vermont'),
+      );
+
+      expect(manhattanIndex).toBeGreaterThanOrEqual(0);
+      if (vermontIndex >= 0) {
+        expect(manhattanIndex).toBeLessThan(vermontIndex);
+      }
     });
 
     test('division filter not shown when feature flag is OFF', async () => {

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -28,6 +28,25 @@ import { CourtDivisionDetails } from '@common/cams/courts';
 const BASE_COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
 const DIVISION_COLUMN_HEADERS = ['Name', 'District', 'Division', 'Chapter', 'Type', 'Status'];
 
+function isUserInSelectedDivision(trustee: TrusteeListItem, selectedDivisions: ComboOption[]) {
+  if (selectedDivisions.length === 0) return true;
+
+  const courtFilter = new Map<string, Set<string>>();
+  for (const opt of selectedDivisions) {
+    const [courtId, code] = opt.value.split('|');
+    if (!courtFilter.has(courtId)) courtFilter.set(courtId, new Set());
+    courtFilter.get(courtId)!.add(code);
+  }
+
+  return trustee.appointments.some((appt) => {
+    const allowed = courtFilter.get(appt.courtId);
+    if (!allowed) return false;
+    if (allowed.has('ALL')) return true;
+    if (!appt.divisionCodes || appt.divisionCodes.length === 0) return true;
+    return appt.divisionCodes.some((code) => allowed.has(code));
+  });
+}
+
 function filterTrustees(
   trustees: TrusteeListItem[],
   selectedDistricts: ComboOption[],
@@ -43,40 +62,20 @@ function filterTrustees(
     return trustees;
   const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
   return trustees.filter((trustee) => {
-    let districtMatch: boolean;
-    if (districtDivisionEnabled) {
-      if (selectedDivisions.length > 0) {
-        const courtFilter = new Map<string, Set<string>>();
-        for (const opt of selectedDivisions) {
-          const [courtId, code] = opt.value.split('|');
-          if (!courtFilter.has(courtId)) courtFilter.set(courtId, new Set());
-          courtFilter.get(courtId)!.add(code);
-        }
-        districtMatch = trustee.appointments.some((appt) => {
-          const allowed = courtFilter.get(appt.courtId);
-          if (!allowed) return false;
-          if (allowed.has('ALL')) return true;
-          if (!appt.divisionCodes || appt.divisionCodes.length === 0) return true;
-          return appt.divisionCodes.some((code) => allowed.has(code));
-        });
-      } else if (selectedDistricts.length > 0) {
-        const selectedCourtIds = new Set(selectedDistricts.map((d) => d.value));
-        districtMatch = trustee.appointments.some((appt) => selectedCourtIds.has(appt.courtId));
-      } else {
-        districtMatch = true;
-      }
-    } else if (selectedDistricts.length === 0) {
-      districtMatch = true;
-    } else {
+    const userNotInSelectedChapter =
+      selectedChapters.length === 0 ||
+      trustee.appointments.some((appt) => selectedChapterValues.has(appt.chapter));
+    if (!userNotInSelectedChapter) return false;
+
+    if (!districtDivisionEnabled) {
+      if (selectedDistricts.length === 0) return true;
       const selectedDivisionCodes = new Set(selectedDistricts.flatMap((d) => d.value.split(',')));
-      districtMatch = trustee.appointments.some(
+      return trustee.appointments.some(
         (appt) => appt.divisionCode && selectedDivisionCodes.has(appt.divisionCode),
       );
     }
-    const chapterMatch =
-      selectedChapters.length === 0 ||
-      trustee.appointments.some((appt) => selectedChapterValues.has(appt.chapter));
-    return districtMatch && chapterMatch;
+
+    return isUserInSelectedDivision(trustee, selectedDivisions);
   });
 }
 

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -27,16 +27,23 @@ function filterTrustees(
   trustees: TrusteeListItem[],
   selectedDistricts: ComboOption[],
   selectedChapters: ComboOption[],
+  districtDivisionEnabled: boolean = false,
 ): TrusteeListItem[] {
   if (selectedDistricts.length === 0 && selectedChapters.length === 0) return trustees;
-  const selectedDivisionCodes = new Set(selectedDistricts.flatMap((d) => d.value.split(',')));
   const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
   return trustees.filter((trustee) => {
-    const districtMatch =
-      selectedDistricts.length === 0 ||
-      trustee.appointments.some(
+    let districtMatch: boolean;
+    if (selectedDistricts.length === 0) {
+      districtMatch = true;
+    } else if (districtDivisionEnabled) {
+      const selectedCourtIds = new Set(selectedDistricts.map((d) => d.value));
+      districtMatch = trustee.appointments.some((appt) => selectedCourtIds.has(appt.courtId));
+    } else {
+      const selectedDivisionCodes = new Set(selectedDistricts.flatMap((d) => d.value.split(',')));
+      districtMatch = trustee.appointments.some(
         (appt) => appt.divisionCode && selectedDivisionCodes.has(appt.divisionCode),
       );
+    }
     const chapterMatch =
       selectedChapters.length === 0 ||
       trustee.appointments.some((appt) => selectedChapterValues.has(appt.chapter));
@@ -162,7 +169,12 @@ export default function TrusteesList() {
   }, [nameSearch, debounce]);
 
   const { filteredTrustees } = useMemo(() => {
-    let filtered = filterTrustees(trustees, selectedDistricts, selectedChapters);
+    let filtered = filterTrustees(
+      trustees,
+      selectedDistricts,
+      selectedChapters,
+      districtDivisionEnabled,
+    );
 
     if (nameSearch.length >= 2) {
       filtered = filtered.filter((t) => nameSearchIds.has(t.trusteeId));
@@ -199,7 +211,12 @@ export default function TrusteesList() {
       selectedDistricts.length === defaults.length &&
       selectedDistricts.every((d) => defaults.some((def) => def.value === d.value));
 
-    const resultCount = filterTrustees(trustees, selectedDistricts, selectedChapters).length;
+    const resultCount = filterTrustees(
+      trustees,
+      selectedDistricts,
+      selectedChapters,
+      districtDivisionEnabled,
+    ).length;
 
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee District Filter Changed' },
@@ -225,7 +242,12 @@ export default function TrusteesList() {
   useEffect(() => {
     if (!isChapterFilterInteracted.current) return;
 
-    const resultCount = filterTrustees(trustees, selectedDistricts, selectedChapters).length;
+    const resultCount = filterTrustees(
+      trustees,
+      selectedDistricts,
+      selectedChapters,
+      districtDivisionEnabled,
+    ).length;
 
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee Chapter Filter Changed' },

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -16,7 +16,11 @@ import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types';
 import Icon from '@/lib/components/uswds/Icon';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
-import { sortTrusteeAppointments, buildDivisionsDisplay } from '@/lib/utils/court-utils';
+import {
+  sortTrusteeAppointments,
+  buildDivisionsDisplay,
+  getDivisionsForDistrict,
+} from '@/lib/utils/court-utils';
 import useFeatureFlags, { TRUSTEE_DISTRICT_DIVISION } from '@/lib/hooks/UseFeatureFlags';
 import { CourtDivisionDetails } from '@common/cams/courts';
 
@@ -28,8 +32,14 @@ function filterTrustees(
   selectedDistricts: ComboOption[],
   selectedChapters: ComboOption[],
   districtDivisionEnabled: boolean = false,
+  selectedDivisions: ComboOption[] = [],
 ): TrusteeListItem[] {
-  if (selectedDistricts.length === 0 && selectedChapters.length === 0) return trustees;
+  if (
+    selectedDistricts.length === 0 &&
+    selectedChapters.length === 0 &&
+    selectedDivisions.length === 0
+  )
+    return trustees;
   const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
   return trustees.filter((trustee) => {
     let districtMatch: boolean;
@@ -37,7 +47,18 @@ function filterTrustees(
       districtMatch = true;
     } else if (districtDivisionEnabled) {
       const selectedCourtIds = new Set(selectedDistricts.map((d) => d.value));
-      districtMatch = trustee.appointments.some((appt) => selectedCourtIds.has(appt.courtId));
+      if (selectedDivisions.length > 0) {
+        const selectedDivisionCodes = new Set(selectedDivisions.map((d) => d.value));
+        districtMatch = trustee.appointments.some(
+          (appt) =>
+            selectedCourtIds.has(appt.courtId) &&
+            (!appt.divisionCodes ||
+              appt.divisionCodes.length === 0 ||
+              appt.divisionCodes.some((code) => selectedDivisionCodes.has(code))),
+        );
+      } else {
+        districtMatch = trustee.appointments.some((appt) => selectedCourtIds.has(appt.courtId));
+      }
     } else {
       const selectedDivisionCodes = new Set(selectedDistricts.flatMap((d) => d.value.split(',')));
       districtMatch = trustee.appointments.some(
@@ -71,6 +92,7 @@ export default function TrusteesList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
+  const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
   const [liveAnnouncement, setLiveAnnouncement] = useState<string>('');
@@ -126,7 +148,12 @@ export default function TrusteesList() {
       defaultDistrictsRef.current = districts;
       isDefaultApplied.current = true;
     }
+    setSelectedDivisions([]);
     setSelectedDistricts(districts);
+  };
+
+  const handleFilterDivision = (divisions: ComboOption[]) => {
+    setSelectedDivisions(divisions);
   };
 
   const handleFilterChapter = (chapters: ComboOption[]) => {
@@ -168,12 +195,42 @@ export default function TrusteesList() {
     }, 300);
   }, [nameSearch, debounce]);
 
+  const availableDivisionOptions = useMemo((): ComboOption[] => {
+    if (!districtDivisionEnabled || selectedDistricts.length === 0) return [];
+    const selectedCourtIds = new Set(selectedDistricts.map((d) => d.value));
+    const divisionCodeSet = new Set<string>();
+    trustees.forEach((trustee) => {
+      trustee.appointments.forEach((appt) => {
+        if (
+          selectedCourtIds.has(appt.courtId) &&
+          appt.divisionCodes &&
+          appt.divisionCodes.length > 0
+        ) {
+          appt.divisionCodes.forEach((code) => divisionCodeSet.add(code));
+        }
+      });
+    });
+    const options: ComboOption[] = [];
+    const seen = new Set<string>();
+    for (const courtId of selectedCourtIds) {
+      const divisions = getDivisionsForDistrict(allCourts, courtId);
+      divisions.forEach((div) => {
+        if (divisionCodeSet.has(div.courtDivisionCode) && !seen.has(div.courtDivisionCode)) {
+          seen.add(div.courtDivisionCode);
+          options.push({ value: div.courtDivisionCode, label: div.courtDivisionName });
+        }
+      });
+    }
+    return options;
+  }, [trustees, selectedDistricts, allCourts, districtDivisionEnabled]);
+
   const { filteredTrustees } = useMemo(() => {
     let filtered = filterTrustees(
       trustees,
       selectedDistricts,
       selectedChapters,
       districtDivisionEnabled,
+      selectedDivisions,
     );
 
     if (nameSearch.length >= 2) {
@@ -202,7 +259,15 @@ export default function TrusteesList() {
     return {
       filteredTrustees: sortedWithAppointments,
     };
-  }, [trustees, selectedDistricts, selectedChapters, nameSearch, nameSearchIds, sortDirection]);
+  }, [
+    trustees,
+    selectedDistricts,
+    selectedChapters,
+    selectedDivisions,
+    nameSearch,
+    nameSearchIds,
+    sortDirection,
+  ]);
 
   useEffect(() => {
     if (!isDefaultApplied.current) return;
@@ -216,6 +281,7 @@ export default function TrusteesList() {
       selectedDistricts,
       selectedChapters,
       districtDivisionEnabled,
+      selectedDivisions,
     ).length;
 
     getAppInsights().appInsights.trackEvent(
@@ -225,9 +291,10 @@ export default function TrusteesList() {
         selectedCount: selectedDistricts.length,
         resultCount,
         chapterCount: selectedChapters.length,
+        divisionCount: selectedDivisions.length,
       },
     );
-  }, [selectedDistricts, selectedChapters, trustees]);
+  }, [selectedDistricts, selectedChapters, selectedDivisions, trustees]);
 
   if (!nameSearchLoading) {
     stableCountRef.current = filteredTrustees.length;
@@ -247,6 +314,7 @@ export default function TrusteesList() {
       selectedDistricts,
       selectedChapters,
       districtDivisionEnabled,
+      selectedDivisions,
     ).length;
 
     getAppInsights().appInsights.trackEvent(
@@ -258,7 +326,7 @@ export default function TrusteesList() {
         selectedChapterValues: selectedChapters.map((c) => c.value).join(','),
       },
     );
-  }, [selectedChapters, selectedDistricts, trustees]);
+  }, [selectedChapters, selectedDistricts, selectedDivisions, trustees]);
 
   useEffect(() => {
     if (!isNameFilterInteracted.current) return;
@@ -334,6 +402,8 @@ export default function TrusteesList() {
         handleFilterDistrict={handleFilterDistrict}
         handleFilterChapter={handleFilterChapter}
         handleFilterName={handleFilterName}
+        handleFilterDivision={handleFilterDivision}
+        availableDivisionOptions={availableDivisionOptions}
         onCourtsLoaded={setAllCourts}
       />
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -20,6 +20,7 @@ import {
   sortTrusteeAppointments,
   buildDivisionsDisplay,
   getDivisionsForDistrict,
+  getDistrictDivisionComboOptions,
 } from '@/lib/utils/court-utils';
 import useFeatureFlags, { TRUSTEE_DISTRICT_DIVISION } from '@/lib/hooks/UseFeatureFlags';
 import { CourtDivisionDetails } from '@common/cams/courts';
@@ -43,22 +44,29 @@ function filterTrustees(
   const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
   return trustees.filter((trustee) => {
     let districtMatch: boolean;
-    if (selectedDistricts.length === 0) {
-      districtMatch = true;
-    } else if (districtDivisionEnabled) {
-      const selectedCourtIds = new Set(selectedDistricts.map((d) => d.value));
+    if (districtDivisionEnabled) {
       if (selectedDivisions.length > 0) {
-        const selectedDivisionCodes = new Set(selectedDivisions.map((d) => d.value));
-        districtMatch = trustee.appointments.some(
-          (appt) =>
-            selectedCourtIds.has(appt.courtId) &&
-            (!appt.divisionCodes ||
-              appt.divisionCodes.length === 0 ||
-              appt.divisionCodes.some((code) => selectedDivisionCodes.has(code))),
-        );
-      } else {
+        const courtFilter = new Map<string, Set<string>>();
+        for (const opt of selectedDivisions) {
+          const [courtId, code] = opt.value.split('|');
+          if (!courtFilter.has(courtId)) courtFilter.set(courtId, new Set());
+          courtFilter.get(courtId)!.add(code);
+        }
+        districtMatch = trustee.appointments.some((appt) => {
+          const allowed = courtFilter.get(appt.courtId);
+          if (!allowed) return false;
+          if (allowed.has('ALL')) return true;
+          if (!appt.divisionCodes || appt.divisionCodes.length === 0) return true;
+          return appt.divisionCodes.some((code) => allowed.has(code));
+        });
+      } else if (selectedDistricts.length > 0) {
+        const selectedCourtIds = new Set(selectedDistricts.map((d) => d.value));
         districtMatch = trustee.appointments.some((appt) => selectedCourtIds.has(appt.courtId));
+      } else {
+        districtMatch = true;
       }
+    } else if (selectedDistricts.length === 0) {
+      districtMatch = true;
     } else {
       const selectedDivisionCodes = new Set(selectedDistricts.flatMap((d) => d.value.split(',')));
       districtMatch = trustee.appointments.some(
@@ -223,6 +231,11 @@ export default function TrusteesList() {
     }
     return options;
   }, [trustees, selectedDistricts, allCourts, districtDivisionEnabled]);
+
+  const combinedDistrictDivisionOptions = useMemo((): ComboOption[] => {
+    if (!districtDivisionEnabled || allCourts.length === 0) return [];
+    return getDistrictDivisionComboOptions(allCourts) as ComboOption[];
+  }, [allCourts, districtDivisionEnabled]);
 
   const { filteredTrustees } = useMemo(() => {
     let filtered = filterTrustees(
@@ -404,6 +417,7 @@ export default function TrusteesList() {
         handleFilterName={handleFilterName}
         handleFilterDivision={handleFilterDivision}
         availableDivisionOptions={availableDivisionOptions}
+        combinedDistrictDivisionOptions={combinedDistrictDivisionOptions}
         onCourtsLoaded={setAllCourts}
       />
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -19,7 +19,6 @@ import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 import {
   sortTrusteeAppointments,
   buildDivisionsDisplay,
-  getDivisionsForDistrict,
   getDistrictDivisionComboOptions,
 } from '@/lib/utils/court-utils';
 import useFeatureFlags, { TRUSTEE_DISTRICT_DIVISION } from '@/lib/hooks/UseFeatureFlags';
@@ -207,35 +206,6 @@ export default function TrusteesList() {
     }, 300);
   }, [nameSearch, debounce]);
 
-  const availableDivisionOptions = useMemo((): ComboOption[] => {
-    if (!districtDivisionEnabled || selectedDistricts.length === 0) return [];
-    const selectedCourtIds = new Set(selectedDistricts.map((d) => d.value));
-    const divisionCodeSet = new Set<string>();
-    trustees.forEach((trustee) => {
-      trustee.appointments.forEach((appt) => {
-        if (
-          selectedCourtIds.has(appt.courtId) &&
-          appt.divisionCodes &&
-          appt.divisionCodes.length > 0
-        ) {
-          appt.divisionCodes.forEach((code) => divisionCodeSet.add(code));
-        }
-      });
-    });
-    const options: ComboOption[] = [];
-    const seen = new Set<string>();
-    for (const courtId of selectedCourtIds) {
-      const divisions = getDivisionsForDistrict(allCourts, courtId);
-      divisions.forEach((div) => {
-        if (divisionCodeSet.has(div.courtDivisionCode) && !seen.has(div.courtDivisionCode)) {
-          seen.add(div.courtDivisionCode);
-          options.push({ value: div.courtDivisionCode, label: div.courtDivisionName });
-        }
-      });
-    }
-    return options;
-  }, [trustees, selectedDistricts, allCourts, districtDivisionEnabled]);
-
   const combinedDistrictDivisionOptions = useMemo((): ComboOption[] => {
     if (!districtDivisionEnabled || allCourts.length === 0) return [];
     return getDistrictDivisionComboOptions(allCourts) as ComboOption[];
@@ -316,7 +286,14 @@ export default function TrusteesList() {
         divisionCount: selectedDivisions.length,
       },
     );
-  }, [selectedDistricts, selectedChapters, selectedDivisions, trustees]);
+  }, [
+    selectedDistricts,
+    selectedChapters,
+    selectedDivisions,
+    trustees,
+    districtDivisionEnabled,
+    divisionFilterMap,
+  ]);
 
   if (!nameSearchLoading) {
     stableCountRef.current = filteredTrustees.length;
@@ -348,7 +325,14 @@ export default function TrusteesList() {
         selectedChapterValues: selectedChapters.map((c) => c.value).join(','),
       },
     );
-  }, [selectedChapters, selectedDistricts, selectedDivisions, trustees]);
+  }, [
+    selectedChapters,
+    selectedDistricts,
+    selectedDivisions,
+    trustees,
+    districtDivisionEnabled,
+    divisionFilterMap,
+  ]);
 
   useEffect(() => {
     if (!isNameFilterInteracted.current) return;
@@ -425,7 +409,6 @@ export default function TrusteesList() {
         handleFilterChapter={handleFilterChapter}
         handleFilterName={handleFilterName}
         handleFilterDivision={handleFilterDivision}
-        availableDivisionOptions={availableDivisionOptions}
         combinedDistrictDivisionOptions={combinedDistrictDivisionOptions}
         onCourtsLoaded={setAllCourts}
       />

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -62,10 +62,10 @@ function filterTrustees(
     return trustees;
   const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
   return trustees.filter((trustee) => {
-    const userNotInSelectedChapter =
+    const trusteeMatchesChapter =
       selectedChapters.length === 0 ||
       trustee.appointments.some((appt) => selectedChapterValues.has(appt.chapter));
-    if (!userNotInSelectedChapter) return false;
+    if (!trusteeMatchesChapter) return false;
 
     if (!districtDivisionEnabled) {
       if (selectedDistricts.length === 0) return true;

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -28,18 +28,23 @@ import { CourtDivisionDetails } from '@common/cams/courts';
 const BASE_COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
 const DIVISION_COLUMN_HEADERS = ['Name', 'District', 'Division', 'Chapter', 'Type', 'Status'];
 
-function isUserInSelectedDivision(trustee: TrusteeListItem, selectedDivisions: ComboOption[]) {
-  if (selectedDivisions.length === 0) return true;
+type DivisionFilterMap = Map<string, Set<string>>;
 
+function buildDivisionFilterMap(selectedDivisions: ComboOption[]): DivisionFilterMap {
   const courtFilter = new Map<string, Set<string>>();
   for (const opt of selectedDivisions) {
     const [courtId, code] = opt.value.split('|');
     if (!courtFilter.has(courtId)) courtFilter.set(courtId, new Set());
     courtFilter.get(courtId)!.add(code);
   }
+  return courtFilter;
+}
+
+function isUserInSelectedDivision(trustee: TrusteeListItem, divisionFilter: DivisionFilterMap) {
+  if (divisionFilter.size === 0) return true;
 
   return trustee.appointments.some((appt) => {
-    const allowed = courtFilter.get(appt.courtId);
+    const allowed = divisionFilter.get(appt.courtId);
     if (!allowed) return false;
     if (allowed.has('ALL')) return true;
     if (!appt.divisionCodes || appt.divisionCodes.length === 0) return true;
@@ -52,12 +57,12 @@ function filterTrustees(
   selectedDistricts: ComboOption[],
   selectedChapters: ComboOption[],
   districtDivisionEnabled: boolean = false,
-  selectedDivisions: ComboOption[] = [],
+  divisionFilterMap: DivisionFilterMap = new Map(),
 ): TrusteeListItem[] {
   if (
     selectedDistricts.length === 0 &&
     selectedChapters.length === 0 &&
-    selectedDivisions.length === 0
+    divisionFilterMap.size === 0
   )
     return trustees;
   const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
@@ -75,7 +80,7 @@ function filterTrustees(
       );
     }
 
-    return isUserInSelectedDivision(trustee, selectedDivisions);
+    return isUserInSelectedDivision(trustee, divisionFilterMap);
   });
 }
 
@@ -236,13 +241,18 @@ export default function TrusteesList() {
     return getDistrictDivisionComboOptions(allCourts) as ComboOption[];
   }, [allCourts, districtDivisionEnabled]);
 
+  const divisionFilterMap = useMemo(
+    () => buildDivisionFilterMap(selectedDivisions),
+    [selectedDivisions],
+  );
+
   const { filteredTrustees } = useMemo(() => {
     let filtered = filterTrustees(
       trustees,
       selectedDistricts,
       selectedChapters,
       districtDivisionEnabled,
-      selectedDivisions,
+      divisionFilterMap,
     );
 
     if (nameSearch.length >= 2) {
@@ -275,7 +285,7 @@ export default function TrusteesList() {
     trustees,
     selectedDistricts,
     selectedChapters,
-    selectedDivisions,
+    divisionFilterMap,
     nameSearch,
     nameSearchIds,
     sortDirection,
@@ -293,7 +303,7 @@ export default function TrusteesList() {
       selectedDistricts,
       selectedChapters,
       districtDivisionEnabled,
-      selectedDivisions,
+      divisionFilterMap,
     ).length;
 
     getAppInsights().appInsights.trackEvent(
@@ -326,7 +336,7 @@ export default function TrusteesList() {
       selectedDistricts,
       selectedChapters,
       districtDivisionEnabled,
-      selectedDivisions,
+      divisionFilterMap,
     ).length;
 
     getAppInsights().appInsights.trackEvent(

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -16,9 +16,12 @@ import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types';
 import Icon from '@/lib/components/uswds/Icon';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
-import { sortTrusteeAppointments } from '@/lib/utils/court-utils';
+import { sortTrusteeAppointments, buildDivisionsDisplay } from '@/lib/utils/court-utils';
+import useFeatureFlags, { TRUSTEE_DISTRICT_DIVISION } from '@/lib/hooks/UseFeatureFlags';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
-const COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
+const BASE_COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
+const DIVISION_COLUMN_HEADERS = ['Name', 'District', 'Division', 'Chapter', 'Type', 'Status'];
 
 function filterTrustees(
   trustees: TrusteeListItem[],
@@ -67,6 +70,10 @@ export default function TrusteesList() {
   const [nameSearch, setNameSearch] = useState('');
   const [nameSearchIds, setNameSearchIds] = useState<Set<string>>(new Set());
   const [nameSearchLoading, setNameSearchLoading] = useState(false);
+  const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]);
+  const flags = useFeatureFlags();
+  const districtDivisionEnabled = !!flags[TRUSTEE_DISTRICT_DIVISION];
+  const COLUMN_HEADERS = districtDivisionEnabled ? DIVISION_COLUMN_HEADERS : BASE_COLUMN_HEADERS;
   const stableCountRef = useRef<number | null>(null);
   const filterRef = useRef<TrusteeDistrictFilterRef>(null);
   const pageLoadStart = useRef(performance.now());
@@ -305,6 +312,7 @@ export default function TrusteesList() {
         handleFilterDistrict={handleFilterDistrict}
         handleFilterChapter={handleFilterChapter}
         handleFilterName={handleFilterName}
+        onCourtsLoaded={setAllCourts}
       />
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">
         {liveAnnouncement}
@@ -383,9 +391,9 @@ export default function TrusteesList() {
                       role="row"
                     >
                       <div
-                        className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[0])}`}
+                        className="trustees-list-cell col-name"
                         role="cell"
-                        {...(idx === 0 ? { 'data-cell': COLUMN_HEADERS[0] } : {})}
+                        {...(idx === 0 ? { 'data-cell': 'Name' } : {})}
                       >
                         {idx === 0 ? (
                           <NavLink
@@ -405,31 +413,32 @@ export default function TrusteesList() {
                         )}
                       </div>
                       <div
-                        className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[1])}`}
+                        className="trustees-list-cell col-district"
                         role="cell"
-                        data-cell={COLUMN_HEADERS[1]}
+                        data-cell="District"
                       >
                         {appt ? formatDistrict(appt) : ''}
                       </div>
+                      {districtDivisionEnabled && (
+                        <div
+                          className="trustees-list-cell col-division"
+                          role="cell"
+                          data-cell="Division"
+                        >
+                          {appt ? buildDivisionsDisplay(appt, allCourts) : ''}
+                        </div>
+                      )}
                       <div
-                        className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[2])}`}
+                        className="trustees-list-cell col-chapter"
                         role="cell"
-                        data-cell={COLUMN_HEADERS[2]}
+                        data-cell="Chapter"
                       >
                         {appt ? formatChapterType(appt.chapter) : ''}
                       </div>
-                      <div
-                        className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[3])}`}
-                        role="cell"
-                        data-cell={COLUMN_HEADERS[3]}
-                      >
+                      <div className="trustees-list-cell col-type" role="cell" data-cell="Type">
                         {appt ? formatAppointmentType(appt.appointmentType) : ''}
                       </div>
-                      <div
-                        className={`trustees-list-cell ${toColClass(COLUMN_HEADERS[4])}`}
-                        role="cell"
-                        data-cell={COLUMN_HEADERS[4]}
-                      >
+                      <div className="trustees-list-cell col-status" role="cell" data-cell="Status">
                         {appt ? formatAppointmentStatus(appt.status) : ''}
                       </div>
                     </div>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -68,7 +68,6 @@ function renderFilter(
       handleFilterChapter={mockHandleFilterChapter}
       handleFilterName={mockHandleFilterName}
       handleFilterDivision={mockHandleFilterDivision}
-      availableDivisionOptions={[]}
       combinedDistrictDivisionOptions={[]}
       onExpandedChange={overrides.onExpandedChange}
     />,

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -58,16 +58,24 @@ function renderFilter(
   const mockHandleFilterDistrict = vi.fn();
   const mockHandleFilterChapter = vi.fn();
   const mockHandleFilterName = vi.fn();
+  const mockHandleFilterDivision = vi.fn();
   render(
     <TrusteeDistrictFilter
       ref={overrides.ref}
       handleFilterDistrict={mockHandleFilterDistrict}
       handleFilterChapter={mockHandleFilterChapter}
       handleFilterName={mockHandleFilterName}
+      handleFilterDivision={mockHandleFilterDivision}
+      availableDivisionOptions={[]}
       onExpandedChange={overrides.onExpandedChange}
     />,
   );
-  return { mockHandleFilterDistrict, mockHandleFilterChapter, mockHandleFilterName };
+  return {
+    mockHandleFilterDistrict,
+    mockHandleFilterChapter,
+    mockHandleFilterName,
+    mockHandleFilterDivision,
+  };
 }
 
 describe('TrusteeDistrictFilter Component', () => {

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -67,6 +67,7 @@ function renderFilter(
       handleFilterName={mockHandleFilterName}
       handleFilterDivision={mockHandleFilterDivision}
       availableDivisionOptions={[]}
+      combinedDistrictDivisionOptions={[]}
       onExpandedChange={overrides.onExpandedChange}
     />,
   );

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -9,6 +9,8 @@ import LocalStorage from '@/lib/utils/local-storage';
 import MockData from '@common/cams/test-utilities/mock-data';
 import { TrusteeDistrictFilterRef } from './trusteeDistrictFilter.types';
 import React from 'react';
+import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
+import { FeatureFlagSet } from '@common/feature-flags';
 
 const mockDistricts: CourtDivisionDetails[] = [
   {
@@ -82,6 +84,9 @@ function renderFilter(
 describe('TrusteeDistrictFilter Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+      'trustee-district-division': false,
+    } as FeatureFlagSet);
     const mockResponse: ResponseBody<CourtDivisionDetails[]> = { data: mockDistricts };
     vi.spyOn(Api2, 'getCourts').mockResolvedValue(mockResponse);
   });

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -41,6 +41,7 @@ const TrusteeDistrictFilter_ = (
   );
   const previousDistrictsRef = useRef<ComboOption[] | undefined>(undefined);
   const previousChaptersRef = useRef<ComboOption[] | undefined>(undefined);
+  const previousDivisionsRef = useRef<ComboOption[] | undefined>(undefined);
   const useCase = trusteeDistrictFilterUseCase(
     store,
     controls,
@@ -48,6 +49,8 @@ const TrusteeDistrictFilter_ = (
     previousDistrictsRef,
     props.handleFilterChapter,
     previousChaptersRef,
+    props.handleFilterDivision,
+    previousDivisionsRef,
     districtDivisionEnabled,
   );
   const globalAlert = useGlobalAlert();
@@ -87,14 +90,20 @@ const TrusteeDistrictFilter_ = (
     }
   }, [store.districts, onCourtsLoaded]);
 
+  const showDivisionFilter = districtDivisionEnabled && store.selectedDistricts.length > 0;
+
   const viewModel: TrusteeDistrictFilterViewModel = {
     districts: store.districts,
     districtsError: store.districtsError,
     selectedDistricts: store.selectedDistricts,
     selectedChapters: store.selectedChapters,
+    selectedDivisions: store.selectedDivisions,
+    availableDivisionOptions: props.availableDivisionOptions,
+    showDivisionFilter,
     isExpanded: store.isExpanded,
     districtFilterRef: controls.districtFilterRef,
     chapterFilterRef: controls.chapterFilterRef,
+    divisionFilterRef: controls.divisionFilterRef,
     nameSearch,
     districtsToComboOptions: useCase.districtsToComboOptions,
     chaptersToComboOptions: useCase.chaptersToComboOptions,
@@ -104,6 +113,8 @@ const TrusteeDistrictFilter_ = (
     handleFilterChapter: useCase.handleFilterChapter,
     handleClearAllChapters: useCase.handleClearAllChapters,
     handleFilterName: handleNameChange,
+    handleFilterDivision: useCase.handleFilterDivision,
+    handleClearAllDivisions: useCase.handleClearAllDivisions,
   };
 
   return <TrusteeDistrictFilterView viewModel={viewModel}></TrusteeDistrictFilterView>;
@@ -118,6 +129,7 @@ function useTrusteeDistrictFilterStoreReact() {
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
   const [defaultDistricts, setDefaultDistricts] = useState<ComboOption[]>([]);
   const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
+  const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   return {
@@ -131,6 +143,8 @@ function useTrusteeDistrictFilterStoreReact() {
     setDefaultDistricts,
     selectedChapters,
     setSelectedChapters,
+    selectedDivisions,
+    setSelectedDivisions,
     isExpanded,
     setIsExpanded,
   };
@@ -139,9 +153,11 @@ function useTrusteeDistrictFilterStoreReact() {
 function useTrusteeDistrictFilterControlsReact() {
   const districtFilterRef = useRef<ComboBoxRef>(null);
   const chapterFilterRef = useRef<ComboBoxRef>(null);
+  const divisionFilterRef = useRef<ComboBoxRef>(null);
 
   return {
     districtFilterRef,
     chapterFilterRef,
+    divisionFilterRef,
   };
 }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -24,7 +24,7 @@ const TrusteeDistrictFilter_ = (
   props: TrusteeDistrictFilterProps,
   ref: React.Ref<TrusteeDistrictFilterRef>,
 ) => {
-  const { handleFilterName } = props;
+  const { handleFilterName, onExpandedChange, onCourtsLoaded } = props;
   const [nameSearch, setNameSearch] = useState('');
   const store: TrusteeDistrictFilterStore = useTrusteeDistrictFilterStoreReact();
   const controls: TrusteeDistrictFilterControls = useTrusteeDistrictFilterControlsReact();
@@ -71,10 +71,17 @@ const TrusteeDistrictFilter_ = (
 
   // Notify parent when expanded state changes
   useEffect(() => {
-    if (props.onExpandedChange) {
-      props.onExpandedChange(store.isExpanded);
+    if (onExpandedChange) {
+      onExpandedChange(store.isExpanded);
     }
-  }, [store.isExpanded, props.onExpandedChange]);
+  }, [store.isExpanded, onExpandedChange]);
+
+  // Notify parent when courts data is loaded
+  useEffect(() => {
+    if (onCourtsLoaded && store.districts.length > 0) {
+      onCourtsLoaded(store.districts);
+    }
+  }, [store.districts, onCourtsLoaded]);
 
   const viewModel: TrusteeDistrictFilterViewModel = {
     districts: store.districts,

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -20,6 +20,7 @@ import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import useFeatureFlags, { TRUSTEE_DISTRICT_DIVISION } from '@/lib/hooks/UseFeatureFlags';
+import { separateDefaultOptions } from '@/lib/utils/court-utils';
 
 const TrusteeDistrictFilter_ = (
   props: TrusteeDistrictFilterProps,
@@ -92,6 +93,11 @@ const TrusteeDistrictFilter_ = (
 
   const showDivisionFilter = districtDivisionEnabled && store.selectedDistricts.length > 0;
 
+  const defaultDivisionValues = new Set((store.defaultDivisions ?? []).map((d) => d.value));
+  const orderedCombinedOptions = districtDivisionEnabled
+    ? separateDefaultOptions(props.combinedDistrictDivisionOptions, defaultDivisionValues)
+    : props.combinedDistrictDivisionOptions;
+
   const viewModel: TrusteeDistrictFilterViewModel = {
     districts: store.districts,
     districtsError: store.districtsError,
@@ -99,7 +105,7 @@ const TrusteeDistrictFilter_ = (
     selectedChapters: store.selectedChapters,
     selectedDivisions: store.selectedDivisions,
     availableDivisionOptions: props.availableDivisionOptions,
-    combinedDistrictDivisionOptions: props.combinedDistrictDivisionOptions,
+    combinedDistrictDivisionOptions: orderedCombinedOptions,
     showDivisionFilter,
     districtDivisionEnabled,
     isExpanded: store.isExpanded,
@@ -133,6 +139,7 @@ function useTrusteeDistrictFilterStoreReact() {
   const [defaultDistricts, setDefaultDistricts] = useState<ComboOption[]>([]);
   const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
   const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
+  const [defaultDivisions, setDefaultDivisions] = useState<ComboOption[]>([]);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   return {
@@ -148,6 +155,8 @@ function useTrusteeDistrictFilterStoreReact() {
     setSelectedChapters,
     selectedDivisions,
     setSelectedDivisions,
+    defaultDivisions,
+    setDefaultDivisions,
     isExpanded,
     setIsExpanded,
   };

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -91,8 +91,6 @@ const TrusteeDistrictFilter_ = (
     }
   }, [store.districts, onCourtsLoaded]);
 
-  const showDivisionFilter = districtDivisionEnabled && store.selectedDistricts.length > 0;
-
   const defaultDivisionValues = new Set((store.defaultDivisions ?? []).map((d) => d.value));
   const orderedCombinedOptions = districtDivisionEnabled
     ? separateDefaultOptions(props.combinedDistrictDivisionOptions, defaultDivisionValues)
@@ -104,9 +102,7 @@ const TrusteeDistrictFilter_ = (
     selectedDistricts: store.selectedDistricts,
     selectedChapters: store.selectedChapters,
     selectedDivisions: store.selectedDivisions,
-    availableDivisionOptions: props.availableDivisionOptions,
     combinedDistrictDivisionOptions: orderedCombinedOptions,
-    showDivisionFilter,
     districtDivisionEnabled,
     isExpanded: store.isExpanded,
     districtFilterRef: controls.districtFilterRef,

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -19,12 +19,15 @@ import React, {
 import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
+import useFeatureFlags, { TRUSTEE_DISTRICT_DIVISION } from '@/lib/hooks/UseFeatureFlags';
 
 const TrusteeDistrictFilter_ = (
   props: TrusteeDistrictFilterProps,
   ref: React.Ref<TrusteeDistrictFilterRef>,
 ) => {
   const { handleFilterName, onExpandedChange, onCourtsLoaded } = props;
+  const flags = useFeatureFlags();
+  const districtDivisionEnabled = !!flags[TRUSTEE_DISTRICT_DIVISION];
   const [nameSearch, setNameSearch] = useState('');
   const store: TrusteeDistrictFilterStore = useTrusteeDistrictFilterStoreReact();
   const controls: TrusteeDistrictFilterControls = useTrusteeDistrictFilterControlsReact();
@@ -45,6 +48,7 @@ const TrusteeDistrictFilter_ = (
     previousDistrictsRef,
     props.handleFilterChapter,
     previousChaptersRef,
+    districtDivisionEnabled,
   );
   const globalAlert = useGlobalAlert();
 

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -99,7 +99,9 @@ const TrusteeDistrictFilter_ = (
     selectedChapters: store.selectedChapters,
     selectedDivisions: store.selectedDivisions,
     availableDivisionOptions: props.availableDivisionOptions,
+    combinedDistrictDivisionOptions: props.combinedDistrictDivisionOptions,
     showDivisionFilter,
+    districtDivisionEnabled,
     isExpanded: store.isExpanded,
     districtFilterRef: controls.districtFilterRef,
     chapterFilterRef: controls.chapterFilterRef,
@@ -115,6 +117,7 @@ const TrusteeDistrictFilter_ = (
     handleFilterName: handleNameChange,
     handleFilterDivision: useCase.handleFilterDivision,
     handleClearAllDivisions: useCase.handleClearAllDivisions,
+    handleFilterCombined: useCase.handleFilterCombined,
   };
 
   return <TrusteeDistrictFilterView viewModel={viewModel}></TrusteeDistrictFilterView>;

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -11,8 +11,9 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
     !viewModel.districtDivisionEnabled &&
     viewModel.districts.length > 0 &&
     !viewModel.districtsError;
+  const pillDistricts = viewModel.districtDivisionEnabled ? [] : viewModel.selectedDistricts;
   const hasPills =
-    viewModel.selectedDistricts.length > 0 ||
+    pillDistricts.length > 0 ||
     viewModel.selectedChapters.length > 0 ||
     viewModel.selectedDivisions.length > 0;
 
@@ -159,12 +160,12 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
           id="filter-pills"
           className="filter-pills-container"
           selections={[
-            ...viewModel.selectedDistricts,
+            ...pillDistricts,
             ...viewModel.selectedDivisions,
             ...viewModel.selectedChapters,
           ]}
           onSelectionChange={(updatedPills) => {
-            const districtValues = new Set(viewModel.selectedDistricts.map((d) => d.value));
+            const districtValues = new Set(pillDistricts.map((d) => d.value));
             const divisionValues = new Set(viewModel.selectedDivisions.map((d) => d.value));
             const chapterValues = new Set(viewModel.selectedChapters.map((c) => c.value));
 
@@ -172,7 +173,7 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
             const updatedDivisions = updatedPills.filter((p) => divisionValues.has(p.value));
             const updatedChapters = updatedPills.filter((p) => chapterValues.has(p.value));
 
-            if (updatedDistricts.length !== viewModel.selectedDistricts.length) {
+            if (updatedDistricts.length !== pillDistricts.length) {
               viewModel.handleFilterChange(updatedDistricts);
             }
             if (updatedDivisions.length !== viewModel.selectedDivisions.length) {

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -4,6 +4,74 @@ import PillBox from '@/lib/components/PillBox';
 import { Accordion, AccordionGroup } from '@/lib/components/uswds/Accordion';
 import { TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
 
+function renderDistrictFilter(
+  viewModel: TrusteeDistrictFilterViewProps['viewModel'],
+  showLegacyDistrictFilter: boolean,
+) {
+  if (viewModel.districtDivisionEnabled) {
+    return (
+      <div className="filter-control">
+        <div className="filter-control-header">
+          <span className="filter-control-label">District (Division)</span>
+          {viewModel.selectedDivisions.length > 0 && (
+            <button
+              type="button"
+              className="filter-clear-link"
+              onClick={viewModel.handleClearAllDivisions}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+        <ComboBox
+          id="district-division-combobox"
+          label="District (Division)"
+          options={viewModel.combinedDistrictDivisionOptions}
+          selections={viewModel.selectedDivisions}
+          onUpdateSelection={viewModel.handleFilterCombined}
+          multiSelect={true}
+          wrapPills={true}
+          pluralLabel="divisions"
+          singularLabel="division"
+          placeholder="- Select one or more -"
+          ref={viewModel.divisionFilterRef}
+          hideClearAllButton={true}
+        />
+      </div>
+    );
+  }
+
+  if (!showLegacyDistrictFilter) return null;
+
+  return (
+    <div className="filter-control">
+      <div className="filter-control-header">
+        <span className="filter-control-label">District</span>
+        {viewModel.selectedDistricts.length > 0 && (
+          <button type="button" className="filter-clear-link" onClick={viewModel.handleClearAll}>
+            Clear
+          </button>
+        )}
+      </div>
+      <ComboBox
+        id="district-combobox"
+        label="District"
+        options={viewModel.districtsToComboOptions(viewModel.districts)}
+        selections={viewModel.selectedDistricts}
+        onUpdateSelection={viewModel.handleFilterChange}
+        multiSelect={true}
+        wrapPills={true}
+        pluralLabel="districts"
+        singularLabel="district"
+        placeholder="- Select one or more -"
+        scrollToSelected={true}
+        ref={viewModel.districtFilterRef}
+        hideClearAllButton={true}
+      />
+    </div>
+  );
+}
+
 function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
   const { viewModel } = props;
 
@@ -59,68 +127,7 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                 />
               </div>
 
-              {viewModel.districtDivisionEnabled ? (
-                <div className="filter-control">
-                  <div className="filter-control-header">
-                    <span className="filter-control-label">District (Division)</span>
-                    {viewModel.selectedDivisions.length > 0 && (
-                      <button
-                        type="button"
-                        className="filter-clear-link"
-                        onClick={viewModel.handleClearAllDivisions}
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
-                  <ComboBox
-                    id="district-division-combobox"
-                    label="District (Division)"
-                    options={viewModel.combinedDistrictDivisionOptions}
-                    selections={viewModel.selectedDivisions}
-                    onUpdateSelection={viewModel.handleFilterCombined}
-                    multiSelect={true}
-                    wrapPills={true}
-                    pluralLabel="divisions"
-                    singularLabel="division"
-                    placeholder="- Select one or more -"
-                    ref={viewModel.divisionFilterRef}
-                    hideClearAllButton={true}
-                  />
-                </div>
-              ) : (
-                showLegacyDistrictFilter && (
-                  <div className="filter-control">
-                    <div className="filter-control-header">
-                      <span className="filter-control-label">District</span>
-                      {viewModel.selectedDistricts.length > 0 && (
-                        <button
-                          type="button"
-                          className="filter-clear-link"
-                          onClick={viewModel.handleClearAll}
-                        >
-                          Clear
-                        </button>
-                      )}
-                    </div>
-                    <ComboBox
-                      id="district-combobox"
-                      label="District"
-                      options={viewModel.districtsToComboOptions(viewModel.districts)}
-                      selections={viewModel.selectedDistricts}
-                      onUpdateSelection={viewModel.handleFilterChange}
-                      multiSelect={true}
-                      wrapPills={true}
-                      pluralLabel="districts"
-                      singularLabel="district"
-                      placeholder="- Select one or more -"
-                      scrollToSelected={true}
-                      ref={viewModel.districtFilterRef}
-                      hideClearAllButton={true}
-                    />
-                  </div>
-                )
-              )}
+              {renderDistrictFilter(viewModel, showLegacyDistrictFilter)}
 
               <div className="filter-control">
                 <div className="filter-control-header">

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -8,7 +8,10 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
   const { viewModel } = props;
 
   const showDistrictFilter = viewModel.districts.length > 0 && !viewModel.districtsError;
-  const hasPills = viewModel.selectedDistricts.length > 0 || viewModel.selectedChapters.length > 0;
+  const hasPills =
+    viewModel.selectedDistricts.length > 0 ||
+    viewModel.selectedChapters.length > 0 ||
+    viewModel.selectedDivisions.length > 0;
 
   return (
     <section className="trustee-district-filter" aria-label="Trustee filter controls">
@@ -84,6 +87,37 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                 </div>
               )}
 
+              {viewModel.showDivisionFilter && (
+                <div className="filter-control">
+                  <div className="filter-control-header">
+                    <span className="filter-control-label">Division</span>
+                    {viewModel.selectedDivisions.length > 0 && (
+                      <button
+                        type="button"
+                        className="filter-clear-link"
+                        onClick={viewModel.handleClearAllDivisions}
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
+                  <ComboBox
+                    id="division-combobox"
+                    label="Division"
+                    options={viewModel.availableDivisionOptions}
+                    selections={viewModel.selectedDivisions}
+                    onUpdateSelection={viewModel.handleFilterDivision}
+                    multiSelect={true}
+                    wrapPills={true}
+                    pluralLabel="divisions"
+                    singularLabel="division"
+                    placeholder="- Select one or more -"
+                    ref={viewModel.divisionFilterRef}
+                    hideClearAllButton={true}
+                  />
+                </div>
+              )}
+
               <div className="filter-control">
                 <div className="filter-control-header">
                   <span className="filter-control-label">Chapter</span>
@@ -121,18 +155,25 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
         <PillBox
           id="filter-pills"
           className="filter-pills-container"
-          selections={[...viewModel.selectedDistricts, ...viewModel.selectedChapters]}
+          selections={[
+            ...viewModel.selectedDistricts,
+            ...viewModel.selectedDivisions,
+            ...viewModel.selectedChapters,
+          ]}
           onSelectionChange={(updatedPills) => {
-            // Separate district and chapter pills
             const districtValues = new Set(viewModel.selectedDistricts.map((d) => d.value));
+            const divisionValues = new Set(viewModel.selectedDivisions.map((d) => d.value));
             const chapterValues = new Set(viewModel.selectedChapters.map((c) => c.value));
 
             const updatedDistricts = updatedPills.filter((p) => districtValues.has(p.value));
+            const updatedDivisions = updatedPills.filter((p) => divisionValues.has(p.value));
             const updatedChapters = updatedPills.filter((p) => chapterValues.has(p.value));
 
-            // Update both filters
             if (updatedDistricts.length !== viewModel.selectedDistricts.length) {
               viewModel.handleFilterChange(updatedDistricts);
+            }
+            if (updatedDivisions.length !== viewModel.selectedDivisions.length) {
+              viewModel.handleFilterDivision(updatedDivisions);
             }
             if (updatedChapters.length !== viewModel.selectedChapters.length) {
               viewModel.handleFilterChapter(updatedChapters);

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -1,8 +1,15 @@
 import './TrusteeDistrictFilter.scss';
-import ComboBox from '@/lib/components/combobox/ComboBox';
+import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import PillBox from '@/lib/components/PillBox';
 import { Accordion, AccordionGroup } from '@/lib/components/uswds/Accordion';
 import { TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
+
+type FilterPillKind = 'district' | 'division' | 'chapter';
+type FilterPill = ComboOption & { kind: FilterPillKind };
+
+function tagPills(options: ComboOption[], kind: FilterPillKind): FilterPill[] {
+  return options.map((o) => ({ ...o, kind }));
+}
 
 function renderDistrictFilter(
   viewModel: TrusteeDistrictFilterViewProps['viewModel'],
@@ -167,18 +174,15 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
           id="filter-pills"
           className="filter-pills-container"
           selections={[
-            ...pillDistricts,
-            ...viewModel.selectedDivisions,
-            ...viewModel.selectedChapters,
+            ...tagPills(pillDistricts, 'district'),
+            ...tagPills(viewModel.selectedDivisions, 'division'),
+            ...tagPills(viewModel.selectedChapters, 'chapter'),
           ]}
           onSelectionChange={(updatedPills) => {
-            const districtValues = new Set(pillDistricts.map((d) => d.value));
-            const divisionValues = new Set(viewModel.selectedDivisions.map((d) => d.value));
-            const chapterValues = new Set(viewModel.selectedChapters.map((c) => c.value));
-
-            const updatedDistricts = updatedPills.filter((p) => districtValues.has(p.value));
-            const updatedDivisions = updatedPills.filter((p) => divisionValues.has(p.value));
-            const updatedChapters = updatedPills.filter((p) => chapterValues.has(p.value));
+            const pills = updatedPills as FilterPill[];
+            const updatedDistricts = pills.filter((p) => p.kind === 'district');
+            const updatedDivisions = pills.filter((p) => p.kind === 'division');
+            const updatedChapters = pills.filter((p) => p.kind === 'chapter');
 
             if (updatedDistricts.length !== pillDistricts.length) {
               viewModel.handleFilterChange(updatedDistricts);

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -7,7 +7,10 @@ import { TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
 function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
   const { viewModel } = props;
 
-  const showDistrictFilter = viewModel.districts.length > 0 && !viewModel.districtsError;
+  const showLegacyDistrictFilter =
+    !viewModel.districtDivisionEnabled &&
+    viewModel.districts.length > 0 &&
+    !viewModel.districtsError;
   const hasPills =
     viewModel.selectedDistricts.length > 0 ||
     viewModel.selectedChapters.length > 0 ||
@@ -55,42 +58,10 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                 />
               </div>
 
-              {showDistrictFilter && (
+              {viewModel.districtDivisionEnabled ? (
                 <div className="filter-control">
                   <div className="filter-control-header">
-                    <span className="filter-control-label">District</span>
-                    {viewModel.selectedDistricts.length > 0 && (
-                      <button
-                        type="button"
-                        className="filter-clear-link"
-                        onClick={viewModel.handleClearAll}
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
-                  <ComboBox
-                    id="district-combobox"
-                    label="District"
-                    options={viewModel.districtsToComboOptions(viewModel.districts)}
-                    selections={viewModel.selectedDistricts}
-                    onUpdateSelection={viewModel.handleFilterChange}
-                    multiSelect={true}
-                    wrapPills={true}
-                    pluralLabel="districts"
-                    singularLabel="district"
-                    placeholder="- Select one or more -"
-                    scrollToSelected={true}
-                    ref={viewModel.districtFilterRef}
-                    hideClearAllButton={true}
-                  />
-                </div>
-              )}
-
-              {viewModel.showDivisionFilter && (
-                <div className="filter-control">
-                  <div className="filter-control-header">
-                    <span className="filter-control-label">Division</span>
+                    <span className="filter-control-label">District (Division)</span>
                     {viewModel.selectedDivisions.length > 0 && (
                       <button
                         type="button"
@@ -102,11 +73,11 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                     )}
                   </div>
                   <ComboBox
-                    id="division-combobox"
-                    label="Division"
-                    options={viewModel.availableDivisionOptions}
+                    id="district-division-combobox"
+                    label="District (Division)"
+                    options={viewModel.combinedDistrictDivisionOptions}
                     selections={viewModel.selectedDivisions}
-                    onUpdateSelection={viewModel.handleFilterDivision}
+                    onUpdateSelection={viewModel.handleFilterCombined}
                     multiSelect={true}
                     wrapPills={true}
                     pluralLabel="divisions"
@@ -116,6 +87,38 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                     hideClearAllButton={true}
                   />
                 </div>
+              ) : (
+                showLegacyDistrictFilter && (
+                  <div className="filter-control">
+                    <div className="filter-control-header">
+                      <span className="filter-control-label">District</span>
+                      {viewModel.selectedDistricts.length > 0 && (
+                        <button
+                          type="button"
+                          className="filter-clear-link"
+                          onClick={viewModel.handleClearAll}
+                        >
+                          Clear
+                        </button>
+                      )}
+                    </div>
+                    <ComboBox
+                      id="district-combobox"
+                      label="District"
+                      options={viewModel.districtsToComboOptions(viewModel.districts)}
+                      selections={viewModel.selectedDistricts}
+                      onUpdateSelection={viewModel.handleFilterChange}
+                      multiSelect={true}
+                      wrapPills={true}
+                      pluralLabel="districts"
+                      singularLabel="district"
+                      placeholder="- Select one or more -"
+                      scrollToSelected={true}
+                      ref={viewModel.districtFilterRef}
+                      hideClearAllButton={true}
+                    />
+                  </div>
+                )
               )}
 
               <div className="filter-control">

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -38,6 +38,8 @@ export interface TrusteeDistrictFilterViewModel {
   selectedDivisions: ComboOption[];
   availableDivisionOptions: ComboOption[];
   showDivisionFilter: boolean;
+  combinedDistrictDivisionOptions: ComboOption[];
+  districtDivisionEnabled: boolean;
   isExpanded: boolean;
   districtFilterRef: React.RefObject<ComboBoxRef | null>;
   chapterFilterRef: React.RefObject<ComboBoxRef | null>;
@@ -54,6 +56,7 @@ export interface TrusteeDistrictFilterViewModel {
   handleFilterName(name: string): void;
   handleFilterDivision(divisions: ComboOption[]): void;
   handleClearAllDivisions(): void;
+  handleFilterCombined(selections: ComboOption[]): void;
 }
 
 export interface TrusteeDistrictFilterRef {
@@ -68,6 +71,7 @@ export type TrusteeDistrictFilterProps = {
   handleFilterName(name: string): void;
   handleFilterDivision(divisions: ComboOption[]): void;
   availableDivisionOptions: ComboOption[];
+  combinedDistrictDivisionOptions: ComboOption[];
   onExpandedChange?: (isExpanded: boolean) => void;
   onCourtsLoaded?: (courts: CourtDivisionDetails[]) => void;
 };
@@ -88,4 +92,5 @@ export interface TrusteeDistrictFilterUseCase {
   handleClearAllChapters(): void;
   handleFilterDivision(divisions: ComboOption[]): void;
   handleClearAllDivisions(): void;
+  handleFilterCombined(selections: ComboOption[]): void;
 }

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -16,6 +16,8 @@ export interface TrusteeDistrictFilterStore {
   setSelectedChapters(val: ComboOption[]): void;
   selectedDivisions: ComboOption[];
   setSelectedDivisions(val: ComboOption[]): void;
+  defaultDivisions: ComboOption[];
+  setDefaultDivisions(val: ComboOption[]): void;
   isExpanded: boolean;
   setIsExpanded(val: boolean): void;
 }

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -38,8 +38,6 @@ export interface TrusteeDistrictFilterViewModel {
   selectedDistricts: ComboOption[];
   selectedChapters: ComboOption[];
   selectedDivisions: ComboOption[];
-  availableDivisionOptions: ComboOption[];
-  showDivisionFilter: boolean;
   combinedDistrictDivisionOptions: ComboOption[];
   districtDivisionEnabled: boolean;
   isExpanded: boolean;
@@ -72,7 +70,6 @@ export type TrusteeDistrictFilterProps = {
   handleFilterChapter(chapters: ComboOption[]): void;
   handleFilterName(name: string): void;
   handleFilterDivision(divisions: ComboOption[]): void;
-  availableDivisionOptions: ComboOption[];
   combinedDistrictDivisionOptions: ComboOption[];
   onExpandedChange?: (isExpanded: boolean) => void;
   onCourtsLoaded?: (courts: CourtDivisionDetails[]) => void;

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -14,6 +14,8 @@ export interface TrusteeDistrictFilterStore {
   setDefaultDistricts(val: ComboOption[]): void;
   selectedChapters: ComboOption[];
   setSelectedChapters(val: ComboOption[]): void;
+  selectedDivisions: ComboOption[];
+  setSelectedDivisions(val: ComboOption[]): void;
   isExpanded: boolean;
   setIsExpanded(val: boolean): void;
 }
@@ -21,6 +23,7 @@ export interface TrusteeDistrictFilterStore {
 export interface TrusteeDistrictFilterControls {
   districtFilterRef: React.RefObject<ComboBoxRef | null>;
   chapterFilterRef: React.RefObject<ComboBoxRef | null>;
+  divisionFilterRef: React.RefObject<ComboBoxRef | null>;
 }
 
 export type TrusteeDistrictFilterViewProps = {
@@ -32,9 +35,13 @@ export interface TrusteeDistrictFilterViewModel {
   districtsError: boolean;
   selectedDistricts: ComboOption[];
   selectedChapters: ComboOption[];
+  selectedDivisions: ComboOption[];
+  availableDivisionOptions: ComboOption[];
+  showDivisionFilter: boolean;
   isExpanded: boolean;
   districtFilterRef: React.RefObject<ComboBoxRef | null>;
   chapterFilterRef: React.RefObject<ComboBoxRef | null>;
+  divisionFilterRef: React.RefObject<ComboBoxRef | null>;
   nameSearch: string;
 
   districtsToComboOptions(districts: CourtDivisionDetails[]): ComboOption[];
@@ -45,6 +52,8 @@ export interface TrusteeDistrictFilterViewModel {
   handleFilterChapter(chapters: ComboOption[]): void;
   handleClearAllChapters(): void;
   handleFilterName(name: string): void;
+  handleFilterDivision(divisions: ComboOption[]): void;
+  handleClearAllDivisions(): void;
 }
 
 export interface TrusteeDistrictFilterRef {
@@ -57,6 +66,8 @@ export type TrusteeDistrictFilterProps = {
   handleFilterDistrict(districts: ComboOption[]): void;
   handleFilterChapter(chapters: ComboOption[]): void;
   handleFilterName(name: string): void;
+  handleFilterDivision(divisions: ComboOption[]): void;
+  availableDivisionOptions: ComboOption[];
   onExpandedChange?: (isExpanded: boolean) => void;
   onCourtsLoaded?: (courts: CourtDivisionDetails[]) => void;
 };
@@ -75,4 +86,6 @@ export interface TrusteeDistrictFilterUseCase {
   handleToggleExpanded(): void;
   handleFilterChapter(chapters: ComboOption[]): void;
   handleClearAllChapters(): void;
+  handleFilterDivision(divisions: ComboOption[]): void;
+  handleClearAllDivisions(): void;
 }

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -58,6 +58,7 @@ export type TrusteeDistrictFilterProps = {
   handleFilterChapter(chapters: ComboOption[]): void;
   handleFilterName(name: string): void;
   onExpandedChange?: (isExpanded: boolean) => void;
+  onCourtsLoaded?: (courts: CourtDivisionDetails[]) => void;
 };
 
 export interface TrusteeDistrictFilterUseCase {

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -77,6 +77,8 @@ describe('trustee district filter use case tests', () => {
     setSelectedChapters: vi.fn(),
     selectedDivisions: [],
     setSelectedDivisions: vi.fn(),
+    defaultDivisions: [],
+    setDefaultDivisions: vi.fn(),
     isExpanded: false,
     setIsExpanded: vi.fn(),
   };
@@ -127,9 +129,11 @@ describe('trustee district filter use case tests', () => {
 
   beforeEach(() => {
     mockStore.defaultDistricts = [];
+    mockStore.defaultDivisions = [];
     mockStore.setSelectedDistricts = vi.fn();
     mockStore.setSelectedChapters = vi.fn();
     mockStore.setSelectedDivisions = vi.fn();
+    mockStore.setDefaultDivisions = vi.fn();
     setSelectedDistrictsSpy = vi.spyOn(mockStore, 'setSelectedDistricts');
     mockOnFilterDistrict.mockReset();
     mockOnFilterChapter.mockReset();
@@ -611,6 +615,101 @@ describe('trustee district filter use case tests', () => {
       await useCase.fetchDistricts();
 
       expect(setDistrictsErrorSpy).toHaveBeenCalledWith(true);
+    });
+
+    test('flag ON: sets default divisions from user session and calls onFilterDivision', async () => {
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockDistricts });
+      const session: CamsSession = {
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '081',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York Region',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '081',
+                      court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
+      const setDefaultDivisionsSpy = vi.spyOn(mockStore, 'setDefaultDivisions');
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+
+      await useCaseWithFlag.fetchDistricts();
+
+      const expectedDivisions = [
+        {
+          value: 'NYSB|081',
+          label: 'Southern District of New York (Manhattan)',
+          selectedLabel: 'Manhattan',
+        },
+      ];
+      expect(setDefaultDivisionsSpy).toHaveBeenCalledWith(expectedDivisions);
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith(expectedDivisions);
+      expect(mockOnFilterDivision).toHaveBeenCalledWith(expectedDivisions);
+    });
+
+    test('flag ON: only includes divisions the user belongs to, not all district divisions', async () => {
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockDistricts });
+      const session: CamsSession = {
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '081',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York Region',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '081',
+                      court: { courtId: 'NYSB', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
+
+      await useCaseWithFlag.fetchDistricts();
+
+      const divisionCall = mockOnFilterDivision.mock.calls[0][0] as ComboOption[];
+      expect(divisionCall).toHaveLength(1);
+      expect(divisionCall[0].value).toBe('NYSB|081');
+      expect(divisionCall.find((d) => d.value === 'NYSB|087')).toBeUndefined();
+    });
+
+    test('flag ON: does not call onFilterDivision when session has no offices', async () => {
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockDistricts });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+
+      await useCaseWithFlag.fetchDistricts();
+
+      expect(mockOnFilterDivision).not.toHaveBeenCalled();
     });
   });
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -750,15 +750,25 @@ describe('trustee district filter use case tests', () => {
   });
 
   describe('handleFilterChange (cascading division clear)', () => {
-    test('should clear divisions when district filter changes', () => {
+    test('should clear divisions when district filter changes and flag is ON', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+      previousDivisionsRef.current = [{ value: '081', label: 'Manhattan' }];
+
+      const newDistricts: ComboOption[] = [{ value: 'VTB', label: 'District of Vermont' }];
+      useCaseWithFlag.handleFilterChange(newDistricts);
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([]);
+      expect(mockOnFilterDivision).toHaveBeenCalledWith([]);
+    });
+
+    test('should NOT clear divisions when district filter changes and flag is OFF', () => {
       const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
       previousDivisionsRef.current = [{ value: '081', label: 'Manhattan' }];
 
       const newDistricts: ComboOption[] = [{ value: 'VTB', label: 'District of Vermont' }];
       useCase.handleFilterChange(newDistricts);
 
-      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([]);
-      expect(mockOnFilterDivision).toHaveBeenCalledWith([]);
+      expect(setSelectedDivisionsSpy).not.toHaveBeenCalledWith([]);
     });
   });
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -662,4 +662,84 @@ describe('trustee district filter use case tests', () => {
       expect(mockOnFilterDivision).toHaveBeenCalledWith([]);
     });
   });
+
+  describe('handleFilterCombined', () => {
+    test('should update divisions and trigger callback', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+      const selections: ComboOption[] = [
+        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+      ];
+
+      useCase.handleFilterCombined(selections);
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith(selections);
+      expect(mockOnFilterDivision).toHaveBeenCalledWith(selections);
+    });
+
+    test('should clear divisions when empty array passed', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+
+      useCase.handleFilterCombined([]);
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([]);
+      expect(mockOnFilterDivision).toHaveBeenCalledWith([]);
+    });
+
+    test('adding ALL option removes specific divisions for that court', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+      previousDivisionsRef.current = [
+        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+      ];
+
+      const selections: ComboOption[] = [
+        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+      ];
+
+      useCase.handleFilterCombined(selections);
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([
+        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+      ]);
+    });
+
+    test('adding specific division removes ALL option for that court', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+      previousDivisionsRef.current = [
+        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+      ];
+
+      const selections: ComboOption[] = [
+        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+      ];
+
+      useCase.handleFilterCombined(selections);
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([
+        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+      ]);
+    });
+
+    test('mutual exclusion does not affect selections from a different court', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+      previousDivisionsRef.current = [
+        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+        { value: 'VTB|ALL', label: 'District of Vermont (All)' },
+      ];
+
+      const selections: ComboOption[] = [
+        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+        { value: 'VTB|ALL', label: 'District of Vermont (All)' },
+        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+      ];
+
+      useCase.handleFilterCombined(selections);
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([
+        { value: 'VTB|ALL', label: 'District of Vermont (All)' },
+        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+      ]);
+    });
+  });
 });

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -4,7 +4,10 @@ import {
   TrusteeDistrictFilterStore,
 } from './trusteeDistrictFilter.types';
 import MockData from '@common/cams/test-utilities/mock-data';
-import trusteeDistrictFilterUseCase from './trusteeDistrictFilterUseCase';
+import trusteeDistrictFilterUseCase, {
+  resolveCombinedSelections,
+  getUserDivisionCodes,
+} from './trusteeDistrictFilterUseCase';
 import { MockInstance } from 'vitest';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import { CamsSession } from '@common/cams/session';
@@ -850,5 +853,123 @@ describe('trustee district filter use case tests', () => {
         { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
       ]);
     });
+  });
+});
+
+describe('resolveCombinedSelections', () => {
+  test('returns empty array when next is empty', () => {
+    const previous = [{ value: 'NYSB|081', label: 'Manhattan' }];
+    expect(resolveCombinedSelections(previous, [])).toEqual([]);
+  });
+
+  test('returns next unchanged when no new options were added', () => {
+    const selections = [{ value: 'NYSB|081', label: 'Manhattan' }];
+    expect(resolveCombinedSelections(selections, selections)).toEqual(selections);
+  });
+
+  test('selecting ALL removes specific divisions for that court', () => {
+    const previous = [{ value: 'NYSB|081', label: 'Manhattan' }];
+    const next = [
+      { value: 'NYSB|081', label: 'Manhattan' },
+      { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+    ];
+    expect(resolveCombinedSelections(previous, next)).toEqual([
+      { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+    ]);
+  });
+
+  test('selecting a specific division removes ALL for that court', () => {
+    const previous = [{ value: 'NYSB|ALL', label: 'Southern District of New York (All)' }];
+    const next = [
+      { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+      { value: 'NYSB|081', label: 'Manhattan' },
+    ];
+    expect(resolveCombinedSelections(previous, next)).toEqual([
+      { value: 'NYSB|081', label: 'Manhattan' },
+    ]);
+  });
+
+  test('mutual exclusion only applies within the same court', () => {
+    const previous = [{ value: 'VTB|088', label: 'Rutland' }];
+    const next = [
+      { value: 'VTB|088', label: 'Rutland' },
+      { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+    ];
+    const result = resolveCombinedSelections(previous, next);
+    expect(result).toContainEqual({ value: 'VTB|088', label: 'Rutland' });
+    expect(result).toContainEqual({
+      value: 'NYSB|ALL',
+      label: 'Southern District of New York (All)',
+    });
+  });
+});
+
+describe('getUserDivisionCodes', () => {
+  test('returns empty set when session is null', () => {
+    expect(getUserDivisionCodes(null).size).toBe(0);
+  });
+
+  test('returns empty set when session has no offices', () => {
+    const session = {
+      ...MockData.getCamsSession(),
+      user: { ...MockData.getCamsSession().user, offices: [] },
+    };
+    expect(getUserDivisionCodes(session).size).toBe(0);
+  });
+
+  test('collects division codes from all offices and groups', () => {
+    const session: CamsSession = {
+      ...MockData.getCamsSession(),
+      user: {
+        ...MockData.getCamsSession().user,
+        offices: [
+          {
+            officeCode: '081',
+            officeName: 'Manhattan',
+            idpGroupName: 'Manhattan',
+            regionId: '02',
+            regionName: 'New York',
+            groups: [
+              {
+                groupDesignator: 'NY',
+                divisions: [
+                  {
+                    divisionCode: '081',
+                    court: { courtId: 'NYSB', courtName: 'SDNY' },
+                    courtOffice: { courtOfficeCode: '081', courtOfficeName: 'Manhattan' },
+                  },
+                  {
+                    divisionCode: '087',
+                    court: { courtId: 'NYSB', courtName: 'SDNY' },
+                    courtOffice: { courtOfficeCode: '087', courtOfficeName: 'White Plains' },
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            officeCode: '088',
+            officeName: 'Rutland',
+            idpGroupName: 'Rutland',
+            regionId: '01',
+            regionName: 'Boston',
+            groups: [
+              {
+                groupDesignator: 'VT',
+                divisions: [
+                  {
+                    divisionCode: '088',
+                    court: { courtId: 'VTB', courtName: 'Vermont' },
+                    courtOffice: { courtOfficeCode: '088', courtOfficeName: 'Rutland' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const codes = getUserDivisionCodes(session);
+    expect(codes).toEqual(new Set(['081', '087', '088']));
   });
 });

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -106,6 +106,16 @@ describe('trustee district filter use case tests', () => {
     previousChaptersRef,
   );
 
+  const useCaseWithFlag = trusteeDistrictFilterUseCase(
+    mockStore,
+    mockControls,
+    mockOnFilterDistrict,
+    previousDistrictsRef,
+    mockOnFilterChapter,
+    previousChaptersRef,
+    true,
+  );
+
   beforeEach(() => {
     mockStore.defaultDistricts = [];
     mockStore.setSelectedDistricts = vi.fn();
@@ -134,6 +144,27 @@ describe('trustee district filter use case tests', () => {
       });
       expect(comboOptions[1]).toEqual({
         value: '088',
+        label: 'District of Vermont',
+      });
+    });
+
+    test('flag OFF: returns options with comma-joined division codes as value', () => {
+      const comboOptions = useCase.districtsToComboOptions(mockDistricts);
+
+      expect(comboOptions[0].value).toBe('081,087');
+      expect(comboOptions[1].value).toBe('088');
+    });
+
+    test('flag ON: returns options with courtId as value', () => {
+      const comboOptions = useCaseWithFlag.districtsToComboOptions(mockDistricts);
+
+      expect(comboOptions).toHaveLength(2);
+      expect(comboOptions[0]).toEqual({
+        value: 'NYSB',
+        label: 'Southern District of New York',
+      });
+      expect(comboOptions[1]).toEqual({
+        value: 'VTB',
         label: 'District of Vermont',
       });
     });

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -62,6 +62,7 @@ describe('trustee district filter use case tests', () => {
 
   const mockOnFilterDistrict = vi.fn();
   const mockOnFilterChapter = vi.fn();
+  const mockOnFilterDivision = vi.fn();
 
   const mockStore: TrusteeDistrictFilterStore = {
     districts: mockDistricts,
@@ -74,6 +75,8 @@ describe('trustee district filter use case tests', () => {
     setDefaultDistricts: vi.fn(),
     selectedChapters: [],
     setSelectedChapters: vi.fn(),
+    selectedDivisions: [],
+    setSelectedDivisions: vi.fn(),
     isExpanded: false,
     setIsExpanded: vi.fn(),
   };
@@ -92,10 +95,12 @@ describe('trustee district filter use case tests', () => {
   const mockControls: TrusteeDistrictFilterControls = {
     districtFilterRef: comboBoxRef,
     chapterFilterRef: comboBoxRef,
+    divisionFilterRef: comboBoxRef,
   };
 
   const previousDistrictsRef = { current: undefined as ComboOption[] | undefined };
   const previousChaptersRef = { current: undefined as ComboOption[] | undefined };
+  const previousDivisionsRef = { current: undefined as ComboOption[] | undefined };
 
   const useCase = trusteeDistrictFilterUseCase(
     mockStore,
@@ -104,6 +109,8 @@ describe('trustee district filter use case tests', () => {
     previousDistrictsRef,
     mockOnFilterChapter,
     previousChaptersRef,
+    mockOnFilterDivision,
+    previousDivisionsRef,
   );
 
   const useCaseWithFlag = trusteeDistrictFilterUseCase(
@@ -113,6 +120,8 @@ describe('trustee district filter use case tests', () => {
     previousDistrictsRef,
     mockOnFilterChapter,
     previousChaptersRef,
+    mockOnFilterDivision,
+    previousDivisionsRef,
     true,
   );
 
@@ -120,12 +129,15 @@ describe('trustee district filter use case tests', () => {
     mockStore.defaultDistricts = [];
     mockStore.setSelectedDistricts = vi.fn();
     mockStore.setSelectedChapters = vi.fn();
+    mockStore.setSelectedDivisions = vi.fn();
     setSelectedDistrictsSpy = vi.spyOn(mockStore, 'setSelectedDistricts');
     mockOnFilterDistrict.mockReset();
     mockOnFilterChapter.mockReset();
+    mockOnFilterDivision.mockReset();
     mockTrackEvent.mockReset();
     previousDistrictsRef.current = undefined;
     previousChaptersRef.current = undefined;
+    previousDivisionsRef.current = undefined;
   });
 
   afterEach(() => {
@@ -599,6 +611,55 @@ describe('trustee district filter use case tests', () => {
       await useCase.fetchDistricts();
 
       expect(setDistrictsErrorSpy).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('handleFilterDivision', () => {
+    test('should update selected divisions and trigger callback', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+      const divisions: ComboOption[] = [{ value: '081', label: 'Manhattan' }];
+
+      useCase.handleFilterDivision(divisions);
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith(divisions);
+      expect(mockOnFilterDivision).toHaveBeenCalledWith(divisions);
+    });
+
+    test('should fire Trustee Division Filter Cleared only when transitioning non-empty to empty', () => {
+      useCase.handleFilterDivision([{ value: '081', label: 'Manhattan' }]);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+
+      useCase.handleFilterDivision([]);
+      expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'Trustee Division Filter Cleared' });
+    });
+
+    test('should not fire Trustee Division Filter Cleared on initial empty call', () => {
+      useCase.handleFilterDivision([]);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleClearAllDivisions', () => {
+    test('should clear selected divisions and notify', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+
+      useCase.handleClearAllDivisions();
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([]);
+      expect(mockOnFilterDivision).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('handleFilterChange (cascading division clear)', () => {
+    test('should clear divisions when district filter changes', () => {
+      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
+      previousDivisionsRef.current = [{ value: '081', label: 'Manhattan' }];
+
+      const newDistricts: ComboOption[] = [{ value: 'VTB', label: 'District of Vermont' }];
+      useCase.handleFilterChange(newDistricts);
+
+      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([]);
+      expect(mockOnFilterDivision).toHaveBeenCalledWith([]);
     });
   });
 });

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -147,8 +147,37 @@ const trusteeDistrictFilterUseCase = (
     handleFilterDivision([]);
   };
 
+  const handleFilterCombined = (selections: ComboOption[]) => {
+    if (selections.length === 0) {
+      handleFilterDivision([]);
+      return;
+    }
+
+    const previousValues = new Set((previousDivisionsRef.current ?? []).map((s) => s.value));
+    const added = selections.filter((s) => !previousValues.has(s.value));
+
+    if (added.length === 0) {
+      handleFilterDivision(selections);
+      return;
+    }
+
+    let resolved = [...selections];
+    for (const newOption of added) {
+      const [courtId, code] = newOption.value.split('|');
+      if (code === 'ALL') {
+        resolved = resolved.filter((s) => {
+          const [sCourt, sCode] = s.value.split('|');
+          return !(sCourt === courtId && sCode !== 'ALL');
+        });
+      } else {
+        resolved = resolved.filter((s) => s.value !== `${courtId}|ALL`);
+      }
+    }
+
+    handleFilterDivision(resolved);
+  };
+
   const handleFilterChange = (districts: ComboOption[]) => {
-    // Only track "cleared" when transitioning from non-empty to empty
     const wasNonEmpty = previousDistrictsRef.current && previousDistrictsRef.current.length > 0;
     const isNowEmpty = districts.length === 0;
 
@@ -158,7 +187,6 @@ const trusteeDistrictFilterUseCase = (
 
     previousDistrictsRef.current = districts;
     store.setSelectedDistricts(districts);
-    // Cascading: clear division selection when district changes
     handleClearAllDivisions();
     notifySelectionChange(districts);
   };
@@ -201,6 +229,7 @@ const trusteeDistrictFilterUseCase = (
     handleClearAllChapters,
     handleFilterDivision,
     handleClearAllDivisions,
+    handleFilterCombined,
   };
 };
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -43,6 +43,18 @@ export function resolveCombinedSelections(
   return resolved;
 }
 
+export function getUserDivisionCodes(session: CamsSession | null): Set<string> {
+  const codes = new Set<string>();
+  session?.user?.offices?.forEach((office) => {
+    office.groups?.forEach((group) => {
+      group.divisions?.forEach((division) => {
+        if (division.divisionCode) codes.add(division.divisionCode);
+      });
+    });
+  });
+  return codes;
+}
+
 const toDistrictOption = (
   district: CourtDivisionDetails,
   divisionCodes: string[],
@@ -96,16 +108,7 @@ const trusteeDistrictFilterUseCase = (
       return [];
     }
 
-    const userDivisionCodes = new Set<string>();
-    session.user.offices.forEach((office) => {
-      office.groups?.forEach((group) => {
-        group.divisions?.forEach((division) => {
-          if (division.divisionCode) {
-            userDivisionCodes.add(division.divisionCode);
-          }
-        });
-      });
-    });
+    const userDivisionCodes = getUserDivisionCodes(session);
 
     const userDistricts = allDistricts.filter((district) =>
       userDivisionCodes.has(district.courtDivisionCode),
@@ -148,15 +151,7 @@ const trusteeDistrictFilterUseCase = (
       if (defaultDistricts.length > 0) {
         notifySelectionChange(defaultDistricts);
         if (districtDivisionEnabled) {
-          const session = LocalStorage.getSession();
-          const userDivisionCodes = new Set<string>();
-          session?.user?.offices?.forEach((office) => {
-            office.groups?.forEach((group) => {
-              group.divisions?.forEach((division) => {
-                if (division.divisionCode) userDivisionCodes.add(division.divisionCode);
-              });
-            });
-          });
+          const userDivisionCodes = getUserDivisionCodes(session);
 
           const defaultDivisions = defaultDistricts.flatMap((d) => {
             const courtId = d.value;

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -36,7 +36,7 @@ const buildDistrictOptions = (
   );
 
   return sortedDistricts.map((district) => {
-    const divisions = districtMap.get(district.courtName)!;
+    const divisions = districtMap.get(district.courtId)!;
     return toDistrictOption(
       district,
       divisions.map((d) => d.courtDivisionCode),

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -57,6 +57,8 @@ const trusteeDistrictFilterUseCase = (
   previousDistrictsRef: { current: ComboOption[] | undefined },
   onFilterChapter: (chapters: ComboOption[]) => void,
   previousChaptersRef: { current: ComboOption[] | undefined },
+  onFilterDivision: (divisions: ComboOption[]) => void,
+  previousDivisionsRef: { current: ComboOption[] | undefined },
   districtDivisionEnabled: boolean = false,
 ): TrusteeDistrictFilterUseCase => {
   const getDefaultDistrictsFromSession = (
@@ -128,6 +130,23 @@ const trusteeDistrictFilterUseCase = (
     controls.districtFilterRef.current?.focusInput();
   };
 
+  const handleFilterDivision = (divisions: ComboOption[]) => {
+    const wasNonEmpty = previousDivisionsRef.current && previousDivisionsRef.current.length > 0;
+    const isNowEmpty = divisions.length === 0;
+
+    if (wasNonEmpty && isNowEmpty) {
+      getAppInsights().appInsights.trackEvent({ name: 'Trustee Division Filter Cleared' });
+    }
+
+    previousDivisionsRef.current = divisions;
+    store.setSelectedDivisions(divisions);
+    onFilterDivision(divisions);
+  };
+
+  const handleClearAllDivisions = () => {
+    handleFilterDivision([]);
+  };
+
   const handleFilterChange = (districts: ComboOption[]) => {
     // Only track "cleared" when transitioning from non-empty to empty
     const wasNonEmpty = previousDistrictsRef.current && previousDistrictsRef.current.length > 0;
@@ -139,6 +158,8 @@ const trusteeDistrictFilterUseCase = (
 
     previousDistrictsRef.current = districts;
     store.setSelectedDistricts(districts);
+    // Cascading: clear division selection when district changes
+    handleClearAllDivisions();
     notifySelectionChange(districts);
   };
 
@@ -178,6 +199,8 @@ const trusteeDistrictFilterUseCase = (
     handleToggleExpanded,
     handleFilterChapter,
     handleClearAllChapters,
+    handleFilterDivision,
+    handleClearAllDivisions,
   };
 };
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -19,12 +19,16 @@ import { AppointmentChapterType, formatChapterType } from '@common/cams/trustees
 const toDistrictOption = (
   district: CourtDivisionDetails,
   divisionCodes: string[],
+  districtDivisionEnabled: boolean,
 ): ComboOption => ({
-  value: divisionCodes.join(','),
+  value: districtDivisionEnabled ? district.courtId : divisionCodes.join(','),
   label: district.courtName,
 });
 
-const buildDistrictOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
+const buildDistrictOptions = (
+  districts: CourtDivisionDetails[],
+  districtDivisionEnabled: boolean,
+): ComboOption[] => {
   const districtMap = groupDivisionsByDistrict(districts);
 
   const sortedDistricts = sortByCourtLocation(
@@ -36,42 +40,9 @@ const buildDistrictOptions = (districts: CourtDivisionDetails[]): ComboOption[] 
     return toDistrictOption(
       district,
       divisions.map((d) => d.courtDivisionCode),
+      districtDivisionEnabled,
     );
   });
-};
-
-const getDefaultDistrictsFromSession = (
-  session: CamsSession | null,
-  allDistricts: CourtDivisionDetails[],
-): ComboOption[] => {
-  if (!session?.user?.offices || session.user.offices.length === 0) {
-    return [];
-  }
-
-  const userDivisionCodes = new Set<string>();
-  session.user.offices.forEach((office) => {
-    office.groups?.forEach((group) => {
-      group.divisions?.forEach((division) => {
-        if (division.divisionCode) {
-          userDivisionCodes.add(division.divisionCode);
-        }
-      });
-    });
-  });
-
-  // Find which districts contain the user's divisions
-  const userDistricts = allDistricts.filter((district) =>
-    userDivisionCodes.has(district.courtDivisionCode),
-  );
-  const userDistrictNames = new Set(userDistricts.map((d) => d.courtName));
-
-  // Group ALL divisions for those districts (not just user's divisions)
-  const allDistrictsForUser = allDistricts.filter((district) =>
-    userDistrictNames.has(district.courtName),
-  );
-
-  // Convert to ComboOptions, one per unique district with ALL division codes
-  return buildDistrictOptions(allDistrictsForUser);
 };
 
 const CHAPTER_OPTIONS: AppointmentChapterType[] = ['7', '11', '11-subchapter-v', '12', '13'];
@@ -86,10 +57,41 @@ const trusteeDistrictFilterUseCase = (
   previousDistrictsRef: { current: ComboOption[] | undefined },
   onFilterChapter: (chapters: ComboOption[]) => void,
   previousChaptersRef: { current: ComboOption[] | undefined },
+  districtDivisionEnabled: boolean = false,
 ): TrusteeDistrictFilterUseCase => {
+  const getDefaultDistrictsFromSession = (
+    session: CamsSession | null,
+    allDistricts: CourtDivisionDetails[],
+  ): ComboOption[] => {
+    if (!session?.user?.offices || session.user.offices.length === 0) {
+      return [];
+    }
+
+    const userDivisionCodes = new Set<string>();
+    session.user.offices.forEach((office) => {
+      office.groups?.forEach((group) => {
+        group.divisions?.forEach((division) => {
+          if (division.divisionCode) {
+            userDivisionCodes.add(division.divisionCode);
+          }
+        });
+      });
+    });
+
+    const userDistricts = allDistricts.filter((district) =>
+      userDivisionCodes.has(district.courtDivisionCode),
+    );
+    const userDistrictNames = new Set(userDistricts.map((d) => d.courtName));
+
+    const allDistrictsForUser = allDistricts.filter((district) =>
+      userDistrictNames.has(district.courtName),
+    );
+
+    return buildDistrictOptions(allDistrictsForUser, districtDivisionEnabled);
+  };
+
   const districtsToComboOptions = (districts: CourtDivisionDetails[]): ComboOption[] => {
-    // Build base options (grouped by district, sorted by court location)
-    const allOptions = buildDistrictOptions(districts);
+    const allOptions = buildDistrictOptions(districts, districtDivisionEnabled);
 
     // Separate defaults from non-defaults and mark them
     const defaultCodesFlat = new Set(

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -145,6 +145,7 @@ const trusteeDistrictFilterUseCase = (
                 selectedLabel: court.courtDivisionName,
               }));
           });
+          store.setDefaultDivisions(defaultDivisions);
           store.setSelectedDivisions(defaultDivisions);
           onFilterDivision(defaultDivisions);
         }

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -214,7 +214,9 @@ const trusteeDistrictFilterUseCase = (
 
     previousDistrictsRef.current = districts;
     store.setSelectedDistricts(districts);
-    handleClearAllDivisions();
+    if (districtDivisionEnabled) {
+      handleClearAllDivisions();
+    }
     notifySelectionChange(districts);
   };
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -120,6 +120,34 @@ const trusteeDistrictFilterUseCase = (
 
       if (defaultDistricts.length > 0) {
         notifySelectionChange(defaultDistricts);
+        if (districtDivisionEnabled) {
+          const session = LocalStorage.getSession();
+          const userDivisionCodes = new Set<string>();
+          session?.user?.offices?.forEach((office) => {
+            office.groups?.forEach((group) => {
+              group.divisions?.forEach((division) => {
+                if (division.divisionCode) userDivisionCodes.add(division.divisionCode);
+              });
+            });
+          });
+
+          const defaultDivisions = defaultDistricts.flatMap((d) => {
+            const courtId = d.value;
+            return districts
+              .filter(
+                (court) =>
+                  court.courtId === courtId && userDivisionCodes.has(court.courtDivisionCode),
+              )
+              .sort((a, b) => a.courtDivisionName.localeCompare(b.courtDivisionName))
+              .map((court) => ({
+                value: `${courtId}|${court.courtDivisionCode}`,
+                label: `${court.courtName} (${court.courtDivisionName})`,
+                selectedLabel: court.courtDivisionName,
+              }));
+          });
+          store.setSelectedDivisions(defaultDivisions);
+          onFilterDivision(defaultDivisions);
+        }
       }
     } catch (_e) {
       store.setDistrictsError(true);

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -16,6 +16,33 @@ import {
 } from '@/lib/utils/court-utils';
 import { AppointmentChapterType, formatChapterType } from '@common/cams/trustees';
 
+export function resolveCombinedSelections(
+  previous: ComboOption[],
+  next: ComboOption[],
+): ComboOption[] {
+  if (next.length === 0) return [];
+
+  const previousValues = new Set(previous.map((s) => s.value));
+  const added = next.filter((s) => !previousValues.has(s.value));
+
+  if (added.length === 0) return next;
+
+  let resolved = [...next];
+  for (const newOption of added) {
+    const [courtId, code] = newOption.value.split('|');
+    if (code === 'ALL') {
+      resolved = resolved.filter((s) => {
+        const [sCourt, sCode] = s.value.split('|');
+        return !(sCourt === courtId && sCode !== 'ALL');
+      });
+    } else {
+      resolved = resolved.filter((s) => s.value !== `${courtId}|ALL`);
+    }
+  }
+
+  return resolved;
+}
+
 const toDistrictOption = (
   district: CourtDivisionDetails,
   divisionCodes: string[],
@@ -177,32 +204,8 @@ const trusteeDistrictFilterUseCase = (
   };
 
   const handleFilterCombined = (selections: ComboOption[]) => {
-    if (selections.length === 0) {
-      handleFilterDivision([]);
-      return;
-    }
-
-    const previousValues = new Set((previousDivisionsRef.current ?? []).map((s) => s.value));
-    const added = selections.filter((s) => !previousValues.has(s.value));
-
-    if (added.length === 0) {
-      handleFilterDivision(selections);
-      return;
-    }
-
-    let resolved = [...selections];
-    for (const newOption of added) {
-      const [courtId, code] = newOption.value.split('|');
-      if (code === 'ALL') {
-        resolved = resolved.filter((s) => {
-          const [sCourt, sCode] = s.value.split('|');
-          return !(sCourt === courtId && sCode !== 'ALL');
-        });
-      } else {
-        resolved = resolved.filter((s) => s.value !== `${courtId}|ALL`);
-      }
-    }
-
+    const previous = previousDivisionsRef.current ?? [];
+    const resolved = resolveCombinedSelections(previous, selections);
     handleFilterDivision(resolved);
   };
 

--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.test.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.test.tsx
@@ -547,7 +547,19 @@ describe('TrusteeAssistantForm', () => {
     });
 
     test('should submit form with complete address', async () => {
-      const { assistant, container } = renderEditMode();
+      // Pre-populate state as 'NY' so the test does not depend on a timing-sensitive
+      // combobox interaction to change a random faker state to a specific value.
+      const { assistant } = renderEditMode({
+        contact: {
+          address: {
+            address1: '1 Old St',
+            city: 'OldCity',
+            state: 'NY',
+            zipCode: '00000',
+            countryCode: 'US',
+          },
+        },
+      });
 
       const updateSpy = vi
         .spyOn(Api2, 'updateTrusteeAssistant')
@@ -574,15 +586,6 @@ describe('TrusteeAssistantForm', () => {
       await userEvent.type(screen.getByTestId('assistant-extension'), '999');
       await userEvent.clear(screen.getByTestId('assistant-email'));
       await userEvent.type(screen.getByTestId('assistant-email'), 'test@example.com');
-
-      // State might already be selected, but ensure NY is set
-      const stateCombobox = container.querySelector('#assistant-state [role="combobox"]');
-      if (stateCombobox) {
-        await userEvent.click(stateCombobox);
-        const nyOptions = await screen.findAllByText(/NY.*New York/i, {}, { timeout: 1000 });
-        // Click the last option (the one in the dropdown, not the screen reader text)
-        await userEvent.click(nyOptions[nyOptions.length - 1]);
-      }
 
       const submitButton = screen.getByRole('button', { name: 'Save' });
       await userEvent.click(submitButton);


### PR DESCRIPTION
# Purpose

Improve trustee list filtering by replacing the separate District and Division dropdowns with a single combined "District (Division)" filter that matches how other screens handle court/division selection, and pre-selects the user's session divisions by default.

<img width="1339" height="707" alt="Screenshot 2026-05-06 at 12 27 47 PM" src="https://github.com/user-attachments/assets/cc512ed9-f62b-459e-85eb-3f0ccdc864eb" />

# Major Changes

* Added cascading Division ComboBox (behind `trustee-district-division` feature flag) that appears when a district is selected — division options derive from trustees with appointments in that district
* Replaced the separate District and Division dropdowns with a single combined "District (Division)" ComboBox when the flag is ON — options formatted as "CourtName (DivisionName)" with an "All" option per district group
* Pre-selects the user's session divisions on load when the flag is ON, rather than defaulting to district level
* Floats user's default divisions to the top of the combined dropdown with a divider, matching the SearchScreen court filter pattern
* Hides district-level pills from the PillBox when the combined filter is active (divisions already represent those selections)
* Extracted `courtId|divCode` value format and mutual-exclusion logic (selecting "All" clears specific division picks; selecting a division clears "All") into the use case layer

# Testing/Validation

Implemented using TDD. Added ~271 use-case unit tests and expanded TrusteesList tests to 945+ lines covering all flag-on/flag-off branches, default selection behavior, mutual exclusion logic, and pill display.

# Notes

The combined dropdown value format (`courtId|divCode`) encodes both the court and division in a single string, allowing the filter to handle both "All" and specific division selections without a separate selection state. Division options are computed dynamically from the current trustee data, so they only show divisions where trustees actually have appointments.

All changes are behind the `trustee-district-division` feature flag — existing behavior is unchanged when the flag is OFF.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce a feature-flagged combined district/division filtering and display model for the Trustees list while preserving existing behavior when the flag is off.

New Features:
- Add a feature-flagged combined "District (Division)" filter for the Trustees list that can target specific divisions or all divisions within a district using encoded court/division values.
- Display a Division column in the Trustees table when the combined district/division feature flag is enabled, including support for "All" and legacy division representations.

Enhancements:
- Update trustee filtering logic to support courtId-based matching and division-aware filtering while maintaining existing division-code behavior when the feature flag is disabled.
- Derive default district and division selections from the user session and surface them at the top of the combined filter options for quicker access.
- Refine filter pill handling to support division selections and hide legacy district pills when the combined filter is active.
- Adjust trustees table column structure and layout to accommodate the optional Division column without breaking existing styling.

Tests:
- Expand TrusteesList tests to cover combined district/division filtering, default session behavior, mutual exclusion between "All" and specific divisions, and Division column visibility under the feature flag.
- Extend trustee district filter use case tests to cover courtId-based district options, default division initialization from session, division filter events, and combined filter mutual-exclusion rules.
- Update TrusteeDistrictFilter component tests to account for the new division-handling props and feature-flagged behavior.

## Summary by Sourcery

Introduce a feature-flagged combined district/division filtering model for the Trustees list and surface it in both the filter controls and table layout while preserving legacy behavior when the flag is disabled.

New Features:
- Add a combined "District (Division)" multi-select filter for trustees that supports court-wide (All) and per-division selection via encoded court/division values.
- Display an optional Division column in the Trustees table when the combined district/division feature flag is enabled.

Enhancements:
- Update trustee filtering logic to support courtId-based matching and division-aware filtering alongside existing chapter filters.
- Derive default district and division selections from the user session and bubble them to the top of the combined filter options.
- Refine filter pill handling so that division selections are represented while legacy district pills are hidden when the combined filter is active.
- Adjust trustees table layout and styles to accommodate the optional Division column without breaking existing columns.
- Expose courts data and combined district/division options from the filter component to the Trustees list via new props and view-model fields.
- Extend the trustee district filter use case to manage divisions, including cascading clears when districts change and mutual exclusion between "All" and specific divisions per court.

Tests:
- Expand TrusteesList tests to cover courtId-based district matching, combined district/division filtering, default session division behavior, pill interactions, and Division column visibility under the feature flag.
- Extend trustee district filter use case tests for courtId-valued districts, default division initialization from session, division filter events, combined filter mutual-exclusion rules, and analytics for clearing division filters.
- Update TrusteeDistrictFilter component tests to exercise the new division-handling callbacks and feature-flagged rendering paths.
- Stabilize TrusteeAssistantForm submission tests by pre-populating a deterministic state value instead of relying on timing-sensitive combobox selection.