### PR TITLE
CAMS-741 Scope trustee form CSS to prevent style leakage

### DIFF
--- a/user-interface/src/trustees/TrusteeDetailScreen.scss
+++ b/user-interface/src/trustees/TrusteeDetailScreen.scss
@@ -4,11 +4,7 @@
   }
 }
 .trustee-detail-screen,
-.trustee-appointment-form-screen,
-.trustee-assistant-form-screen,
-.trustee-internal-contact-form-screen,
-.trustee-public-contact-form-screen,
-.trustee-edit-appointment-form-screen {
+[class$="-trustee-form-screen"] {
   .field-group {
     .usa-form-group {
       margin-top: 0;

--- a/user-interface/src/trustees/TrusteeDetailScreen.scss
+++ b/user-interface/src/trustees/TrusteeDetailScreen.scss
@@ -4,7 +4,11 @@
   }
 }
 .trustee-detail-screen,
-.trustee-form-screen {
+.trustee-appointment-form-screen,
+.trustee-assistant-form-screen,
+.trustee-internal-contact-form-screen,
+.trustee-public-contact-form-screen,
+.trustee-edit-appointment-form-screen {
   .field-group {
     .usa-form-group {
       margin-top: 0;

--- a/user-interface/src/trustees/forms/EditTrusteeAppointment.tsx
+++ b/user-interface/src/trustees/forms/EditTrusteeAppointment.tsx
@@ -46,7 +46,7 @@ export default function EditTrusteeAppointment() {
 
   if (error || !appointment || !trusteeId) {
     return (
-      <div className="trustee-form-screen">
+      <div className="trustee-edit-appointment-form-screen">
         <Alert type={UswdsAlertStyle.Error} inline={true} show={true}>
           {error || 'Unable to load appointment'}
         </Alert>

--- a/user-interface/src/trustees/forms/EditTrusteeAppointment.tsx
+++ b/user-interface/src/trustees/forms/EditTrusteeAppointment.tsx
@@ -46,7 +46,7 @@ export default function EditTrusteeAppointment() {
 
   if (error || !appointment || !trusteeId) {
     return (
-      <div className="trustee-edit-appointment-form-screen">
+      <div className="trustee-error-alert-form-screen">
         <Alert type={UswdsAlertStyle.Error} inline={true} show={true}>
           {error || 'Unable to load appointment'}
         </Alert>

--- a/user-interface/src/trustees/forms/EditTrusteeAppointment.tsx
+++ b/user-interface/src/trustees/forms/EditTrusteeAppointment.tsx
@@ -46,7 +46,7 @@ export default function EditTrusteeAppointment() {
 
   if (error || !appointment || !trusteeId) {
     return (
-      <div className="error-alert-trustee-form-screen">
+      <div className="trustee-form-error-page">
         <Alert type={UswdsAlertStyle.Error} inline={true} show={true}>
           {error || 'Unable to load appointment'}
         </Alert>

--- a/user-interface/src/trustees/forms/EditTrusteeAppointment.tsx
+++ b/user-interface/src/trustees/forms/EditTrusteeAppointment.tsx
@@ -46,7 +46,7 @@ export default function EditTrusteeAppointment() {
 
   if (error || !appointment || !trusteeId) {
     return (
-      <div className="trustee-error-alert-form-screen">
+      <div className="error-alert-trustee-form-screen">
         <Alert type={UswdsAlertStyle.Error} inline={true} show={true}>
           {error || 'Unable to load appointment'}
         </Alert>

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
@@ -4,10 +4,6 @@
   // CSS variable for consistent field width
   --form-field-max-width: 385px;
 
-  .usa-alert-container {
-    margin-left: 0;
-  }
-
   .field-group.appointedDate {
     margin-bottom: 0.5rem;
   }

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
@@ -1,12 +1,13 @@
 @use 'uswds-core' as *;
 
-.trustee-form-screen {
+.trustee-appointment-form-screen {
   // CSS variable for consistent field width
   --form-field-max-width: 385px;
 
   .usa-alert-container {
     margin-left: 0;
   }
+
   .field-group.appointedDate {
     margin-bottom: 0.5rem;
   }

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
@@ -1,6 +1,6 @@
 @use 'uswds-core' as *;
 
-.trustee-appointment-form-screen {
+.appointment-trustee-form-screen {
   // CSS variable for consistent field width
   --form-field-max-width: 385px;
 

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -589,7 +589,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
         </div>
 
         {validationError && (
-          <div ref={validationAlertRef} tabIndex={-1}>
+          <div ref={validationAlertRef} tabIndex={-1} className="trustee-error-alert-form-screen">
             <Alert
               type={UswdsAlertStyle.Error}
               inline={true}

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -575,7 +575,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   }
 
   return (
-    <div className="trustee-appointment-form-screen">
+    <div className="appointment-trustee-form-screen">
       <form
         aria-label={isEditMode ? 'Edit Trustee Appointment' : 'Add Trustee Appointment'}
         data-testid="trustee-appointment-form"
@@ -589,7 +589,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
         </div>
 
         {validationError && (
-          <div ref={validationAlertRef} tabIndex={-1} className="trustee-error-alert-form-screen">
+          <div ref={validationAlertRef} tabIndex={-1} className="error-alert-trustee-form-screen">
             <Alert
               type={UswdsAlertStyle.Error}
               inline={true}

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -436,7 +436,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
     !!formData.appointedDate &&
     !validationError;
 
-  const handleSubmit = async (ev: React.FormEvent): Promise<void> => {
+  const handleSubmit = async (ev: React.SubmitEvent<HTMLFormElement>): Promise<void> => {
     ev.preventDefault();
 
     if (validationError) {

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -589,7 +589,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
         </div>
 
         {validationError && (
-          <div ref={validationAlertRef} tabIndex={-1} className="error-alert-trustee-form-screen">
+          <div ref={validationAlertRef} tabIndex={-1} className="trustee-form-error-wrapper">
             <Alert
               type={UswdsAlertStyle.Error}
               inline={true}

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -575,7 +575,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
   }
 
   return (
-    <div className="trustee-form-screen">
+    <div className="trustee-appointment-form-screen">
       <form
         aria-label={isEditMode ? 'Edit Trustee Appointment' : 'Add Trustee Appointment'}
         data-testid="trustee-appointment-form"

--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.scss
@@ -1,4 +1,4 @@
-.trustee-assistant-form-screen {
+.assistant-trustee-form-screen {
   .form-container {
     .form-column {
       .field-group {

--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.scss
@@ -1,4 +1,4 @@
-.trustee-form-screen {
+.trustee-assistant-form-screen {
   .form-container {
     .form-column {
       .field-group {

--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
@@ -218,7 +218,7 @@ function TrusteeAssistantForm(props: Readonly<TrusteeAssistantFormProps>) {
     }, 300);
   };
 
-  const handleSubmit = async (ev: React.FormEvent): Promise<void> => {
+  const handleSubmit = async (ev: React.SubmitEvent<HTMLFormElement>): Promise<void> => {
     ev.preventDefault();
     const currentFormData = normalizeFormData(formData);
 

--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
@@ -298,7 +298,7 @@ function TrusteeAssistantForm(props: Readonly<TrusteeAssistantFormProps>) {
   }
 
   return (
-    <div className="trustee-form-screen">
+    <div className="trustee-assistant-form-screen">
       <form
         noValidate
         aria-label={isCreateMode ? 'Create Trustee Assistant' : 'Edit Trustee Assistant'}

--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
@@ -450,16 +450,18 @@ function TrusteeAssistantForm(props: Readonly<TrusteeAssistantFormProps>) {
           </div>
         </div>
 
-        <Alert
-          role="alert"
-          id="assistant-form-error-alert"
-          className="form-field-warning"
-          type={UswdsAlertStyle.Error}
-          inline={true}
-          slim={false}
-          ref={partialAddressAlertRef}
-          message={saveAlert ?? ''}
-        />
+        <div className="trustee-error-alert-form-screen">
+          <Alert
+            role="alert"
+            id="assistant-form-error-alert"
+            className="form-field-warning"
+            type={UswdsAlertStyle.Error}
+            inline={true}
+            slim={false}
+            ref={partialAddressAlertRef}
+            message={saveAlert ?? ''}
+          />
+        </div>
         <div className="usa-button-group">
           <Button id="submit-button" type="submit">
             {isSubmitting ? 'Saving…' : 'Save'}

--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
@@ -450,7 +450,7 @@ function TrusteeAssistantForm(props: Readonly<TrusteeAssistantFormProps>) {
           </div>
         </div>
 
-        <div className="error-alert-trustee-form-screen">
+        <div className="trustee-form-error-wrapper">
           <Alert
             role="alert"
             id="assistant-form-error-alert"

--- a/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAssistantForm.tsx
@@ -298,7 +298,7 @@ function TrusteeAssistantForm(props: Readonly<TrusteeAssistantFormProps>) {
   }
 
   return (
-    <div className="trustee-assistant-form-screen">
+    <div className="assistant-trustee-form-screen">
       <form
         noValidate
         aria-label={isCreateMode ? 'Create Trustee Assistant' : 'Edit Trustee Assistant'}
@@ -450,7 +450,7 @@ function TrusteeAssistantForm(props: Readonly<TrusteeAssistantFormProps>) {
           </div>
         </div>
 
-        <div className="trustee-error-alert-form-screen">
+        <div className="error-alert-trustee-form-screen">
           <Alert
             role="alert"
             id="assistant-form-error-alert"

--- a/user-interface/src/trustees/forms/TrusteeContactForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeContactForm.scss
@@ -1,10 +1,11 @@
-.error-alert-trustee-form-screen {
+.trustee-form-error-page,
+.trustee-form-error-wrapper {
   .usa-alert-container {
     margin-left: 0;
   }
 }
 
-[class$="-trustee-form-screen"]:not(.error-alert-trustee-form-screen) {
+[class$="-trustee-form-screen"]:not(.trustee-form-error-page):not(.trustee-form-error-wrapper) {
   h1.create-trustee {
     display: block;
     margin: 1rem 0 1.5rem 0;
@@ -60,7 +61,7 @@
 }
 
 @media screen and (max-width: 1023px) {
-  [class$="-trustee-form-screen"]:not(.error-alert-trustee-form-screen) form {
+  [class$="-trustee-form-screen"]:not(.trustee-form-error-page):not(.trustee-form-error-wrapper) form {
     .form-container {
       .form-column {
         min-width: 200px;
@@ -78,7 +79,7 @@
 }
 
 @media screen and (max-width: 599px) {
-  [class$="-trustee-form-screen"]:not(.error-alert-trustee-form-screen) form {
+  [class$="-trustee-form-screen"]:not(.trustee-form-error-page):not(.trustee-form-error-wrapper) form {
     .form-container {
       flex-direction: column;
       gap: 0;

--- a/user-interface/src/trustees/forms/TrusteeContactForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeContactForm.scss
@@ -1,12 +1,10 @@
-.trustee-error-alert-form-screen {
+.error-alert-trustee-form-screen {
   .usa-alert-container {
     margin-left: 0;
   }
 }
 
-.trustee-appointment-form-screen,
-.trustee-internal-contact-form-screen,
-.trustee-public-contact-form-screen {
+[class$="-trustee-form-screen"]:not(.error-alert-trustee-form-screen) {
   h1.create-trustee {
     display: block;
     margin: 1rem 0 1.5rem 0;
@@ -62,9 +60,7 @@
 }
 
 @media screen and (max-width: 1023px) {
-  .trustee-appointment-form-screen form,
-  .trustee-internal-contact-form-screen form,
-  .trustee-public-contact-form-screen form {
+  [class$="-trustee-form-screen"]:not(.error-alert-trustee-form-screen) form {
     .form-container {
       .form-column {
         min-width: 200px;
@@ -82,9 +78,7 @@
 }
 
 @media screen and (max-width: 599px) {
-  .trustee-appointment-form-screen form,
-  .trustee-internal-contact-form-screen form,
-  .trustee-public-contact-form-screen form {
+  [class$="-trustee-form-screen"]:not(.error-alert-trustee-form-screen) form {
     .form-container {
       flex-direction: column;
       gap: 0;

--- a/user-interface/src/trustees/forms/TrusteeContactForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeContactForm.scss
@@ -1,4 +1,5 @@
-.trustee-form-screen {
+.trustee-internal-contact-form-screen,
+.trustee-public-contact-form-screen {
   h1.create-trustee {
     display: block;
     margin: 1rem 0 1.5rem 0;
@@ -24,9 +25,7 @@
           .usa-form-group.trustee-phone-input {
             max-width: 220px;
             width: 100%;
-            margin-right: 15px;
           }
-
           .usa-form-group.trustee-extension-input {
             max-width: 150px;
             width: 100%;
@@ -56,14 +55,13 @@
 }
 
 @media screen and (max-width: 1023px) {
-  .trustee-form-screen form {
+  .trustee-internal-contact-form-screen form,
+.trustee-public-contact-form-screen form {
     .form-container {
       .form-column {
         min-width: 200px;
-
         .field-group {
           gap: 0;
-
           .usa-form-group.trustee-zip-input,
           .usa-form-group.trustee-phone-input,
           .usa-form-group.trustee-extension-input {
@@ -76,7 +74,8 @@
 }
 
 @media screen and (max-width: 599px) {
-  .trustee-form-screen form {
+  .trustee-internal-contact-form-screen form,
+.trustee-public-contact-form-screen form {
     .form-container {
       flex-direction: column;
       gap: 0;

--- a/user-interface/src/trustees/forms/TrusteeContactForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeContactForm.scss
@@ -1,3 +1,4 @@
+.trustee-appointment-form-screen,
 .trustee-internal-contact-form-screen,
 .trustee-public-contact-form-screen {
   h1.create-trustee {
@@ -55,8 +56,9 @@
 }
 
 @media screen and (max-width: 1023px) {
+  .trustee-appointment-form-screen form,
   .trustee-internal-contact-form-screen form,
-.trustee-public-contact-form-screen form {
+  .trustee-public-contact-form-screen form {
     .form-container {
       .form-column {
         min-width: 200px;
@@ -74,8 +76,9 @@
 }
 
 @media screen and (max-width: 599px) {
+  .trustee-appointment-form-screen form,
   .trustee-internal-contact-form-screen form,
-.trustee-public-contact-form-screen form {
+  .trustee-public-contact-form-screen form {
     .form-container {
       flex-direction: column;
       gap: 0;

--- a/user-interface/src/trustees/forms/TrusteeContactForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeContactForm.scss
@@ -1,3 +1,9 @@
+.trustee-error-alert-form-screen {
+  .usa-alert-container {
+    margin-left: 0;
+  }
+}
+
 .trustee-appointment-form-screen,
 .trustee-internal-contact-form-screen,
 .trustee-public-contact-form-screen {

--- a/user-interface/src/trustees/forms/TrusteeContactForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeContactForm.scss
@@ -24,7 +24,9 @@
           .usa-form-group.trustee-phone-input {
             max-width: 220px;
             width: 100%;
+            margin-right: 15px;
           }
+
           .usa-form-group.trustee-extension-input {
             max-width: 150px;
             width: 100%;
@@ -58,8 +60,10 @@
     .form-container {
       .form-column {
         min-width: 200px;
+
         .field-group {
           gap: 0;
+
           .usa-form-group.trustee-zip-input,
           .usa-form-group.trustee-phone-input,
           .usa-form-group.trustee-extension-input {
@@ -98,6 +102,7 @@
         }
       }
     }
+
     .usa-button-group {
       padding: 1rem 15px;
     }

--- a/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
@@ -317,15 +317,17 @@ function TrusteeInternalContactForm(props: Readonly<TrusteeInternalContactFormPr
           </div>
         </div>
 
-        <Alert
-          role="alert"
-          className="form-field-warning"
-          type={UswdsAlertStyle.Error}
-          inline={true}
-          slim={false}
-          ref={partialAddressAlertRef}
-          message={saveAlert ?? ''}
-        />
+        <div className="trustee-error-alert-form-screen">
+          <Alert
+            role="alert"
+            className="form-field-warning"
+            type={UswdsAlertStyle.Error}
+            inline={true}
+            slim={false}
+            ref={partialAddressAlertRef}
+            message={saveAlert ?? ''}
+          />
+        </div>
         <div className="usa-button-group">
           <Button id="submit-button" type="submit">
             {isSubmitting ? 'Saving…' : 'Save'}

--- a/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
@@ -204,7 +204,7 @@ function TrusteeInternalContactForm(props: Readonly<TrusteeInternalContactFormPr
   }
 
   return (
-    <div className="trustee-internal-contact-form-screen">
+    <div className="internal-contact-trustee-form-screen">
       <form aria-label="Edit Trustee" data-testid="trustee-internal-form" onSubmit={handleSubmit}>
         <div className="form-container">
           <div className="form-column">
@@ -317,7 +317,7 @@ function TrusteeInternalContactForm(props: Readonly<TrusteeInternalContactFormPr
           </div>
         </div>
 
-        <div className="trustee-error-alert-form-screen">
+        <div className="error-alert-trustee-form-screen">
           <Alert
             role="alert"
             className="form-field-warning"

--- a/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
@@ -204,7 +204,7 @@ function TrusteeInternalContactForm(props: Readonly<TrusteeInternalContactFormPr
   }
 
   return (
-    <div className="trustee-form-screen">
+    <div className="trustee-internal-contact-form-screen">
       <form aria-label="Edit Trustee" data-testid="trustee-internal-form" onSubmit={handleSubmit}>
         <div className="form-container">
           <div className="form-column">

--- a/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
@@ -317,7 +317,7 @@ function TrusteeInternalContactForm(props: Readonly<TrusteeInternalContactFormPr
           </div>
         </div>
 
-        <div className="error-alert-trustee-form-screen">
+        <div className="trustee-form-error-wrapper">
           <Alert
             role="alert"
             className="form-field-warning"

--- a/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeInternalContactForm.tsx
@@ -131,7 +131,7 @@ function TrusteeInternalContactForm(props: Readonly<TrusteeInternalContactFormPr
     navigate.navigateTo(cancelTo);
   }, [navigate, cancelTo]);
 
-  const handleSubmit = async (ev: React.FormEvent): Promise<void> => {
+  const handleSubmit = async (ev: React.SubmitEvent<HTMLFormElement>): Promise<void> => {
     ev.preventDefault();
     const currentFormData = normalizeFormData(formData);
 

--- a/user-interface/src/trustees/forms/TrusteeMeetingOfCreditorsInfoForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeMeetingOfCreditorsInfoForm.tsx
@@ -104,7 +104,7 @@ function TrusteeZoomInfoForm(props: Readonly<TrusteeZoomInfoFormProps>) {
   const isSaveDisabled = isSubmitting || hasErrors || hasEmptyFields;
 
   return (
-    <div className="trustee-zoom-info-form-screen">
+    <div className="zoom-info-trustee-form-screen">
       <p>
         A red asterisk (<span className="text-secondary-dark">*</span>) indicates a required field.
       </p>

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.scss
@@ -1,6 +1,6 @@
 @import '@/lib/components/uswds/forms.scss';
 
-.trustee-other-info-form-screen {
+.other-info-trustee-form-screen {
   .form-container {
     .bank-field {
       position: relative;
@@ -37,7 +37,7 @@
 }
 
 @media screen and (max-width: 500px) {
-  .trustee-other-info-form-screen {
+  .other-info-trustee-form-screen {
     .form-container {
       .bank-field {
         .bank-field-input {
@@ -52,7 +52,7 @@
 }
 
 @media screen and (max-width: 479px) {
-  .trustee-other-info-form-screen {
+  .other-info-trustee-form-screen {
     .cancel-button {
       margin: 1rem auto;
     }

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
@@ -86,7 +86,7 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
   }
 
   return (
-    <div className="trustee-other-info-form-screen">
+    <div className="other-info-trustee-form-screen">
       <form data-testid="trustee-other-info-form">
         <div className="form-container">
           <div className="form-column">

--- a/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
@@ -260,7 +260,7 @@ function TrusteePublicContactForm(props: Readonly<TrusteePublicContactFormProps>
   }
 
   return (
-    <div className="trustee-form-screen">
+    <div className="trustee-public-contact-form-screen">
       <div className="form-header">
         {isCreate && (
           <h1 className="text-no-wrap display-inline-block margin-right-1 create-trustee">
@@ -296,8 +296,6 @@ function TrusteePublicContactForm(props: Readonly<TrusteePublicContactFormProps>
                 autoComplete="off"
                 {...isRequired('firstName')}
               />
-            </div>
-            <div className="field-group">
               <Input
                 id="trustee-middle-name"
                 className="trustee-middle-name-input"
@@ -308,8 +306,6 @@ function TrusteePublicContactForm(props: Readonly<TrusteePublicContactFormProps>
                 errorMessage={fieldErrors['middleName']}
                 autoComplete="off"
               />
-            </div>
-            <div className="field-group">
               <Input
                 id="trustee-last-name"
                 className="trustee-last-name-input"

--- a/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
@@ -136,7 +136,7 @@ function TrusteePublicContactForm(props: Readonly<TrusteePublicContactFormProps>
     return patch;
   };
 
-  const handleSubmit = async (ev: React.FormEvent): Promise<void> => {
+  const handleSubmit = async (ev: React.SubmitEvent<HTMLFormElement>): Promise<void> => {
     ev.preventDefault();
     const currentFormData = normalizeFormData(formData);
 

--- a/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
@@ -260,7 +260,7 @@ function TrusteePublicContactForm(props: Readonly<TrusteePublicContactFormProps>
   }
 
   return (
-    <div className="trustee-public-contact-form-screen">
+    <div className="public-contact-trustee-form-screen">
       <div className="form-header">
         {isCreate && (
           <h1 className="text-no-wrap display-inline-block margin-right-1 create-trustee">

--- a/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteePublicContactForm.tsx
@@ -296,6 +296,8 @@ function TrusteePublicContactForm(props: Readonly<TrusteePublicContactFormProps>
                 autoComplete="off"
                 {...isRequired('firstName')}
               />
+            </div>
+            <div className="field-group">
               <Input
                 id="trustee-middle-name"
                 className="trustee-middle-name-input"
@@ -306,6 +308,8 @@ function TrusteePublicContactForm(props: Readonly<TrusteePublicContactFormProps>
                 errorMessage={fieldErrors['middleName']}
                 autoComplete="off"
               />
+            </div>
+            <div className="field-group">
               <Input
                 id="trustee-last-name"
                 className="trustee-last-name-input"


### PR DESCRIPTION
# Bug

Trustee form screens shared the generic \`trustee-form-screen\` classname, causing CSS rules added to one form's SCSS to silently affect all other trustee forms. The root cause was \`TrusteeAppointmentForm.scss\` adding a \`.field-group { gap: 0 }\` rule that stripped spacing from every form on the page sharing that class.

# Purpose

Ensure each trustee form has a unique, component-specific classname so SCSS rules cannot leak between forms. Centralize any truly shared styles in \`TrusteeContactForm.scss\` using a CSS attribute wildcard selector so new forms get shared styles automatically.

# Major Changes

* Rename all trustee form wrapper classnames from the shared \`trustee-form-screen\` to unique per-component names following the \`*-trustee-form-screen\` convention (e.g. \`appointment-trustee-form-screen\`, \`assistant-trustee-form-screen\`)
* Replace long explicit selector lists in \`TrusteeDetailScreen.scss\` and \`TrusteeContactForm.scss\` with \`[class$="-trustee-form-screen"]\` wildcard — any future form following the naming convention gets shared styles for free
* Extract the \`usa-alert-container\` margin rule into a dedicated \`error-alert-trustee-form-screen\` classname shared by all trustee error alert wrappers
* Fix name field spacing and phone/extension gap on the public contact form (original regression from CAMS-742)

# Testing/Validation

Manually verified spacing and alert styling on add/edit trustee forms at desktop and tablet breakpoints. No logic changes — pure CSS/classname refactor.

# Notes

The naming convention is \`<descriptor>-trustee-form-screen\`. The wildcard \`[class$="-trustee-form-screen"]\` matches any element whose class ends with that suffix, so shared base layout rules and responsive breakpoints apply automatically to all current and future trustee form screens without updating the selector list.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application