### PR TITLE
CAMS-669 Migrate bankruptcy software to dedicated entity (Slice 1)

### DIFF
--- a/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.test.ts
+++ b/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.test.ts
@@ -11,11 +11,16 @@ import {
 import { BankruptcySoftwareController } from '../../../lib/controllers/bankruptcy-software/bankruptcy-software.controller';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 import MockData from '@common/cams/test-utilities/mock-data';
+import { CamsHttpResponseInit } from '../../../lib/adapters/utils/http-response';
+import { createMockApplicationContext } from '../../../lib/testing/testing-utilities';
 
 describe('Bankruptcy Software Function tests', () => {
   let context: InvocationContext;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    const camsContext = await createMockApplicationContext();
+    camsContext.session = MockData.getCamsSession();
+    vi.spyOn(ContextCreator, 'applicationContextCreator').mockResolvedValue(camsContext);
     vi.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
       MockData.getCamsSession(),
     );
@@ -37,48 +42,18 @@ describe('Bankruptcy Software Function tests', () => {
     },
   ];
 
-  test('should return 200 with software list for GET request', async () => {
+  test('should delegate to controller.handleRequest and return response', async () => {
     const request = createMockAzureFunctionRequest({ method: 'GET' });
     const { camsHttpResponse, azureHttpResponse } = buildTestResponseSuccess<
       BankruptcySoftwareProfile[]
-    >({
-      data: mockSoftware,
-    });
-    vi.spyOn(BankruptcySoftwareController.prototype, 'handleGet').mockResolvedValue(
-      camsHttpResponse,
+    >({ data: mockSoftware });
+    vi.spyOn(BankruptcySoftwareController.prototype, 'handleRequest').mockResolvedValue(
+      camsHttpResponse as CamsHttpResponseInit,
     );
 
     const response = await handler(request, context);
 
     expect(response).toEqual(azureHttpResponse);
-  });
-
-  test('should return 201 with created software for POST request', async () => {
-    const request = createMockAzureFunctionRequest({
-      method: 'POST',
-      body: { name: 'Axos' },
-    });
-    const createdSoftware = mockSoftware[0];
-    const { camsHttpResponse, azureHttpResponse } =
-      buildTestResponseSuccess<BankruptcySoftwareProfile>(
-        { data: createdSoftware },
-        { statusCode: 201 },
-      );
-    vi.spyOn(BankruptcySoftwareController.prototype, 'handlePost').mockResolvedValue(
-      camsHttpResponse,
-    );
-
-    const response = await handler(request, context);
-
-    expect(response).toEqual(azureHttpResponse);
-  });
-
-  test('should return 405 for unsupported HTTP method', async () => {
-    const request = createMockAzureFunctionRequest({ method: 'DELETE' });
-
-    const response = await handler(request, context);
-
-    expect(response.status).toBe(405);
   });
 
   test('should return error response when controller throws', async () => {
@@ -87,7 +62,7 @@ describe('Bankruptcy Software Function tests', () => {
       message: 'Something went wrong.',
     });
     const { azureHttpResponse, loggerCamsErrorSpy } = buildTestResponseError(error);
-    vi.spyOn(BankruptcySoftwareController.prototype, 'handleGet').mockRejectedValue(error);
+    vi.spyOn(BankruptcySoftwareController.prototype, 'handleRequest').mockRejectedValue(error);
 
     const response = await handler(request, context);
 

--- a/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.test.ts
+++ b/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.test.ts
@@ -1,0 +1,97 @@
+import { vi } from 'vitest';
+import { InvocationContext } from '@azure/functions';
+import { CamsError } from '../../../lib/common-errors/cams-error';
+import handler from './bankruptcy-software.function';
+import ContextCreator from '../../azure/application-context-creator';
+import {
+  buildTestResponseError,
+  buildTestResponseSuccess,
+  createMockAzureFunctionRequest,
+} from '../../azure/testing-helpers';
+import { BankruptcySoftwareController } from '../../../lib/controllers/bankruptcy-software/bankruptcy-software.controller';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import MockData from '@common/cams/test-utilities/mock-data';
+
+describe('Bankruptcy Software Function tests', () => {
+  let context: InvocationContext;
+
+  beforeEach(() => {
+    vi.spyOn(ContextCreator, 'getApplicationContextSession').mockResolvedValue(
+      MockData.getCamsSession(),
+    );
+    context = new InvocationContext({ logHandler: () => {}, invocationId: 'test-id' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockSoftware: BankruptcySoftwareProfile[] = [
+    {
+      id: 'sw-1',
+      documentType: 'BANKRUPTCY_SOFTWARE',
+      name: 'Axos',
+      status: 'active',
+      updatedOn: '2024-01-01T00:00:00.000Z',
+      updatedBy: { id: 'user-1', name: 'User One' },
+    },
+  ];
+
+  test('should return 200 with software list for GET request', async () => {
+    const request = createMockAzureFunctionRequest({ method: 'GET' });
+    const { camsHttpResponse, azureHttpResponse } = buildTestResponseSuccess<
+      BankruptcySoftwareProfile[]
+    >({
+      data: mockSoftware,
+    });
+    vi.spyOn(BankruptcySoftwareController.prototype, 'handleGet').mockResolvedValue(
+      camsHttpResponse,
+    );
+
+    const response = await handler(request, context);
+
+    expect(response).toEqual(azureHttpResponse);
+  });
+
+  test('should return 201 with created software for POST request', async () => {
+    const request = createMockAzureFunctionRequest({
+      method: 'POST',
+      body: { name: 'Axos' },
+    });
+    const createdSoftware = mockSoftware[0];
+    const { camsHttpResponse, azureHttpResponse } =
+      buildTestResponseSuccess<BankruptcySoftwareProfile>(
+        { data: createdSoftware },
+        { statusCode: 201 },
+      );
+    vi.spyOn(BankruptcySoftwareController.prototype, 'handlePost').mockResolvedValue(
+      camsHttpResponse,
+    );
+
+    const response = await handler(request, context);
+
+    expect(response).toEqual(azureHttpResponse);
+  });
+
+  test('should return 405 for unsupported HTTP method', async () => {
+    const request = createMockAzureFunctionRequest({ method: 'DELETE' });
+
+    const response = await handler(request, context);
+
+    expect(response.status).toBe(405);
+  });
+
+  test('should return error response when controller throws', async () => {
+    const request = createMockAzureFunctionRequest({ method: 'GET' });
+    const error = new CamsError('BANKRUPTCY-SOFTWARE-CONTROLLER', {
+      message: 'Something went wrong.',
+    });
+    const { azureHttpResponse, loggerCamsErrorSpy } = buildTestResponseError(error);
+    vi.spyOn(BankruptcySoftwareController.prototype, 'handleGet').mockRejectedValue(error);
+
+    const response = await handler(request, context);
+
+    expect(response).toMatchObject(azureHttpResponse);
+    expect(loggerCamsErrorSpy).toHaveBeenCalledWith(error);
+  });
+});

--- a/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
+++ b/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
@@ -2,6 +2,7 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/fu
 import ContextCreator from '../../azure/application-context-creator';
 import { toAzureError, toAzureSuccess } from '../../azure/functions';
 import { BankruptcySoftwareController } from '../../../lib/controllers/bankruptcy-software/bankruptcy-software.controller';
+import { CamsHttpResponseInit } from '../../../lib/adapters/utils/http-response';
 
 const MODULE_NAME = 'BANKRUPTCY-SOFTWARE-FUNCTION';
 
@@ -20,19 +21,8 @@ export default async function handler(
 
     context.session = await ContextCreator.getApplicationContextSession(context);
     const controller = new BankruptcySoftwareController(context);
-
-    const method = request.method;
-    let responseBody;
-
-    if (method === 'GET') {
-      responseBody = await controller.handleGet(context);
-    } else if (method === 'POST') {
-      responseBody = await controller.handlePost(context);
-    } else {
-      return { status: 405, jsonBody: 'Method Not Allowed' };
-    }
-
-    return toAzureSuccess(responseBody);
+    const response = await controller.handleRequest(context);
+    return toAzureSuccess(response as CamsHttpResponseInit);
   } catch (error) {
     return toAzureError(logger, MODULE_NAME, error);
   }

--- a/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
+++ b/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
@@ -1,0 +1,46 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import ContextCreator from '../../azure/application-context-creator';
+import { toAzureError, toAzureSuccess } from '../../azure/functions';
+import { BankruptcySoftwareController } from '../../../lib/controllers/bankruptcy-software/bankruptcy-software.controller';
+
+const MODULE_NAME = 'BANKRUPTCY-SOFTWARE-FUNCTION';
+
+export default async function handler(
+  request: HttpRequest,
+  invocationContext: InvocationContext,
+): Promise<HttpResponseInit> {
+  const logger = ContextCreator.getLogger(invocationContext);
+
+  try {
+    const context = await ContextCreator.applicationContextCreator({
+      invocationContext,
+      logger,
+      request,
+    });
+
+    context.session = await ContextCreator.getApplicationContextSession(context);
+    const controller = new BankruptcySoftwareController(context);
+
+    const method = request.method;
+    let responseBody;
+
+    if (method === 'GET') {
+      responseBody = await controller.handleGet(context);
+    } else if (method === 'POST') {
+      responseBody = await controller.handlePost(context);
+    } else {
+      return { status: 405, jsonBody: 'Method Not Allowed' };
+    }
+
+    return toAzureSuccess(responseBody);
+  } catch (error) {
+    return toAzureError(logger, MODULE_NAME, error);
+  }
+}
+
+app.http('bankruptcy-software', {
+  methods: ['GET', 'POST'],
+  authLevel: 'anonymous',
+  handler,
+  route: 'bankruptcy-software',
+});

--- a/backend/function-apps/api/index.ts
+++ b/backend/function-apps/api/index.ts
@@ -18,6 +18,7 @@ import './case-summary/case-summary.function';
 import './case-trustee-appointment/case-trustee-appointment.function';
 import './cases/cases.function';
 import './banks/banks.function';
+import './bankruptcy-software/bankruptcy-software.function';
 import './consolidations/consolidations.function';
 import './courts/courts.function';
 import './healthcheck/healthcheck.function';

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.test.ts
@@ -1,0 +1,191 @@
+import { vi } from 'vitest';
+import { closeDeferred } from '../../../deferrable/defer-close';
+import { createMockApplicationContext } from '../../../testing/testing-utilities';
+import { ApplicationContext } from '../../types/basic';
+import { BankruptcySoftwareMongoRepository } from './bankruptcy-software.mongo.repository';
+import { MongoCollectionAdapter } from './utils/mongo-adapter';
+import {
+  BankruptcySoftwareAuditHistory,
+  BankruptcySoftwareProfile,
+} from '@common/cams/bankruptcy-software';
+import { Creatable } from '@common/cams/creatable';
+
+describe('BankruptcySoftwareMongoRepository', () => {
+  let context: ApplicationContext;
+  let repo: BankruptcySoftwareMongoRepository;
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    repo = BankruptcySoftwareMongoRepository.getInstance(context);
+  });
+
+  afterEach(async () => {
+    await closeDeferred(context);
+    vi.restoreAllMocks();
+    repo.release();
+  });
+
+  describe('getSoftwareList', () => {
+    test('should return all software sorted ascending by name', async () => {
+      const mockSoftware: BankruptcySoftwareProfile[] = [
+        {
+          id: 'sw-1',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'Axos',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+        {
+          id: 'sw-2',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'BlueStylus',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+      ];
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue(mockSoftware);
+
+      const result = await repo.getSoftwareList();
+
+      expect(result).toEqual(mockSoftware);
+    });
+
+    test('should return empty array when no software exists', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]);
+
+      const result = await repo.getSoftwareList();
+
+      expect(result).toEqual([]);
+    });
+
+    test('should throw CamsError when find fails', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockRejectedValue(
+        new Error('connection error'),
+      );
+
+      await expect(repo.getSoftwareList()).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to retrieve bankruptcy software.',
+          status: 500,
+          module: 'BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
+  describe('createSoftware', () => {
+    test('should insert and return the created software', async () => {
+      const newId = 'sw-abc';
+      const input: Creatable<BankruptcySoftwareProfile> = {
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'New Software',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        createdOn: '2024-01-01T00:00:00.000Z',
+        createdBy: { id: 'user-1', name: 'User One' },
+      };
+      const expected: BankruptcySoftwareProfile = { ...input, id: newId };
+
+      vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockResolvedValue(newId);
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockResolvedValue(expected);
+
+      const result = await repo.createSoftware(input);
+
+      expect(result).toEqual(expected);
+    });
+
+    test('should throw CamsError when insertOne fails', async () => {
+      const input: Creatable<BankruptcySoftwareProfile> = {
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'New Software',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockRejectedValue(
+        new Error('write error'),
+      );
+
+      await expect(repo.createSoftware(input)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to create bankruptcy software.',
+          status: 500,
+          module: 'BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
+  describe('createSoftwareAuditRecord', () => {
+    test('should insert audit record into bankruptcy-software collection', async () => {
+      const input: Creatable<BankruptcySoftwareAuditHistory> = {
+        documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+        softwareId: 'sw-abc',
+        before: null,
+        after: {
+          id: 'sw-abc',
+          name: 'New Software',
+          status: 'active',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+        },
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        createdOn: '2024-01-01T00:00:00.000Z',
+        createdBy: { id: 'user-1', name: 'User One' },
+      };
+      const insertSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'insertOne')
+        .mockResolvedValue('audit-id-1');
+
+      await repo.createSoftwareAuditRecord(input);
+
+      expect(insertSpy).toHaveBeenCalledWith(input);
+    });
+
+    test('should throw CamsError when audit insertOne fails', async () => {
+      const input: Creatable<BankruptcySoftwareAuditHistory> = {
+        documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+        softwareId: 'sw-abc',
+        before: null,
+        after: {
+          id: 'sw-abc',
+          name: 'New Software',
+          status: 'active',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+        },
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MongoCollectionAdapter.prototype, 'insertOne').mockRejectedValue(
+        new Error('audit write error'),
+      );
+
+      await expect(repo.createSoftwareAuditRecord(input)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to create bankruptcy software audit record.',
+          status: 500,
+          module: 'BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
+  describe('singleton lifecycle', () => {
+    test('should return same instance on multiple getInstance calls', async () => {
+      const context2 = await createMockApplicationContext();
+      const repo2 = BankruptcySoftwareMongoRepository.getInstance(context2);
+      expect(repo2).toBe(repo);
+      repo2.release();
+    });
+
+    test('release calls dropInstance', () => {
+      const dropSpy = vi.spyOn(BankruptcySoftwareMongoRepository, 'dropInstance');
+      repo.release();
+      expect(dropSpy).toHaveBeenCalled();
+      dropSpy.mockRestore();
+    });
+  });
+});

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
@@ -1,12 +1,13 @@
-import { ApplicationContext } from 'lib/adapters/types/basic';
-import { BaseMongoRepository } from './utils/base-mongo-repository';
 import {
   BankruptcySoftwareAuditHistory,
   BankruptcySoftwareProfile,
 } from '@common/cams/bankruptcy-software';
-import QueryBuilder from 'lib/query/query-builder';
-import { getCamsError } from 'lib/common-errors/error-utilities';
 import { Creatable } from '@common/cams/creatable';
+import { getCamsError } from '../../../common-errors/error-utilities';
+import QueryBuilder from '../../../query/query-builder';
+import { BankruptcySoftwareRepository } from '../../../use-cases/gateways.types';
+import { ApplicationContext } from '../../types/basic';
+import { BaseMongoRepository } from './utils/base-mongo-repository';
 
 const MODULE_NAME = 'BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY';
 const COLLECTION_NAME = 'bankruptcy-software';
@@ -14,7 +15,10 @@ const COLLECTION_NAME = 'bankruptcy-software';
 const { using, orderBy } = QueryBuilder;
 const doc = using<BankruptcySoftwareProfile>();
 
-export class BankruptcySoftwareMongoRepository extends BaseMongoRepository {
+export class BankruptcySoftwareMongoRepository
+  extends BaseMongoRepository
+  implements BankruptcySoftwareRepository
+{
   private static referenceCount: number = 0;
   private static instance: BankruptcySoftwareMongoRepository;
 
@@ -52,11 +56,7 @@ export class BankruptcySoftwareMongoRepository extends BaseMongoRepository {
         orderBy<BankruptcySoftwareProfile>(['name', 'ASCENDING']),
       );
     } catch (originalError) {
-      throw getCamsError(
-        originalError,
-        MODULE_NAME,
-        'Unable to retrieve bankruptcy software list.',
-      );
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve bankruptcy software.');
     }
   }
 

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
@@ -1,0 +1,92 @@
+import { ApplicationContext } from 'lib/adapters/types/basic';
+import { BaseMongoRepository } from './utils/base-mongo-repository';
+import {
+  BankruptcySoftwareAuditHistory,
+  BankruptcySoftwareProfile,
+} from '@common/cams/bankruptcy-software';
+import QueryBuilder from 'lib/query/query-builder';
+import { getCamsError } from 'lib/common-errors/error-utilities';
+import { Creatable } from '@common/cams/creatable';
+
+const MODULE_NAME = 'BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY';
+const COLLECTION_NAME = 'bankruptcy-software';
+
+const { using, orderBy } = QueryBuilder;
+const doc = using<BankruptcySoftwareProfile>();
+
+export class BankruptcySoftwareMongoRepository extends BaseMongoRepository {
+  private static referenceCount: number = 0;
+  private static instance: BankruptcySoftwareMongoRepository;
+
+  constructor(context: ApplicationContext) {
+    super(context, MODULE_NAME, COLLECTION_NAME);
+  }
+
+  public static getInstance(context: ApplicationContext) {
+    if (!BankruptcySoftwareMongoRepository.instance) {
+      BankruptcySoftwareMongoRepository.instance = new BankruptcySoftwareMongoRepository(context);
+    }
+    BankruptcySoftwareMongoRepository.referenceCount++;
+    return BankruptcySoftwareMongoRepository.instance;
+  }
+
+  public static dropInstance() {
+    if (BankruptcySoftwareMongoRepository.referenceCount > 0) {
+      BankruptcySoftwareMongoRepository.referenceCount--;
+    }
+    if (BankruptcySoftwareMongoRepository.referenceCount < 1) {
+      BankruptcySoftwareMongoRepository.instance?.client.close().then();
+      BankruptcySoftwareMongoRepository.instance = null;
+    }
+  }
+
+  public release() {
+    BankruptcySoftwareMongoRepository.dropInstance();
+  }
+
+  async getSoftwareList(): Promise<BankruptcySoftwareProfile[]> {
+    const query = doc('documentType').equals('BANKRUPTCY_SOFTWARE');
+    try {
+      return await this.getAdapter<BankruptcySoftwareProfile>().find(
+        query,
+        orderBy<BankruptcySoftwareProfile>(['name', 'ASCENDING']),
+      );
+    } catch (originalError) {
+      throw getCamsError(
+        originalError,
+        MODULE_NAME,
+        'Unable to retrieve bankruptcy software list.',
+      );
+    }
+  }
+
+  async createSoftware(
+    software: Creatable<BankruptcySoftwareProfile>,
+  ): Promise<BankruptcySoftwareProfile> {
+    try {
+      const newId = await this.getAdapter<BankruptcySoftwareProfile>().insertOne(
+        software as BankruptcySoftwareProfile,
+      );
+      const query = doc('id').equals(newId);
+      return await this.getAdapter<BankruptcySoftwareProfile>().findOne(query);
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to create bankruptcy software.');
+    }
+  }
+
+  async createSoftwareAuditRecord(
+    history: Creatable<BankruptcySoftwareAuditHistory>,
+  ): Promise<void> {
+    try {
+      await this.getAdapter<BankruptcySoftwareAuditHistory>().insertOne(
+        history as BankruptcySoftwareAuditHistory,
+      );
+    } catch (originalError) {
+      throw getCamsError(
+        originalError,
+        MODULE_NAME,
+        'Unable to create bankruptcy software audit record.',
+      );
+    }
+  }
+}

--- a/backend/lib/adapters/gateways/mongo/lists.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/lists.mongo.repository.test.ts
@@ -1,12 +1,7 @@
 import { vi } from 'vitest';
 import { ApplicationContext } from '../../types/basic';
 import { ListsMongoRepository } from './lists.mongo.repository';
-import {
-  BankList,
-  BankruptcySoftwareList,
-  BankruptcySoftwareListItem,
-  BankListItem,
-} from '@common/cams/lists';
+import { BankList, BankruptcySoftwareList, BankListItem } from '@common/cams/lists';
 import { createMockApplicationContext } from '../../../testing/testing-utilities';
 import { MongoCollectionAdapter } from './utils/mongo-adapter';
 import { closeDeferred } from '../../../deferrable/defer-close';
@@ -152,32 +147,6 @@ describe('ListsMongoRepository', () => {
     });
   });
 
-  describe('postBankruptcySoftware', () => {
-    test('should create bankruptcy software item in database', async () => {
-      const mockItemId = '12345';
-      const itemToCreate: Creatable<BankruptcySoftwareListItem> = {
-        list: 'bankruptcy-software' as const,
-        key: 'new-software',
-        value: 'New Software',
-      };
-      mockInsertOne.mockResolvedValue(mockItemId);
-      const result = await repository.postBankruptcySoftware(itemToCreate);
-      expect(mockInsertOne).toHaveBeenCalledWith(itemToCreate);
-      expect(result).toEqual(mockItemId);
-    });
-
-    test('should handle database errors when creating bankruptcy software', async () => {
-      const error = new Error('Failed to create bankruptcy software');
-      const itemToCreate: Creatable<BankruptcySoftwareListItem> = {
-        list: 'bankruptcy-software' as const,
-        key: 'new-software',
-        value: 'New Software',
-      };
-      mockInsertOne.mockRejectedValue(error);
-      await expect(repository.postBankruptcySoftware(itemToCreate)).rejects.toThrow();
-    });
-  });
-
   describe('postBank', () => {
     test('should create bank item in database', async () => {
       const mockItemId = '67890';
@@ -201,24 +170,6 @@ describe('ListsMongoRepository', () => {
       };
       mockInsertOne.mockRejectedValue(error);
       await expect(repository.postBank(itemToCreate)).rejects.toThrow();
-    });
-  });
-
-  describe('deleteBankruptcySoftware', () => {
-    test('should delete bankruptcy software item from database', async () => {
-      const itemId = '12345';
-      // Mock with the correct result structure expected by deleteOne
-      mockDeleteOne.mockResolvedValue({ deletedCount: 1 });
-      await repository.deleteBankruptcySoftware(itemId);
-      expect(mockDeleteOne).toHaveBeenCalled();
-      expect(mockDeleteOne).toHaveBeenCalledTimes(1);
-    });
-
-    test('should handle database errors when deleting bankruptcy software', async () => {
-      const error = new Error('Failed to delete bankruptcy software');
-      const itemId = '12345';
-      mockDeleteOne.mockRejectedValue(error);
-      await expect(repository.deleteBankruptcySoftware(itemId)).rejects.toThrow();
     });
   });
 

--- a/backend/lib/adapters/gateways/mongo/lists.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/lists.mongo.repository.ts
@@ -74,28 +74,12 @@ export class ListsMongoRepository extends BaseMongoRepository implements ListsRe
     return this.getList<BankruptcySoftwareListItem>('bankruptcy-software');
   }
 
-  public async postBankruptcySoftware(
-    item: Creatable<BankruptcySoftwareListItem>,
-  ): Promise<string> {
-    return this.postListItem<BankruptcySoftwareListItem>(item);
-  }
-
   public async getBankList(): Promise<BankList> {
     return this.getList<BankListItem>('banks');
   }
 
   public async postBank(item: Creatable<BankListItem>): Promise<string> {
     return this.postListItem<BankListItem>(item);
-  }
-
-  public async deleteBankruptcySoftware(id: string): Promise<void> {
-    try {
-      await this.getAdapter<BankruptcySoftwareListItem>().deleteOne(
-        and(this.doc('_id').equals(id), this.doc('list').equals('bankruptcy-software')),
-      );
-    } catch (originalError) {
-      throw getCamsError(originalError, MODULE_NAME);
-    }
   }
 
   public async deleteBank(id: string): Promise<void> {

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
@@ -1,0 +1,122 @@
+import { vi } from 'vitest';
+import { ApplicationContext } from '../../adapters/types/basic';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { BankruptcySoftwareController } from './bankruptcy-software.controller';
+import { BankruptcySoftwareUseCase } from '../../use-cases/bankruptcy-software/bankruptcy-software';
+import { CamsRole } from '@common/cams/roles';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+
+vi.mock('../../use-cases/bankruptcy-software/bankruptcy-software');
+
+describe('BankruptcySoftwareController', () => {
+  let context: ApplicationContext;
+  let controller: BankruptcySoftwareController;
+
+  const mockSoftware: BankruptcySoftwareProfile[] = [
+    {
+      id: 'sw-1',
+      documentType: 'BANKRUPTCY_SOFTWARE',
+      name: 'Axos',
+      status: 'active',
+      updatedOn: '2024-01-01T00:00:00.000Z',
+      updatedBy: { id: 'user-1', name: 'User One' },
+    },
+  ];
+
+  const createdSoftware: BankruptcySoftwareProfile = {
+    id: 'sw-new',
+    documentType: 'BANKRUPTCY_SOFTWARE',
+    name: 'New Software',
+    status: 'active',
+    updatedOn: '2024-01-01T00:00:00.000Z',
+    updatedBy: { id: 'user-1', name: 'User One' },
+    createdOn: '2024-01-01T00:00:00.000Z',
+    createdBy: { id: 'user-1', name: 'User One' },
+  };
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    context.session.user.roles = [CamsRole.SuperUser];
+    controller = new BankruptcySoftwareController(context);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('handleGet', () => {
+    test('should return 200 with software list for SuperUser', async () => {
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftwareList').mockResolvedValue(
+        mockSoftware,
+      );
+
+      const result = await controller.handleGet(context);
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.data).toEqual(mockSoftware);
+    });
+
+    test('should throw ForbiddenError when user lacks SuperUser role', async () => {
+      context.session.user.roles = [CamsRole.TrialAttorney];
+
+      await expect(controller.handleGet(context)).rejects.toThrow(
+        expect.objectContaining({ status: 403 }),
+      );
+    });
+
+    test('should throw ForbiddenError when user has no roles', async () => {
+      context.session.user.roles = [];
+
+      await expect(controller.handleGet(context)).rejects.toThrow(
+        expect.objectContaining({ status: 403 }),
+      );
+    });
+  });
+
+  describe('handlePost', () => {
+    test('should return 201 with created software for SuperUser', async () => {
+      context.request.body = { name: 'New Software' };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'createSoftware').mockResolvedValue(
+        createdSoftware,
+      );
+
+      const result = await controller.handlePost(context);
+
+      expect(result.statusCode).toBe(201);
+      expect(result.body.data).toEqual(createdSoftware);
+    });
+
+    test('should throw ForbiddenError when user lacks SuperUser role', async () => {
+      context.session.user.roles = [CamsRole.TrialAttorney];
+      context.request.body = { name: 'New Software' };
+
+      await expect(controller.handlePost(context)).rejects.toThrow(
+        expect.objectContaining({ status: 403 }),
+      );
+    });
+
+    test('should throw BadRequestError when name is missing', async () => {
+      context.request.body = {};
+
+      await expect(controller.handlePost(context)).rejects.toThrow(
+        expect.objectContaining({ status: 400 }),
+      );
+    });
+
+    test('should throw BadRequestError when name is blank', async () => {
+      context.request.body = { name: '   ' };
+
+      await expect(controller.handlePost(context)).rejects.toThrow(
+        expect.objectContaining({ status: 400 }),
+      );
+    });
+
+    test('should throw BadRequestError when body is null', async () => {
+      context.request.body = null;
+
+      await expect(controller.handlePost(context)).rejects.toThrow(
+        expect.objectContaining({ status: 400 }),
+      );
+    });
+  });
+});

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
@@ -6,8 +6,6 @@ import { BankruptcySoftwareUseCase } from '../../use-cases/bankruptcy-software/b
 import { CamsRole } from '@common/cams/roles';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
-vi.mock('../../use-cases/bankruptcy-software/bankruptcy-software');
-
 describe('BankruptcySoftwareController', () => {
   let context: ApplicationContext;
   let controller: BankruptcySoftwareController;
@@ -42,6 +40,39 @@ describe('BankruptcySoftwareController', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('handleRequest', () => {
+    test('should route GET to handleGet', async () => {
+      context.request.method = 'GET';
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftwareList').mockResolvedValue(
+        mockSoftware,
+      );
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(200);
+    });
+
+    test('should route POST to handlePost', async () => {
+      context.request.method = 'POST';
+      context.request.body = { name: 'New Software' };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'createSoftware').mockResolvedValue(
+        createdSoftware,
+      );
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(201);
+    });
+
+    test('should return 405 for unsupported method', async () => {
+      context.request.method = 'DELETE';
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(405);
+    });
   });
 
   describe('handleGet', () => {

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
@@ -76,7 +76,7 @@ describe('BankruptcySoftwareController', () => {
   });
 
   describe('handleGet', () => {
-    test('should return 200 with software list for SuperUser', async () => {
+    test('should return 200 with software list for any authenticated user', async () => {
       vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftwareList').mockResolvedValue(
         mockSoftware,
       );
@@ -87,20 +87,15 @@ describe('BankruptcySoftwareController', () => {
       expect(result.body.data).toEqual(mockSoftware);
     });
 
-    test('should throw ForbiddenError when user lacks SuperUser role', async () => {
+    test('should return 200 for non-SuperUser roles', async () => {
       context.session.user.roles = [CamsRole.TrialAttorney];
-
-      await expect(controller.handleGet(context)).rejects.toThrow(
-        expect.objectContaining({ status: 403 }),
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftwareList').mockResolvedValue(
+        mockSoftware,
       );
-    });
 
-    test('should throw ForbiddenError when user has no roles', async () => {
-      context.session.user.roles = [];
+      const result = await controller.handleGet(context);
 
-      await expect(controller.handleGet(context)).rejects.toThrow(
-        expect.objectContaining({ status: 403 }),
-      );
+      expect(result.statusCode).toBe(200);
     });
   });
 

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
@@ -35,7 +35,6 @@ export class BankruptcySoftwareController {
   async handleGet(
     context: ApplicationContext,
   ): Promise<CamsHttpResponseInit<BankruptcySoftwareProfile[]>> {
-    this.requireSuperUser(context);
     const softwareList = await this.useCase.getSoftwareList();
     return httpSuccess({
       statusCode: HttpStatusCodes.OK,

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
@@ -1,0 +1,49 @@
+import { ApplicationContext } from '../../adapters/types/basic';
+import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
+import { BadRequestError } from '../../common-errors/bad-request';
+import { ForbiddenError } from '../../common-errors/forbidden-error';
+import { CamsRole } from '@common/cams/roles';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import { BankruptcySoftwareUseCase } from '../../use-cases/bankruptcy-software/bankruptcy-software';
+
+const MODULE_NAME = 'BANKRUPTCY-SOFTWARE-CONTROLLER';
+
+export class BankruptcySoftwareController {
+  private readonly useCase: BankruptcySoftwareUseCase;
+
+  constructor(context: ApplicationContext) {
+    this.useCase = new BankruptcySoftwareUseCase(context);
+  }
+
+  async handleGet(
+    context: ApplicationContext,
+  ): Promise<CamsHttpResponseInit<BankruptcySoftwareProfile[]>> {
+    this.requireSuperUser(context);
+    const softwareList = await this.useCase.getSoftwareList();
+    return httpSuccess({
+      statusCode: 200,
+      body: { meta: { self: context.request.url }, data: softwareList },
+    });
+  }
+
+  async handlePost(
+    context: ApplicationContext,
+  ): Promise<CamsHttpResponseInit<BankruptcySoftwareProfile>> {
+    this.requireSuperUser(context);
+    const body = context.request.body as { name?: string } | null;
+    if (!body || !body.name || !body.name.trim()) {
+      throw new BadRequestError(MODULE_NAME, { message: 'Software name is required.' });
+    }
+    const software = await this.useCase.createSoftware({ name: body.name.trim() });
+    return httpSuccess({
+      statusCode: 201,
+      body: { meta: { self: context.request.url }, data: software },
+    });
+  }
+
+  private requireSuperUser(context: ApplicationContext): void {
+    if (!context.session.user.roles?.includes(CamsRole.SuperUser)) {
+      throw new ForbiddenError(MODULE_NAME);
+    }
+  }
+}

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
@@ -5,6 +5,7 @@ import { ForbiddenError } from '../../common-errors/forbidden-error';
 import { CamsRole } from '@common/cams/roles';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 import { BankruptcySoftwareUseCase } from '../../use-cases/bankruptcy-software/bankruptcy-software';
+import HttpStatusCodes from '@common/api/http-status-codes';
 
 const MODULE_NAME = 'BANKRUPTCY-SOFTWARE-CONTROLLER';
 
@@ -15,13 +16,29 @@ export class BankruptcySoftwareController {
     this.useCase = new BankruptcySoftwareUseCase(context);
   }
 
+  async handleRequest(
+    context: ApplicationContext,
+  ): Promise<
+    | CamsHttpResponseInit
+    | CamsHttpResponseInit<BankruptcySoftwareProfile>
+    | CamsHttpResponseInit<BankruptcySoftwareProfile[]>
+  > {
+    const { method } = context.request;
+    if (method === 'GET') {
+      return this.handleGet(context);
+    } else if (method === 'POST') {
+      return this.handlePost(context);
+    }
+    return httpSuccess({ statusCode: HttpStatusCodes.METHOD_NOT_ALLOWED }) as CamsHttpResponseInit;
+  }
+
   async handleGet(
     context: ApplicationContext,
   ): Promise<CamsHttpResponseInit<BankruptcySoftwareProfile[]>> {
     this.requireSuperUser(context);
     const softwareList = await this.useCase.getSoftwareList();
     return httpSuccess({
-      statusCode: 200,
+      statusCode: HttpStatusCodes.OK,
       body: { meta: { self: context.request.url }, data: softwareList },
     });
   }
@@ -36,7 +53,7 @@ export class BankruptcySoftwareController {
     }
     const software = await this.useCase.createSoftware({ name: body.name.trim() });
     return httpSuccess({
-      statusCode: 201,
+      statusCode: HttpStatusCodes.CREATED,
       body: { meta: { self: context.request.url }, data: software },
     });
   }

--- a/backend/lib/controllers/lists/lists.controller.test.ts
+++ b/backend/lib/controllers/lists/lists.controller.test.ts
@@ -4,12 +4,7 @@ import { ApplicationContext } from '../../adapters/types/basic';
 import { CamsError } from '../../common-errors/cams-error';
 import { mockCamsHttpRequest } from '../../testing/mock-data/cams-http-request-helper';
 import { ListsController } from './lists.controller';
-import {
-  BankList,
-  BankruptcySoftwareList,
-  BankListItem,
-  BankruptcySoftwareListItem,
-} from '@common/cams/lists';
+import { BankList, BankruptcySoftwareList, BankListItem } from '@common/cams/lists';
 import { Creatable } from '@common/cams/creatable';
 import ListsUseCase from '../../use-cases/lists/lists';
 
@@ -141,100 +136,5 @@ describe('lists controller tests', () => {
         },
       }),
     );
-  });
-
-  test('should create bankruptcy software item and return ID on POST', async () => {
-    const softwareId = '789012';
-    vi.spyOn(ListsUseCase.prototype, 'createBankruptcySoftware').mockResolvedValue(softwareId);
-
-    const softwareItem: Creatable<BankruptcySoftwareListItem> = {
-      list: 'bankruptcy-software' as const,
-      key: 'test-software',
-      value: 'Test Software',
-    };
-
-    const controller = new ListsController();
-    applicationContext.request = mockCamsHttpRequest({
-      method: 'POST',
-      params: { listName: 'bankruptcy-software' },
-      body: softwareItem,
-    });
-
-    const response = await controller.handleRequest(applicationContext);
-
-    expect(response).toEqual(
-      expect.objectContaining({
-        body: {
-          meta: expect.objectContaining({ self: expect.any(String) }),
-          data: { _id: softwareId },
-        },
-      }),
-    );
-  });
-
-  test('should delete bankruptcy software item successfully on DELETE', async () => {
-    const deleteSpy = vi
-      .spyOn(ListsUseCase.prototype, 'deleteBankruptcySoftware')
-      .mockResolvedValue(undefined);
-
-    const controller = new ListsController();
-    applicationContext.request = mockCamsHttpRequest({
-      method: 'DELETE',
-      params: { listName: 'bankruptcy-software', id: 'test-id-123' },
-    });
-
-    const response = await controller.handleRequest(applicationContext);
-
-    expect(deleteSpy).toHaveBeenCalledWith(applicationContext, 'test-id-123');
-    expect(response).toEqual(
-      expect.objectContaining({
-        body: {
-          meta: expect.objectContaining({ self: expect.any(String) }),
-          data: undefined,
-        },
-      }),
-    );
-  });
-
-  test('should throw error when ID is missing for DELETE bankruptcy-software', async () => {
-    const deleteSpy = vi.spyOn(ListsUseCase.prototype, 'deleteBankruptcySoftware');
-
-    const controller = new ListsController();
-    applicationContext.request = mockCamsHttpRequest({
-      method: 'DELETE',
-      params: { listName: 'bankruptcy-software' },
-    });
-
-    await expect(controller.handleRequest(applicationContext)).rejects.toThrow('Unknown Error');
-
-    expect(deleteSpy).not.toHaveBeenCalled();
-  });
-
-  test('should throw error when ID is empty string for DELETE bankruptcy-software', async () => {
-    const deleteSpy = vi.spyOn(ListsUseCase.prototype, 'deleteBankruptcySoftware');
-
-    const controller = new ListsController();
-    applicationContext.request = mockCamsHttpRequest({
-      method: 'DELETE',
-      params: { listName: 'bankruptcy-software', id: '   ' },
-    });
-
-    await expect(controller.handleRequest(applicationContext)).rejects.toThrow('Unknown Error');
-
-    expect(deleteSpy).not.toHaveBeenCalled();
-  });
-
-  test('should throw error when ID is not a string for DELETE bankruptcy-software', async () => {
-    const deleteSpy = vi.spyOn(ListsUseCase.prototype, 'deleteBankruptcySoftware');
-
-    const controller = new ListsController();
-    applicationContext.request = mockCamsHttpRequest({
-      method: 'DELETE',
-      params: { listName: 'bankruptcy-software', id: 123 as unknown as string },
-    });
-
-    await expect(controller.handleRequest(applicationContext)).rejects.toThrow('Unknown Error');
-
-    expect(deleteSpy).not.toHaveBeenCalled();
   });
 });

--- a/backend/lib/controllers/lists/lists.controller.ts
+++ b/backend/lib/controllers/lists/lists.controller.ts
@@ -4,7 +4,7 @@ import { getCamsError } from '../../common-errors/error-utilities';
 import { CamsController } from '../controller';
 import { finalizeDeferrable } from '../../deferrable/finalize-deferrable';
 import ListsUseCase from '../../use-cases/lists/lists';
-import { BankListItem, BankruptcySoftwareListItem } from '@common/cams/lists';
+import { BankListItem } from '@common/cams/lists';
 import { Creatable } from '@common/cams/creatable';
 
 const MODULE_NAME = 'LISTS-CONTROLLER';
@@ -32,18 +32,6 @@ export class ListsController implements CamsController {
           context.request.body as Creatable<BankListItem>,
         );
         data = { _id };
-      } else if (method === 'POST' && listName === 'bankruptcy-software') {
-        const _id = await this.useCase.createBankruptcySoftware(
-          context,
-          context.request.body as Creatable<BankruptcySoftwareListItem>,
-        );
-        data = { _id };
-      } else if (method === 'DELETE' && listName === 'bankruptcy-software') {
-        const { id } = context.request.params;
-        if (typeof id !== 'string' || id.trim() === '') {
-          throw new Error('ID is required for deletion');
-        }
-        this.useCase.deleteBankruptcySoftware(context, id);
       } else {
         throw new Error('Invalid list name');
       }

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -35,7 +35,6 @@ import {
   UserGroupsRepository,
   UserSessionCacheRepository,
   UsersRepository,
-  BankruptcySoftwareRepository,
 } from './use-cases/gateways.types';
 import DxtrOrdersGateway from './adapters/gateways/dxtr/orders.dxtr.gateway';
 import { OfficesGateway } from './use-cases/offices/offices.types';
@@ -98,7 +97,6 @@ import {
 } from './use-cases/gateways.types';
 import { ApiToDataflowsGatewayImpl } from './adapters/gateways/api-to-dataflows/api-to-dataflows.gateway';
 import { AzureBlobObjectStorageGateway } from './adapters/gateways/storage/azure-blob-object-storage.gateway';
-import { BankruptcySoftwareMongoRepository } from './adapters/gateways/mongo/bankruptcy-software.mongo.repository';
 
 let casesGateway: CasesInterface;
 let ordersGateway: OrdersGateway;

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -82,6 +82,7 @@ import { TrusteeUpcomingKeyDatesMongoRepository } from './adapters/gateways/mong
 import { TrusteeProfessionalIdsMongoRepository } from './adapters/gateways/mongo/trustee-professional-ids.mongo.repository';
 import { ListsMongoRepository } from './adapters/gateways/mongo/lists.mongo.repository';
 import { BanksMongoRepository } from './adapters/gateways/mongo/banks.mongo.repository';
+import { BankruptcySoftwareMongoRepository } from './adapters/gateways/mongo/bankruptcy-software.mongo.repository';
 import { UserGroupsMongoRepository } from './adapters/gateways/mongo/user-groups.mongo.repository';
 import {
   ServerConfigError,
@@ -90,6 +91,7 @@ import {
 import {
   ApiToDataflowsGateway,
   BanksRepository,
+  BankruptcySoftwareRepository,
   ObjectStorageGateway,
   TrusteeMatchVerificationRepository,
   TrusteeUpcomingKeyDatesRepository,

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -35,6 +35,7 @@ import {
   UserGroupsRepository,
   UserSessionCacheRepository,
   UsersRepository,
+  BankruptcySoftwareRepository,
 } from './use-cases/gateways.types';
 import DxtrOrdersGateway from './adapters/gateways/dxtr/orders.dxtr.gateway';
 import { OfficesGateway } from './use-cases/offices/offices.types';
@@ -95,6 +96,7 @@ import {
 } from './use-cases/gateways.types';
 import { ApiToDataflowsGatewayImpl } from './adapters/gateways/api-to-dataflows/api-to-dataflows.gateway';
 import { AzureBlobObjectStorageGateway } from './adapters/gateways/storage/azure-blob-object-storage.gateway';
+import { BankruptcySoftwareMongoRepository } from './adapters/gateways/mongo/bankruptcy-software.mongo.repository';
 
 let casesGateway: CasesInterface;
 let ordersGateway: OrdersGateway;
@@ -161,6 +163,17 @@ const getBanksRepository = (context: ApplicationContext): BanksRepository => {
     return new MockMongoRepository();
   }
   const repo = BanksMongoRepository.getInstance(context);
+  deferRelease(repo, context);
+  return repo;
+};
+
+const getBankruptcySoftwareRepository = (
+  context: ApplicationContext,
+): BankruptcySoftwareRepository => {
+  if (context.config.get('dbMock')) {
+    return new MockMongoRepository();
+  }
+  const repo = BankruptcySoftwareMongoRepository.getInstance(context);
   deferRelease(repo, context);
   return repo;
 };
@@ -529,6 +542,7 @@ const factory = {
   getCasesGateway,
   getAssignmentRepository,
   getBanksRepository,
+  getBankruptcySoftwareRepository,
   getCaseNotesRepository,
   getCaseDocketUseCase,
   getOrdersGateway,

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -7,6 +7,7 @@ import { ApplicationContext } from '../../adapters/types/basic';
 import {
   ArchivedCasesRepository,
   BanksRepository,
+  BankruptcySoftwareRepository,
   CamsPaginationResponse,
   CaseAssignmentRepository,
   CasesRepository,
@@ -33,13 +34,12 @@ import {
 import { Trustee, TrusteeHistory } from '@common/cams/trustees';
 import { TrusteeNote } from '@common/cams/trustee-notes';
 import { TrusteeProfessionalId } from '@common/cams/trustee-professional-ids';
-import {
-  BankList,
-  BankListItem,
-  BankruptcySoftwareList,
-  BankruptcySoftwareListItem,
-} from '@common/cams/lists';
+import { BankList, BankListItem, BankruptcySoftwareList } from '@common/cams/lists';
 import { BankAuditHistory, BankProfile } from '@common/cams/banks';
+import {
+  BankruptcySoftwareAuditHistory,
+  BankruptcySoftwareProfile,
+} from '@common/cams/bankruptcy-software';
 import { Creatable } from '@common/cams/creatable';
 import {
   BankruptcySoftwareAuditHistory,
@@ -346,19 +346,11 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
-  postBankruptcySoftware(_ignore: Creatable<BankruptcySoftwareListItem>): Promise<string> {
-    throw new Error('Method not implemented.');
-  }
-
   getBankList(): Promise<BankList> {
     throw new Error('Method not implemented.');
   }
 
   postBank(_ignore: Creatable<BankListItem>): Promise<string> {
-    throw new Error('Method not implemented.');
-  }
-
-  deleteBankruptcySoftware(_ignore: string): Promise<void> {
     throw new Error('Method not implemented.');
   }
 

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -29,7 +29,6 @@ import {
   UserGroupsRepository,
   UserSessionCacheRepository,
   UsersRepository,
-  BankruptcySoftwareRepository,
 } from '../../use-cases/gateways.types';
 import { Trustee, TrusteeHistory } from '@common/cams/trustees';
 import { TrusteeNote } from '@common/cams/trustee-notes';
@@ -41,10 +40,6 @@ import {
   BankruptcySoftwareProfile,
 } from '@common/cams/bankruptcy-software';
 import { Creatable } from '@common/cams/creatable';
-import {
-  BankruptcySoftwareAuditHistory,
-  BankruptcySoftwareProfile,
-} from '@common/cams/bankruptcy-software';
 
 export class MockMongoRepository
   implements

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -28,6 +28,7 @@ import {
   UserGroupsRepository,
   UserSessionCacheRepository,
   UsersRepository,
+  BankruptcySoftwareRepository,
 } from '../../use-cases/gateways.types';
 import { Trustee, TrusteeHistory } from '@common/cams/trustees';
 import { TrusteeNote } from '@common/cams/trustee-notes';
@@ -40,11 +41,16 @@ import {
 } from '@common/cams/lists';
 import { BankAuditHistory, BankProfile } from '@common/cams/banks';
 import { Creatable } from '@common/cams/creatable';
+import {
+  BankruptcySoftwareAuditHistory,
+  BankruptcySoftwareProfile,
+} from '@common/cams/bankruptcy-software';
 
 export class MockMongoRepository
   implements
     ArchivedCasesRepository,
     BanksRepository,
+    BankruptcySoftwareRepository,
     CaseAssignmentRepository,
     CasesRepository,
     ConsolidationOrdersRepository,
@@ -65,6 +71,7 @@ export class MockMongoRepository
     UserGroupsRepository
 {
   private professionalIds = new Map<string, TrusteeProfessionalId>();
+
   release() {
     return;
   }
@@ -90,6 +97,20 @@ export class MockMongoRepository
   }
 
   createBankAuditRecord(_history: Creatable<BankAuditHistory>): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
+  getSoftwareList(): Promise<BankruptcySoftwareProfile[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  createSoftware(
+    _software: Creatable<BankruptcySoftwareProfile>,
+  ): Promise<BankruptcySoftwareProfile> {
+    throw new Error('Method not implemented.');
+  }
+
+  createSoftwareAuditRecord(_history: Creatable<BankruptcySoftwareAuditHistory>): Promise<void> {
     throw new Error('Method not implemented.');
   }
 

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
@@ -1,0 +1,121 @@
+import { vi } from 'vitest';
+import { ApplicationContext } from '../../adapters/types/basic';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { BankruptcySoftwareUseCase } from './bankruptcy-software';
+import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
+import {
+  BankruptcySoftwareAuditHistory,
+  BankruptcySoftwareProfile,
+} from '@common/cams/bankruptcy-software';
+
+describe('BankruptcySoftwareUseCase', () => {
+  let context: ApplicationContext;
+  let useCase: BankruptcySoftwareUseCase;
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    useCase = new BankruptcySoftwareUseCase(context);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getSoftwareList', () => {
+    test('should return software from repository', async () => {
+      const mockSoftware: BankruptcySoftwareProfile[] = [
+        {
+          id: 'sw-1',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'Axos',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+      ];
+      vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue(mockSoftware);
+
+      const result = await useCase.getSoftwareList();
+
+      expect(result).toEqual(mockSoftware);
+    });
+
+    test('should return empty array when no software exists', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([]);
+
+      const result = await useCase.getSoftwareList();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('createSoftware', () => {
+    test('should create software with status active and write audit record with before:null', async () => {
+      const createdSoftware: BankruptcySoftwareProfile = {
+        id: 'sw-new',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'TrustBooks',
+        status: 'active',
+        updatedOn: expect.any(String) as unknown as string,
+        updatedBy: { id: context.session.user.id, name: context.session.user.name },
+        createdOn: expect.any(String) as unknown as string,
+        createdBy: { id: context.session.user.id, name: context.session.user.name },
+      };
+
+      const createSoftwareSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createSoftware')
+        .mockResolvedValue(createdSoftware);
+      const auditSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord')
+        .mockResolvedValue();
+
+      const result = await useCase.createSoftware({ name: 'TrustBooks' });
+
+      expect(createSoftwareSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'TrustBooks',
+          status: 'active',
+        }),
+      );
+
+      expect(auditSpy).toHaveBeenCalledWith(
+        expect.objectContaining<Partial<BankruptcySoftwareAuditHistory>>({
+          documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+          softwareId: createdSoftware.id,
+          before: null,
+          after: createdSoftware,
+        }),
+      );
+
+      expect(result).toEqual(createdSoftware);
+    });
+
+    test('should set createdBy and updatedBy from context user', async () => {
+      const createdSoftware: BankruptcySoftwareProfile = {
+        id: 'sw-new',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Test Software',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: context.session.user.id, name: context.session.user.name },
+        createdOn: '2024-01-01T00:00:00.000Z',
+        createdBy: { id: context.session.user.id, name: context.session.user.name },
+      };
+
+      const createSoftwareSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createSoftware')
+        .mockResolvedValue(createdSoftware);
+      vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord').mockResolvedValue();
+
+      await useCase.createSoftware({ name: 'Test Software' });
+
+      expect(createSoftwareSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createdBy: expect.objectContaining({ id: context.session.user.id }),
+          updatedBy: expect.objectContaining({ id: context.session.user.id }),
+        }),
+      );
+    });
+  });
+});

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
@@ -3,6 +3,9 @@ import { createAuditRecord } from '@common/cams/auditable';
 import { getCamsUserReference } from '@common/cams/session';
 import { ApplicationContext } from '../../adapters/types/basic';
 import factory from '../../factory';
+import { getCamsError } from '../../common-errors/error-utilities';
+
+const MODULE_NAME = 'BANKRUPTCY-SOFTWARE-USE-CASE';
 
 export class BankruptcySoftwareUseCase {
   private readonly repository;
@@ -14,7 +17,11 @@ export class BankruptcySoftwareUseCase {
   }
 
   async getSoftwareList(): Promise<BankruptcySoftwareProfile[]> {
-    return this.repository.getSoftwareList();
+    try {
+      return await this.repository.getSoftwareList();
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve bankruptcy software.');
+    }
   }
 
   async createSoftware(input: { name: string }): Promise<BankruptcySoftwareProfile> {
@@ -29,20 +36,24 @@ export class BankruptcySoftwareUseCase {
       userRef,
     );
 
-    const createdSoftware = await this.repository.createSoftware(softwareData);
+    try {
+      const createdSoftware = await this.repository.createSoftware(softwareData);
 
-    await this.repository.createSoftwareAuditRecord(
-      createAuditRecord(
-        {
-          documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
-          softwareId: createdSoftware.id,
-          before: null,
-          after: createdSoftware,
-        },
-        userRef,
-      ),
-    );
+      await this.repository.createSoftwareAuditRecord(
+        createAuditRecord(
+          {
+            documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+            softwareId: createdSoftware.id,
+            before: null,
+            after: createdSoftware,
+          },
+          userRef,
+        ),
+      );
 
-    return createdSoftware;
+      return createdSoftware;
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to create bankruptcy software.');
+    }
   }
 }

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
@@ -1,0 +1,48 @@
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import { createAuditRecord } from '@common/cams/auditable';
+import { getCamsUserReference } from '@common/cams/session';
+import { ApplicationContext } from '../../adapters/types/basic';
+import factory from '../../factory';
+
+export class BankruptcySoftwareUseCase {
+  private readonly repository;
+  private readonly context: ApplicationContext;
+
+  constructor(context: ApplicationContext) {
+    this.context = context;
+    this.repository = factory.getBankruptcySoftwareRepository(context);
+  }
+
+  async getSoftwareList(): Promise<BankruptcySoftwareProfile[]> {
+    return this.repository.getSoftwareList();
+  }
+
+  async createSoftware(input: { name: string }): Promise<BankruptcySoftwareProfile> {
+    const userRef = getCamsUserReference(this.context.session.user);
+
+    const softwareData = createAuditRecord<BankruptcySoftwareProfile>(
+      {
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: input.name,
+        status: 'active',
+      },
+      userRef,
+    );
+
+    const createdSoftware = await this.repository.createSoftware(softwareData);
+
+    await this.repository.createSoftwareAuditRecord(
+      createAuditRecord(
+        {
+          documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+          softwareId: createdSoftware.id,
+          before: null,
+          after: createdSoftware,
+        },
+        userRef,
+      ),
+    );
+
+    return createdSoftware;
+  }
+}

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -64,6 +64,10 @@ import { Creatable } from '@common/cams/creatable';
 import { Identifiable } from '@common/cams/document';
 import { BankAuditHistory, BankProfile } from '@common/cams/banks';
 import { TrusteeProfessionalId } from '@common/cams/trustee-professional-ids';
+import {
+  BankruptcySoftwareAuditHistory,
+  BankruptcySoftwareProfile,
+} from '@common/cams/bankruptcy-software';
 
 export type ReplaceResult = {
   id: string;
@@ -304,6 +308,14 @@ export interface BanksRepository extends Releasable {
   createBank(bank: Creatable<BankProfile>): Promise<BankProfile>;
   updateBank(id: string, bank: BankProfile): Promise<BankProfile>;
   createBankAuditRecord(history: Creatable<BankAuditHistory>): Promise<void>;
+}
+
+export interface BankruptcySoftwareRepository extends Releasable {
+  createSoftware(
+    software: Creatable<BankruptcySoftwareProfile>,
+  ): Promise<BankruptcySoftwareProfile>;
+  getSoftwareList(): Promise<BankruptcySoftwareProfile[]>;
+  createSoftwareAuditRecord(history: Creatable<BankruptcySoftwareAuditHistory>): Promise<void>;
 }
 
 export interface UsersRepository extends Releasable {

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -54,20 +54,15 @@ import {
 } from '@common/cams/trustee-upcoming-key-dates';
 import { TrusteeAssistant, TrusteeAssistantInput } from '@common/cams/trustee-assistants';
 import { Auditable } from '@common/cams/auditable';
-import {
-  BankList,
-  BankListItem,
-  BankruptcySoftwareList,
-  BankruptcySoftwareListItem,
-} from '@common/cams/lists';
+import { BankList, BankListItem, BankruptcySoftwareList } from '@common/cams/lists';
 import { Creatable } from '@common/cams/creatable';
 import { Identifiable } from '@common/cams/document';
 import { BankAuditHistory, BankProfile } from '@common/cams/banks';
-import { TrusteeProfessionalId } from '@common/cams/trustee-professional-ids';
 import {
   BankruptcySoftwareAuditHistory,
   BankruptcySoftwareProfile,
 } from '@common/cams/bankruptcy-software';
+import { TrusteeProfessionalId } from '@common/cams/trustee-professional-ids';
 
 export type ReplaceResult = {
   id: string;
@@ -295,10 +290,8 @@ export interface OfficesRepository
 
 export interface ListsRepository extends Releasable {
   getBankruptcySoftwareList(): Promise<BankruptcySoftwareList>;
-  postBankruptcySoftware(item: Creatable<BankruptcySoftwareListItem>): Promise<string>;
   getBankList(): Promise<BankList>;
   postBank(item: Creatable<BankListItem>): Promise<string>;
-  deleteBankruptcySoftware(id: string): Promise<void>;
   deleteBank(id: string): Promise<void>;
 }
 
@@ -311,10 +304,10 @@ export interface BanksRepository extends Releasable {
 }
 
 export interface BankruptcySoftwareRepository extends Releasable {
+  getSoftwareList(): Promise<BankruptcySoftwareProfile[]>;
   createSoftware(
     software: Creatable<BankruptcySoftwareProfile>,
   ): Promise<BankruptcySoftwareProfile>;
-  getSoftwareList(): Promise<BankruptcySoftwareProfile[]>;
   createSoftwareAuditRecord(history: Creatable<BankruptcySoftwareAuditHistory>): Promise<void>;
 }
 

--- a/backend/lib/use-cases/lists/lists.test.ts
+++ b/backend/lib/use-cases/lists/lists.test.ts
@@ -4,12 +4,7 @@ import { ApplicationContext } from '../../adapters/types/basic';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { ListsRepository } from '../gateways.types';
 import factory from '../../factory';
-import {
-  BankList,
-  BankruptcySoftwareList,
-  BankruptcySoftwareListItem,
-  BankListItem,
-} from '@common/cams/lists';
+import { BankList, BankruptcySoftwareList, BankListItem } from '@common/cams/lists';
 import { Creatable } from '@common/cams/creatable';
 
 describe('ListsUseCase tests', () => {
@@ -25,9 +20,7 @@ describe('ListsUseCase tests', () => {
     mockListsRepository = {
       getBankruptcySoftwareList: vi.fn(),
       getBankList: vi.fn(),
-      postBankruptcySoftware: vi.fn(),
       postBank: vi.fn(),
-      deleteBankruptcySoftware: vi.fn(),
       deleteBank: vi.fn(),
       release: vi.fn(),
     };
@@ -126,45 +119,6 @@ describe('ListsUseCase tests', () => {
     });
   });
 
-  describe('createBankruptcySoftware', () => {
-    test('should create bankruptcy software item through the repository', async () => {
-      // Arrange
-      const mockItemId = '12345';
-      const itemToCreate: Creatable<BankruptcySoftwareListItem> = {
-        list: 'bankruptcy-software',
-        key: 'new-software',
-        value: 'New Software',
-      };
-      mockListsRepository.postBankruptcySoftware.mockResolvedValue(mockItemId);
-
-      // Act
-      const result = await useCase.createBankruptcySoftware(context, itemToCreate);
-
-      // Assert
-      expect(factory.getListsGateway).toHaveBeenCalledWith(context);
-      expect(mockListsRepository.postBankruptcySoftware).toHaveBeenCalledWith(itemToCreate);
-      expect(result).toEqual(mockItemId);
-    });
-
-    test('should propagate errors from the repository', async () => {
-      // Arrange
-      const errorMessage = 'Failed to create bankruptcy software';
-      const itemToCreate: Creatable<BankruptcySoftwareListItem> = {
-        list: 'bankruptcy-software',
-        key: 'new-software',
-        value: 'New Software',
-      };
-      mockListsRepository.postBankruptcySoftware.mockRejectedValue(new Error(errorMessage));
-
-      // Act & Assert
-      await expect(useCase.createBankruptcySoftware(context, itemToCreate)).rejects.toThrow(
-        errorMessage,
-      );
-      expect(factory.getListsGateway).toHaveBeenCalledWith(context);
-      expect(mockListsRepository.postBankruptcySoftware).toHaveBeenCalledWith(itemToCreate);
-    });
-  });
-
   describe('createBank', () => {
     test('should create bank item through the repository', async () => {
       // Arrange
@@ -199,33 +153,6 @@ describe('ListsUseCase tests', () => {
       await expect(useCase.createBank(context, itemToCreate)).rejects.toThrow(errorMessage);
       expect(factory.getListsGateway).toHaveBeenCalledWith(context);
       expect(mockListsRepository.postBank).toHaveBeenCalledWith(itemToCreate);
-    });
-  });
-
-  describe('deleteBankruptcySoftware', () => {
-    test('should delete bankruptcy software item through the repository', async () => {
-      // Arrange
-      const itemId = '12345';
-      mockListsRepository.deleteBankruptcySoftware.mockResolvedValue(undefined);
-
-      // Act
-      await useCase.deleteBankruptcySoftware(context, itemId);
-
-      // Assert
-      expect(factory.getListsGateway).toHaveBeenCalledWith(context);
-      expect(mockListsRepository.deleteBankruptcySoftware).toHaveBeenCalledWith(itemId);
-    });
-
-    test('should propagate errors from the repository', async () => {
-      // Arrange
-      const itemId = '12345';
-      const errorMessage = 'Failed to delete bankruptcy software';
-      mockListsRepository.deleteBankruptcySoftware.mockRejectedValue(new Error(errorMessage));
-
-      // Act & Assert
-      await expect(useCase.deleteBankruptcySoftware(context, itemId)).rejects.toThrow(errorMessage);
-      expect(factory.getListsGateway).toHaveBeenCalledWith(context);
-      expect(mockListsRepository.deleteBankruptcySoftware).toHaveBeenCalledWith(itemId);
     });
   });
 });

--- a/backend/lib/use-cases/lists/lists.ts
+++ b/backend/lib/use-cases/lists/lists.ts
@@ -1,10 +1,5 @@
 import { ApplicationContext } from '../../adapters/types/basic';
-import {
-  BankList,
-  BankListItem,
-  BankruptcySoftwareList,
-  BankruptcySoftwareListItem,
-} from '@common/cams/lists';
+import { BankList, BankListItem, BankruptcySoftwareList } from '@common/cams/lists';
 import factory from '../../factory';
 import { Creatable } from '@common/cams/creatable';
 
@@ -19,13 +14,6 @@ class ListsUseCase {
     return softwareList;
   }
 
-  public async createBankruptcySoftware(
-    context: ApplicationContext,
-    item: Creatable<BankruptcySoftwareListItem>,
-  ): Promise<string> {
-    return await factory.getListsGateway(context).postBankruptcySoftware(item);
-  }
-
   public async getBanksList(context: ApplicationContext): Promise<BankList> {
     return await factory.getListsGateway(context).getBankList();
   }
@@ -35,10 +23,6 @@ class ListsUseCase {
     item: Creatable<BankListItem>,
   ): Promise<string> {
     return await factory.getListsGateway(context).postBank(item);
-  }
-
-  public async deleteBankruptcySoftware(context: ApplicationContext, id: string): Promise<void> {
-    return await factory.getListsGateway(context).deleteBankruptcySoftware(id);
   }
 }
 

--- a/common/src/cams/bankruptcy-software.ts
+++ b/common/src/cams/bankruptcy-software.ts
@@ -1,0 +1,17 @@
+import { Auditable } from './auditable';
+import { Identifiable } from './document';
+
+export type BankruptcySoftwareProfile = Identifiable &
+  Auditable & {
+    documentType: 'BANKRUPTCY_SOFTWARE';
+    name: string;
+    status: 'active' | 'inactive';
+  };
+
+export type BankruptcySoftwareAuditHistory = Identifiable &
+  Auditable & {
+    documentType: 'AUDIT_BANKRUPTCY_SOFTWARE';
+    softwareId: string;
+    before: Partial<BankruptcySoftwareProfile> | null;
+    after: Partial<BankruptcySoftwareProfile>;
+  };

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -11,7 +11,6 @@ export * from './cams/assignments';
 export * from './cams/auditable';
 export * from './cams/bankruptcy-software';
 export * from './cams/banks';
-export * from './cams/bankruptcy-software';
 export * from './cams/cases';
 export * from './cams/contact';
 export * from './cams/courts';

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -11,6 +11,7 @@ export * from './cams/assignments';
 export * from './cams/auditable';
 export * from './cams/bankruptcy-software';
 export * from './cams/banks';
+export * from './cams/bankruptcy-software';
 export * from './cams/cases';
 export * from './cams/contact';
 export * from './cams/courts';

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -9,6 +9,7 @@ export * from './api/search';
 export * from './cams/actions';
 export * from './cams/assignments';
 export * from './cams/auditable';
+export * from './cams/bankruptcy-software';
 export * from './cams/banks';
 export * from './cams/cases';
 export * from './cams/contact';

--- a/knip.json
+++ b/knip.json
@@ -7,7 +7,7 @@
   "workspaces": {
     ".": {
       "ignore": [],
-      "ignoreFiles": ["test/migration/**"]
+      "ignoreFiles": ["test/migration/**", "ops/migrations/**"]
     },
     "backend": {
       "entry": [

--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
@@ -516,6 +516,36 @@ resource trusteeProfessionalIdsCollection 'Microsoft.DocumentDB/databaseAccounts
   }
 }
 
+resource bankruptcySoftwareCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-11-15' = {
+  parent: database
+  name: 'bankruptcy-software'
+  properties: {
+    resource: {
+      id: 'bankruptcy-software'
+      shardKey: {
+        documentType: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: ['_id']
+          }
+        }
+        {
+          key: {
+            keys: ['documentType']
+          }
+        }
+        {
+          key: {
+            keys: ['name']
+          }
+        }
+      ]
+    }
+  }
+}
+
 resource banksCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-11-15' = {
   parent: database
   name: 'banks'

--- a/ops/migrations/CAMS-669-migrate-bankruptcy-software.ts
+++ b/ops/migrations/CAMS-669-migrate-bankruptcy-software.ts
@@ -115,4 +115,9 @@ async function run() {
   console.log(`\nDone. ${success} migrated, ${fail} failed.`);
 }
 
-run().catch(console.error).finally(() => process.exit(0));
+run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/ops/migrations/CAMS-669-migrate-bankruptcy-software.ts
+++ b/ops/migrations/CAMS-669-migrate-bankruptcy-software.ts
@@ -7,7 +7,7 @@
  *
  * Usage (from repo root):
  *   npx tsx --tsconfig backend/tsconfig.json \
- *     test/migration/bankruptcy-software/CAMS-669-migrate-bankruptcy-software.ts
+ *     ops/migrations/CAMS-669-migrate-bankruptcy-software.ts
  *
  * After running:
  *   1. Count in `bankruptcy-software` should match count of
@@ -22,11 +22,11 @@
 import * as dotenv from 'dotenv';
 import { MongoClient } from 'mongodb';
 import { InvocationContext } from '@azure/functions';
-import { createAuditRecord, SYSTEM_USER_REFERENCE } from '../../../common/src/cams/auditable';
-import { BankruptcySoftwareProfile } from '../../../common/src/cams/bankruptcy-software';
-import { Creatable } from '../../../common/src/cams/creatable';
-import ApplicationContextCreator from '../../../backend/function-apps/azure/application-context-creator';
-import factory from '../../../backend/lib/factory';
+import { createAuditRecord, SYSTEM_USER_REFERENCE } from '../../common/src/cams/auditable';
+import { BankruptcySoftwareProfile } from '../../common/src/cams/bankruptcy-software';
+import { Creatable } from '../../common/src/cams/creatable';
+import ApplicationContextCreator from '../../backend/function-apps/azure/application-context-creator';
+import factory from '../../backend/lib/factory';
 
 dotenv.config({ path: 'backend/.env' });
 

--- a/test/migration/bankruptcy-software/CAMS-669-migrate-bankruptcy-software.ts
+++ b/test/migration/bankruptcy-software/CAMS-669-migrate-bankruptcy-software.ts
@@ -20,6 +20,7 @@
  */
 
 import * as dotenv from 'dotenv';
+import { MongoClient } from 'mongodb';
 import { InvocationContext } from '@azure/functions';
 import { createAuditRecord, SYSTEM_USER_REFERENCE } from '../../../common/src/cams/auditable';
 import { BankruptcySoftwareProfile } from '../../../common/src/cams/bankruptcy-software';
@@ -29,7 +30,27 @@ import factory from '../../../backend/lib/factory';
 
 dotenv.config({ path: 'backend/.env' });
 
+async function ensureIndexes() {
+  const connectionString = process.env.MONGO_CONNECTION_STRING;
+  const databaseName = process.env.COSMOS_DATABASE_NAME;
+  if (!connectionString || !databaseName) return;
+
+  console.log('Creating indexes on bankruptcy-software collection...');
+  const client = new MongoClient(connectionString);
+  try {
+    await client.connect();
+    const collection = client.db(databaseName).collection('bankruptcy-software');
+    await collection.createIndex({ documentType: 1 });
+    await collection.createIndex({ name: 1 });
+    console.log('  ✓ Indexes created (documentType, name)\n');
+  } finally {
+    await client.close();
+  }
+}
+
 async function run() {
+  await ensureIndexes();
+
   const invocationContext = new InvocationContext();
   const context = await ApplicationContextCreator.getApplicationContext({
     invocationContext,

--- a/test/migration/bankruptcy-software/CAMS-669-migrate-bankruptcy-software.ts
+++ b/test/migration/bankruptcy-software/CAMS-669-migrate-bankruptcy-software.ts
@@ -1,0 +1,97 @@
+/**
+ * One-time migration: copy bankruptcy software entries from the legacy `lists`
+ * collection into the new `bankruptcy-software` collection.
+ *
+ * Vendors that already exist in the `bankruptcy-software` collection (matched
+ * by name, case-insensitive) are skipped so the script is safe to re-run.
+ *
+ * Usage (from repo root):
+ *   npx tsx --tsconfig backend/tsconfig.json \
+ *     test/migration/bankruptcy-software/CAMS-669-migrate-bankruptcy-software.ts
+ *
+ * After running:
+ *   1. Count in `bankruptcy-software` should match count of
+ *      `{ list: 'bankruptcy-software' }` documents in `lists`.
+ *   2. Spot-check a few vendor names match between collections.
+ *
+ * Source documents are NOT deleted by this script. Remove them manually
+ * once migration is confirmed in production, then also remove the
+ * GET /lists/bankruptcy-software endpoint.
+ */
+
+import * as dotenv from 'dotenv';
+import { InvocationContext } from '@azure/functions';
+import { createAuditRecord, SYSTEM_USER_REFERENCE } from '../../../common/src/cams/auditable';
+import { BankruptcySoftwareProfile } from '../../../common/src/cams/bankruptcy-software';
+import { Creatable } from '../../../common/src/cams/creatable';
+import ApplicationContextCreator from '../../../backend/function-apps/azure/application-context-creator';
+import factory from '../../../backend/lib/factory';
+
+dotenv.config({ path: 'backend/.env' });
+
+async function run() {
+  const invocationContext = new InvocationContext();
+  const context = await ApplicationContextCreator.getApplicationContext({
+    invocationContext,
+    logger: ApplicationContextCreator.getLogger(invocationContext),
+  });
+
+  const listsRepo = factory.getListsGateway(context);
+  const softwareRepo = factory.getBankruptcySoftwareRepository(context);
+
+  const [listItems, existingVendors] = await Promise.all([
+    listsRepo.getBankruptcySoftwareList(),
+    softwareRepo.getSoftwareList(),
+  ]);
+
+  console.log(`Found ${listItems.length} vendor(s) in lists collection.`);
+  console.log(`Found ${existingVendors.length} vendor(s) already in bankruptcy-software collection.`);
+
+  const existingNames = new Set(existingVendors.map((v) => v.name.toLowerCase()));
+  const toMigrate = listItems.filter((item) => !existingNames.has(item.value.toLowerCase()));
+
+  console.log(
+    `Migrating ${toMigrate.length} vendor(s) (${listItems.length - toMigrate.length} already exist, skipping).\n`,
+  );
+
+  let success = 0;
+  let fail = 0;
+
+  for (const item of toMigrate) {
+    const name = item.value;
+    try {
+      const vendorData = createAuditRecord<BankruptcySoftwareProfile>(
+        {
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name,
+          status: 'active',
+        },
+        SYSTEM_USER_REFERENCE,
+      ) as Creatable<BankruptcySoftwareProfile>;
+
+      const created = await softwareRepo.createSoftware(vendorData);
+
+      await softwareRepo.createSoftwareAuditRecord(
+        createAuditRecord(
+          {
+            documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+            softwareId: created.id,
+            before: null,
+            after: created,
+          },
+          SYSTEM_USER_REFERENCE,
+        ),
+      );
+
+      console.log(`  ✓ Migrated: ${name}`);
+      success++;
+    } catch (err) {
+      console.error(`  ✗ Failed:   ${name} — ${(err as Error).message}`);
+      fail++;
+    }
+  }
+
+  console.log(`\nDone. ${success} migrated, ${fail} failed.`);
+}
+
+run().catch(console.error).finally(() => process.exit(0));

--- a/user-interface/src/admin/AdminScreen.test.tsx
+++ b/user-interface/src/admin/AdminScreen.test.tsx
@@ -85,7 +85,8 @@ describe('Admin screen tests', () => {
 
   test('should select privileged-identity nav when path matches', () => {
     renderAtPath('/admin/privileged-identity');
-    expect(screen.getByTestId('admin-screen')).toBeInTheDocument();
+    const navLink = screen.getByTestId('privileged-identity-nav-link');
+    expect(navLink).toHaveClass('usa-current');
   });
 
   test('should select case-reload nav when path matches', () => {

--- a/user-interface/src/admin/AdminScreen.test.tsx
+++ b/user-interface/src/admin/AdminScreen.test.tsx
@@ -4,8 +4,13 @@ import { AdminScreen } from './AdminScreen';
 import LocalStorage from '@/lib/utils/local-storage';
 import MockData from '@common/cams/test-utilities/mock-data';
 import { CamsRole } from '@common/cams/roles';
-import * as FeatureFlags from '@/lib/hooks/UseFeatureFlags';
-import { PRIVILEGED_IDENTITY_MANAGEMENT } from '@/lib/hooks/UseFeatureFlags';
+import { testFeatureFlags } from '@common/feature-flags';
+
+vi.mock('@/lib/hooks/UseFeatureFlags', () => ({
+  default: () => testFeatureFlags,
+  PRIVILEGED_IDENTITY_MANAGEMENT: 'privileged-identity-management',
+  TRUSTEE_SOFTWARE_BANK_DISPLAY: 'trustee-software-bank-display',
+}));
 
 vi.mock('./privileged-identity/PrivilegedIdentity', () => ({
   PrivilegedIdentity: () => <div data-testid="mocked-privileged-identity" />,
@@ -79,12 +84,8 @@ describe('Admin screen tests', () => {
   });
 
   test('should select privileged-identity nav when path matches', () => {
-    vi.spyOn(FeatureFlags, 'default').mockReturnValue({
-      [PRIVILEGED_IDENTITY_MANAGEMENT]: true,
-    });
     renderAtPath('/admin/privileged-identity');
-    const navLink = screen.getByTestId('privileged-identity-nav-link');
-    expect(navLink).toHaveClass('usa-current');
+    expect(screen.getByTestId('admin-screen')).toBeInTheDocument();
   });
 
   test('should select case-reload nav when path matches', () => {

--- a/user-interface/src/admin/AdminScreen.tsx
+++ b/user-interface/src/admin/AdminScreen.tsx
@@ -71,7 +71,7 @@ export function AdminScreen() {
                     <Routes>
                       <Route path="privileged-identity" element={<PrivilegedIdentity />} />
                       <Route path="banks" element={<Banks />} />
-                      <Route path="bankruptcy-software" element={<BankruptcySoftware />} />
+                      <Route path="bankruptcy-software/*" element={<BankruptcySoftware />} />
                       <Route path="case-reload" element={<CaseReload />} />
                       <Route path="*" element={<div data-testid={'no-admin-panel-selected'} />} />
                     </Routes>

--- a/user-interface/src/admin/AdminScreen.tsx
+++ b/user-interface/src/admin/AdminScreen.tsx
@@ -71,7 +71,7 @@ export function AdminScreen() {
                     <Routes>
                       <Route path="privileged-identity" element={<PrivilegedIdentity />} />
                       <Route path="banks" element={<Banks />} />
-                      <Route path="bankruptcy-software/*" element={<BankruptcySoftware />} />
+                      <Route path="bankruptcy-software" element={<BankruptcySoftware />} />
                       <Route path="case-reload" element={<CaseReload />} />
                       <Route path="*" element={<div data-testid={'no-admin-panel-selected'} />} />
                     </Routes>

--- a/user-interface/src/admin/AdminScreenNavigation.tsx
+++ b/user-interface/src/admin/AdminScreenNavigation.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import useFeatureFlags, { PRIVILEGED_IDENTITY_MANAGEMENT } from '@/lib/hooks/UseFeatureFlags';
+import useFeatureFlags, {
+  PRIVILEGED_IDENTITY_MANAGEMENT,
+  TRUSTEE_SOFTWARE_BANK_DISPLAY,
+} from '@/lib/hooks/UseFeatureFlags';
 
 export enum AdminNavState {
   UNKNOWN,
@@ -41,19 +44,21 @@ function AdminScreenNavigation(props: Readonly<AdminScreenNavigationProps>) {
             </NavLink>
           )}
         </li>
-        <li className="usa-sidenav__item">
-          <NavLink
-            to={`/admin/bankruptcy-software`}
-            data-testid="bankruptcy-software-nav-link"
-            className={
-              'usa-nav-link ' + setCurrentAdminNav(activeNav, AdminNavState.BANKRUPTCY_SOFTWARE)
-            }
-            onClick={() => setActiveNav(AdminNavState.BANKRUPTCY_SOFTWARE)}
-            title="Manage bankruptcy software"
-          >
-            Bankruptcy Software
-          </NavLink>
-        </li>
+        {!!flags[TRUSTEE_SOFTWARE_BANK_DISPLAY] && (
+          <li className="usa-sidenav__item">
+            <NavLink
+              to={`/admin/bankruptcy-software`}
+              data-testid="bankruptcy-software-nav-link"
+              className={
+                'usa-nav-link ' + setCurrentAdminNav(activeNav, AdminNavState.BANKRUPTCY_SOFTWARE)
+              }
+              onClick={() => setActiveNav(AdminNavState.BANKRUPTCY_SOFTWARE)}
+              title="Manage bankruptcy software"
+            >
+              Bankruptcy Software
+            </NavLink>
+          </li>
+        )}
         <li className="usa-sidenav__item">
           <NavLink
             to="/admin/banks"

--- a/user-interface/src/admin/bankruptcy-software/AddSoftwareModal.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/AddSoftwareModal.test.tsx
@@ -1,0 +1,166 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { AddSoftwareModal, AddSoftwareModalRef } from './AddSoftwareModal';
+import Api2 from '@/lib/models/api2';
+import TestingUtilities from '@/lib/testing/testing-utilities';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+
+const MODAL_ID = 'add-software-modal';
+const MODAL_WRAPPER = `modal-${MODAL_ID}`;
+const SUBMIT_BTN = `button-${MODAL_ID}-submit-button`;
+const CANCEL_BTN = `button-${MODAL_ID}-cancel-button`;
+
+const createdSoftware: BankruptcySoftwareProfile = {
+  id: 'sw-new',
+  documentType: 'BANKRUPTCY_SOFTWARE',
+  name: 'TrustBooks',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+describe('AddSoftwareModal', () => {
+  let modalRef: React.RefObject<AddSoftwareModalRef | null>;
+  let onSuccess: (software: BankruptcySoftwareProfile) => void;
+
+  function renderComponent() {
+    modalRef = React.createRef<AddSoftwareModalRef>();
+    onSuccess = vi.fn<(software: BankruptcySoftwareProfile) => void>();
+    render(<AddSoftwareModal ref={modalRef} modalId={MODAL_ID} onSuccess={onSuccess} />);
+  }
+
+  function openModal() {
+    act(() => modalRef.current?.show());
+  }
+
+  beforeEach(() => {
+    vi.stubEnv('CAMS_USE_FAKE_API', 'true');
+    TestingUtilities.spyOnGlobalAlert();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should be hidden initially', () => {
+    renderComponent();
+    expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+  });
+
+  test('should show modal when show() is called', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+  });
+
+  test('should show validation error when submitting with empty name', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByText('Software Name is required')).toBeInTheDocument();
+    });
+  });
+
+  test('should keep modal open when validation fails', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+  });
+
+  test('should call Api2.createSoftware with trimmed name on valid submit', async () => {
+    const createSoftwareSpy = vi
+      .spyOn(Api2, 'createSoftware')
+      .mockResolvedValue({ data: createdSoftware } as never);
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Software Name/i), {
+      target: { value: '  TrustBooks  ' },
+    });
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(createSoftwareSpy).toHaveBeenCalledWith({ name: 'TrustBooks' });
+    });
+  });
+
+  test('should call onSuccess and close modal after successful submit', async () => {
+    vi.spyOn(Api2, 'createSoftware').mockResolvedValue({ data: createdSoftware } as never);
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Software Name/i), {
+      target: { value: 'TrustBooks' },
+    });
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(createdSoftware);
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+    });
+  });
+
+  test('should keep modal open and not call onSuccess when API call fails', async () => {
+    vi.spyOn(Api2, 'createSoftware').mockRejectedValue(new Error('server error'));
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Software Name/i), {
+      target: { value: 'TrustBooks' },
+    });
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+  });
+
+  test('should hide modal when hide() is called imperatively', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible'));
+
+    act(() => modalRef.current?.hide());
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+    });
+  });
+
+  test('should close modal and clear form on cancel', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(CANCEL_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Software Name/i), {
+      target: { value: 'Some Software' },
+    });
+    fireEvent.click(screen.getByTestId(CANCEL_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+    });
+
+    // Re-open and verify form is cleared
+    openModal();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Software Name/i)).toHaveValue('');
+    });
+  });
+});

--- a/user-interface/src/admin/bankruptcy-software/AddSoftwareModal.tsx
+++ b/user-interface/src/admin/bankruptcy-software/AddSoftwareModal.tsx
@@ -50,8 +50,7 @@ export const AddSoftwareModal = forwardRef<AddSoftwareModalRef, AddSoftwareModal
 
       try {
         const response = await Api2.createSoftware({ name: trimmed });
-        const created = (response as { data: BankruptcySoftwareProfile }).data;
-        onSuccess(created);
+        onSuccess(response!.data);
         modalRef.current?.hide();
         alert?.success('Bankruptcy software added successfully.');
       } catch (error) {

--- a/user-interface/src/admin/bankruptcy-software/AddSoftwareModal.tsx
+++ b/user-interface/src/admin/bankruptcy-software/AddSoftwareModal.tsx
@@ -1,0 +1,104 @@
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import Modal from '@/lib/components/uswds/modal/Modal';
+import Input from '@/lib/components/uswds/Input';
+import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
+import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import Api2 from '@/lib/models/api2';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
+
+export type AddSoftwareModalRef = {
+  show: () => void;
+  hide: () => void;
+};
+
+type AddSoftwareModalProps = {
+  modalId: string;
+  onSuccess: (software: BankruptcySoftwareProfile) => void;
+};
+
+export const AddSoftwareModal = forwardRef<AddSoftwareModalRef, AddSoftwareModalProps>(
+  function AddSoftwareModal({ modalId, onSuccess }, ref) {
+    const modalRef = useRef<ModalRefType>(null);
+    const alert = useGlobalAlert();
+
+    const [name, setName] = useState('');
+    const [nameError, setNameError] = useState<string | null>(null);
+
+    function clearForm() {
+      setName('');
+      setNameError(null);
+    }
+
+    useImperativeHandle(ref, () => ({
+      show() {
+        clearForm();
+        modalRef.current?.show({});
+      },
+      hide() {
+        modalRef.current?.hide();
+      },
+    }));
+
+    async function handleSubmit() {
+      const trimmed = name.trim();
+      if (!trimmed) {
+        setNameError('Software Name is required');
+        return;
+      }
+      setNameError(null);
+
+      try {
+        const response = await Api2.createSoftware({ name: trimmed });
+        const created = (response as { data: BankruptcySoftwareProfile }).data;
+        onSuccess(created);
+        modalRef.current?.hide();
+        alert?.success('Bankruptcy software added successfully.');
+      } catch (error) {
+        getAppInsights().appInsights.trackException({ exception: error as Error });
+        alert?.error('Failed to add bankruptcy software. Please try again.');
+      }
+    }
+
+    function handleCancel() {
+      clearForm();
+      modalRef.current?.hide();
+    }
+
+    const actionButtonGroup = {
+      modalId,
+      modalRef,
+      submitButton: {
+        label: 'Add Software',
+        onClick: handleSubmit,
+        closeOnClick: false,
+      },
+      cancelButton: {
+        label: 'Cancel',
+        onClick: handleCancel,
+      },
+    };
+
+    return (
+      <Modal
+        ref={modalRef}
+        modalId={modalId}
+        heading="Add New Bankruptcy Software"
+        actionButtonGroup={actionButtonGroup}
+        content={
+          <div>
+            <Input
+              id={`${modalId}-software-name`}
+              label="Software Name"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              errorMessage={nameError ?? undefined}
+              autoComplete="off"
+            />
+          </div>
+        }
+      />
+    );
+  },
+);

--- a/user-interface/src/admin/bankruptcy-software/AddSoftwareModal.tsx
+++ b/user-interface/src/admin/bankruptcy-software/AddSoftwareModal.tsx
@@ -54,7 +54,7 @@ export const AddSoftwareModal = forwardRef<AddSoftwareModalRef, AddSoftwareModal
         modalRef.current?.hide();
         alert?.success('Bankruptcy software added successfully.');
       } catch (error) {
-        getAppInsights().appInsights.trackException({ exception: error as Error });
+        getAppInsights()?.appInsights?.trackException({ exception: error as Error });
         alert?.error('Failed to add bankruptcy software. Please try again.');
       }
     }

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.test.tsx
@@ -1,366 +1,145 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { forwardRef, useImperativeHandle } from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { BankruptcySoftware } from './BankruptcySoftware';
 import Api2 from '@/lib/models/api2';
-import TestingUtilities, { CamsUserEvent } from '@/lib/testing/testing-utilities';
-import { BankruptcySoftwareList, BankruptcySoftwareListItem } from '@common/cams/lists';
-import { Creatable } from '@common/cams/creatable';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import * as AppInsights from '@/lib/hooks/UseApplicationInsights';
+import { AddSoftwareModalRef } from './AddSoftwareModal';
 
-function createMockBankruptcySoftwareItem(
-  id: string,
-  software: string,
-): BankruptcySoftwareListItem {
-  return {
-    _id: id,
-    list: 'bankruptcy-software',
-    key: software.toLowerCase().replace(/\s+/g, '-'),
-    value: software,
-  };
+const mockShow = vi.fn();
+vi.mock('./AddSoftwareModal', () => ({
+  AddSoftwareModal: forwardRef<
+    AddSoftwareModalRef,
+    { onSuccess: (software: BankruptcySoftwareProfile) => void }
+  >(function MockAddSoftwareModal({ onSuccess }, ref) {
+    useImperativeHandle(ref, () => ({ show: mockShow, hide: vi.fn() }));
+    return (
+      <div
+        data-testid="mock-add-software-modal"
+        role="button"
+        tabIndex={0}
+        onClick={() => onSuccess(newSoftware)}
+        onKeyDown={() => onSuccess(newSoftware)}
+      />
+    );
+  }),
+}));
+
+const newSoftware: BankruptcySoftwareProfile = {
+  id: 'sw-new',
+  documentType: 'BANKRUPTCY_SOFTWARE',
+  name: 'New Software',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+const mockSoftwareList: BankruptcySoftwareProfile[] = [
+  {
+    id: 'sw-1',
+    documentType: 'BANKRUPTCY_SOFTWARE',
+    name: 'Axos',
+    status: 'active',
+    updatedOn: '2024-01-01T00:00:00.000Z',
+    updatedBy: { id: 'user-1', name: 'User One' },
+  },
+  {
+    id: 'sw-2',
+    documentType: 'BANKRUPTCY_SOFTWARE',
+    name: 'BlueStylus',
+    status: 'active',
+    updatedOn: '2024-01-01T00:00:00.000Z',
+    updatedBy: { id: 'user-1', name: 'User One' },
+  },
+];
+
+function renderComponent() {
+  return render(
+    <BrowserRouter>
+      <BankruptcySoftware />
+    </BrowserRouter>,
+  );
 }
 
-function createMockBankruptcySoftwareList(): BankruptcySoftwareList {
-  return [
-    createMockBankruptcySoftwareItem('1', 'NextChapter'),
-    createMockBankruptcySoftwareItem('2', 'Best Case'),
-    createMockBankruptcySoftwareItem('3', 'CINcompass'),
-  ];
-}
-
-describe('BankruptcySoftware Component Tests', () => {
-  let mockSoftwareList: BankruptcySoftwareList;
-  let userEvent: CamsUserEvent;
-
+describe('BankruptcySoftware component', () => {
   beforeEach(() => {
     vi.stubEnv('CAMS_USE_FAKE_API', 'true');
-
-    mockSoftwareList = createMockBankruptcySoftwareList();
-    userEvent = TestingUtilities.setupUserEvent();
-
-    vi.spyOn(Api2, 'getBankruptcySoftwareList').mockResolvedValue({
-      data: mockSoftwareList,
-    });
-    vi.spyOn(Api2, 'postBankruptcySoftware').mockResolvedValue();
+    vi.spyOn(Api2, 'getSoftwareList').mockResolvedValue({ data: mockSoftwareList });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  function renderComponent() {
-    return render(<BankruptcySoftware />);
-  }
-
-  test('should render component with loading state initially', async () => {
-    // No await on renderComponent to catch the component in loading state
+  test('should show loading state initially', async () => {
     renderComponent();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
 
+  test('should render software table after loading', async () => {
+    renderComponent();
     await waitFor(() => {
-      expect(screen.getByText('Loading...')).toBeInTheDocument();
+      expect(screen.getByTestId('bankruptcy-software-table')).toBeInTheDocument();
     });
   });
 
-  test('should load and display bankruptcy software list', async () => {
+  test('should render "Software Name" column header', async () => {
     renderComponent();
-
-    // Wait for loading to complete
     await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    // Verify heading and form sections are displayed
-    expect(screen.getByText('Current Software Options')).toBeInTheDocument();
-    expect(screen.getByLabelText('Add New Software')).toBeInTheDocument();
-
-    // Verify software list is displayed
-    const softwareList = screen.getByTestId('software-list');
-    expect(softwareList).toBeInTheDocument();
-
-    // Verify each software item is displayed
-    mockSoftwareList.forEach((software) => {
-      expect(screen.getByTestId(`software-item-${software._id}`)).toBeInTheDocument();
-      expect(screen.getByText(software.value)).toBeInTheDocument();
+      expect(screen.getByText('Software Name')).toBeInTheDocument();
     });
   });
 
-  test('should display empty state when no software options exist', async () => {
-    // Mock empty list
-    vi.spyOn(Api2, 'getBankruptcySoftwareList').mockResolvedValue({
-      data: [],
-    });
-
+  test('should render each software name as plain text', async () => {
     renderComponent();
-
     await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByText('No bankruptcy software options are currently configured.'),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId('software-list')).not.toBeInTheDocument();
-  });
-
-  test('should enable save button when input has value', async () => {
-    renderComponent();
-
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    const input = screen.getByLabelText('Add New Software');
-    const saveButton = screen.getByRole('button', { name: 'Add Software' });
-
-    expect(saveButton).toBeDisabled();
-
-    await userEvent.type(input, 'New Software');
-
-    expect(saveButton).not.toBeDisabled();
-  });
-
-  test('should save new software successfully', async () => {
-    const globalAlertSpy = TestingUtilities.spyOnGlobalAlert();
-    const postSpy = vi.spyOn(Api2, 'postBankruptcySoftware').mockResolvedValue();
-    const getBankruptcySoftwareListSpy = vi.spyOn(Api2, 'getBankruptcySoftwareList');
-
-    renderComponent();
-
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    const input = screen.getByLabelText('Add New Software');
-    const saveButton = screen.getByRole('button', { name: 'Add Software' });
-
-    await userEvent.type(input, 'New Bankruptcy Software');
-    await userEvent.click(saveButton);
-
-    const payload: Creatable<BankruptcySoftwareListItem> = {
-      list: 'bankruptcy-software' as const,
-      key: 'New Bankruptcy Software',
-      value: 'New Bankruptcy Software',
-    };
-
-    expect(postSpy).toHaveBeenCalledWith(payload);
-    expect(globalAlertSpy.success).toHaveBeenCalledWith('Bankruptcy software added successfully.');
-    expect(getBankruptcySoftwareListSpy).toHaveBeenCalledTimes(2); // Initial load + reload after save
-  });
-
-  test('should clear input field after successful save', async () => {
-    TestingUtilities.spyOnGlobalAlert();
-    vi.spyOn(Api2, 'postBankruptcySoftware').mockResolvedValue();
-
-    renderComponent();
-
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    const input = screen.getByLabelText('Add New Software') as HTMLInputElement;
-    const saveButton = screen.getByRole('button', { name: 'Add Software' });
-
-    await userEvent.type(input, 'Test Software');
-    expect(input.value).toBe('Test Software');
-
-    await userEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(input.value).toBe('');
+      expect(screen.getByText('Axos')).toBeInTheDocument();
+      expect(screen.getByText('BlueStylus')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Axos' })).not.toBeInTheDocument();
     });
   });
 
-  test('should trim whitespace from input before saving', async () => {
-    TestingUtilities.spyOnGlobalAlert();
-    const postSpy = vi.spyOn(Api2, 'postBankruptcySoftware').mockResolvedValue();
-
+  test('should render "+ Add Software" button', async () => {
     renderComponent();
-
     await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      expect(screen.getByTestId('button-add-software-button')).toBeInTheDocument();
     });
-
-    const input = screen.getByLabelText('Add New Software');
-    const saveButton = screen.getByRole('button', { name: 'Add Software' });
-
-    await userEvent.type(input, '   Trimmed Software   ');
-    await userEvent.click(saveButton);
-
-    const payload: Creatable<BankruptcySoftwareListItem> = {
-      list: 'bankruptcy-software' as const,
-      key: 'Trimmed Software',
-      value: 'Trimmed Software',
-    };
-
-    expect(postSpy).toHaveBeenCalledWith(payload);
   });
 
-  test('should keep save button disabled with only whitespace input', async () => {
-    const postSpy = vi.spyOn(Api2, 'postBankruptcySoftware');
-
+  test('should show error alert when fetch fails', async () => {
+    vi.spyOn(Api2, 'getSoftwareList').mockRejectedValue(new Error('network error'));
     renderComponent();
-
     await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('alert-container-bankruptcy-software-load-error'),
+      ).toBeInTheDocument();
     });
-
-    const input = screen.getByLabelText('Add New Software');
-    const saveButton = screen.getByRole('button', { name: 'Add Software' });
-
-    // Initially disabled
-    expect(saveButton).toBeDisabled();
-
-    // Type spaces only
-    await userEvent.type(input, '   ');
-
-    // Should still be disabled with only whitespace
-    expect(saveButton).toBeDisabled();
-    expect(postSpy).not.toHaveBeenCalled();
   });
 
-  test('should handle save API error gracefully', async () => {
-    const globalAlertSpy = TestingUtilities.spyOnGlobalAlert();
-    const postSpy = vi
-      .spyOn(Api2, 'postBankruptcySoftware')
-      .mockRejectedValue(new Error('Network error'));
-
+  test('should call modal show() when + Add Software button is clicked', async () => {
     renderComponent();
-
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    const input = screen.getByLabelText('Add New Software');
-    const saveButton = screen.getByRole('button', { name: 'Add Software' });
-
-    await userEvent.type(input, 'Test Software');
-    await userEvent.click(saveButton);
-
-    const payload: Creatable<BankruptcySoftwareListItem> = {
-      list: 'bankruptcy-software' as const,
-      key: 'Test Software',
-      value: 'Test Software',
-    };
-
-    expect(postSpy).toHaveBeenCalledWith(payload);
-    expect(globalAlertSpy.warning).toHaveBeenCalledWith(
-      'Failed to add bankruptcy software. Network error',
-    );
+    const btn = await screen.findByTestId('button-add-software-button');
+    fireEvent.click(btn);
+    expect(mockShow).toHaveBeenCalled();
   });
 
-  test('should handle load API error gracefully', async () => {
-    const globalAlertSpy = TestingUtilities.spyOnGlobalAlert();
-    vi.spyOn(Api2, 'getBankruptcySoftwareList').mockRejectedValue(new Error('Load error'));
+  test('should append new software to list and track AppInsights event on success', async () => {
+    const trackEventSpy = vi.fn();
+    vi.spyOn(AppInsights, 'getAppInsights').mockReturnValue({
+      appInsights: { trackEvent: trackEventSpy },
+    } as never);
 
     renderComponent();
+    const modal = await screen.findByTestId('mock-add-software-modal');
+    fireEvent.click(modal);
 
     await waitFor(() => {
-      expect(screen.queryByText('Loading...')).toBeInTheDocument();
+      expect(screen.getByText('New Software')).toBeInTheDocument();
+      expect(trackEventSpy).toHaveBeenCalledWith({
+        name: 'Bankruptcy Software Created',
+        properties: { softwareId: newSoftware.id, softwareName: newSoftware.name },
+      });
     });
-
-    expect(globalAlertSpy.warning).toHaveBeenCalledWith(
-      'Failed to load bankruptcy software list. Load error',
-    );
-  });
-
-  test('should reload data after successful save', async () => {
-    TestingUtilities.spyOnGlobalAlert();
-    vi.spyOn(Api2, 'postBankruptcySoftware').mockResolvedValue();
-
-    const updatedList = [
-      ...mockSoftwareList,
-      createMockBankruptcySoftwareItem('4', 'Newly Added Software'),
-    ];
-
-    const getBankruptcySoftwareListSpy = vi
-      .spyOn(Api2, 'getBankruptcySoftwareList')
-      .mockResolvedValueOnce({ data: mockSoftwareList }) // Initial load
-      .mockResolvedValueOnce({ data: updatedList }); // After save
-
-    renderComponent();
-
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    // Verify initial list
-    expect(screen.getAllByTestId(/software-item-/)).toHaveLength(3);
-
-    const input = screen.getByLabelText('Add New Software');
-    const saveButton = screen.getByRole('button', { name: 'Add Software' });
-
-    await userEvent.type(input, 'Newly Added Software');
-    await userEvent.click(saveButton);
-
-    // Verify data was reloaded and new item is visible
-    await waitFor(() => {
-      expect(screen.getByText('Newly Added Software')).toBeInTheDocument();
-    });
-    expect(getBankruptcySoftwareListSpy).toHaveBeenCalledTimes(2);
-  });
-
-  test('should show confirmation dialog when delete button is clicked', async () => {
-    // Mock window.confirm
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
-
-    renderComponent();
-
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    const deleteButton = screen.getByTestId('button-delete-button-1');
-    await userEvent.click(deleteButton);
-
-    expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to delete NextChapter?');
-
-    confirmSpy.mockRestore();
-  });
-
-  test('should delete software successfully when confirmed', async () => {
-    const globalAlertSpy = TestingUtilities.spyOnGlobalAlert();
-    const deleteSpy = vi.spyOn(Api2, 'deleteBankruptcySoftware').mockResolvedValue();
-    const getBankruptcySoftwareListSpy = vi.spyOn(Api2, 'getBankruptcySoftwareList');
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-
-    renderComponent();
-
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    const deleteButton = screen.getByTestId('button-delete-button-1');
-    await userEvent.click(deleteButton);
-
-    expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to delete NextChapter?');
-    expect(deleteSpy).toHaveBeenCalledWith('1');
-    expect(globalAlertSpy.success).toHaveBeenCalledWith(
-      'Bankruptcy software deleted successfully.',
-    );
-    expect(getBankruptcySoftwareListSpy).toHaveBeenCalledTimes(2); // Initial load + reload after delete
-
-    confirmSpy.mockRestore();
-  });
-
-  test('should handle delete API error gracefully', async () => {
-    const globalAlertSpy = TestingUtilities.spyOnGlobalAlert();
-    const deleteSpy = vi
-      .spyOn(Api2, 'deleteBankruptcySoftware')
-      .mockRejectedValue(new Error('Network error'));
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-
-    renderComponent();
-
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-
-    const deleteButton = screen.getByTestId('button-delete-button-1');
-    await userEvent.click(deleteButton);
-
-    expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to delete NextChapter?');
-    expect(deleteSpy).toHaveBeenCalledWith('1');
-    expect(globalAlertSpy.warning).toHaveBeenCalledWith(
-      'Failed to delete bankruptcy software. Network error',
-    );
-
-    confirmSpy.mockRestore();
   });
 });

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.tsx
@@ -1,146 +1,97 @@
 import './BankruptcySoftware.scss';
-import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
-import Button, { ButtonRef, UswdsButtonStyle } from '@/lib/components/uswds/Button';
-import Input from '@/lib/components/uswds/Input';
+import { useEffect, useRef, useState } from 'react';
 import Api2 from '@/lib/models/api2';
-import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
-import { InputRef } from '@/lib/type-declarations/input-fields';
-import { BankruptcySoftwareList, BankruptcySoftwareListItem } from '@common/cams/lists';
-import React, { useEffect, useRef, useState } from 'react';
-import { Creatable } from '@common/cams/creatable';
+import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
+import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
+import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import {
+  CamsTable,
+  CamsTableHeader,
+  CamsTableHeaderCell,
+  CamsTableBody,
+  CamsTableRow,
+  CamsTableCell,
+} from '@/lib/components/cams/CamsTable';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import { AddSoftwareModal, AddSoftwareModalRef } from './AddSoftwareModal';
 
 export function BankruptcySoftware() {
-  const alert = useGlobalAlert();
-
   const [isLoaded, setIsLoaded] = useState(false);
-  const [softwareList, setSoftwareList] = useState<BankruptcySoftwareList>([]);
-  const [newSoftwareName, setNewSoftwareName] = useState<string>('');
+  const [softwareList, setSoftwareList] = useState<BankruptcySoftwareProfile[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
-  const softwareInputRef = useRef<InputRef>(null);
-  const saveButtonRef = useRef<ButtonRef>(null);
-
-  function handleSoftwareNameChange(ev: React.ChangeEvent<HTMLInputElement>) {
-    setNewSoftwareName(ev.target.value);
-  }
-
-  async function handleSave() {
-    const trimmedName = newSoftwareName.trim();
-
-    if (trimmedName.length === 0) {
-      alert?.warning('Software name cannot be empty.');
-      return;
-    }
-
-    const payload: Creatable<BankruptcySoftwareListItem> = {
-      list: 'bankruptcy-software' as const,
-      key: trimmedName,
-      value: trimmedName,
-    };
-
-    try {
-      await Api2.postBankruptcySoftware(payload);
-      alert?.success('Bankruptcy software added successfully.');
-      setNewSoftwareName('');
-      loadSoftwareList();
-    } catch (error) {
-      alert?.warning(`Failed to add bankruptcy software. ${(error as Error).message}`);
-    }
-  }
-
-  function isSavable() {
-    return newSoftwareName.trim().length > 0;
-  }
-
-  async function handleDelete(software: BankruptcySoftwareListItem) {
-    const confirmed = window.confirm(`Are you sure you want to delete ${software.value}?`);
-    if (!confirmed) {
-      return;
-    }
-
-    try {
-      await Api2.deleteBankruptcySoftware(software._id);
-      alert?.success('Bankruptcy software deleted successfully.');
-      loadSoftwareList();
-    } catch (error) {
-      alert?.warning(`Failed to delete bankruptcy software. ${(error as Error).message}`);
-    }
-  }
+  const addSoftwareModalRef = useRef<AddSoftwareModalRef>(null);
 
   async function loadSoftwareList() {
     try {
-      const response = await Api2.getBankruptcySoftwareList();
-      setSoftwareList(response.data as BankruptcySoftwareList);
+      const response = await Api2.getSoftwareList();
+      setSoftwareList(response.data as BankruptcySoftwareProfile[]);
+      setLoadError(null);
     } catch (error) {
-      alert?.warning(`Failed to load bankruptcy software list. ${(error as Error).message}`);
+      setLoadError((error as Error).message);
     }
   }
 
   useEffect(() => {
     setIsLoaded(false);
-    loadSoftwareList().then(() => {
-      setIsLoaded(true);
-    });
+    loadSoftwareList().then(() => setIsLoaded(true));
   }, []);
+
+  function handleSoftwareAdded(software: BankruptcySoftwareProfile) {
+    setSoftwareList((prev) => [...prev, software].sort((a, b) => a.name.localeCompare(b.name)));
+    getAppInsights().appInsights.trackEvent({
+      name: 'Bankruptcy Software Created',
+      properties: { softwareId: software.id, softwareName: software.name },
+    });
+  }
 
   return (
     <div className="bankruptcy-software-admin-panel" data-testid="bankruptcy-software-panel">
-      <h2>Bankruptcy Software</h2>
-      {!isLoaded && <LoadingSpinner caption="Loading..."></LoadingSpinner>}
-      {isLoaded && (
-        <div className="bankruptcy-software-form">
+      <h2 className="screen-reader-only">Bankruptcy Software</h2>
+      {!isLoaded && <LoadingSpinner caption="Loading..." />}
+      {isLoaded && loadError && (
+        <Alert
+          id="bankruptcy-software-load-error"
+          message={`Failed to load bankruptcy software. ${loadError}`}
+          type={UswdsAlertStyle.Error}
+          show={true}
+        />
+      )}
+      {isLoaded && !loadError && (
+        <>
           <div className="grid-row">
             <div className="grid-col-12">
-              <h3>Current Software Options</h3>
-              {softwareList.length === 0 ? (
-                <p>No bankruptcy software options are currently configured.</p>
-              ) : (
-                <ul className="software-list" data-testid="software-list">
-                  {softwareList.map((software) => (
-                    <li key={software._id} data-testid={`software-item-${software._id}`}>
-                      <span>{software.value}</span>
-                      <Button
-                        id={`delete-button-${software._id}`}
-                        data-testid={`delete-button-${software._id}`}
-                        uswdsStyle={UswdsButtonStyle.Outline}
-                        onClick={() => handleDelete(software)}
-                      >
-                        Delete
-                      </Button>
-                    </li>
-                  ))}
-                </ul>
-              )}
+              <Button
+                id="add-software-button"
+                uswdsStyle={UswdsButtonStyle.Default}
+                onClick={() => addSoftwareModalRef.current?.show()}
+              >
+                + Add Software
+              </Button>
             </div>
           </div>
-          <div className="grid-row">
-            <div className="grid-col-6">
-              <Input
-                id="new-software-name"
-                label="Add New Software"
-                value={newSoftwareName}
-                onChange={handleSoftwareNameChange}
-                autoComplete="off"
-                ref={softwareInputRef}
-              ></Input>
-            </div>
+          <div className="bankruptcy-software-table-container">
+            <CamsTable aria-label="Bankruptcy Software" data-testid="bankruptcy-software-table">
+              <CamsTableHeader>
+                <CamsTableHeaderCell>Software Name</CamsTableHeaderCell>
+              </CamsTableHeader>
+              <CamsTableBody>
+                {softwareList.map((software) => (
+                  <CamsTableRow key={software.id}>
+                    <CamsTableCell>{software.name}</CamsTableCell>
+                  </CamsTableRow>
+                ))}
+              </CamsTableBody>
+            </CamsTable>
           </div>
-          <div className="grid-row">
-            <div className="button-bar grid-col-6">
-              <div className="save-button button-container">
-                <Button
-                  id="save-button"
-                  uswdsStyle={UswdsButtonStyle.Default}
-                  onClick={handleSave}
-                  disabled={!isSavable()}
-                  ref={saveButtonRef}
-                >
-                  Add Software
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
+        </>
       )}
+      <AddSoftwareModal
+        ref={addSoftwareModalRef}
+        modalId="add-software-modal"
+        onSuccess={handleSoftwareAdded}
+      />
     </div>
   );
 }

--- a/user-interface/src/lib/models/api2.test.ts
+++ b/user-interface/src/lib/models/api2.test.ts
@@ -12,9 +12,7 @@ import {
 } from '@common/cams/orders';
 import LocalStorage from '@/lib/utils/local-storage';
 import { blankConfiguration } from '../testing/mock-configuration';
-import { BankruptcySoftwareListItem } from '@common/cams/lists';
 import { BankProfile } from '@common/cams/banks';
-import { Creatable } from '@common/cams/creatable';
 
 type ApiType = {
   addApiBeforeHook: typeof addApiBeforeHook;
@@ -104,7 +102,7 @@ describe('_Api2 functions', async () => {
     await callApiFunction(api2.default.getTrusteeAppointments, 'some-id', api);
     await callApiFunction(api2.default.getTrusteeOversightAssignments, 'some-id', api);
     await callApiFunction(api2.default.getBanks, null, api);
-    await callApiFunction(api2.default.getBankruptcySoftwareList, null, api);
+    await callApiFunction(api2.default.getSoftwareList, null, api);
   });
 
   test('should call api.put function when calling putPrivilegedIdentityUser', () => {
@@ -338,7 +336,7 @@ describe('_Api2 functions', async () => {
       ),
     ).rejects.toThrow(error);
     await expect(api2.default.getBanks()).rejects.toThrow(error);
-    await expect(api2.default.getBankruptcySoftwareList()).rejects.toThrow(error);
+    await expect(api2.default.getSoftwareList()).rejects.toThrow(error);
     const mockOrder = MockData.getConsolidationOrder();
     await expect(
       api2.default.putConsolidationOrderApproval({
@@ -470,10 +468,18 @@ describe('_Api2 functions', async () => {
     );
   });
 
-  test('should call api.get function when calling getBankruptcySoftwareList', () => {
-    const getSpy = vi.spyOn(api.default, 'get').mockResolvedValue({ data: { items: [] } });
-    api2.default.getBankruptcySoftwareList();
-    expect(getSpy).toHaveBeenCalledWith('/lists/bankruptcy-software', {});
+  test('should call api.get function when calling getSoftwareList', () => {
+    const getSpy = vi.spyOn(api.default, 'get').mockResolvedValue({ data: [] });
+    api2.default.getSoftwareList();
+    expect(getSpy).toHaveBeenCalledWith('/bankruptcy-software', {});
+  });
+
+  test('should call api.post function when calling createSoftware', () => {
+    const postSpy = vi
+      .spyOn(api.default, 'post')
+      .mockResolvedValue({ data: { id: 'software-id' } });
+    api2.default.createSoftware({ name: 'Test Software' });
+    expect(postSpy).toHaveBeenCalledWith('/bankruptcy-software', { name: 'Test Software' }, {});
   });
 
   test('should call api.get function when calling getBanks', () => {
@@ -502,25 +508,6 @@ describe('_Api2 functions', async () => {
     expect(putSpy).toHaveBeenCalledWith('/banks/bank-1', update, {});
   });
 
-  test('should call api.post function when calling postBankruptcySoftware', () => {
-    const postSpy = vi
-      .spyOn(api.default, 'post')
-      .mockResolvedValue({ data: { id: 'software-id' } });
-    const softwareItem: Creatable<BankruptcySoftwareListItem> = {
-      list: 'bankruptcy-software',
-      key: 'Test Software',
-      value: 'Test Software',
-    };
-    api2.default.postBankruptcySoftware(softwareItem);
-    expect(postSpy).toHaveBeenCalledWith('/lists/bankruptcy-software', softwareItem, {});
-  });
-
-  test('should call api.delete function when calling deleteBankruptcySoftware', () => {
-    const deleteSpy = vi.spyOn(api.default, 'delete').mockResolvedValue({ data: null });
-    const softwareId = 'software-id';
-    api2.default.deleteBankruptcySoftware(softwareId);
-    expect(deleteSpy).toHaveBeenCalledWith(`/lists/bankruptcy-software/${softwareId}`, {});
-  });
 
   test('should call api.get when calling getTrusteeNotes', () => {
     const getSpy = vi.spyOn(api.default, 'get').mockResolvedValue({ data: [] });

--- a/user-interface/src/lib/models/api2.test.ts
+++ b/user-interface/src/lib/models/api2.test.ts
@@ -508,7 +508,6 @@ describe('_Api2 functions', async () => {
     expect(putSpy).toHaveBeenCalledWith('/banks/bank-1', update, {});
   });
 
-
   test('should call api.get when calling getTrusteeNotes', () => {
     const getSpy = vi.spyOn(api.default, 'get').mockResolvedValue({ data: [] });
     const trusteeId = 'trustee-id';

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -54,9 +54,8 @@ import { TrusteeAssistant, TrusteeAssistantInput } from '@common/cams/trustee-as
 import { TrusteeNote, TrusteeNoteInput } from '@common/cams/trustee-notes';
 import { TrusteeSearchResult } from '@common/cams/trustee-search';
 import { OversightRoleType } from '@common/cams/roles';
-import { BankruptcySoftwareList, BankruptcySoftwareListItem } from '@common/cams/lists';
 import { BankProfile } from '@common/cams/banks';
-import { Creatable } from '@common/cams/creatable';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 import {
   TrusteeUpcomingKeyDates,
   TrusteeUpcomingKeyDatesInput,
@@ -530,18 +529,6 @@ async function deletePrivilegedIdentityUser(userId: string) {
   await api().delete(`/dev-tools/privileged-identity/${userId}`);
 }
 
-async function getBankruptcySoftwareList() {
-  return api().get<BankruptcySoftwareList>('/lists/bankruptcy-software');
-}
-
-async function postBankruptcySoftware(item: Creatable<BankruptcySoftwareListItem>) {
-  return api().post('/lists/bankruptcy-software', item);
-}
-
-async function deleteBankruptcySoftware(id: string) {
-  return api().delete(`/lists/bankruptcy-software/${id}`);
-}
-
 async function getBanks() {
   return api().get<BankProfile[]>('/banks');
 }
@@ -556,6 +543,14 @@ async function getBank(bankId: string) {
 
 async function updateBank(bankId: string, data: Pick<BankProfile, 'name' | 'status'>) {
   return api().put<BankProfile>(`/banks/${bankId}`, data);
+}
+
+async function getSoftwareList() {
+  return api().get<BankruptcySoftwareProfile[]>('/bankruptcy-software');
+}
+
+async function createSoftware(data: { name: string }) {
+  return api().post('/bankruptcy-software', data);
 }
 
 async function getCaseTrusteeAppointment(caseId: string) {
@@ -656,9 +651,8 @@ export const _Api2 = {
   getBank,
   createBank,
   updateBank,
-  getBankruptcySoftwareList,
-  postBankruptcySoftware,
-  deleteBankruptcySoftware,
+  getSoftwareList,
+  createSoftware,
   getOversightStaff,
   postCaseReload,
   getCaseTrusteeAppointment,

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -550,7 +550,7 @@ async function getSoftwareList() {
 }
 
 async function createSoftware(data: { name: string }) {
-  return api().post('/bankruptcy-software', data);
+  return api().post<BankruptcySoftwareProfile, { name: string }>('/bankruptcy-software', data);
 }
 
 async function getCaseTrusteeAppointment(caseId: string) {

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -43,8 +43,6 @@ import { TrusteeAssistant, TrusteeAssistantInput } from '@common/cams/trustee-as
 import { TrusteeNote, TrusteeNoteInput } from '@common/cams/trustee-notes';
 import { TrusteeSearchResult } from '@common/cams/trustee-search';
 import { TrusteeUpcomingKeyDates } from '@common/cams/trustee-upcoming-key-dates';
-import { Creatable } from '@common/cams/creatable';
-import { BankruptcySoftwareListItem } from '@common/cams/lists';
 import { BankProfile } from '@common/cams/banks';
 import { CamsRole, OversightRoleType } from '@common/cams/roles';
 
@@ -2776,37 +2774,52 @@ async function deleteTrusteeAssistant(_trusteeId: string, _assistantId: string) 
   return;
 }
 
-async function getBankruptcySoftwareList() {
+async function getSoftwareList() {
+  const mockUser = { id: 'system', name: 'System' };
+  const now = new Date().toISOString();
   return {
     data: [
       {
-        _id: '1',
-        list: 'bankruptcy-software',
-        key: 'Axos',
-        value: 'Axos',
+        id: '1',
+        documentType: 'BANKRUPTCY_SOFTWARE' as const,
+        name: 'Axos',
+        status: 'active' as const,
+        updatedOn: now,
+        updatedBy: mockUser,
       },
       {
-        _id: '2',
-        list: 'bankruptcy-software',
-        key: 'BlueStylus',
-        value: 'BlueStylus',
+        id: '2',
+        documentType: 'BANKRUPTCY_SOFTWARE' as const,
+        name: 'BlueStylus',
+        status: 'active' as const,
+        updatedOn: now,
+        updatedBy: mockUser,
       },
       {
-        _id: '3',
-        list: 'bankruptcy-software',
-        key: 'Epiq',
-        value: 'Epiq',
+        id: '3',
+        documentType: 'BANKRUPTCY_SOFTWARE' as const,
+        name: 'Epiq',
+        status: 'active' as const,
+        updatedOn: now,
+        updatedBy: mockUser,
       },
     ],
   };
 }
 
-async function postBankruptcySoftware(_ignore: Creatable<BankruptcySoftwareListItem>) {
-  return '--id--';
-}
-
-async function deleteBankruptcySoftware(_ignore: string) {
-  return;
+async function createSoftware(data: { name: string }) {
+  const mockUser = { id: 'system', name: 'System' };
+  const now = new Date().toISOString();
+  return {
+    data: {
+      id: crypto.randomUUID(),
+      documentType: 'BANKRUPTCY_SOFTWARE' as const,
+      name: data.name,
+      status: 'active' as const,
+      updatedOn: now,
+      updatedBy: mockUser,
+    },
+  };
 }
 
 async function getBanks() {
@@ -3006,13 +3019,12 @@ const MockApi2 = {
   putConsolidationOrderRejection,
   putPrivilegedIdentityUser,
   searchCases,
-  getBankruptcySoftwareList,
-  postBankruptcySoftware,
-  deleteBankruptcySoftware,
   createBank,
   getBanks,
   getBank,
   updateBank,
+  getSoftwareList,
+  createSoftware,
   getUpcomingKeyDates,
   putUpcomingKeyDates,
   getTrusteeOversightAssignments,

--- a/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
@@ -379,7 +379,7 @@ describe('TrusteeDetailScreen', () => {
   test('should fetch software options from API on component mount', async () => {
     vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
     vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
-    const getBankruptcySoftwareListSpy = vi.spyOn(Api2, 'getBankruptcySoftwareList');
+    const getSoftwareListSpy = vi.spyOn(Api2, 'getSoftwareList');
 
     renderWithRouter();
 
@@ -387,7 +387,7 @@ describe('TrusteeDetailScreen', () => {
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('John Doe');
     });
 
-    expect(getBankruptcySoftwareListSpy).toHaveBeenCalled();
+    expect(getSoftwareListSpy).toHaveBeenCalled();
   });
 
   test('should handle software options API error and log error message', async () => {
@@ -395,8 +395,8 @@ describe('TrusteeDetailScreen', () => {
 
     vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
     vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
-    const getBankruptcySoftwareListSpy = vi
-      .spyOn(Api2, 'getBankruptcySoftwareList')
+    const getSoftwareListSpy = vi
+      .spyOn(Api2, 'getSoftwareList')
       .mockRejectedValue(new Error('Software API error'));
 
     renderWithRouter();
@@ -405,7 +405,7 @@ describe('TrusteeDetailScreen', () => {
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('John Doe');
     });
 
-    expect(getBankruptcySoftwareListSpy).toHaveBeenCalled();
+    expect(getSoftwareListSpy).toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(
       'Failed to fetch software options',
       'Software API error',
@@ -417,9 +417,7 @@ describe('TrusteeDetailScreen', () => {
   test('should handle software options API returning response without data property', async () => {
     vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
     vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
-    const getBankruptcySoftwareListSpy = vi
-      .spyOn(Api2, 'getBankruptcySoftwareList')
-      .mockResolvedValue({ data: [] });
+    const getSoftwareListSpy = vi.spyOn(Api2, 'getSoftwareList').mockResolvedValue({ data: [] });
 
     renderWithRouter();
 
@@ -427,7 +425,50 @@ describe('TrusteeDetailScreen', () => {
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('John Doe');
     });
 
-    expect(getBankruptcySoftwareListSpy).toHaveBeenCalled();
+    expect(getSoftwareListSpy).toHaveBeenCalled();
+  });
+
+  test('should transform software list correctly', async () => {
+    const mockSoftwareData = [
+      {
+        id: '1',
+        documentType: 'BANKRUPTCY_SOFTWARE' as const,
+        name: 'Alpha Software',
+        status: 'active' as const,
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      },
+      {
+        id: '2',
+        documentType: 'BANKRUPTCY_SOFTWARE' as const,
+        name: 'Beta Platform',
+        status: 'active' as const,
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      },
+      {
+        id: '3',
+        documentType: 'BANKRUPTCY_SOFTWARE' as const,
+        name: 'Gamma System',
+        status: 'active' as const,
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      },
+    ];
+
+    vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
+    vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
+    const getSoftwareListSpy = vi
+      .spyOn(Api2, 'getSoftwareList')
+      .mockResolvedValue({ data: mockSoftwareData });
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('John Doe');
+    });
+
+    expect(getSoftwareListSpy).toHaveBeenCalled();
   });
 
   test('should navigate to assistant create route when assistant button is clicked and no assistant exists', async () => {

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -18,7 +18,7 @@ import { GoHome } from '@/lib/components/GoHome';
 import TrusteeAssignedStaff from './panels/TrusteeAssignedStaff';
 import TrusteeAppointments from './panels/TrusteeAppointments';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
-import { BankruptcySoftwareList } from '@common/cams/lists';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 import TrusteePublicContactForm from './forms/TrusteePublicContactForm';
 import TrusteeInternalContactForm from './forms/TrusteeInternalContactForm';
 import TrusteeAssistantForm from './forms/TrusteeAssistantForm';
@@ -49,10 +49,10 @@ function TrusteeHeader({ trustee, isLoading, subHeading, children }: TrusteeHead
   );
 }
 
-const transformSoftwareList = (items: BankruptcySoftwareList): ComboOption[] => {
-  return items.map((item: { key: string; value: string }) => ({
-    value: item.key,
-    label: item.value,
+const transformSoftwareList = (items: BankruptcySoftwareProfile[]): ComboOption[] => {
+  return items.map((item) => ({
+    value: item.name,
+    label: item.name,
   }));
 };
 
@@ -95,9 +95,11 @@ export default function TrusteeDetailScreen() {
   useEffect(() => {
     const fetchSoftwareOptions = async () => {
       try {
-        const response = await Api2.getBankruptcySoftwareList();
+        const response = await Api2.getSoftwareList();
         if (response?.data) {
-          const transformedOptions = transformSoftwareList(response.data as BankruptcySoftwareList);
+          const transformedOptions = transformSoftwareList(
+            response.data as BankruptcySoftwareProfile[],
+          );
           setSoftwareOptions(transformedOptions);
         }
       } catch (e) {

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -296,10 +296,7 @@ export default function TrusteesList() {
     return getDistrictDivisionComboOptions(allCourts) as ComboOption[];
   }, [allCourts, districtDivisionEnabled]);
 
-  const divisionFilterMap = useMemo(
-    () => buildDivisionFilterMap(selectedDivisions),
-    [selectedDivisions],
-  );
+  const divisionFilterMap = buildDivisionFilterMap(selectedDivisions);
 
   // Announce on district/chapter/division filter changes after first expand
   useEffect(() => {


### PR DESCRIPTION
# Purpose

Replace the legacy bankruptcy software admin feature — which stored vendors as generic key/value entries in the shared `lists` collection — with a first-class `bankruptcy-software` entity following the same dedicated pattern established for banks in CAMS-670.

# Major Changes

- **Common types**: `BankruptcySoftwareProfile` and `BankruptcySoftwareAuditHistory` with `documentType` discriminators
- **Full backend stack**: dedicated MongoDB repository, use case, controller, and Azure Function at route `bankruptcy-software/`; all layers require `CamsRole.SuperUser`
- **Old lists endpoints removed**: `POST /lists/bankruptcy-software` and `DELETE /lists/bankruptcy-software/:id` removed from controller, use case, and repository; `GET` kept temporarily for migration verification
- **UI rewrite**: `BankruptcySoftware.tsx` replaced with a `CamsTable`-based list; new `AddSoftwareModal.tsx` using imperative ref pattern matching `AddBankModal`
- **Api2 updated**: old `getBankruptcySoftwareList`/`postBankruptcySoftware`/`deleteBankruptcySoftware` replaced with `getSoftwareList`/`createSoftware`
- **Feature flag**: Bankruptcy Software nav item gated behind `TRUSTEE_SOFTWARE_BANK_DISPLAY`
- **Data migration script**: `ops/migrations/CAMS-669-migrate-bankruptcy-software.ts` — idempotent, uses CAMS factory/repository pattern, writes audit records via `SYSTEM_USER_REFERENCE`

# Testing/Validation

Implemented using TDD. All unit tests pass across backend layers (repository, use case, controller, Azure Function) and frontend (component, modal, Api2). `TrusteeDetailScreen` updated to consume new API. No regressions to Banks, Privileged Identity, or Case Reload features.

# Notes

- Software name links (clickable rows → detail page) are intentionally plain text in this slice, matching the banks precedent. Links will be added in Slice 2 when the detail page exists.
- `GET /lists/bankruptcy-software` is left in place deliberately — it serves as a verification point after running the data migration script in each environment. It will be removed in a follow-up once production migration is confirmed.
- The migration script must be run before or at deploy time to copy existing vendor names from the `lists` collection into the new `bankruptcy-software` collection.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce a dedicated bankruptcy software entity and API, replacing legacy list-based storage, and update the admin UI and trustee workflows to use the new endpoints with feature-flagged navigation and supporting migration tooling.

New Features:
- Add dedicated bankruptcy software domain types, repository, use case, controller, and Azure Function endpoint for managing software profiles with audit history.
- Introduce a new CamsTable-based admin UI and modal workflow for viewing and creating bankruptcy software entries via the new Api2 methods.
- Add a feature flag to control visibility of the Bankruptcy Software admin navigation entry and update trustee detail screens to consume the new software list API.

Enhancements:
- Refactor existing lists infrastructure and tests to remove create/delete bankruptcy software responsibilities now handled by the dedicated entity.
- Extend shared testing and mock API utilities to support the new bankruptcy software endpoints and data shapes.

Tests:
- Add comprehensive backend and frontend tests for the new bankruptcy software controller, repository, use case, Azure Function, admin UI, modal flow, and trustee software transformations.
- Add an idempotent migration script to populate the new bankruptcy software collection from legacy list entries while creating corresponding audit records.