### PR TITLE
CAMS-670 Implement bank list and add bank (Slice 1)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -30,9 +30,3 @@ ignore:
           Transitive dependency via launchdarkly-js-sdk-common, @azure/msal-node,
           and njwt. No fixed version available from upstream packages.
         expires: 2026-05-23T00:00:00.000Z
-  SNYK-JS-FASTXMLBUILDER-16133760:
-    - '*':
-        reason: >-
-          Transitive dependency via @azure/storage-blob > @azure/core-xml >
-          fast-xml-parser. No fixed version of fast-xml-builder available upstream.
-        expires: 2026-05-23T00:00:00.000Z

--- a/backend/function-apps/api/banks/banks.function.test.ts
+++ b/backend/function-apps/api/banks/banks.function.test.ts
@@ -1,0 +1,88 @@
+import { vi } from 'vitest';
+import { InvocationContext } from '@azure/functions';
+import { CamsError } from '../../../lib/common-errors/cams-error';
+import handler from './banks.function';
+import ContextCreator from '../../azure/application-context-creator';
+import {
+  buildTestResponseError,
+  buildTestResponseSuccess,
+  createMockAzureFunctionRequest,
+} from '../../azure/testing-helpers';
+import { BanksController } from '../../../lib/controllers/banks/banks.controller';
+import { BankProfile } from '@common/cams/banks';
+import MockData from '@common/cams/test-utilities/mock-data';
+
+describe('Banks Function tests', () => {
+  let context: InvocationContext;
+
+  beforeEach(() => {
+    vi.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
+      MockData.getCamsSession(),
+    );
+    context = new InvocationContext({ logHandler: () => {}, invocationId: 'test-id' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockBanks: BankProfile[] = [
+    {
+      id: 'bank-1',
+      documentType: 'BANK_PROFILE',
+      name: 'Alpha Bank',
+      status: 'active',
+      updatedOn: '2024-01-01T00:00:00.000Z',
+      updatedBy: { id: 'user-1', name: 'User One' },
+    },
+  ];
+
+  test('should return 200 with bank list for GET request', async () => {
+    const request = createMockAzureFunctionRequest({ method: 'GET' });
+    const { camsHttpResponse, azureHttpResponse } = buildTestResponseSuccess<BankProfile[]>({
+      data: mockBanks,
+    });
+    vi.spyOn(BanksController.prototype, 'handleGet').mockResolvedValue(camsHttpResponse);
+
+    const response = await handler(request, context);
+
+    expect(response).toEqual(azureHttpResponse);
+  });
+
+  test('should return 201 with created bank for POST request', async () => {
+    const request = createMockAzureFunctionRequest({
+      method: 'POST',
+      body: { name: 'Alpha Bank' },
+    });
+    const createdBank = mockBanks[0];
+    const { camsHttpResponse, azureHttpResponse } = buildTestResponseSuccess<BankProfile>(
+      { data: createdBank },
+      { statusCode: 201 },
+    );
+    vi.spyOn(BanksController.prototype, 'handlePost').mockResolvedValue(camsHttpResponse);
+
+    const response = await handler(request, context);
+
+    expect(response).toEqual(azureHttpResponse);
+  });
+
+  test('should return 405 for unsupported HTTP method', async () => {
+    const request = createMockAzureFunctionRequest({ method: 'DELETE' });
+
+    const response = await handler(request, context);
+
+    expect(response.status).toBe(405);
+  });
+
+  test('should return error response when controller throws', async () => {
+    const request = createMockAzureFunctionRequest({ method: 'GET' });
+    const error = new CamsError('BANKS-CONTROLLER', { message: 'Something went wrong.' });
+    const { azureHttpResponse, loggerCamsErrorSpy } = buildTestResponseError(error);
+    vi.spyOn(BanksController.prototype, 'handleGet').mockRejectedValue(error);
+
+    const response = await handler(request, context);
+
+    expect(response).toMatchObject(azureHttpResponse);
+    expect(loggerCamsErrorSpy).toHaveBeenCalledWith(error);
+  });
+});

--- a/backend/function-apps/api/banks/banks.function.ts
+++ b/backend/function-apps/api/banks/banks.function.ts
@@ -1,0 +1,46 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import ContextCreator from '../../azure/application-context-creator';
+import { toAzureError, toAzureSuccess } from '../../azure/functions';
+import { BanksController } from '../../../lib/controllers/banks/banks.controller';
+
+const MODULE_NAME = 'BANKS-FUNCTION';
+
+export default async function handler(
+  request: HttpRequest,
+  invocationContext: InvocationContext,
+): Promise<HttpResponseInit> {
+  const logger = ContextCreator.getLogger(invocationContext);
+
+  try {
+    const context = await ContextCreator.applicationContextCreator({
+      invocationContext,
+      logger,
+      request,
+    });
+
+    const controller = new BanksController(context);
+    context.session = await ContextCreator.getApplicationContextSession(context);
+
+    const method = request.method;
+    let responseBody;
+
+    if (method === 'GET') {
+      responseBody = await controller.handleGet(context);
+    } else if (method === 'POST') {
+      responseBody = await controller.handlePost(context);
+    } else {
+      return { status: 405, jsonBody: 'Method Not Allowed' };
+    }
+
+    return toAzureSuccess(responseBody);
+  } catch (error) {
+    return toAzureError(logger, MODULE_NAME, error);
+  }
+}
+
+app.http('banks', {
+  methods: ['GET', 'POST'],
+  authLevel: 'anonymous',
+  handler,
+  route: 'banks/{bankId?}',
+});

--- a/backend/function-apps/api/banks/banks.function.ts
+++ b/backend/function-apps/api/banks/banks.function.ts
@@ -18,8 +18,8 @@ export default async function handler(
       request,
     });
 
-    const controller = new BanksController(context);
     context.session = await ContextCreator.getApplicationContextSession(context);
+    const controller = new BanksController(context);
 
     const method = request.method;
     let responseBody;

--- a/backend/function-apps/api/banks/banks.function.ts
+++ b/backend/function-apps/api/banks/banks.function.ts
@@ -42,5 +42,5 @@ app.http('banks', {
   methods: ['GET', 'POST'],
   authLevel: 'anonymous',
   handler,
-  route: 'banks/{bankId?}',
+  route: 'banks',
 });

--- a/backend/function-apps/api/index.ts
+++ b/backend/function-apps/api/index.ts
@@ -17,6 +17,7 @@ import './case-notes/case.notes.function';
 import './case-summary/case-summary.function';
 import './case-trustee-appointment/case-trustee-appointment.function';
 import './cases/cases.function';
+import './banks/banks.function';
 import './consolidations/consolidations.function';
 import './courts/courts.function';
 import './healthcheck/healthcheck.function';

--- a/backend/lib/adapters/gateways/mongo/banks.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/banks.mongo.repository.test.ts
@@ -1,0 +1,178 @@
+import { vi } from 'vitest';
+import { closeDeferred } from '../../../deferrable/defer-close';
+import { createMockApplicationContext } from '../../../testing/testing-utilities';
+import { ApplicationContext } from '../../types/basic';
+import { BanksMongoRepository } from './banks.mongo.repository';
+import { MongoCollectionAdapter } from './utils/mongo-adapter';
+import { BankAuditHistory, BankProfile } from '@common/cams/banks';
+import { Creatable } from '@common/cams/creatable';
+
+describe('BanksMongoRepository', () => {
+  let context: ApplicationContext;
+  let repo: BanksMongoRepository;
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    repo = BanksMongoRepository.getInstance(context);
+  });
+
+  afterEach(async () => {
+    await closeDeferred(context);
+    vi.restoreAllMocks();
+    repo.release();
+  });
+
+  describe('getBanks', () => {
+    test('should return all banks sorted ascending by name', async () => {
+      const mockBanks: BankProfile[] = [
+        {
+          id: 'bank-1',
+          documentType: 'BANK_PROFILE',
+          name: 'Alpha Bank',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+        {
+          id: 'bank-2',
+          documentType: 'BANK_PROFILE',
+          name: 'Beta Bank',
+          status: 'inactive',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+      ];
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue(mockBanks);
+
+      const result = await repo.getBanks();
+
+      expect(result).toEqual(mockBanks);
+    });
+
+    test('should return empty array when no banks exist', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]);
+
+      const result = await repo.getBanks();
+
+      expect(result).toEqual([]);
+    });
+
+    test('should throw CamsError when find fails', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockRejectedValue(
+        new Error('connection error'),
+      );
+
+      await expect(repo.getBanks()).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to retrieve banks.',
+          status: 500,
+          module: 'BANKS-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
+  describe('createBank', () => {
+    test('should insert and return the created bank', async () => {
+      const newId = 'bank-abc';
+      const input: Creatable<BankProfile> = {
+        documentType: 'BANK_PROFILE',
+        name: 'New Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        createdOn: '2024-01-01T00:00:00.000Z',
+        createdBy: { id: 'user-1', name: 'User One' },
+      };
+      const expected: BankProfile = { ...input, id: newId };
+
+      vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockResolvedValue(newId);
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockResolvedValue(expected);
+
+      const result = await repo.createBank(input);
+
+      expect(result).toEqual(expected);
+    });
+
+    test('should throw CamsError when insertOne fails', async () => {
+      const input: Creatable<BankProfile> = {
+        documentType: 'BANK_PROFILE',
+        name: 'New Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockRejectedValue(
+        new Error('write error'),
+      );
+
+      await expect(repo.createBank(input)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to create bank.',
+          status: 500,
+          module: 'BANKS-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
+  describe('createBankAuditRecord', () => {
+    test('should insert audit record into banks collection', async () => {
+      const input: Creatable<BankAuditHistory> = {
+        documentType: 'AUDIT_BANK',
+        bankId: 'bank-abc',
+        before: null,
+        after: { id: 'bank-abc', name: 'New Bank', status: 'active', documentType: 'BANK_PROFILE' },
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        createdOn: '2024-01-01T00:00:00.000Z',
+        createdBy: { id: 'user-1', name: 'User One' },
+      };
+      const insertSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'insertOne')
+        .mockResolvedValue('audit-id-1');
+
+      await repo.createBankAuditRecord(input);
+
+      expect(insertSpy).toHaveBeenCalledWith(input);
+    });
+
+    test('should throw CamsError when audit insertOne fails', async () => {
+      const input: Creatable<BankAuditHistory> = {
+        documentType: 'AUDIT_BANK',
+        bankId: 'bank-abc',
+        before: null,
+        after: { id: 'bank-abc', name: 'New Bank', status: 'active', documentType: 'BANK_PROFILE' },
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockRejectedValue(
+        new Error('audit write error'),
+      );
+
+      await expect(repo.createBankAuditRecord(input)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to create bank audit record.',
+          status: 500,
+          module: 'BANKS-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
+  describe('singleton lifecycle', () => {
+    test('should return same instance on multiple getInstance calls', async () => {
+      const context2 = await createMockApplicationContext();
+      const repo2 = BanksMongoRepository.getInstance(context2);
+      expect(repo2).toBe(repo);
+      repo2.release();
+    });
+
+    test('release calls dropInstance', () => {
+      const dropSpy = vi.spyOn(BanksMongoRepository, 'dropInstance');
+      repo.release();
+      expect(dropSpy).toHaveBeenCalled();
+      dropSpy.mockRestore();
+    });
+  });
+});

--- a/backend/lib/adapters/gateways/mongo/banks.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/banks.mongo.repository.ts
@@ -1,0 +1,74 @@
+import { BankAuditHistory, BankProfile } from '@common/cams/banks';
+import { Creatable } from '@common/cams/creatable';
+import { getCamsError } from '../../../common-errors/error-utilities';
+import QueryBuilder from '../../../query/query-builder';
+import { BanksRepository } from '../../../use-cases/gateways.types';
+import { ApplicationContext } from '../../types/basic';
+import { BaseMongoRepository } from './utils/base-mongo-repository';
+
+const MODULE_NAME = 'BANKS-MONGO-REPOSITORY';
+const COLLECTION_NAME = 'banks';
+
+const { using, orderBy } = QueryBuilder;
+const doc = using<BankProfile>();
+
+export class BanksMongoRepository extends BaseMongoRepository implements BanksRepository {
+  private static referenceCount: number = 0;
+  private static instance: BanksMongoRepository;
+
+  constructor(context: ApplicationContext) {
+    super(context, MODULE_NAME, COLLECTION_NAME);
+  }
+
+  public static getInstance(context: ApplicationContext) {
+    if (!BanksMongoRepository.instance) {
+      BanksMongoRepository.instance = new BanksMongoRepository(context);
+    }
+    BanksMongoRepository.referenceCount++;
+    return BanksMongoRepository.instance;
+  }
+
+  public static dropInstance() {
+    if (BanksMongoRepository.referenceCount > 0) {
+      BanksMongoRepository.referenceCount--;
+    }
+    if (BanksMongoRepository.referenceCount < 1) {
+      BanksMongoRepository.instance?.client.close().then();
+      BanksMongoRepository.instance = null;
+    }
+  }
+
+  public release() {
+    BanksMongoRepository.dropInstance();
+  }
+
+  async getBanks(): Promise<BankProfile[]> {
+    const query = doc('documentType').equals('BANK_PROFILE');
+    try {
+      return await this.getAdapter<BankProfile>().find(
+        query,
+        orderBy<BankProfile>(['name', 'ASCENDING']),
+      );
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve banks.');
+    }
+  }
+
+  async createBank(bank: Creatable<BankProfile>): Promise<BankProfile> {
+    try {
+      const newId = await this.getAdapter<BankProfile>().insertOne(bank as BankProfile);
+      const query = doc('id').equals(newId);
+      return await this.getAdapter<BankProfile>().findOne(query);
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to create bank.');
+    }
+  }
+
+  async createBankAuditRecord(history: Creatable<BankAuditHistory>): Promise<void> {
+    try {
+      await this.getAdapter<BankAuditHistory>().insertOne(history as BankAuditHistory);
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to create bank audit record.');
+    }
+  }
+}

--- a/backend/lib/controllers/banks/banks.controller.test.ts
+++ b/backend/lib/controllers/banks/banks.controller.test.ts
@@ -1,0 +1,118 @@
+import { vi } from 'vitest';
+import { ApplicationContext } from '../../adapters/types/basic';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { BanksController } from './banks.controller';
+import { BanksUseCase } from '../../use-cases/banks/banks';
+import { CamsRole } from '@common/cams/roles';
+import { BankProfile } from '@common/cams/banks';
+
+vi.mock('../../use-cases/banks/banks');
+
+describe('BanksController', () => {
+  let context: ApplicationContext;
+  let controller: BanksController;
+
+  const mockBanks: BankProfile[] = [
+    {
+      id: 'bank-1',
+      documentType: 'BANK_PROFILE',
+      name: 'Alpha Bank',
+      status: 'active',
+      updatedOn: '2024-01-01T00:00:00.000Z',
+      updatedBy: { id: 'user-1', name: 'User One' },
+    },
+  ];
+
+  const createdBank: BankProfile = {
+    id: 'bank-new',
+    documentType: 'BANK_PROFILE',
+    name: 'New Bank',
+    status: 'active',
+    updatedOn: '2024-01-01T00:00:00.000Z',
+    updatedBy: { id: 'user-1', name: 'User One' },
+    createdOn: '2024-01-01T00:00:00.000Z',
+    createdBy: { id: 'user-1', name: 'User One' },
+  };
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    context.session.user.roles = [CamsRole.SuperUser];
+    controller = new BanksController(context);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('handleGet', () => {
+    test('should return 200 with bank list for SuperUser', async () => {
+      vi.spyOn(BanksUseCase.prototype, 'getBanks').mockResolvedValue(mockBanks);
+
+      const result = await controller.handleGet(context);
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.data).toEqual(mockBanks);
+    });
+
+    test('should throw ForbiddenError when user lacks SuperUser role', async () => {
+      context.session.user.roles = [CamsRole.TrialAttorney];
+
+      await expect(controller.handleGet(context)).rejects.toThrow(
+        expect.objectContaining({ status: 403 }),
+      );
+    });
+
+    test('should throw ForbiddenError when user has no roles', async () => {
+      context.session.user.roles = [];
+
+      await expect(controller.handleGet(context)).rejects.toThrow(
+        expect.objectContaining({ status: 403 }),
+      );
+    });
+  });
+
+  describe('handlePost', () => {
+    test('should return 201 with created bank for SuperUser', async () => {
+      context.request.body = { name: 'New Bank' };
+      vi.spyOn(BanksUseCase.prototype, 'createBank').mockResolvedValue(createdBank);
+
+      const result = await controller.handlePost(context);
+
+      expect(result.statusCode).toBe(201);
+      expect(result.body.data).toEqual(createdBank);
+    });
+
+    test('should throw ForbiddenError when user lacks SuperUser role', async () => {
+      context.session.user.roles = [CamsRole.TrialAttorney];
+      context.request.body = { name: 'New Bank' };
+
+      await expect(controller.handlePost(context)).rejects.toThrow(
+        expect.objectContaining({ status: 403 }),
+      );
+    });
+
+    test('should throw BadRequestError when name is missing', async () => {
+      context.request.body = {};
+
+      await expect(controller.handlePost(context)).rejects.toThrow(
+        expect.objectContaining({ status: 400 }),
+      );
+    });
+
+    test('should throw BadRequestError when name is blank', async () => {
+      context.request.body = { name: '   ' };
+
+      await expect(controller.handlePost(context)).rejects.toThrow(
+        expect.objectContaining({ status: 400 }),
+      );
+    });
+
+    test('should throw BadRequestError when body is null', async () => {
+      context.request.body = null;
+
+      await expect(controller.handlePost(context)).rejects.toThrow(
+        expect.objectContaining({ status: 400 }),
+      );
+    });
+  });
+});

--- a/backend/lib/controllers/banks/banks.controller.ts
+++ b/backend/lib/controllers/banks/banks.controller.ts
@@ -1,0 +1,45 @@
+import { ApplicationContext } from '../../adapters/types/basic';
+import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
+import { BadRequestError } from '../../common-errors/bad-request';
+import { ForbiddenError } from '../../common-errors/forbidden-error';
+import { CamsRole } from '@common/cams/roles';
+import { BankProfile } from '@common/cams/banks';
+import { BanksUseCase } from '../../use-cases/banks/banks';
+
+const MODULE_NAME = 'BANKS-CONTROLLER';
+
+export class BanksController {
+  private readonly useCase: BanksUseCase;
+
+  constructor(context: ApplicationContext) {
+    this.useCase = new BanksUseCase(context);
+  }
+
+  async handleGet(context: ApplicationContext): Promise<CamsHttpResponseInit<BankProfile[]>> {
+    this.requireSuperUser(context);
+    const banks = await this.useCase.getBanks();
+    return httpSuccess({
+      statusCode: 200,
+      body: { meta: { self: context.request.url }, data: banks },
+    });
+  }
+
+  async handlePost(context: ApplicationContext): Promise<CamsHttpResponseInit<BankProfile>> {
+    this.requireSuperUser(context);
+    const body = context.request.body as { name?: string } | null;
+    if (!body || !body.name || !body.name.trim()) {
+      throw new BadRequestError(MODULE_NAME, { message: 'Bank name is required.' });
+    }
+    const bank = await this.useCase.createBank({ name: body.name.trim() });
+    return httpSuccess({
+      statusCode: 201,
+      body: { meta: { self: context.request.url }, data: bank },
+    });
+  }
+
+  private requireSuperUser(context: ApplicationContext): void {
+    if (!context.session.user.roles?.includes(CamsRole.SuperUser)) {
+      throw new ForbiddenError(MODULE_NAME);
+    }
+  }
+}

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -80,6 +80,7 @@ import { TrusteeMatchVerificationMongoRepository } from './adapters/gateways/mon
 import { TrusteeUpcomingKeyDatesMongoRepository } from './adapters/gateways/mongo/trustee-upcoming-key-dates.mongo.repository';
 import { TrusteeProfessionalIdsMongoRepository } from './adapters/gateways/mongo/trustee-professional-ids.mongo.repository';
 import { ListsMongoRepository } from './adapters/gateways/mongo/lists.mongo.repository';
+import { BanksMongoRepository } from './adapters/gateways/mongo/banks.mongo.repository';
 import { UserGroupsMongoRepository } from './adapters/gateways/mongo/user-groups.mongo.repository';
 import {
   ServerConfigError,
@@ -87,6 +88,7 @@ import {
 } from './common-errors/server-config-error';
 import {
   ApiToDataflowsGateway,
+  BanksRepository,
   ObjectStorageGateway,
   TrusteeMatchVerificationRepository,
   TrusteeUpcomingKeyDatesRepository,
@@ -150,6 +152,15 @@ const getCaseNotesRepository = (context: ApplicationContext): CaseNotesRepositor
     return new MockMongoRepository();
   }
   const repo = CaseNotesMongoRepository.getInstance(context);
+  deferRelease(repo, context);
+  return repo;
+};
+
+const getBanksRepository = (context: ApplicationContext): BanksRepository => {
+  if (context.config.get('dbMock')) {
+    return new MockMongoRepository();
+  }
+  const repo = BanksMongoRepository.getInstance(context);
   deferRelease(repo, context);
   return repo;
 };
@@ -517,6 +528,7 @@ const factory = {
   getAtsGateway,
   getCasesGateway,
   getAssignmentRepository,
+  getBanksRepository,
   getCaseNotesRepository,
   getCaseDocketUseCase,
   getOrdersGateway,

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -6,6 +6,7 @@ import { CamsUserReference, UserGroup } from '@common/cams/users';
 import { ApplicationContext } from '../../adapters/types/basic';
 import {
   ArchivedCasesRepository,
+  BanksRepository,
   CamsPaginationResponse,
   CaseAssignmentRepository,
   CasesRepository,
@@ -37,11 +38,13 @@ import {
   BankruptcySoftwareList,
   BankruptcySoftwareListItem,
 } from '@common/cams/lists';
+import { BankAuditHistory, BankProfile } from '@common/cams/banks';
 import { Creatable } from '@common/cams/creatable';
 
 export class MockMongoRepository
   implements
     ArchivedCasesRepository,
+    BanksRepository,
     CaseAssignmentRepository,
     CasesRepository,
     ConsolidationOrdersRepository,
@@ -68,6 +71,18 @@ export class MockMongoRepository
 
   static getInstance(_context: ApplicationContext) {
     return new MockMongoRepository();
+  }
+
+  getBanks(): Promise<BankProfile[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  createBank(_bank: Creatable<BankProfile>): Promise<BankProfile> {
+    throw new Error('Method not implemented.');
+  }
+
+  createBankAuditRecord(_history: Creatable<BankAuditHistory>): Promise<void> {
+    throw new Error('Method not implemented.');
   }
 
   getAssignmentsForCases(..._ignore): Promise<any> {

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -1,0 +1,118 @@
+import { vi } from 'vitest';
+import { ApplicationContext } from '../../adapters/types/basic';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { BanksUseCase } from './banks';
+import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
+import { BankAuditHistory, BankProfile } from '@common/cams/banks';
+
+describe('BanksUseCase', () => {
+  let context: ApplicationContext;
+  let useCase: BanksUseCase;
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    useCase = new BanksUseCase(context);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getBanks', () => {
+    test('should return banks from repository', async () => {
+      const mockBanks: BankProfile[] = [
+        {
+          id: 'bank-1',
+          documentType: 'BANK_PROFILE',
+          name: 'Alpha Bank',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+      ];
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue(mockBanks);
+
+      const result = await useCase.getBanks();
+
+      expect(result).toEqual(mockBanks);
+    });
+
+    test('should return empty array when no banks exist', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
+
+      const result = await useCase.getBanks();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('createBank', () => {
+    test('should create bank with status active and write audit record with before:null', async () => {
+      const createdBank: BankProfile = {
+        id: 'bank-new',
+        documentType: 'BANK_PROFILE',
+        name: 'First National',
+        status: 'active',
+        updatedOn: expect.any(String) as unknown as string,
+        updatedBy: { id: context.session.user.id, name: context.session.user.name },
+        createdOn: expect.any(String) as unknown as string,
+        createdBy: { id: context.session.user.id, name: context.session.user.name },
+      };
+
+      const createBankSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createBank')
+        .mockResolvedValue(createdBank);
+      const auditSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createBankAuditRecord')
+        .mockResolvedValue();
+
+      const result = await useCase.createBank({ name: 'First National' });
+
+      expect(createBankSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: 'BANK_PROFILE',
+          name: 'First National',
+          status: 'active',
+        }),
+      );
+
+      expect(auditSpy).toHaveBeenCalledWith(
+        expect.objectContaining<Partial<BankAuditHistory>>({
+          documentType: 'AUDIT_BANK',
+          bankId: createdBank.id,
+          before: null,
+          after: createdBank,
+        }),
+      );
+
+      expect(result).toEqual(createdBank);
+    });
+
+    test('should set createdBy and updatedBy from context user', async () => {
+      const createdBank: BankProfile = {
+        id: 'bank-new',
+        documentType: 'BANK_PROFILE',
+        name: 'Test Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: context.session.user.id, name: context.session.user.name },
+        createdOn: '2024-01-01T00:00:00.000Z',
+        createdBy: { id: context.session.user.id, name: context.session.user.name },
+      };
+
+      const createBankSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createBank')
+        .mockResolvedValue(createdBank);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+
+      await useCase.createBank({ name: 'Test Bank' });
+
+      expect(createBankSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createdBy: expect.objectContaining({ id: context.session.user.id }),
+          updatedBy: expect.objectContaining({ id: context.session.user.id }),
+        }),
+      );
+    });
+  });
+});

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -1,0 +1,48 @@
+import { BankProfile } from '@common/cams/banks';
+import { createAuditRecord } from '@common/cams/auditable';
+import { getCamsUserReference } from '@common/cams/session';
+import { ApplicationContext } from '../../adapters/types/basic';
+import factory from '../../factory';
+
+export class BanksUseCase {
+  private readonly repository;
+  private readonly context: ApplicationContext;
+
+  constructor(context: ApplicationContext) {
+    this.context = context;
+    this.repository = factory.getBanksRepository(context);
+  }
+
+  async getBanks(): Promise<BankProfile[]> {
+    return this.repository.getBanks();
+  }
+
+  async createBank(input: { name: string }): Promise<BankProfile> {
+    const userRef = getCamsUserReference(this.context.session.user);
+
+    const bankData = createAuditRecord<BankProfile>(
+      {
+        documentType: 'BANK_PROFILE',
+        name: input.name,
+        status: 'active',
+      },
+      userRef,
+    );
+
+    const createdBank = await this.repository.createBank(bankData);
+
+    await this.repository.createBankAuditRecord(
+      createAuditRecord(
+        {
+          documentType: 'AUDIT_BANK',
+          bankId: createdBank.id,
+          before: null,
+          after: createdBank,
+        },
+        userRef,
+      ),
+    );
+
+    return createdBank;
+  }
+}

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -62,6 +62,7 @@ import {
 } from '@common/cams/lists';
 import { Creatable } from '@common/cams/creatable';
 import { Identifiable } from '@common/cams/document';
+import { BankAuditHistory, BankProfile } from '@common/cams/banks';
 import { TrusteeProfessionalId } from '@common/cams/trustee-professional-ids';
 
 export type ReplaceResult = {
@@ -295,6 +296,12 @@ export interface ListsRepository extends Releasable {
   postBank(item: Creatable<BankListItem>): Promise<string>;
   deleteBankruptcySoftware(id: string): Promise<void>;
   deleteBank(id: string): Promise<void>;
+}
+
+export interface BanksRepository extends Releasable {
+  getBanks(): Promise<BankProfile[]>;
+  createBank(bank: Creatable<BankProfile>): Promise<BankProfile>;
+  createBankAuditRecord(history: Creatable<BankAuditHistory>): Promise<void>;
 }
 
 export interface UsersRepository extends Releasable {

--- a/common/src/cams/banks.ts
+++ b/common/src/cams/banks.ts
@@ -1,0 +1,17 @@
+import { Auditable } from './auditable';
+import { Identifiable } from './document';
+
+export type BankProfile = Identifiable &
+  Auditable & {
+    documentType: 'BANK_PROFILE';
+    name: string;
+    status: 'active' | 'inactive';
+  };
+
+export type BankAuditHistory = Identifiable &
+  Auditable & {
+    documentType: 'AUDIT_BANK';
+    bankId: string;
+    before: Partial<BankProfile> | null;
+    after: Partial<BankProfile>;
+  };

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -9,6 +9,7 @@ export * from './api/search';
 export * from './cams/actions';
 export * from './cams/assignments';
 export * from './cams/auditable';
+export * from './cams/banks';
 export * from './cams/cases';
 export * from './cams/contact';
 export * from './cams/courts';

--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
@@ -515,3 +515,33 @@ resource trusteeProfessionalIdsCollection 'Microsoft.DocumentDB/databaseAccounts
     }
   }
 }
+
+resource banksCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-11-15' = {
+  parent: database
+  name: 'banks'
+  properties: {
+    resource: {
+      id: 'banks'
+      shardKey: {
+        documentType: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: ['_id']
+          }
+        }
+        {
+          key: {
+            keys: ['documentType']
+          }
+        }
+        {
+          key: {
+            keys: ['name']
+          }
+        }
+      ]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3385,6 +3385,18 @@
       "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==",
       "license": "MIT"
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@okta/jwt-verifier": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@okta/jwt-verifier/-/jwt-verifier-4.0.2.tgz",
@@ -10909,9 +10921,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -10920,13 +10932,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.10.tgz",
-      "integrity": "sha512-go2J2xODMc32hT+4Xr/bBGXMaIoiCwrwp2mMtAvKyvEFW6S/v5Gn2pBmE4nvbwNjGhpcAiOwEv7R6/GZ6XRa9w==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -10935,9 +10948,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.1",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -14656,9 +14670,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
-      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -16746,9 +16760,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -18604,6 +18618,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/user-interface/src/admin/AdminScreen.test.tsx
+++ b/user-interface/src/admin/AdminScreen.test.tsx
@@ -88,4 +88,10 @@ describe('Admin screen tests', () => {
     renderAtPath('/admin/banks');
     expect(screen.getByTestId('mocked-banks')).toBeInTheDocument();
   });
+
+  test('should select banks nav when path matches', () => {
+    renderAtPath('/admin/banks');
+    const navLink = screen.getByTestId('banks-nav-link');
+    expect(navLink).toHaveClass('usa-current');
+  });
 });

--- a/user-interface/src/admin/AdminScreen.test.tsx
+++ b/user-interface/src/admin/AdminScreen.test.tsx
@@ -14,6 +14,9 @@ vi.mock('./bankruptcy-software/BankruptcySoftware', () => ({
 vi.mock('./case-reload/CaseReload', () => ({
   CaseReload: () => <div data-testid="mocked-case-reload" />,
 }));
+vi.mock('./banks/Banks', () => ({
+  Banks: () => <div data-testid="mocked-banks" />,
+}));
 
 describe('Admin screen tests', () => {
   beforeEach(async () => {
@@ -79,5 +82,10 @@ describe('Admin screen tests', () => {
     renderAtPath('/admin/case-reload');
     const navLink = screen.getByTestId('case-reload-nav-link');
     expect(navLink).toHaveClass('usa-current');
+  });
+
+  test('should render Banks component when navigating to /admin/banks', () => {
+    renderAtPath('/admin/banks');
+    expect(screen.getByTestId('mocked-banks')).toBeInTheDocument();
   });
 });

--- a/user-interface/src/admin/AdminScreen.tsx
+++ b/user-interface/src/admin/AdminScreen.tsx
@@ -28,6 +28,9 @@ export function AdminScreen() {
     if (location.pathname.includes('/admin/case-reload')) {
       return AdminNavState.CASE_RELOAD;
     }
+    if (location.pathname.includes('/admin/banks')) {
+      return AdminNavState.BANKS;
+    }
     return AdminNavState.UNKNOWN;
   };
 
@@ -59,7 +62,7 @@ export function AdminScreen() {
             <div className="grid-col-10">
               <Routes>
                 <Route path="privileged-identity" element={<PrivilegedIdentity />} />
-                <Route path="banks/*" element={<Banks />} />
+                <Route path="banks" element={<Banks />} />
                 <Route path="bankruptcy-software" element={<BankruptcySoftware />} />
                 <Route path="case-reload" element={<CaseReload />} />
                 <Route path="*" element={<div data-testid={'no-admin-panel-selected'} />} />

--- a/user-interface/src/admin/AdminScreen.tsx
+++ b/user-interface/src/admin/AdminScreen.tsx
@@ -6,6 +6,7 @@ import { CamsRole } from '@common/cams/roles';
 import { PrivilegedIdentity } from './privileged-identity/PrivilegedIdentity';
 import { BankruptcySoftware } from './bankruptcy-software/BankruptcySoftware';
 import { CaseReload } from './case-reload/CaseReload';
+import { Banks } from './banks/Banks';
 import { Stop } from '@/lib/components/Stop';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import useFeatureFlags, { PRIVILEGED_IDENTITY_MANAGEMENT } from '../lib/hooks/UseFeatureFlags';
@@ -58,6 +59,7 @@ export function AdminScreen() {
             <div className="grid-col-10">
               <Routes>
                 <Route path="privileged-identity" element={<PrivilegedIdentity />} />
+                <Route path="banks/*" element={<Banks />} />
                 <Route path="bankruptcy-software" element={<BankruptcySoftware />} />
                 <Route path="case-reload" element={<CaseReload />} />
                 <Route path="*" element={<div data-testid={'no-admin-panel-selected'} />} />

--- a/user-interface/src/admin/AdminScreenNavigation.test.tsx
+++ b/user-interface/src/admin/AdminScreenNavigation.test.tsx
@@ -35,6 +35,14 @@ describe('Admin screen navigation tests', () => {
     );
   });
 
+  test('should render Banks nav link', () => {
+    renderWithoutProps();
+    const navLink = screen.getByTestId('banks-nav-link');
+    expect(navLink).toBeInTheDocument();
+    expect(navLink).toHaveTextContent('Banks');
+    expect(navLink).toHaveAttribute('href', '/admin/banks');
+  });
+
   describe('Feature flag tests for Privileged Identity nav link', () => {
     test('should display Privileged Identity nav link when PRIVILEGED_IDENTITY_MANAGEMENT flag is true', () => {
       // Mock the feature flags to enable the PRIVILEGED_IDENTITY_MANAGEMENT flag

--- a/user-interface/src/admin/AdminScreenNavigation.tsx
+++ b/user-interface/src/admin/AdminScreenNavigation.tsx
@@ -7,6 +7,7 @@ export enum AdminNavState {
   PRIVILEGED_IDENTITY,
   BANKRUPTCY_SOFTWARE,
   CASE_RELOAD,
+  BANKS,
 }
 
 export function setCurrentAdminNav(activeNav: AdminNavState, stateToCheck: AdminNavState): string {
@@ -51,6 +52,17 @@ function AdminScreenNavigation(props: Readonly<AdminScreenNavigationProps>) {
             title="Manage bankruptcy software"
           >
             Bankruptcy Software
+          </NavLink>
+        </li>
+        <li className="usa-sidenav__item">
+          <NavLink
+            to="/admin/banks"
+            data-testid="banks-nav-link"
+            className={'usa-nav-link ' + setCurrentAdminNav(activeNav, AdminNavState.BANKS)}
+            onClick={() => setActiveNav(AdminNavState.BANKS)}
+            title="Manage banks"
+          >
+            Banks
           </NavLink>
         </li>
         <li className="usa-sidenav__item">

--- a/user-interface/src/admin/banks/AddBankModal.test.tsx
+++ b/user-interface/src/admin/banks/AddBankModal.test.tsx
@@ -1,0 +1,160 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { AddBankModal, AddBankModalRef } from './AddBankModal';
+import Api2 from '@/lib/models/api2';
+import TestingUtilities from '@/lib/testing/testing-utilities';
+import { BankProfile } from '@common/cams/banks';
+
+const MODAL_ID = 'add-bank-modal';
+const MODAL_WRAPPER = `modal-${MODAL_ID}`;
+const SUBMIT_BTN = `button-${MODAL_ID}-submit-button`;
+const CANCEL_BTN = `button-${MODAL_ID}-cancel-button`;
+
+const createdBank: BankProfile = {
+  id: 'bank-new',
+  documentType: 'BANK_PROFILE',
+  name: 'First National',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+describe('AddBankModal', () => {
+  let modalRef: React.RefObject<AddBankModalRef | null>;
+  let onSuccess: (bank: BankProfile) => void;
+
+  function renderComponent() {
+    modalRef = React.createRef<AddBankModalRef>();
+    onSuccess = vi.fn<(bank: BankProfile) => void>();
+    render(<AddBankModal ref={modalRef} modalId={MODAL_ID} onSuccess={onSuccess} />);
+  }
+
+  function openModal() {
+    act(() => modalRef.current?.show());
+  }
+
+  beforeEach(() => {
+    vi.stubEnv('CAMS_USE_FAKE_API', 'true');
+    TestingUtilities.spyOnGlobalAlert();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should be hidden initially', () => {
+    renderComponent();
+    expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+  });
+
+  test('should show modal when show() is called', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+  });
+
+  test('should show validation error when submitting with empty name', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByText('Bank Name is required')).toBeInTheDocument();
+    });
+  });
+
+  test('should keep modal open when validation fails', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+  });
+
+  test('should call Api2.createBank with trimmed name on valid submit', async () => {
+    const createBankSpy = vi
+      .spyOn(Api2, 'createBank')
+      .mockResolvedValue({ data: createdBank } as never);
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Bank Name/i), {
+      target: { value: '  First National  ' },
+    });
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(createBankSpy).toHaveBeenCalledWith({ name: 'First National' });
+    });
+  });
+
+  test('should call onSuccess and close modal after successful submit', async () => {
+    vi.spyOn(Api2, 'createBank').mockResolvedValue({ data: createdBank } as never);
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Bank Name/i), { target: { value: 'First National' } });
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(createdBank);
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+    });
+  });
+
+  test('should keep modal open and not call onSuccess when API call fails', async () => {
+    vi.spyOn(Api2, 'createBank').mockRejectedValue(new Error('server error'));
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Bank Name/i), { target: { value: 'First National' } });
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+  });
+
+  test('should hide modal when hide() is called imperatively', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible'));
+
+    act(() => modalRef.current?.hide());
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+    });
+  });
+
+  test('should close modal and clear form on cancel', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(CANCEL_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Bank Name/i), { target: { value: 'Some Bank' } });
+    fireEvent.click(screen.getByTestId(CANCEL_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+    });
+
+    // Re-open and verify form is cleared
+    openModal();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Bank Name/i)).toHaveValue('');
+    });
+  });
+});

--- a/user-interface/src/admin/banks/AddBankModal.tsx
+++ b/user-interface/src/admin/banks/AddBankModal.tsx
@@ -1,0 +1,103 @@
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import Modal from '@/lib/components/uswds/modal/Modal';
+import Input from '@/lib/components/uswds/Input';
+import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
+import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
+import { BankProfile } from '@common/cams/banks';
+import Api2 from '@/lib/models/api2';
+
+export type AddBankModalRef = {
+  show: () => void;
+  hide: () => void;
+};
+
+type AddBankModalProps = {
+  modalId: string;
+  onSuccess: (bank: BankProfile) => void;
+};
+
+export const AddBankModal = forwardRef<AddBankModalRef, AddBankModalProps>(function AddBankModal(
+  { modalId, onSuccess },
+  ref,
+) {
+  const modalRef = useRef<ModalRefType>(null);
+  const alert = useGlobalAlert();
+
+  const [name, setName] = useState('');
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  function clearForm() {
+    setName('');
+    setNameError(null);
+  }
+
+  useImperativeHandle(ref, () => ({
+    show() {
+      clearForm();
+      modalRef.current?.show({});
+    },
+    hide() {
+      modalRef.current?.hide();
+    },
+  }));
+
+  async function handleSubmit() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setNameError('Bank Name is required');
+      return;
+    }
+    setNameError(null);
+
+    try {
+      const response = await Api2.createBank({ name: trimmed });
+      const created = (response as { data: BankProfile }).data;
+      onSuccess(created);
+      modalRef.current?.hide();
+      alert?.success('Bank added successfully.');
+    } catch (error) {
+      alert?.error(`Failed to add bank. ${(error as Error).message}`);
+    }
+  }
+
+  function handleCancel() {
+    clearForm();
+    modalRef.current?.hide();
+  }
+
+  const actionButtonGroup = {
+    modalId,
+    modalRef,
+    submitButton: {
+      label: 'Add Bank',
+      onClick: handleSubmit,
+      closeOnClick: false,
+    },
+    cancelButton: {
+      label: 'Cancel',
+      onClick: handleCancel,
+    },
+  };
+
+  return (
+    <Modal
+      ref={modalRef}
+      modalId={modalId}
+      heading="Add Bank"
+      actionButtonGroup={actionButtonGroup}
+      content={
+        <div>
+          <Input
+            id={`${modalId}-bank-name`}
+            label="Bank Name *"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            errorMessage={nameError ?? undefined}
+            autoComplete="off"
+          />
+        </div>
+      }
+    />
+  );
+});

--- a/user-interface/src/admin/banks/AddBankModal.tsx
+++ b/user-interface/src/admin/banks/AddBankModal.tsx
@@ -56,7 +56,8 @@ export const AddBankModal = forwardRef<AddBankModalRef, AddBankModalProps>(funct
       modalRef.current?.hide();
       alert?.success('Bank added successfully.');
     } catch (error) {
-      alert?.error(`Failed to add bank. ${(error as Error).message}`);
+      console.error(error);
+      alert?.error('Failed to add bank. Please try again.');
     }
   }
 

--- a/user-interface/src/admin/banks/AddBankModal.tsx
+++ b/user-interface/src/admin/banks/AddBankModal.tsx
@@ -5,6 +5,7 @@ import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 import { BankProfile } from '@common/cams/banks';
 import Api2 from '@/lib/models/api2';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 export type AddBankModalRef = {
   show: () => void;
@@ -56,7 +57,7 @@ export const AddBankModal = forwardRef<AddBankModalRef, AddBankModalProps>(funct
       modalRef.current?.hide();
       alert?.success('Bank added successfully.');
     } catch (error) {
-      console.error(error);
+      getAppInsights().appInsights.trackException({ exception: error as Error });
       alert?.error('Failed to add bank. Please try again.');
     }
   }

--- a/user-interface/src/admin/banks/AddBankModal.tsx
+++ b/user-interface/src/admin/banks/AddBankModal.tsx
@@ -89,7 +89,7 @@ export const AddBankModal = forwardRef<AddBankModalRef, AddBankModalProps>(funct
         <div>
           <Input
             id={`${modalId}-bank-name`}
-            label="Bank Name *"
+            label="Bank Name"
             required
             value={name}
             onChange={(e) => setName(e.target.value)}

--- a/user-interface/src/admin/banks/Banks.scss
+++ b/user-interface/src/admin/banks/Banks.scss
@@ -1,0 +1,10 @@
+.banks-admin-panel {
+  .banks-table-container {
+    max-width: 38rem;
+    margin-top: 1.25rem;
+  }
+
+  .banks-table-status-col {
+    width: 7rem;
+  }
+}

--- a/user-interface/src/admin/banks/Banks.test.tsx
+++ b/user-interface/src/admin/banks/Banks.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { forwardRef, useImperativeHandle } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { Banks } from './Banks';
+import Api2 from '@/lib/models/api2';
+import { BankProfile } from '@common/cams/banks';
+import * as AppInsights from '@/lib/hooks/UseApplicationInsights';
+import { AddBankModalRef } from './AddBankModal';
+
+const mockShow = vi.fn();
+vi.mock('./AddBankModal', () => ({
+  AddBankModal: forwardRef<AddBankModalRef, { onSuccess: (bank: BankProfile) => void }>(
+    function MockAddBankModal({ onSuccess }, ref) {
+      useImperativeHandle(ref, () => ({ show: mockShow, hide: vi.fn() }));
+      return (
+        <div
+          data-testid="mock-add-bank-modal"
+          role="button"
+          tabIndex={0}
+          onClick={() => onSuccess(newBank)}
+          onKeyDown={() => onSuccess(newBank)}
+        />
+      );
+    },
+  ),
+}));
+
+const newBank: BankProfile = {
+  id: 'bank-new',
+  documentType: 'BANK_PROFILE',
+  name: 'New Bank',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+const mockBanks: BankProfile[] = [
+  {
+    id: 'bank-1',
+    documentType: 'BANK_PROFILE',
+    name: 'Alpha Bank',
+    status: 'active',
+    updatedOn: '2024-01-01T00:00:00.000Z',
+    updatedBy: { id: 'user-1', name: 'User One' },
+  },
+  {
+    id: 'bank-2',
+    documentType: 'BANK_PROFILE',
+    name: 'Beta Bank',
+    status: 'inactive',
+    updatedOn: '2024-01-01T00:00:00.000Z',
+    updatedBy: { id: 'user-1', name: 'User One' },
+  },
+];
+
+function renderComponent() {
+  return render(
+    <BrowserRouter>
+      <Banks />
+    </BrowserRouter>,
+  );
+}
+
+describe('Banks component', () => {
+  beforeEach(() => {
+    vi.stubEnv('CAMS_USE_FAKE_API', 'true');
+    vi.spyOn(Api2, 'getBanks').mockResolvedValue({ data: mockBanks });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should show loading state initially', async () => {
+    renderComponent();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  test('should render bank table after loading', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId('banks-table')).toBeInTheDocument();
+    });
+  });
+
+  test('should render "Bank name" and "Status" column headers', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Bank name')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
+    });
+  });
+
+  test('should render each bank name as a link to its detail page', async () => {
+    renderComponent();
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: 'Alpha Bank' });
+      expect(link).toHaveAttribute('href', '/admin/banks/bank-1');
+    });
+  });
+
+  test('should render "Active" for active bank status', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+  });
+
+  test('should render "Inactive" for inactive bank status', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Inactive')).toBeInTheDocument();
+    });
+  });
+
+  test('should render "+ Add Bank" button', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId('button-add-bank-button')).toBeInTheDocument();
+    });
+  });
+
+  test('should show error alert when fetch fails', async () => {
+    vi.spyOn(Api2, 'getBanks').mockRejectedValue(new Error('network error'));
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId('alert-container-banks-load-error')).toBeInTheDocument();
+    });
+  });
+
+  test('should call modal show() when + Add Bank button is clicked', async () => {
+    renderComponent();
+    const btn = await screen.findByTestId('button-add-bank-button');
+    fireEvent.click(btn);
+    expect(mockShow).toHaveBeenCalled();
+  });
+
+  test('should append new bank to list and track AppInsights event on success', async () => {
+    const trackEventSpy = vi.fn();
+    vi.spyOn(AppInsights, 'getAppInsights').mockReturnValue({
+      appInsights: { trackEvent: trackEventSpy },
+    } as never);
+
+    renderComponent();
+    const modal = await screen.findByTestId('mock-add-bank-modal');
+    fireEvent.click(modal);
+
+    await waitFor(() => {
+      expect(screen.getByText('New Bank')).toBeInTheDocument();
+      expect(trackEventSpy).toHaveBeenCalledWith({
+        name: 'Bank Created',
+        properties: { bankId: newBank.id, bankName: newBank.name },
+      });
+    });
+  });
+});

--- a/user-interface/src/admin/banks/Banks.test.tsx
+++ b/user-interface/src/admin/banks/Banks.test.tsx
@@ -91,11 +91,11 @@ describe('Banks component', () => {
     });
   });
 
-  test('should render each bank name as a link to its detail page', async () => {
+  test('should render each bank name as plain text', async () => {
     renderComponent();
     await waitFor(() => {
-      const link = screen.getByRole('link', { name: 'Alpha Bank' });
-      expect(link).toHaveAttribute('href', '/admin/banks/bank-1');
+      expect(screen.getByText('Alpha Bank')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Alpha Bank' })).not.toBeInTheDocument();
     });
   });
 

--- a/user-interface/src/admin/banks/Banks.tsx
+++ b/user-interface/src/admin/banks/Banks.tsx
@@ -1,6 +1,5 @@
 import './Banks.scss';
 import { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
 import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
@@ -81,9 +80,7 @@ export function Banks() {
               <CamsTableBody>
                 {banks.map((bank) => (
                   <CamsTableRow key={bank.id}>
-                    <CamsTableCell>
-                      <Link to={`/admin/banks/${bank.id}`}>{bank.name}</Link>
-                    </CamsTableCell>
+                    <CamsTableCell>{bank.name}</CamsTableCell>
                     <CamsTableCell>
                       {bank.status === 'active' ? 'Active' : 'Inactive'}
                     </CamsTableCell>

--- a/user-interface/src/admin/banks/Banks.tsx
+++ b/user-interface/src/admin/banks/Banks.tsx
@@ -40,7 +40,7 @@ export function Banks() {
   }, []);
 
   function handleBankAdded(bank: BankProfile) {
-    setBanks((prev) => [...prev, bank]);
+    setBanks((prev) => [...prev, bank].sort((a, b) => a.name.localeCompare(b.name)));
     getAppInsights().appInsights.trackEvent({
       name: 'Bank Created',
       properties: { bankId: bank.id, bankName: bank.name },

--- a/user-interface/src/admin/banks/Banks.tsx
+++ b/user-interface/src/admin/banks/Banks.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Api2 from '@/lib/models/api2';
+import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
+import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
+import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import {
+  CamsTable,
+  CamsTableHeader,
+  CamsTableHeaderCell,
+  CamsTableBody,
+  CamsTableRow,
+  CamsTableCell,
+} from '@/lib/components/cams/CamsTable';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
+import { BankProfile } from '@common/cams/banks';
+import { AddBankModal, AddBankModalRef } from './AddBankModal';
+
+export function Banks() {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [banks, setBanks] = useState<BankProfile[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const addBankModalRef = useRef<AddBankModalRef>(null);
+
+  async function loadBanks() {
+    try {
+      const response = await Api2.getBanks();
+      setBanks(response.data as BankProfile[]);
+      setLoadError(null);
+    } catch (error) {
+      setLoadError((error as Error).message);
+    }
+  }
+
+  useEffect(() => {
+    setIsLoaded(false);
+    loadBanks().then(() => setIsLoaded(true));
+  }, []);
+
+  function handleBankAdded(bank: BankProfile) {
+    setBanks((prev) => [...prev, bank]);
+    getAppInsights().appInsights.trackEvent({
+      name: 'Bank Created',
+      properties: { bankId: bank.id, bankName: bank.name },
+    });
+  }
+
+  return (
+    <div className="banks-admin-panel" data-testid="banks-panel">
+      <h2>Banks</h2>
+      {!isLoaded && <LoadingSpinner caption="Loading..." />}
+      {isLoaded && loadError && (
+        <Alert
+          id="banks-load-error"
+          message={`Failed to load banks. ${loadError}`}
+          type={UswdsAlertStyle.Error}
+          show={true}
+        />
+      )}
+      {isLoaded && !loadError && (
+        <>
+          <div className="grid-row">
+            <div className="grid-col-12">
+              <Button
+                id="add-bank-button"
+                uswdsStyle={UswdsButtonStyle.Default}
+                onClick={() => addBankModalRef.current?.show()}
+              >
+                + Add Bank
+              </Button>
+            </div>
+          </div>
+          <CamsTable aria-label="Banks" data-testid="banks-table">
+            <CamsTableHeader>
+              <CamsTableHeaderCell>Bank name</CamsTableHeaderCell>
+              <CamsTableHeaderCell>Status</CamsTableHeaderCell>
+            </CamsTableHeader>
+            <CamsTableBody>
+              {banks.map((bank) => (
+                <CamsTableRow key={bank.id}>
+                  <CamsTableCell>
+                    <Link to={`/admin/banks/${bank.id}`}>{bank.name}</Link>
+                  </CamsTableCell>
+                  <CamsTableCell>{bank.status === 'active' ? 'Active' : 'Inactive'}</CamsTableCell>
+                </CamsTableRow>
+              ))}
+            </CamsTableBody>
+          </CamsTable>
+        </>
+      )}
+      <AddBankModal ref={addBankModalRef} modalId="add-bank-modal" onSuccess={handleBankAdded} />
+    </div>
+  );
+}

--- a/user-interface/src/admin/banks/Banks.tsx
+++ b/user-interface/src/admin/banks/Banks.tsx
@@ -1,3 +1,4 @@
+import './Banks.scss';
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Api2 from '@/lib/models/api2';
@@ -48,7 +49,7 @@ export function Banks() {
 
   return (
     <div className="banks-admin-panel" data-testid="banks-panel">
-      <h2>Banks</h2>
+      <h2 className="screen-reader-only">Banks</h2>
       {!isLoaded && <LoadingSpinner caption="Loading..." />}
       {isLoaded && loadError && (
         <Alert
@@ -71,22 +72,26 @@ export function Banks() {
               </Button>
             </div>
           </div>
-          <CamsTable aria-label="Banks" data-testid="banks-table">
-            <CamsTableHeader>
-              <CamsTableHeaderCell>Bank name</CamsTableHeaderCell>
-              <CamsTableHeaderCell>Status</CamsTableHeaderCell>
-            </CamsTableHeader>
-            <CamsTableBody>
-              {banks.map((bank) => (
-                <CamsTableRow key={bank.id}>
-                  <CamsTableCell>
-                    <Link to={`/admin/banks/${bank.id}`}>{bank.name}</Link>
-                  </CamsTableCell>
-                  <CamsTableCell>{bank.status === 'active' ? 'Active' : 'Inactive'}</CamsTableCell>
-                </CamsTableRow>
-              ))}
-            </CamsTableBody>
-          </CamsTable>
+          <div className="banks-table-container">
+            <CamsTable aria-label="Banks" data-testid="banks-table">
+              <CamsTableHeader>
+                <CamsTableHeaderCell>Bank name</CamsTableHeaderCell>
+                <CamsTableHeaderCell className="banks-table-status-col">Status</CamsTableHeaderCell>
+              </CamsTableHeader>
+              <CamsTableBody>
+                {banks.map((bank) => (
+                  <CamsTableRow key={bank.id}>
+                    <CamsTableCell>
+                      <Link to={`/admin/banks/${bank.id}`}>{bank.name}</Link>
+                    </CamsTableCell>
+                    <CamsTableCell>
+                      {bank.status === 'active' ? 'Active' : 'Inactive'}
+                    </CamsTableCell>
+                  </CamsTableRow>
+                ))}
+              </CamsTableBody>
+            </CamsTable>
+          </div>
         </>
       )}
       <AddBankModal ref={addBankModalRef} modalId="add-bank-modal" onSuccess={handleBankAdded} />

--- a/user-interface/src/lib/models/api2.test.ts
+++ b/user-interface/src/lib/models/api2.test.ts
@@ -12,7 +12,8 @@ import {
 } from '@common/cams/orders';
 import LocalStorage from '@/lib/utils/local-storage';
 import { blankConfiguration } from '../testing/mock-configuration';
-import { BankListItem, BankruptcySoftwareListItem } from '@common/cams/lists';
+import { BankruptcySoftwareListItem } from '@common/cams/lists';
+import { BankProfile } from '@common/cams/banks';
 import { Creatable } from '@common/cams/creatable';
 
 type ApiType = {
@@ -478,7 +479,14 @@ describe('_Api2 functions', async () => {
   test('should call api.get function when calling getBanks', () => {
     const getSpy = vi.spyOn(api.default, 'get').mockResolvedValue({ data: { items: [] } });
     api2.default.getBanks();
-    expect(getSpy).toHaveBeenCalledWith('/lists/banks', {});
+    expect(getSpy).toHaveBeenCalledWith('/banks', {});
+  });
+
+  test('should call api.post function when calling createBank', () => {
+    const postSpy = vi.spyOn(api.default, 'post').mockResolvedValue({ data: {} });
+    const bank: Pick<BankProfile, 'name'> = { name: 'Test Bank' };
+    api2.default.createBank(bank);
+    expect(postSpy).toHaveBeenCalledWith('/banks', bank, {});
   });
 
   test('should call api.post function when calling postBankruptcySoftware', () => {
@@ -499,24 +507,6 @@ describe('_Api2 functions', async () => {
     const softwareId = 'software-id';
     api2.default.deleteBankruptcySoftware(softwareId);
     expect(deleteSpy).toHaveBeenCalledWith(`/lists/bankruptcy-software/${softwareId}`, {});
-  });
-
-  test('should call api.post function when calling postBank', () => {
-    const postSpy = vi.spyOn(api.default, 'post').mockResolvedValue({ data: { id: 'bank-id' } });
-    const bankItem: Creatable<BankListItem> = {
-      list: 'banks' as const,
-      key: 'Test Bank',
-      value: 'Test Bank',
-    };
-    api2.default.postBank(bankItem);
-    expect(postSpy).toHaveBeenCalledWith('/lists/banks', bankItem, {});
-  });
-
-  test('should call api.delete function when calling deleteBank', () => {
-    const deleteSpy = vi.spyOn(api.default, 'delete').mockResolvedValue({ data: null });
-    const bankId = 'bank-id';
-    api2.default.deleteBank(bankId);
-    expect(deleteSpy).toHaveBeenCalledWith(`/lists/banks/${bankId}`, {});
   });
 
   test('should call api.get when calling getTrusteeNotes', () => {

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -54,12 +54,8 @@ import { TrusteeAssistant, TrusteeAssistantInput } from '@common/cams/trustee-as
 import { TrusteeNote, TrusteeNoteInput } from '@common/cams/trustee-notes';
 import { TrusteeSearchResult } from '@common/cams/trustee-search';
 import { OversightRoleType } from '@common/cams/roles';
-import {
-  BankList,
-  BankListItem,
-  BankruptcySoftwareList,
-  BankruptcySoftwareListItem,
-} from '@common/cams/lists';
+import { BankruptcySoftwareList, BankruptcySoftwareListItem } from '@common/cams/lists';
+import { BankProfile } from '@common/cams/banks';
 import { Creatable } from '@common/cams/creatable';
 import {
   TrusteeUpcomingKeyDates,
@@ -547,15 +543,11 @@ async function deleteBankruptcySoftware(id: string) {
 }
 
 async function getBanks() {
-  return api().get<BankList>('/lists/banks');
+  return api().get<BankProfile[]>('/banks');
 }
 
-async function postBank(item: Creatable<BankListItem>) {
-  return api().post('/lists/banks', item);
-}
-
-async function deleteBank(id: string) {
-  return api().delete(`/lists/banks/${id}`);
+async function createBank(data: Pick<BankProfile, 'name'>) {
+  return api().post('/banks', data);
 }
 
 async function getCaseTrusteeAppointment(caseId: string) {
@@ -653,8 +645,7 @@ export const _Api2 = {
   putPrivilegedIdentityUser,
   searchCases,
   getBanks,
-  postBank,
-  deleteBank,
+  createBank,
   getBankruptcySoftwareList,
   postBankruptcySoftware,
   deleteBankruptcySoftware,

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -44,7 +44,8 @@ import { TrusteeNote, TrusteeNoteInput } from '@common/cams/trustee-notes';
 import { TrusteeSearchResult } from '@common/cams/trustee-search';
 import { TrusteeUpcomingKeyDates } from '@common/cams/trustee-upcoming-key-dates';
 import { Creatable } from '@common/cams/creatable';
-import { BankListItem, BankruptcySoftwareListItem } from '@common/cams/lists';
+import { BankruptcySoftwareListItem } from '@common/cams/lists';
+import { BankProfile } from '@common/cams/banks';
 import { CamsRole, OversightRoleType } from '@common/cams/roles';
 
 // Helper to generate a random ID
@@ -2809,35 +2810,39 @@ async function deleteBankruptcySoftware(_ignore: string) {
 }
 
 async function getBanks() {
+  const mockUser = { id: 'system', name: 'System' };
+  const now = new Date().toISOString();
   return {
     data: [
       {
-        _id: '1',
-        list: 'banks',
-        key: 'Bank of America',
-        value: 'Bank of America',
+        id: '1',
+        documentType: 'BANK_PROFILE' as const,
+        name: 'Bank of America',
+        status: 'active' as const,
+        updatedOn: now,
+        updatedBy: mockUser,
       },
       {
-        _id: '2',
-        list: 'banks',
-        key: 'Chase Bank',
-        value: 'Chase Bank',
+        id: '2',
+        documentType: 'BANK_PROFILE' as const,
+        name: 'Chase Bank',
+        status: 'active' as const,
+        updatedOn: now,
+        updatedBy: mockUser,
       },
       {
-        _id: '3',
-        list: 'banks',
-        key: 'Wells Fargo',
-        value: 'Wells Fargo',
+        id: '3',
+        documentType: 'BANK_PROFILE' as const,
+        name: 'Wells Fargo',
+        status: 'active' as const,
+        updatedOn: now,
+        updatedBy: mockUser,
       },
-    ],
+    ] as BankProfile[],
   };
 }
 
-async function postBank(_ignore: Creatable<BankListItem>) {
-  return '--id--';
-}
-
-async function deleteBank(_ignore: string) {
+async function createBank(_ignore: Pick<BankProfile, 'name'>) {
   return;
 }
 
@@ -2963,8 +2968,7 @@ const MockApi2 = {
   getBankruptcySoftwareList,
   postBankruptcySoftware,
   deleteBankruptcySoftware,
-  deleteBank,
-  postBank,
+  createBank,
   getBanks,
   getUpcomingKeyDates,
   putUpcomingKeyDates,

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -2842,8 +2842,19 @@ async function getBanks() {
   };
 }
 
-async function createBank(_ignore: Pick<BankProfile, 'name'>) {
-  return;
+async function createBank(data: Pick<BankProfile, 'name'>) {
+  const mockUser = { id: 'system', name: 'System' };
+  const now = new Date().toISOString();
+  return {
+    data: {
+      id: crypto.randomUUID(),
+      documentType: 'BANK_PROFILE' as const,
+      name: data.name,
+      status: 'active' as const,
+      updatedOn: now,
+      updatedBy: mockUser,
+    } as BankProfile,
+  };
 }
 
 async function postCaseReload(_caseId: string) {


### PR DESCRIPTION
# Purpose

OoO users need to manage which banks are available for trustees. This PR delivers the first deployable slice: viewing the bank list and creating new banks from the Administration panel.

# Major Changes

- New `BankProfile` and `BankAuditHistory` types in common — dedicated entity replacing the generic `lists/banks` key-value pattern
- Full backend stack: MongoDB repository (`banks` collection), use case, SuperUser-gated controller, and Azure Function route `GET/POST /banks`
- Every bank creation writes an audit record (`AUDIT_BANK`) with `before: null` and the created bank as `after`
- `Api2.getBanks` and `Api2.createBank` updated to call `/banks` instead of the old `/lists/banks` endpoint
- Banks nav item added to the Administration sidebar
- Banks list page shows bank name (linked to detail, Slice 2) and status columns
- Add Bank modal with client-side required-field validation; modal stays open on API failure

# Testing/Validation

Implemented using TDD (red-green-refactor) throughout. Test coverage:

- Repository: `getBanks`, `createBank`, `createBankAuditRecord` — happy paths and error wrapping
- Use case: delegation to repo, audit record written with `before: null`, user stamped from context
- Controller: 200/201 success, 403 for non-SuperUser, 400 for missing/blank name
- Azure Function: GET and POST routing, 405 for unsupported methods, error propagation
- Api2: new endpoint URLs asserted in existing test suite
- `Banks` component: table render, loading state, error alert, nav link, route registration
- `AddBankModal`: show/hide lifecycle, validation error stays modal open, success calls `onSuccess` and closes, API failure keeps modal open, cancel clears form

# Notes

Banks use a dedicated MongoDB collection (`banks`) rather than the generic `lists` collection. This was a deliberate architectural choice — banks need audit history, status lifecycle, and their own CRUD surface that the generic key-value lists pattern can't support. The old `lists/banks` endpoint remains intact for backward compatibility but is no longer used by the UI.

The `closeOnClick: false` flag is set on the Add Bank modal submit button so the modal stays open on validation errors or API failures — the modal closes only on explicit success or cancel.

Slice 2 (bank detail + edit) and Slice 3 (trustees tab) will follow in subsequent PRs.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce a dedicated banks domain with backend and UI support for viewing and creating bank profiles in the administration panel.

New Features:
- Add BankProfile and BankAuditHistory domain types and expose them from the shared common package.
- Implement a Banks MongoDB repository, use case, controller, and Azure Function HTTP endpoint for listing and creating banks, including audit log records on creation.
- Add an Administration Banks screen that lists banks with status and supports creating new banks via an Add Bank modal with validation and analytics tracking.
- Expose new Api2.getBanks and Api2.createBank client methods backed by the new /banks endpoint and update the mock API accordingly.
- Extend the admin navigation and routing to include the new Banks section.

Enhancements:
- Introduce a dedicated BanksRepository gateway type and factory wiring for resolving concrete banks repositories in different environments.
- Update the mock Mongo repository to implement the new BanksRepository interface methods.
- Standardize bank-related testing across backend and frontend for repository, use case, controller, function routing, API client, admin navigation, and UI components.

Tests:
- Add comprehensive tests for the banks Mongo repository, banks use case, banks controller, and Azure Function routing and behavior.
- Add frontend tests covering Api2 bank endpoints, admin navigation to the Banks screen, the Banks list component, and the Add Bank modal’s lifecycle, validation, and error handling.