### PR TITLE
CAMS-669 Slice 2: Bankruptcy software vendor detail, edit, and contact info

### DIFF
--- a/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
+++ b/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
@@ -29,8 +29,8 @@ export default async function handler(
 }
 
 app.http('bankruptcy-software', {
-  methods: ['GET', 'POST'],
+  methods: ['GET', 'POST', 'PUT'],
   authLevel: 'anonymous',
   handler,
-  route: 'bankruptcy-software',
+  route: 'bankruptcy-software/{softwareId?}',
 });

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.test.ts
@@ -173,6 +173,82 @@ describe('BankruptcySoftwareMongoRepository', () => {
     });
   });
 
+  describe('findSoftwareById', () => {
+    test('should return the software by id', async () => {
+      const software: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockResolvedValue(software);
+
+      const result = await repo.findSoftwareById('sw-1');
+
+      expect(result).toEqual(software);
+    });
+
+    test('should throw CamsError when findOne fails', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockRejectedValue(
+        new Error('not found'),
+      );
+
+      await expect(repo.findSoftwareById('sw-1')).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to retrieve bankruptcy software.',
+          status: 500,
+          module: 'BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
+  describe('updateSoftware', () => {
+    test('should replace document and return the updated software', async () => {
+      const updated: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos Updated',
+        status: 'active',
+        updatedOn: '2024-01-02T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const replaceSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')
+        .mockResolvedValue({ id: 'sw-1', modifiedCount: 1, upsertedCount: 0 });
+
+      const result = await repo.updateSoftware('sw-1', updated);
+
+      expect(replaceSpy).toHaveBeenCalled();
+      expect(result).toEqual(updated);
+    });
+
+    test('should throw CamsError when replaceOne fails', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'replaceOne').mockRejectedValue(
+        new Error('write error'),
+      );
+
+      await expect(
+        repo.updateSoftware('sw-1', {
+          id: 'sw-1',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'Axos',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        }),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to update bankruptcy software.',
+          status: 500,
+          module: 'BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
   describe('singleton lifecycle', () => {
     test('should return same instance on multiple getInstance calls', async () => {
       const context2 = await createMockApplicationContext();

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
@@ -60,6 +60,28 @@ export class BankruptcySoftwareMongoRepository
     }
   }
 
+  async findSoftwareById(id: string): Promise<BankruptcySoftwareProfile> {
+    const query = doc('id').equals(id);
+    try {
+      return await this.getAdapter<BankruptcySoftwareProfile>().findOne(query);
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve bankruptcy software.');
+    }
+  }
+
+  async updateSoftware(
+    id: string,
+    update: BankruptcySoftwareProfile,
+  ): Promise<BankruptcySoftwareProfile> {
+    const query = doc('id').equals(id);
+    try {
+      await this.getAdapter<BankruptcySoftwareProfile>().replaceOne(query, update);
+      return update;
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to update bankruptcy software.');
+    }
+  }
+
   async createSoftware(
     software: Creatable<BankruptcySoftwareProfile>,
   ): Promise<BankruptcySoftwareProfile> {

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
@@ -43,10 +43,22 @@ describe('BankruptcySoftwareController', () => {
   });
 
   describe('handleRequest', () => {
-    test('should route GET to handleGet', async () => {
+    test('should route GET (no id) to handleGet', async () => {
       context.request.method = 'GET';
       vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftwareList').mockResolvedValue(
         mockSoftware,
+      );
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(200);
+    });
+
+    test('should route GET with softwareId to handleGetOne', async () => {
+      context.request.method = 'GET';
+      context.request.params = { softwareId: 'sw-1' };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftware').mockResolvedValue(
+        mockSoftware[0],
       );
 
       const result = await controller.handleRequest(context);
@@ -66,12 +78,101 @@ describe('BankruptcySoftwareController', () => {
       expect(result.statusCode).toBe(201);
     });
 
+    test('should route PUT with softwareId to handlePut', async () => {
+      context.request.method = 'PUT';
+      context.request.params = { softwareId: 'sw-1' };
+      context.request.body = { name: 'Updated Name' };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'updateSoftware').mockResolvedValue(
+        createdSoftware,
+      );
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(200);
+    });
+
     test('should return 405 for unsupported method', async () => {
       context.request.method = 'DELETE';
 
       const result = await controller.handleRequest(context);
 
       expect(result.statusCode).toBe(405);
+    });
+  });
+
+  describe('handleGetOne', () => {
+    test('should return 200 with full profile including contact for SuperUser', async () => {
+      const softwareWithContact = {
+        ...mockSoftware[0],
+        contact: { contactNames: ['Jane Doe'], emails: ['jane@axos.com'] },
+      };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftware').mockResolvedValue(
+        softwareWithContact,
+      );
+
+      const result = await controller.handleGetOne(context, 'sw-1');
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.data).toHaveProperty('contact');
+    });
+
+    test('should strip contact field for non-SuperUser', async () => {
+      context.session.user.roles = [CamsRole.TrialAttorney];
+      const softwareWithContact = {
+        ...mockSoftware[0],
+        contact: { contactNames: ['Jane Doe'] },
+      };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftware').mockResolvedValue(
+        softwareWithContact,
+      );
+
+      const result = await controller.handleGetOne(context, 'sw-1');
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.data).not.toHaveProperty('contact');
+    });
+  });
+
+  describe('handlePut', () => {
+    test('should return 200 with updated software for SuperUser', async () => {
+      context.request.params = { softwareId: 'sw-1' };
+      context.request.body = { name: 'Updated Name', status: 'inactive' };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'updateSoftware').mockResolvedValue(
+        createdSoftware,
+      );
+
+      const result = await controller.handlePut(context, 'sw-1');
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.data).toEqual(createdSoftware);
+    });
+
+    test('should throw ForbiddenError for non-SuperUser', async () => {
+      context.session.user.roles = [CamsRole.TrialAttorney];
+      context.request.body = { name: 'Updated' };
+
+      await expect(controller.handlePut(context, 'sw-1')).rejects.toThrow(
+        expect.objectContaining({ status: 403 }),
+      );
+    });
+
+    test('should throw BadRequestError when name is blank', async () => {
+      context.request.body = { name: '   ' };
+
+      await expect(controller.handlePut(context, 'sw-1')).rejects.toThrow(
+        expect.objectContaining({ status: 400 }),
+      );
+    });
+
+    test('should allow update with only contact field (no name validation)', async () => {
+      context.request.body = { contact: { emails: ['test@test.com'] } };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'updateSoftware').mockResolvedValue(
+        createdSoftware,
+      );
+
+      const result = await controller.handlePut(context, 'sw-1');
+
+      expect(result.statusCode).toBe(200);
     });
   });
 

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
@@ -24,12 +24,44 @@ export class BankruptcySoftwareController {
     | CamsHttpResponseInit<BankruptcySoftwareProfile[]>
   > {
     const { method } = context.request;
-    if (method === 'GET') {
-      return this.handleGet(context);
-    } else if (method === 'POST') {
-      return this.handlePost(context);
-    }
+    const softwareId = context.request.params?.softwareId;
+    if (method === 'GET' && softwareId) return this.handleGetOne(context, softwareId);
+    if (method === 'GET') return this.handleGet(context);
+    if (method === 'POST') return this.handlePost(context);
+    if (method === 'PUT' && softwareId) return this.handlePut(context, softwareId);
     return httpSuccess({ statusCode: HttpStatusCodes.METHOD_NOT_ALLOWED }) as CamsHttpResponseInit;
+  }
+
+  async handleGetOne(
+    context: ApplicationContext,
+    softwareId: string,
+  ): Promise<CamsHttpResponseInit<BankruptcySoftwareProfile>> {
+    const software = await this.useCase.getSoftware(softwareId);
+    const isSuperUser = context.session.user.roles?.includes(CamsRole.SuperUser);
+    const { contact: _contact, ...safeProfile } = software;
+    const responseData = isSuperUser ? software : safeProfile;
+    return httpSuccess({
+      statusCode: HttpStatusCodes.OK,
+      body: { meta: { self: context.request.url }, data: responseData },
+    });
+  }
+
+  async handlePut(
+    context: ApplicationContext,
+    softwareId: string,
+  ): Promise<CamsHttpResponseInit<BankruptcySoftwareProfile>> {
+    this.requireSuperUser(context);
+    const body = context.request.body as Partial<
+      Pick<BankruptcySoftwareProfile, 'name' | 'status' | 'contact'>
+    > | null;
+    if (body?.name !== undefined && !body.name.trim()) {
+      throw new BadRequestError(MODULE_NAME, { message: 'Software name is required.' });
+    }
+    const software = await this.useCase.updateSoftware(softwareId, body ?? {});
+    return httpSuccess({
+      statusCode: HttpStatusCodes.OK,
+      body: { meta: { self: context.request.url }, data: software },
+    });
   }
 
   async handleGet(

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -105,6 +105,17 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
+  findSoftwareById(_id: string): Promise<BankruptcySoftwareProfile> {
+    throw new Error('Method not implemented.');
+  }
+
+  updateSoftware(
+    _id: string,
+    _update: BankruptcySoftwareProfile,
+  ): Promise<BankruptcySoftwareProfile> {
+    throw new Error('Method not implemented.');
+  }
+
   createSoftwareAuditRecord(_history: Creatable<BankruptcySoftwareAuditHistory>): Promise<void> {
     throw new Error('Method not implemented.');
   }

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
@@ -49,6 +49,69 @@ describe('BankruptcySoftwareUseCase', () => {
     });
   });
 
+  describe('getSoftware', () => {
+    test('should return software by id from repository', async () => {
+      const software: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue(software);
+
+      const result = await useCase.getSoftware('sw-1');
+
+      expect(result).toEqual(software);
+    });
+  });
+
+  describe('updateSoftware', () => {
+    test('should fetch current, merge update, save, write audit record, and return updated', async () => {
+      const current: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankruptcySoftwareProfile = {
+        ...current,
+        name: 'Axos Renamed',
+        status: 'inactive',
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue(current);
+      const updateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'updateSoftware')
+        .mockResolvedValue(updated);
+      const auditSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord')
+        .mockResolvedValue();
+
+      const result = await useCase.updateSoftware('sw-1', {
+        name: 'Axos Renamed',
+        status: 'inactive',
+      });
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        'sw-1',
+        expect.objectContaining({ name: 'Axos Renamed', status: 'inactive' }),
+      );
+      expect(auditSpy).toHaveBeenCalledWith(
+        expect.objectContaining<Partial<BankruptcySoftwareAuditHistory>>({
+          documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+          softwareId: 'sw-1',
+          before: current,
+          after: updated,
+        }),
+      );
+      expect(result).toEqual(updated);
+    });
+  });
+
   describe('createSoftware', () => {
     test('should create software with status active and write audit record with before:null', async () => {
       const createdSoftware: BankruptcySoftwareProfile = {

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
@@ -22,6 +22,16 @@ describe('BankruptcySoftwareUseCase', () => {
   });
 
   describe('getSoftwareList', () => {
+    test('should throw CamsError when repository fails', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockRejectedValue(
+        new Error('db error'),
+      );
+
+      await expect(useCase.getSoftwareList()).rejects.toMatchObject({
+        message: 'Unable to retrieve bankruptcy software.',
+      });
+    });
+
     test('should return software from repository', async () => {
       const mockSoftware: BankruptcySoftwareProfile[] = [
         {
@@ -50,6 +60,16 @@ describe('BankruptcySoftwareUseCase', () => {
   });
 
   describe('getSoftware', () => {
+    test('should throw CamsError when repository fails', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockRejectedValue(
+        new Error('not found'),
+      );
+
+      await expect(useCase.getSoftware('sw-missing')).rejects.toMatchObject({
+        message: 'Unable to retrieve bankruptcy software.',
+      });
+    });
+
     test('should return software by id from repository', async () => {
       const software: BankruptcySoftwareProfile = {
         id: 'sw-1',
@@ -68,6 +88,16 @@ describe('BankruptcySoftwareUseCase', () => {
   });
 
   describe('updateSoftware', () => {
+    test('should throw CamsError when repository fails', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockRejectedValue(
+        new Error('db error'),
+      );
+
+      await expect(useCase.updateSoftware('sw-1', { name: 'New Name' })).rejects.toMatchObject({
+        message: 'Unable to update bankruptcy software.',
+      });
+    });
+
     test('should fetch current, merge update, save, write audit record, and return updated', async () => {
       const current: BankruptcySoftwareProfile = {
         id: 'sw-1',
@@ -113,6 +143,16 @@ describe('BankruptcySoftwareUseCase', () => {
   });
 
   describe('createSoftware', () => {
+    test('should throw CamsError when repository fails', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'createSoftware').mockRejectedValue(
+        new Error('db error'),
+      );
+
+      await expect(useCase.createSoftware({ name: 'TrustBooks' })).rejects.toMatchObject({
+        message: 'Unable to create bankruptcy software.',
+      });
+    });
+
     test('should create software with status active and write audit record with before:null', async () => {
       const createdSoftware: BankruptcySoftwareProfile = {
         id: 'sw-new',

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
@@ -24,6 +24,45 @@ export class BankruptcySoftwareUseCase {
     }
   }
 
+  async getSoftware(id: string): Promise<BankruptcySoftwareProfile> {
+    try {
+      return await this.repository.findSoftwareById(id);
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve bankruptcy software.');
+    }
+  }
+
+  async updateSoftware(
+    id: string,
+    update: Partial<Pick<BankruptcySoftwareProfile, 'name' | 'status' | 'contact'>>,
+  ): Promise<BankruptcySoftwareProfile> {
+    try {
+      const userRef = getCamsUserReference(this.context.session.user);
+      const current = await this.repository.findSoftwareById(id);
+      const merged: BankruptcySoftwareProfile = {
+        ...current,
+        ...update,
+        updatedBy: userRef,
+        updatedOn: new Date().toISOString(),
+      };
+      const updated = await this.repository.updateSoftware(id, merged);
+      await this.repository.createSoftwareAuditRecord(
+        createAuditRecord(
+          {
+            documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+            softwareId: id,
+            before: current,
+            after: updated,
+          },
+          userRef,
+        ),
+      );
+      return updated;
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to update bankruptcy software.');
+    }
+  }
+
   async createSoftware(input: { name: string }): Promise<BankruptcySoftwareProfile> {
     const userRef = getCamsUserReference(this.context.session.user);
 

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -305,9 +305,11 @@ export interface BanksRepository extends Releasable {
 
 export interface BankruptcySoftwareRepository extends Releasable {
   getSoftwareList(): Promise<BankruptcySoftwareProfile[]>;
+  findSoftwareById(id: string): Promise<BankruptcySoftwareProfile>;
   createSoftware(
     software: Creatable<BankruptcySoftwareProfile>,
   ): Promise<BankruptcySoftwareProfile>;
+  updateSoftware(id: string, update: BankruptcySoftwareProfile): Promise<BankruptcySoftwareProfile>;
   createSoftwareAuditRecord(history: Creatable<BankruptcySoftwareAuditHistory>): Promise<void>;
 }
 

--- a/common/src/cams/bankruptcy-software.ts
+++ b/common/src/cams/bankruptcy-software.ts
@@ -1,11 +1,21 @@
 import { Auditable } from './auditable';
 import { Identifiable } from './document';
+import { Address, PhoneNumber } from './contact';
+
+export type SoftwareContactInfo = {
+  contactNames?: string[];
+  address?: Partial<Address>;
+  phone?: Partial<PhoneNumber>;
+  emails?: string[];
+  website?: string;
+};
 
 export type BankruptcySoftwareProfile = Identifiable &
   Auditable & {
     documentType: 'BANKRUPTCY_SOFTWARE';
     name: string;
     status: 'active' | 'inactive';
+    contact?: SoftwareContactInfo;
   };
 
 export type BankruptcySoftwareAuditHistory = Identifiable &

--- a/common/src/cams/contact.ts
+++ b/common/src/cams/contact.ts
@@ -27,3 +27,11 @@ export type ContactInformation = {
   website?: string;
   companyName?: string;
 };
+
+export type ContactWithPartialPhoneAndAddress = Omit<
+  Partial<ContactInformation>,
+  'address' | 'phone'
+> & {
+  address?: Partial<Address>;
+  phone?: Partial<PhoneNumber>;
+};

--- a/user-interface/src/admin/AdminScreen.scss
+++ b/user-interface/src/admin/AdminScreen.scss
@@ -1,0 +1,5 @@
+.admin-screen {
+  .admin-nav-column {
+    display: flex;
+  }
+}

--- a/user-interface/src/admin/AdminScreen.tsx
+++ b/user-interface/src/admin/AdminScreen.tsx
@@ -1,3 +1,4 @@
+import './AdminScreen.scss';
 import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
 import AdminScreenNavigation, { AdminNavState } from './AdminScreenNavigation';
 import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
@@ -64,7 +65,7 @@ export function AdminScreen() {
                   </div>
                 </div>
                 <div className="grid-row grid-gap-lg">
-                  <div className="grid-col-2">
+                  <div className="grid-col-2 admin-nav-column">
                     <div className="left-navigation-pane-container">
                       <AdminScreenNavigation initiallySelectedNavLink={getInitialNavState()} />
                     </div>

--- a/user-interface/src/admin/AdminScreen.tsx
+++ b/user-interface/src/admin/AdminScreen.tsx
@@ -5,6 +5,7 @@ import LocalStorage from '@/lib/utils/local-storage';
 import { CamsRole } from '@common/cams/roles';
 import { PrivilegedIdentity } from './privileged-identity/PrivilegedIdentity';
 import { BankruptcySoftware } from './bankruptcy-software/BankruptcySoftware';
+import { BankruptcySoftwareDetail } from './bankruptcy-software/BankruptcySoftwareDetail';
 import { CaseReload } from './case-reload/CaseReload';
 import { Banks } from './banks/Banks';
 import { BankDetail } from './banks/BankDetail';
@@ -52,6 +53,7 @@ export function AdminScreen() {
       ) : (
         <Routes>
           <Route path="banks/:bankId/*" element={<BankDetail />} />
+          <Route path="bankruptcy-software/:softwareId/*" element={<BankruptcySoftwareDetail />} />
           <Route
             path="*"
             element={

--- a/user-interface/src/admin/AdminScreenNavigation.test.tsx
+++ b/user-interface/src/admin/AdminScreenNavigation.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import AdminScreenNavigation, { AdminNavState, setCurrentAdminNav } from './AdminScreenNavigation';
 import * as FeatureFlags from '@/lib/hooks/UseFeatureFlags';
-import { PRIVILEGED_IDENTITY_MANAGEMENT } from '@/lib/hooks/UseFeatureFlags';
+import {
+  PRIVILEGED_IDENTITY_MANAGEMENT,
+  TRUSTEE_SOFTWARE_BANK_DISPLAY,
+} from '@/lib/hooks/UseFeatureFlags';
 
 describe('Admin screen navigation tests', () => {
   beforeEach(async () => {
@@ -13,12 +17,16 @@ describe('Admin screen navigation tests', () => {
     vi.restoreAllMocks();
   });
 
-  function renderWithoutProps() {
+  function renderNav(initialNavState: AdminNavState = AdminNavState.PRIVILEGED_IDENTITY) {
     render(
       <BrowserRouter>
-        <AdminScreenNavigation initiallySelectedNavLink={AdminNavState.PRIVILEGED_IDENTITY} />
+        <AdminScreenNavigation initiallySelectedNavLink={initialNavState} />
       </BrowserRouter>,
     );
+  }
+
+  function renderWithoutProps() {
+    renderNav(AdminNavState.PRIVILEGED_IDENTITY);
   }
 
   test('should return the proper class name', async () => {
@@ -38,6 +46,68 @@ describe('Admin screen navigation tests', () => {
     expect(navLink).toHaveAttribute('href', '/admin/banks');
   });
 
+  test('should render Case Reload nav link', () => {
+    renderWithoutProps();
+    const navLink = screen.getByTestId('case-reload-nav-link');
+    expect(navLink).toBeInTheDocument();
+    expect(navLink).toHaveTextContent('Reload Case');
+    expect(navLink).toHaveAttribute('href', '/admin/case-reload');
+  });
+
+  test('should apply active class to initially selected nav link', () => {
+    renderNav(AdminNavState.BANKS);
+    expect(screen.getByTestId('banks-nav-link')).toHaveClass('usa-current');
+    expect(screen.getByTestId('case-reload-nav-link')).not.toHaveClass('usa-current');
+  });
+
+  test('should update active nav when Banks link is clicked', async () => {
+    renderWithoutProps();
+    await userEvent.click(screen.getByTestId('banks-nav-link'));
+    expect(screen.getByTestId('banks-nav-link')).toHaveClass('usa-current');
+  });
+
+  test('should update active nav when Case Reload link is clicked', async () => {
+    renderWithoutProps();
+    await userEvent.click(screen.getByTestId('case-reload-nav-link'));
+    expect(screen.getByTestId('case-reload-nav-link')).toHaveClass('usa-current');
+  });
+
+  describe('Feature flag tests for Bankruptcy Software nav link', () => {
+    test('should display Bankruptcy Software nav link when TRUSTEE_SOFTWARE_BANK_DISPLAY flag is true', () => {
+      vi.spyOn(FeatureFlags, 'default').mockReturnValue({
+        [TRUSTEE_SOFTWARE_BANK_DISPLAY]: true,
+      });
+
+      renderWithoutProps();
+
+      const navLink = screen.queryByTestId('bankruptcy-software-nav-link');
+      expect(navLink).toBeInTheDocument();
+      expect(navLink).toHaveTextContent('Bankruptcy Software');
+      expect(navLink).toHaveAttribute('href', '/admin/bankruptcy-software');
+    });
+
+    test('should not display Bankruptcy Software nav link when TRUSTEE_SOFTWARE_BANK_DISPLAY flag is false', () => {
+      vi.spyOn(FeatureFlags, 'default').mockReturnValue({
+        [TRUSTEE_SOFTWARE_BANK_DISPLAY]: false,
+      });
+
+      renderWithoutProps();
+
+      expect(screen.queryByTestId('bankruptcy-software-nav-link')).not.toBeInTheDocument();
+    });
+
+    test('should update active nav when Bankruptcy Software link is clicked', async () => {
+      vi.spyOn(FeatureFlags, 'default').mockReturnValue({
+        [TRUSTEE_SOFTWARE_BANK_DISPLAY]: true,
+      });
+
+      renderNav(AdminNavState.BANKS);
+      await userEvent.click(screen.getByTestId('bankruptcy-software-nav-link'));
+      expect(screen.getByTestId('bankruptcy-software-nav-link')).toHaveClass('usa-current');
+      expect(screen.getByTestId('banks-nav-link')).not.toHaveClass('usa-current');
+    });
+  });
+
   describe('Feature flag tests for Privileged Identity nav link', () => {
     test('should display Privileged Identity nav link when PRIVILEGED_IDENTITY_MANAGEMENT flag is true', () => {
       // Mock the feature flags to enable the PRIVILEGED_IDENTITY_MANAGEMENT flag
@@ -50,6 +120,17 @@ describe('Admin screen navigation tests', () => {
       const navLink = screen.queryByTestId('privileged-identity-nav-link');
       expect(navLink).toBeInTheDocument();
       expect(navLink).toHaveTextContent('Privileged Identity');
+    });
+
+    test('should update active nav when Privileged Identity link is clicked', async () => {
+      vi.spyOn(FeatureFlags, 'default').mockReturnValue({
+        [PRIVILEGED_IDENTITY_MANAGEMENT]: true,
+      });
+
+      renderNav(AdminNavState.BANKS);
+      await userEvent.click(screen.getByTestId('privileged-identity-nav-link'));
+      expect(screen.getByTestId('privileged-identity-nav-link')).toHaveClass('usa-current');
+      expect(screen.getByTestId('banks-nav-link')).not.toHaveClass('usa-current');
     });
 
     test('should not display Privileged Identity nav link when PRIVILEGED_IDENTITY_MANAGEMENT flag is false', () => {

--- a/user-interface/src/admin/AdminScreenNavigation.tsx
+++ b/user-interface/src/admin/AdminScreenNavigation.tsx
@@ -26,6 +26,22 @@ function AdminScreenNavigation(props: Readonly<AdminScreenNavigationProps>) {
   const [activeNav, setActiveNav] = useState<AdminNavState>(initiallySelectedNavLink);
   const flags = useFeatureFlags();
 
+  function handleNavPrivilegedIdentity() {
+    setActiveNav(AdminNavState.PRIVILEGED_IDENTITY);
+  }
+
+  function handleNavBankruptcySoftware() {
+    setActiveNav(AdminNavState.BANKRUPTCY_SOFTWARE);
+  }
+
+  function handleNavBanks() {
+    setActiveNav(AdminNavState.BANKS);
+  }
+
+  function handleNavCaseReload() {
+    setActiveNav(AdminNavState.CASE_RELOAD);
+  }
+
   return (
     <nav className={`admin-screen-navigation`} aria-label="Admin Side navigation" role="navigation">
       <ul className="usa-sidenav">
@@ -37,7 +53,7 @@ function AdminScreenNavigation(props: Readonly<AdminScreenNavigationProps>) {
               className={
                 'usa-nav-link ' + setCurrentAdminNav(activeNav, AdminNavState.PRIVILEGED_IDENTITY)
               }
-              onClick={() => setActiveNav(AdminNavState.PRIVILEGED_IDENTITY)}
+              onClick={handleNavPrivilegedIdentity}
               title="Manage privileged identity"
             >
               Privileged Identity
@@ -52,7 +68,7 @@ function AdminScreenNavigation(props: Readonly<AdminScreenNavigationProps>) {
               className={
                 'usa-nav-link ' + setCurrentAdminNav(activeNav, AdminNavState.BANKRUPTCY_SOFTWARE)
               }
-              onClick={() => setActiveNav(AdminNavState.BANKRUPTCY_SOFTWARE)}
+              onClick={handleNavBankruptcySoftware}
               title="Manage bankruptcy software"
             >
               Bankruptcy Software
@@ -64,7 +80,7 @@ function AdminScreenNavigation(props: Readonly<AdminScreenNavigationProps>) {
             to="/admin/banks"
             data-testid="banks-nav-link"
             className={'usa-nav-link ' + setCurrentAdminNav(activeNav, AdminNavState.BANKS)}
-            onClick={() => setActiveNav(AdminNavState.BANKS)}
+            onClick={handleNavBanks}
             title="Manage banks"
           >
             Banks
@@ -75,7 +91,7 @@ function AdminScreenNavigation(props: Readonly<AdminScreenNavigationProps>) {
             to="/admin/case-reload"
             data-testid="case-reload-nav-link"
             className={'usa-nav-link ' + setCurrentAdminNav(activeNav, AdminNavState.CASE_RELOAD)}
-            onClick={() => setActiveNav(AdminNavState.CASE_RELOAD)}
+            onClick={handleNavCaseReload}
             title="Manually reload cases from DXTR"
           >
             Reload Case

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.test.tsx
@@ -102,7 +102,7 @@ describe('BankruptcySoftware component', () => {
     });
   });
 
-  test('should render "+ Add Software" button', async () => {
+  test('should render "Add Software" button', async () => {
     renderComponent();
     await waitFor(() => {
       expect(screen.getByTestId('button-add-software-button')).toBeInTheDocument();
@@ -119,7 +119,7 @@ describe('BankruptcySoftware component', () => {
     });
   });
 
-  test('should call modal show() when + Add Software button is clicked', async () => {
+  test('should call modal show() when Add Software button is clicked', async () => {
     renderComponent();
     const btn = await screen.findByTestId('button-add-software-button');
     fireEvent.click(btn);

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.test.tsx
@@ -91,12 +91,14 @@ describe('BankruptcySoftware component', () => {
     });
   });
 
-  test('should render each software name as plain text', async () => {
+  test('should render each software name as a link to the detail page', async () => {
     renderComponent();
     await waitFor(() => {
-      expect(screen.getByText('Axos')).toBeInTheDocument();
-      expect(screen.getByText('BlueStylus')).toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'Axos' })).not.toBeInTheDocument();
+      const axosLink = screen.getByRole('link', { name: 'Axos' });
+      expect(axosLink).toBeInTheDocument();
+      expect(axosLink).toHaveAttribute('href', '/admin/bankruptcy-software/sw-1');
+      const blueStylusLink = screen.getByRole('link', { name: 'BlueStylus' });
+      expect(blueStylusLink).toHaveAttribute('href', '/admin/bankruptcy-software/sw-2');
     });
   });
 

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
+import Icon from '@/lib/components/uswds/Icon';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import {
   CamsTable,
@@ -68,7 +69,7 @@ export function BankruptcySoftware() {
                 uswdsStyle={UswdsButtonStyle.Default}
                 onClick={() => addSoftwareModalRef.current?.show()}
               >
-                + Add Software
+                <Icon name="add" /> Add Software
               </Button>
             </div>
           </div>

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.tsx
@@ -40,6 +40,10 @@ export function BankruptcySoftware() {
     loadSoftwareList().then(() => setIsLoaded(true));
   }, []);
 
+  function handleAddSoftwareClick() {
+    addSoftwareModalRef.current?.show();
+  }
+
   function handleSoftwareAdded(software: BankruptcySoftwareProfile) {
     setSoftwareList((prev) => [...prev, software].sort((a, b) => a.name.localeCompare(b.name)));
     getAppInsights().appInsights.trackEvent({
@@ -67,7 +71,7 @@ export function BankruptcySoftware() {
               <Button
                 id="add-software-button"
                 uswdsStyle={UswdsButtonStyle.Default}
-                onClick={() => addSoftwareModalRef.current?.show()}
+                onClick={handleAddSoftwareClick}
               >
                 <Icon name="add" /> Add Software
               </Button>

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.tsx
@@ -1,5 +1,6 @@
 import './BankruptcySoftware.scss';
 import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
@@ -79,7 +80,9 @@ export function BankruptcySoftware() {
               <CamsTableBody>
                 {softwareList.map((software) => (
                   <CamsTableRow key={software.id}>
-                    <CamsTableCell>{software.name}</CamsTableCell>
+                    <CamsTableCell>
+                      <Link to={`/admin/bankruptcy-software/${software.id}`}>{software.name}</Link>
+                    </CamsTableCell>
                   </CamsTableRow>
                 ))}
               </CamsTableBody>

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { BankruptcySoftwareDetail } from './BankruptcySoftwareDetail';
 import Api2 from '@/lib/models/api2';
@@ -70,6 +71,63 @@ describe('BankruptcySoftwareDetail', () => {
     await waitFor(() => {
       expect(screen.getByTestId('software-overview-nav-link')).toBeInTheDocument();
     });
+  });
+
+  test('should render contact info form at contact-info route', async () => {
+    render(
+      <MemoryRouter initialEntries={[`/admin/bankruptcy-software/sw-1/contact-info`]}>
+        <Routes>
+          <Route
+            path="/admin/bankruptcy-software/:softwareId/*"
+            element={<BankruptcySoftwareDetail />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('contact-info-form')).toBeInTheDocument();
+    });
+  });
+
+  test('should update software name when contact form calls onSaved', async () => {
+    const updatedSoftware: BankruptcySoftwareProfile = { ...mockSoftware, name: 'Axos Renamed' };
+    vi.spyOn(Api2, 'updateSoftware').mockResolvedValue({ data: updatedSoftware });
+
+    render(
+      <MemoryRouter initialEntries={[`/admin/bankruptcy-software/sw-1/contact-info`]}>
+        <Routes>
+          <Route
+            path="/admin/bankruptcy-software/:softwareId/*"
+            element={<BankruptcySoftwareDetail />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('contact-info-form')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId('button-save-contact-info'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Axos Renamed', level: 1 })).toBeInTheDocument();
+    });
+  });
+
+  test('should cancel fetch when component unmounts', async () => {
+    let resolvePromise: (value: { data: BankruptcySoftwareProfile }) => void;
+    vi.spyOn(Api2, 'getSoftware').mockReturnValue(
+      new Promise((resolve) => {
+        resolvePromise = resolve;
+      }),
+    );
+
+    const { unmount } = renderDetail();
+    unmount();
+    resolvePromise!({ data: mockSoftware });
+
+    expect(screen.queryByRole('heading', { name: 'Axos', level: 1 })).not.toBeInTheDocument();
   });
 
   test('should show error alert when fetch fails', async () => {

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.test.tsx
@@ -65,11 +65,10 @@ describe('BankruptcySoftwareDetail', () => {
     });
   });
 
-  test('should render Overview nav link and Trustees placeholder', async () => {
+  test('should render Overview nav link', async () => {
     renderDetail();
     await waitFor(() => {
       expect(screen.getByTestId('software-overview-nav-link')).toBeInTheDocument();
-      expect(screen.getByTestId('software-trustees-nav-item')).toBeInTheDocument();
     });
   });
 

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { BankruptcySoftwareDetail } from './BankruptcySoftwareDetail';
+import Api2 from '@/lib/models/api2';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+
+const mockSoftware: BankruptcySoftwareProfile = {
+  id: 'sw-1',
+  documentType: 'BANKRUPTCY_SOFTWARE',
+  name: 'Axos',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+function renderDetail(softwareId = 'sw-1') {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/bankruptcy-software/${softwareId}`]}>
+      <Routes>
+        <Route
+          path="/admin/bankruptcy-software/:softwareId/*"
+          element={<BankruptcySoftwareDetail />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('BankruptcySoftwareDetail', () => {
+  beforeEach(() => {
+    vi.spyOn(Api2, 'getSoftware').mockResolvedValue({ data: mockSoftware });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should show loading state initially', () => {
+    renderDetail();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  test('should render vendor name heading after loading', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Axos', level: 1 })).toBeInTheDocument();
+    });
+  });
+
+  test('should render "Bankruptcy Software" subtitle', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Bankruptcy Software', level: 2 }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('should render back link to software list', async () => {
+    renderDetail();
+    await waitFor(() => {
+      const backLink = screen.getByTestId('back-to-software-link');
+      expect(backLink).toBeInTheDocument();
+      expect(backLink).toHaveAttribute('href', '/admin/bankruptcy-software');
+    });
+  });
+
+  test('should render Overview nav link and Trustees placeholder', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByTestId('software-overview-nav-link')).toBeInTheDocument();
+      expect(screen.getByTestId('software-trustees-nav-item')).toBeInTheDocument();
+    });
+  });
+
+  test('should show error alert when fetch fails', async () => {
+    vi.spyOn(Api2, 'getSoftware').mockRejectedValue(new Error('not found'));
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByTestId('alert-container-software-detail-load-error')).toBeInTheDocument();
+    });
+  });
+});

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.tsx
@@ -1,11 +1,11 @@
 import '@/styles/left-navigation-pane.scss';
 import { useEffect, useRef, useState } from 'react';
-import { Link, Navigate, Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useNavigate, useParams } from 'react-router-dom';
 import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
-import Icon from '@/lib/components/uswds/Icon';
+import { BackLink } from '@/lib/components/cams/BackLink/BackLink';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 import { EditSoftwareModal, EditSoftwareModalRef } from './EditSoftwareModal';
 import { BankruptcySoftwareDetailNavigation } from './BankruptcySoftwareDetailNavigation';
@@ -53,15 +53,6 @@ export function BankruptcySoftwareDetail() {
   return (
     <div className="bankruptcy-software-detail" data-testid="bankruptcy-software-detail">
       {software && <DocumentTitle name={software.name} />}
-      <Link
-        to="/admin/bankruptcy-software"
-        className="usa-link back-link"
-        title="Back to Bankruptcy Software list"
-        data-testid="back-to-software-link"
-      >
-        <Icon name="navigate_before" />
-        Back to Bankruptcy Software
-      </Link>
 
       {!isLoaded && <LoadingSpinner caption="Loading..." />}
 
@@ -75,47 +66,57 @@ export function BankruptcySoftwareDetail() {
       )}
 
       {isLoaded && !loadError && software && (
-        <>
-          <div className="grid-row">
-            <div className="grid-col-12">
-              <h1>{software.name}</h1>
-              <h2>Bankruptcy Software</h2>
-            </div>
-          </div>
-          <div className="grid-row grid-gap-lg">
-            <div className="grid-col-2">
-              <div className="left-navigation-pane-container">
-                <BankruptcySoftwareDetailNavigation softwareId={softwareId!} />
-              </div>
-            </div>
-            <div className="grid-col-10">
-              <Routes>
-                <Route
-                  path="overview"
-                  element={
-                    <BankruptcySoftwareDetailOverview
-                      software={software}
-                      onEditGeneral={() => editModalRef.current?.show()}
-                      onEditContact={() =>
-                        navigate(`/admin/bankruptcy-software/${softwareId}/contact-info`)
-                      }
-                    />
-                  }
+        <Routes>
+          <Route
+            path="contact-info"
+            element={
+              <SoftwareVendorContactInfoForm software={software} onSaved={handleSoftwareUpdated} />
+            }
+          />
+          <Route
+            path="*"
+            element={
+              <>
+                <BackLink
+                  to="/admin/bankruptcy-software"
+                  label="Back to Bankruptcy Software"
+                  title="Back to Bankruptcy Software list"
+                  testId="back-to-software-link"
                 />
-                <Route
-                  path="contact-info"
-                  element={
-                    <SoftwareVendorContactInfoForm
-                      software={software}
-                      onSaved={handleSoftwareUpdated}
-                    />
-                  }
-                />
-                <Route path="*" element={<Navigate to="overview" replace />} />
-              </Routes>
-            </div>
-          </div>
-        </>
+                <div className="grid-row">
+                  <div className="grid-col-12">
+                    <h1>{software.name}</h1>
+                    <h2>Bankruptcy Software</h2>
+                  </div>
+                </div>
+                <div className="grid-row grid-gap-lg">
+                  <div className="grid-col-2">
+                    <div className="left-navigation-pane-container">
+                      <BankruptcySoftwareDetailNavigation softwareId={softwareId!} />
+                    </div>
+                  </div>
+                  <div className="grid-col-10">
+                    <Routes>
+                      <Route
+                        path="overview"
+                        element={
+                          <BankruptcySoftwareDetailOverview
+                            software={software}
+                            onEditGeneral={() => editModalRef.current?.show()}
+                            onEditContact={() =>
+                              navigate(`/admin/bankruptcy-software/${softwareId}/contact-info`)
+                            }
+                          />
+                        }
+                      />
+                      <Route path="*" element={<Navigate to="overview" replace />} />
+                    </Routes>
+                  </div>
+                </div>
+              </>
+            }
+          />
+        </Routes>
       )}
 
       {software && (

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.tsx
@@ -1,0 +1,131 @@
+import '@/styles/left-navigation-pane.scss';
+import { useEffect, useRef, useState } from 'react';
+import { Link, Navigate, Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import Api2 from '@/lib/models/api2';
+import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
+import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
+import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
+import Icon from '@/lib/components/uswds/Icon';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import { EditSoftwareModal, EditSoftwareModalRef } from './EditSoftwareModal';
+import { BankruptcySoftwareDetailNavigation } from './BankruptcySoftwareDetailNavigation';
+import { BankruptcySoftwareDetailOverview } from './BankruptcySoftwareDetailOverview';
+import { SoftwareVendorContactInfoForm } from './SoftwareVendorContactInfoForm';
+
+export function BankruptcySoftwareDetail() {
+  const { softwareId } = useParams();
+  const navigate = useNavigate();
+  const [software, setSoftware] = useState<BankruptcySoftwareProfile | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const editModalRef = useRef<EditSoftwareModalRef>(null);
+
+  useEffect(() => {
+    if (!softwareId) return;
+
+    let isCancelled = false;
+
+    setIsLoaded(false);
+    Api2.getSoftware(softwareId)
+      .then((response) => {
+        if (isCancelled) return;
+        setSoftware(response.data);
+        setLoadError(null);
+      })
+      .catch((error: Error) => {
+        if (isCancelled) return;
+        setLoadError(error.message);
+      })
+      .finally(() => {
+        if (isCancelled) return;
+        setIsLoaded(true);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [softwareId]);
+
+  function handleSoftwareUpdated(updated: BankruptcySoftwareProfile) {
+    setSoftware(updated);
+  }
+
+  return (
+    <div className="bankruptcy-software-detail" data-testid="bankruptcy-software-detail">
+      {software && <DocumentTitle name={software.name} />}
+      <Link
+        to="/admin/bankruptcy-software"
+        className="usa-link back-link"
+        title="Back to Bankruptcy Software list"
+        data-testid="back-to-software-link"
+      >
+        <Icon name="navigate_before" />
+        Back to Bankruptcy Software
+      </Link>
+
+      {!isLoaded && <LoadingSpinner caption="Loading..." />}
+
+      {isLoaded && loadError && (
+        <Alert
+          id="software-detail-load-error"
+          message={`Failed to load bankruptcy software. ${loadError}`}
+          type={UswdsAlertStyle.Error}
+          show={true}
+        />
+      )}
+
+      {isLoaded && !loadError && software && (
+        <>
+          <div className="grid-row">
+            <div className="grid-col-12">
+              <h1>{software.name}</h1>
+              <h2>Bankruptcy Software</h2>
+            </div>
+          </div>
+          <div className="grid-row grid-gap-lg">
+            <div className="grid-col-2">
+              <div className="left-navigation-pane-container">
+                <BankruptcySoftwareDetailNavigation softwareId={softwareId!} />
+              </div>
+            </div>
+            <div className="grid-col-10">
+              <Routes>
+                <Route
+                  path="overview"
+                  element={
+                    <BankruptcySoftwareDetailOverview
+                      software={software}
+                      onEditGeneral={() => editModalRef.current?.show()}
+                      onEditContact={() =>
+                        navigate(`/admin/bankruptcy-software/${softwareId}/contact-info`)
+                      }
+                    />
+                  }
+                />
+                <Route
+                  path="contact-info"
+                  element={
+                    <SoftwareVendorContactInfoForm
+                      software={software}
+                      onSaved={handleSoftwareUpdated}
+                    />
+                  }
+                />
+                <Route path="*" element={<Navigate to="overview" replace />} />
+              </Routes>
+            </div>
+          </div>
+        </>
+      )}
+
+      {software && (
+        <EditSoftwareModal
+          ref={editModalRef}
+          modalId="edit-software-modal"
+          software={software}
+          onSuccess={handleSoftwareUpdated}
+        />
+      )}
+    </div>
+  );
+}

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetail.tsx
@@ -50,6 +50,14 @@ export function BankruptcySoftwareDetail() {
     setSoftware(updated);
   }
 
+  function handleEditGeneral() {
+    editModalRef.current?.show();
+  }
+
+  function handleEditContact() {
+    navigate(`/admin/bankruptcy-software/${softwareId}/contact-info`);
+  }
+
   return (
     <div className="bankruptcy-software-detail" data-testid="bankruptcy-software-detail">
       {software && <DocumentTitle name={software.name} />}
@@ -102,10 +110,8 @@ export function BankruptcySoftwareDetail() {
                         element={
                           <BankruptcySoftwareDetailOverview
                             software={software}
-                            onEditGeneral={() => editModalRef.current?.show()}
-                            onEditContact={() =>
-                              navigate(`/admin/bankruptcy-software/${softwareId}/contact-info`)
-                            }
+                            onEditGeneral={handleEditGeneral}
+                            onEditContact={handleEditContact}
                           />
                         }
                       />

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailNavigation.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailNavigation.tsx
@@ -22,11 +22,6 @@ export function BankruptcySoftwareDetailNavigation({
             Overview
           </NavLink>
         </li>
-        <li className="usa-sidenav__item">
-          <span className="usa-sidenav__link" data-testid="software-trustees-nav-item">
-            Trustees
-          </span>
-        </li>
       </ul>
     </nav>
   );

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailNavigation.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailNavigation.tsx
@@ -1,0 +1,33 @@
+import { NavLink } from 'react-router-dom';
+
+interface BankruptcySoftwareDetailNavigationProps {
+  softwareId: string;
+}
+
+export function BankruptcySoftwareDetailNavigation({
+  softwareId,
+}: Readonly<BankruptcySoftwareDetailNavigationProps>) {
+  return (
+    <nav aria-label="Bankruptcy software detail navigation">
+      <ul className="usa-sidenav">
+        <li className="usa-sidenav__item">
+          <NavLink
+            to={`/admin/bankruptcy-software/${softwareId}/overview`}
+            data-testid="software-overview-nav-link"
+            className={({ isActive }) =>
+              'usa-sidenav__link' + (isActive ? ' usa-current current' : '')
+            }
+            title="Software vendor overview"
+          >
+            Overview
+          </NavLink>
+        </li>
+        <li className="usa-sidenav__item">
+          <span className="usa-sidenav__link" data-testid="software-trustees-nav-item">
+            Trustees
+          </span>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailOverview.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailOverview.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { BankruptcySoftwareDetailOverview } from './BankruptcySoftwareDetailOverview';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+
+const softwareNoContact: BankruptcySoftwareProfile = {
+  id: 'sw-1',
+  documentType: 'BANKRUPTCY_SOFTWARE',
+  name: 'Axos',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+const softwareWithContact: BankruptcySoftwareProfile = {
+  ...softwareNoContact,
+  contact: {
+    contactNames: ['Jane Doe'],
+    emails: ['jane@axos.com'],
+    website: 'https://axos.com',
+  },
+};
+
+function renderOverview(
+  software: BankruptcySoftwareProfile,
+  onEditGeneral = vi.fn(),
+  onEditContact = vi.fn(),
+) {
+  return render(
+    <BrowserRouter>
+      <BankruptcySoftwareDetailOverview
+        software={software}
+        onEditGeneral={onEditGeneral}
+        onEditContact={onEditContact}
+      />
+    </BrowserRouter>,
+  );
+}
+
+describe('BankruptcySoftwareDetailOverview', () => {
+  test('should render General Information card with name and status', () => {
+    renderOverview(softwareNoContact);
+    expect(screen.getByText('General Information')).toBeInTheDocument();
+    expect(screen.getByText('Axos')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  test('should render Vendor Contact Info. card', () => {
+    renderOverview(softwareNoContact);
+    expect(screen.getByText('Vendor Contact Info.')).toBeInTheDocument();
+  });
+
+  test('should show "(none)" when no contact info exists', () => {
+    renderOverview(softwareNoContact);
+    expect(screen.getByTestId('no-contact-info')).toBeInTheDocument();
+  });
+
+  test('should show FormattedContact when contact info exists', () => {
+    renderOverview(softwareWithContact);
+    expect(screen.queryByTestId('no-contact-info')).not.toBeInTheDocument();
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+  });
+});

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailOverview.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailOverview.test.tsx
@@ -45,6 +45,11 @@ describe('BankruptcySoftwareDetailOverview', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
   });
 
+  test('should render Inactive status when software is inactive', () => {
+    renderOverview({ ...softwareNoContact, status: 'inactive' });
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
   test('should render Vendor Contact Info. card', () => {
     renderOverview(softwareNoContact);
     expect(screen.getByText('Vendor Contact Info.')).toBeInTheDocument();

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailOverview.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailOverview.tsx
@@ -1,0 +1,59 @@
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import { ContactInformation } from '@common/cams/contact';
+import InfoCard from '@/trustees/panels/InfoCard';
+import FormattedContact from '@/lib/components/cams/FormattedContact';
+
+interface BankruptcySoftwareDetailOverviewProps {
+  software: BankruptcySoftwareProfile;
+  onEditGeneral: () => void;
+  onEditContact: () => void;
+}
+
+export function BankruptcySoftwareDetailOverview({
+  software,
+  onEditGeneral,
+  onEditContact,
+}: Readonly<BankruptcySoftwareDetailOverviewProps>) {
+  const contactForDisplay: Partial<ContactInformation> | undefined = software.contact
+    ? {
+        companyName: software.contact.contactNames?.[0],
+        address: software.contact.address as ContactInformation['address'],
+        phone: software.contact.phone as ContactInformation['phone'],
+        email: software.contact.emails?.[0],
+        website: software.contact.website,
+      }
+    : undefined;
+
+  return (
+    <div className="grid-row grid-gap-lg" data-testid="software-detail-overview">
+      <div className="grid-col-6">
+        <InfoCard
+          id="edit-software-general"
+          title="General Information"
+          onEdit={onEditGeneral}
+          fields={[
+            { label: 'Name', value: software.name },
+            { label: 'Status', value: software.status === 'active' ? 'Active' : 'Inactive' },
+          ]}
+        />
+      </div>
+      <div className="grid-col-6">
+        <InfoCard
+          id="edit-software-contact"
+          title="Vendor Contact Info."
+          onEdit={onEditContact}
+          fields={[
+            {
+              label: '',
+              value: contactForDisplay ? (
+                <FormattedContact contact={contactForDisplay} showLinks={true} />
+              ) : (
+                <span data-testid="no-contact-info">(none)</span>
+              ),
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailOverview.tsx
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftwareDetailOverview.tsx
@@ -1,5 +1,5 @@
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
-import { ContactInformation } from '@common/cams/contact';
+
 import InfoCard from '@/trustees/panels/InfoCard';
 import FormattedContact from '@/lib/components/cams/FormattedContact';
 
@@ -14,11 +14,11 @@ export function BankruptcySoftwareDetailOverview({
   onEditGeneral,
   onEditContact,
 }: Readonly<BankruptcySoftwareDetailOverviewProps>) {
-  const contactForDisplay: Partial<ContactInformation> | undefined = software.contact
+  const contactForDisplay = software.contact
     ? {
         companyName: software.contact.contactNames?.[0],
-        address: software.contact.address as ContactInformation['address'],
-        phone: software.contact.phone as ContactInformation['phone'],
+        address: software.contact.address,
+        phone: software.contact.phone,
         email: software.contact.emails?.[0],
         website: software.contact.website,
       }

--- a/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.test.tsx
@@ -1,0 +1,128 @@
+import { createRef } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { EditSoftwareModal, EditSoftwareModalRef } from './EditSoftwareModal';
+import Api2 from '@/lib/models/api2';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import TestingUtilities from '@/lib/testing/testing-utilities';
+
+const software: BankruptcySoftwareProfile = {
+  id: 'sw-1',
+  documentType: 'BANKRUPTCY_SOFTWARE',
+  name: 'Axos',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+const updatedSoftware: BankruptcySoftwareProfile = {
+  ...software,
+  name: 'Axos Renamed',
+  status: 'inactive',
+};
+
+const modalRef = createRef<EditSoftwareModalRef>();
+
+function renderModal(onSuccess: (updated: BankruptcySoftwareProfile) => void = vi.fn()) {
+  render(
+    <BrowserRouter>
+      <EditSoftwareModal
+        ref={modalRef}
+        modalId="edit-software-modal"
+        software={software}
+        onSuccess={onSuccess}
+      />
+    </BrowserRouter>,
+  );
+}
+
+describe('EditSoftwareModal', () => {
+  let successSpy: (updated: BankruptcySoftwareProfile) => void;
+  let alertHook: ReturnType<typeof TestingUtilities.spyOnGlobalAlert>;
+
+  beforeEach(() => {
+    successSpy = vi.fn();
+    alertHook = TestingUtilities.spyOnGlobalAlert();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should open modal and pre-fill with current software values', async () => {
+    renderModal(successSpy);
+    modalRef.current?.show();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Axos')).toBeInTheDocument();
+      expect(screen.getByTestId('radio-edit-software-modal-status-active')).toBeChecked();
+    });
+  });
+
+  test('should show validation error when name is blank', async () => {
+    renderModal(successSpy);
+    modalRef.current?.show();
+
+    const nameInput = await screen.findByDisplayValue('Axos');
+    fireEvent.change(nameInput, { target: { value: '' } });
+    fireEvent.click(screen.getByText('Edit Software'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Software Name is required')).toBeInTheDocument();
+    });
+    expect(successSpy).not.toHaveBeenCalled();
+  });
+
+  test('should call updateSoftware, invoke onSuccess, and show success alert on valid submit', async () => {
+    vi.spyOn(Api2, 'updateSoftware').mockResolvedValue({ data: updatedSoftware });
+
+    renderModal(successSpy);
+    modalRef.current?.show();
+
+    await screen.findByDisplayValue('Axos');
+    const nameInput = screen.getByDisplayValue('Axos');
+    fireEvent.change(nameInput, { target: { value: 'Axos Renamed' } });
+    fireEvent.click(
+      screen.getByTestId('button-radio-edit-software-modal-status-inactive-click-target'),
+    );
+    fireEvent.click(screen.getByText('Edit Software'));
+
+    await waitFor(() => {
+      expect(Api2.updateSoftware).toHaveBeenCalledWith('sw-1', {
+        name: 'Axos Renamed',
+        status: 'inactive',
+      });
+      expect(successSpy).toHaveBeenCalledWith(updatedSoftware);
+      expect(alertHook.success).toHaveBeenCalledWith('Bankruptcy software updated successfully.');
+    });
+  });
+
+  test('should show error alert and keep modal open on API failure', async () => {
+    vi.spyOn(Api2, 'updateSoftware').mockRejectedValue(new Error('server error'));
+
+    renderModal(successSpy);
+    modalRef.current?.show();
+
+    await screen.findByDisplayValue('Axos');
+    fireEvent.click(screen.getByText('Edit Software'));
+
+    await waitFor(() => {
+      expect(alertHook.error).toHaveBeenCalledWith(
+        'Failed to update bankruptcy software. Please try again.',
+      );
+      expect(successSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  test('should reset form and close modal on cancel', async () => {
+    renderModal(successSpy);
+    modalRef.current?.show();
+
+    await screen.findByDisplayValue('Axos');
+    const nameInput = screen.getByDisplayValue('Axos');
+    fireEvent.change(nameInput, { target: { value: 'Modified' } });
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(successSpy).not.toHaveBeenCalled();
+  });
+});

--- a/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.test.tsx
@@ -114,6 +114,29 @@ describe('EditSoftwareModal', () => {
     });
   });
 
+  test('should call hide on the modal ref', async () => {
+    renderModal(successSpy);
+    modalRef.current?.show();
+    await screen.findByDisplayValue('Axos');
+    modalRef.current?.hide();
+    expect(successSpy).not.toHaveBeenCalled();
+  });
+
+  test('should set status to active when active radio is clicked', async () => {
+    renderModal(successSpy);
+    modalRef.current?.show();
+
+    await screen.findByDisplayValue('Axos');
+    fireEvent.click(
+      screen.getByTestId('button-radio-edit-software-modal-status-inactive-click-target'),
+    );
+    fireEvent.click(
+      screen.getByTestId('button-radio-edit-software-modal-status-active-click-target'),
+    );
+
+    expect(screen.getByTestId('radio-edit-software-modal-status-active')).toBeChecked();
+  });
+
   test('should reset form and close modal on cancel', async () => {
     renderModal(successSpy);
     modalRef.current?.show();

--- a/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.tsx
@@ -1,0 +1,135 @@
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import Modal from '@/lib/components/uswds/modal/Modal';
+import Input from '@/lib/components/uswds/Input';
+import Radio from '@/lib/components/uswds/Radio';
+import { RadioGroup } from '@/lib/components/uswds/RadioGroup';
+import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
+import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import Api2 from '@/lib/models/api2';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
+
+export type EditSoftwareModalRef = {
+  show: () => void;
+  hide: () => void;
+};
+
+type EditSoftwareModalProps = {
+  modalId: string;
+  software: BankruptcySoftwareProfile;
+  onSuccess: (updated: BankruptcySoftwareProfile) => void;
+};
+
+export const EditSoftwareModal = forwardRef<EditSoftwareModalRef, EditSoftwareModalProps>(
+  function EditSoftwareModal({ modalId, software, onSuccess }, ref) {
+    const modalRef = useRef<ModalRefType>(null);
+    const alert = useGlobalAlert();
+
+    const [name, setName] = useState('');
+    const [status, setStatus] = useState<'active' | 'inactive'>('active');
+    const [nameError, setNameError] = useState<string | null>(null);
+
+    function resetForm() {
+      setName(software.name);
+      setStatus(software.status);
+      setNameError(null);
+    }
+
+    useImperativeHandle(ref, () => ({
+      show() {
+        resetForm();
+        modalRef.current?.show({});
+      },
+      hide() {
+        modalRef.current?.hide();
+      },
+    }));
+
+    async function handleSubmit() {
+      const trimmed = name.trim();
+      if (!trimmed) {
+        setNameError('Software Name is required');
+        return;
+      }
+      setNameError(null);
+
+      try {
+        const response = await Api2.updateSoftware(software.id, { name: trimmed, status });
+        const updated = response!.data;
+        onSuccess(updated);
+        modalRef.current?.hide();
+        alert?.success('Bankruptcy software updated successfully.');
+      } catch (error) {
+        getAppInsights()?.appInsights?.trackException({ exception: error as Error });
+        alert?.error('Failed to update bankruptcy software. Please try again.');
+      }
+    }
+
+    function handleCancel() {
+      resetForm();
+      modalRef.current?.hide();
+    }
+
+    const actionButtonGroup = {
+      modalId,
+      modalRef,
+      submitButton: {
+        label: 'Edit Software',
+        onClick: handleSubmit,
+        closeOnClick: false,
+      },
+      cancelButton: {
+        label: 'Cancel',
+        onClick: handleCancel,
+      },
+    };
+
+    return (
+      <Modal
+        ref={modalRef}
+        modalId={modalId}
+        heading="Edit Bankruptcy Software"
+        actionButtonGroup={actionButtonGroup}
+        content={
+          <div>
+            <p>
+              Updating the bankruptcy software name will change it everywhere it appears in CAMS.
+            </p>
+            <Input
+              id={`${modalId}-software-name`}
+              label="Software Name"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              errorMessage={nameError ?? undefined}
+              autoComplete="off"
+            />
+            <p>
+              Bankruptcy software with an inactive status will not appear as a bankruptcy software
+              option for Trustees. Marking a status as inactive will not remove it from existing
+              Trustees.
+            </p>
+            <RadioGroup label="Status" className="status-radio-group">
+              <Radio
+                id={`${modalId}-status-active`}
+                name={`${modalId}-status`}
+                label="Active"
+                value="active"
+                checked={status === 'active'}
+                onChange={() => setStatus('active')}
+              />
+              <Radio
+                id={`${modalId}-status-inactive`}
+                name={`${modalId}-status`}
+                label="Inactive"
+                value="inactive"
+                checked={status === 'inactive'}
+                onChange={() => setStatus('inactive')}
+              />
+            </RadioGroup>
+          </div>
+        }
+      />
+    );
+  },
+);

--- a/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.tsx
@@ -35,6 +35,14 @@ export const EditSoftwareModal = forwardRef<EditSoftwareModalRef, EditSoftwareMo
       setNameError(null);
     }
 
+    function handleSetStatusActive() {
+      setStatus('active');
+    }
+
+    function handleSetStatusInactive() {
+      setStatus('inactive');
+    }
+
     useImperativeHandle(ref, () => ({
       show() {
         resetForm();
@@ -116,7 +124,7 @@ export const EditSoftwareModal = forwardRef<EditSoftwareModalRef, EditSoftwareMo
                 label="Active"
                 value="active"
                 checked={status === 'active'}
-                onChange={() => setStatus('active')}
+                onChange={handleSetStatusActive}
               />
               <Radio
                 id={`${modalId}-status-inactive`}
@@ -124,7 +132,7 @@ export const EditSoftwareModal = forwardRef<EditSoftwareModalRef, EditSoftwareMo
                 label="Inactive"
                 value="inactive"
                 checked={status === 'inactive'}
-                onChange={() => setStatus('inactive')}
+                onChange={handleSetStatusInactive}
               />
             </RadioGroup>
           </div>

--- a/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.scss
+++ b/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.scss
@@ -1,0 +1,72 @@
+.contact-info-form {
+  // Main two-column layout: stacked by default, side-by-side above 690px
+  .form-columns {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+
+    .form-col {
+      width: 100%;
+      padding-left: 0;
+    }
+
+    @media (min-width: 690px) {
+      flex-direction: row;
+      gap: 2rem;
+
+      .form-col {
+        flex: 0 0 calc(50% - 1rem);
+        max-width: calc(50% - 1rem);
+        padding-left: 0;
+
+        &:first-child {
+          padding-left: 0;
+        }
+      }
+    }
+  }
+
+  // Phone + extension: stacked by default, side-by-side above 960px
+  .phone-extension-row {
+    display: flex;
+    flex-direction: column;
+
+    .phone-col,
+    .extension-col {
+      width: 100%;
+    }
+
+    @media (min-width: 960px) {
+      flex-direction: row;
+      gap: 1rem;
+      max-width: 32rem;
+
+      .phone-col {
+        flex: 0 0 60%;
+      }
+
+      .extension-col {
+        flex: 1;
+      }
+    }
+  }
+
+  .contact-add-button {
+    margin-top: 1.25rem;
+    column-gap: 0;
+
+    .usa-icon {
+      width: 1.9rem;
+      height: 1.9rem;
+      margin-left: -0.25rem;
+    }
+  }
+
+  .usa-form-group:first-child {
+    margin-top: 0;
+  }
+
+  .zip-code-input {
+    max-width: 18rem;
+  }
+}

--- a/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.scss
+++ b/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.scss
@@ -10,6 +10,10 @@
       padding-left: 0;
     }
 
+    .form-col:last-child {
+      margin-top: 1.5rem;
+    }
+
     @media (min-width: 690px) {
       flex-direction: row;
       gap: 2rem;
@@ -21,6 +25,10 @@
 
         &:first-child {
           padding-left: 0;
+        }
+
+        &:last-child {
+          margin-top: 0;
         }
       }
     }
@@ -36,10 +44,14 @@
       width: 100%;
     }
 
+    .extension-col {
+      margin-top: 1.5rem;
+    }
+
     @media (min-width: 960px) {
       flex-direction: row;
       gap: 1rem;
-      max-width: 32rem;
+      max-width: 30rem;
 
       .phone-col {
         flex: 0 0 60%;
@@ -47,6 +59,7 @@
 
       .extension-col {
         flex: 1;
+        margin-top: 0;
       }
     }
   }
@@ -61,6 +74,10 @@
       margin-left: -0.25rem;
     }
   }
+  .input-under-button {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
 
   .usa-form-group:first-child {
     margin-top: 0;
@@ -68,5 +85,19 @@
 
   .zip-code-input {
     max-width: 18rem;
+  }
+
+  .usa-link.margin-left-2 {
+    display: block;
+    text-align: center;
+    padding-top: 1rem;
+    margin-left: 0;
+
+    @media (min-width: 480px) {
+      display: inline;
+      text-align: unset;
+      padding-top: 0;
+      margin-left: 1rem;
+    }
   }
 }

--- a/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TestingUtilities from '@/lib/testing/testing-utilities';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { SoftwareVendorContactInfoForm } from './SoftwareVendorContactInfoForm';
 import Api2 from '@/lib/models/api2';
@@ -49,6 +50,12 @@ function renderForm(sw = software, onSaved = vi.fn()) {
 }
 
 describe('SoftwareVendorContactInfoForm', () => {
+  let alertHook: ReturnType<typeof TestingUtilities.spyOnGlobalAlert>;
+
+  beforeEach(() => {
+    alertHook = TestingUtilities.spyOnGlobalAlert();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -109,6 +116,110 @@ describe('SoftwareVendorContactInfoForm', () => {
       );
       expect(onSaved).toHaveBeenCalledWith(updatedSoftware);
     });
+  });
+
+  test('should render phone, extension, and address fields', () => {
+    renderForm();
+    expect(screen.getByLabelText('Software Contact Phone')).toBeInTheDocument();
+    expect(screen.getByLabelText('Extension')).toBeInTheDocument();
+    expect(screen.getByLabelText('Software Contact Address Line 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Software Contact Zip Code')).toBeInTheDocument();
+    expect(screen.getByLabelText('Software Contact State')).toBeInTheDocument();
+  });
+
+  test('should pre-fill phone and extension from existing contact', () => {
+    renderForm(softwareWithContact);
+    expect(screen.getByDisplayValue('303-555-1234')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('101')).toBeInTheDocument();
+  });
+
+  test('should update contact name when typed into', () => {
+    const { container } = renderForm();
+    const nameInput = container.querySelector('input[id="contact-name-0"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'Updated Name' } });
+    expect(nameInput.value).toBe('Updated Name');
+  });
+
+  test('should update email when typed into additional email field', () => {
+    const { container } = renderForm();
+    fireEvent.click(screen.getByTestId('add-email-button'));
+    const emailInputs = container.querySelectorAll('input[id^="email-"]');
+    fireEvent.change(emailInputs[1], { target: { value: 'second@axos.com' } });
+    expect((emailInputs[1] as HTMLInputElement).value).toBe('second@axos.com');
+  });
+
+  test('should include phone and address in save payload', async () => {
+    const onSaved = vi.fn();
+    vi.spyOn(Api2, 'updateSoftware').mockResolvedValue({ data: updatedSoftware });
+
+    renderForm(software, onSaved);
+    fireEvent.change(screen.getByLabelText('Software Contact Phone'), {
+      target: { value: '303-555-0000' },
+    });
+    fireEvent.change(screen.getByLabelText('Software Contact Address Line 1'), {
+      target: { value: '456 Oak Ave' },
+    });
+    fireEvent.change(screen.getByLabelText('Software Contact City'), {
+      target: { value: 'Boulder' },
+    });
+    fireEvent.click(screen.getByTestId('button-save-contact-info'));
+
+    await waitFor(() => {
+      expect(Api2.updateSoftware).toHaveBeenCalledWith(
+        'sw-1',
+        expect.objectContaining({
+          contact: expect.objectContaining({
+            phone: expect.objectContaining({ number: '303-555-0000' }),
+            address: expect.objectContaining({ address1: '456 Oak Ave', city: 'Boulder' }),
+          }),
+        }),
+      );
+    });
+  });
+
+  test('should show error alert when save fails', async () => {
+    vi.spyOn(Api2, 'updateSoftware').mockRejectedValue(new Error('server error'));
+
+    renderForm();
+    fireEvent.click(screen.getByTestId('button-save-contact-info'));
+
+    await waitFor(() => {
+      expect(alertHook.error).toHaveBeenCalledWith(
+        'Failed to update vendor contact information. Please try again.',
+      );
+    });
+  });
+
+  test('should show success alert on save', async () => {
+    vi.spyOn(Api2, 'updateSoftware').mockResolvedValue({ data: updatedSoftware });
+
+    renderForm();
+    fireEvent.click(screen.getByTestId('button-save-contact-info'));
+
+    await waitFor(() => {
+      expect(alertHook.success).toHaveBeenCalledWith(
+        'Vendor contact information updated successfully.',
+      );
+    });
+  });
+
+  test('should update address line 2, zip, extension, and website when typed into', () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText('Software Contact Address Line 2'), {
+      target: { value: 'Suite 100' },
+    });
+    fireEvent.change(screen.getByLabelText('Software Contact Zip Code'), {
+      target: { value: '80201' },
+    });
+    fireEvent.change(screen.getByLabelText('Extension'), {
+      target: { value: '123' },
+    });
+    fireEvent.change(screen.getByLabelText('Website'), {
+      target: { value: 'https://example.com' },
+    });
+    expect(screen.getByDisplayValue('Suite 100')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://example.com')).toBeInTheDocument();
   });
 
   test('should not call Api2.updateSoftware when Cancel is clicked', () => {

--- a/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SoftwareVendorContactInfoForm } from './SoftwareVendorContactInfoForm';
+import Api2 from '@/lib/models/api2';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+
+const software: BankruptcySoftwareProfile = {
+  id: 'sw-1',
+  documentType: 'BANKRUPTCY_SOFTWARE',
+  name: 'Axos',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+const softwareWithContact: BankruptcySoftwareProfile = {
+  ...software,
+  contact: {
+    contactNames: ['Jane Doe'],
+    address: {
+      address1: '123 Main St',
+      city: 'Denver',
+      state: 'CO',
+      zipCode: '80201',
+      countryCode: 'US',
+    },
+    phone: { number: '303-555-1234', extension: '101' },
+    emails: ['jane@axos.com'],
+    website: 'https://axos.com',
+  },
+};
+
+const updatedSoftware: BankruptcySoftwareProfile = {
+  ...software,
+  contact: { emails: ['jane@axos.com'] },
+};
+
+function renderForm(sw = software, onSaved = vi.fn()) {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/bankruptcy-software/sw-1/contact-info`]}>
+      <Routes>
+        <Route
+          path="/admin/bankruptcy-software/:softwareId/contact-info"
+          element={<SoftwareVendorContactInfoForm software={sw} onSaved={onSaved} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('SoftwareVendorContactInfoForm', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should render all expected fields', () => {
+    renderForm();
+    expect(screen.getByLabelText('Software Contact Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Software Contact Address Line 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Software Contact City')).toBeInTheDocument();
+    expect(screen.getByLabelText('Software Contact Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Website')).toBeInTheDocument();
+    expect(screen.getByTestId('add-contact-name-button')).toBeInTheDocument();
+    expect(screen.getByTestId('add-email-button')).toBeInTheDocument();
+  });
+
+  test('should pre-fill fields from existing contact', () => {
+    renderForm(softwareWithContact);
+    expect(screen.getByDisplayValue('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('123 Main St')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Denver')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('jane@axos.com')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://axos.com')).toBeInTheDocument();
+  });
+
+  test('should add a new contact name input when "+ Add Another Contact Name" is clicked', () => {
+    const { container } = renderForm();
+    const before = container.querySelectorAll('input[id^="contact-name-"]').length;
+    fireEvent.click(screen.getByTestId('add-contact-name-button'));
+    const after = container.querySelectorAll('input[id^="contact-name-"]').length;
+    expect(after).toBe(before + 1);
+  });
+
+  test('should add a new email input when "+ Add Another Email" is clicked', () => {
+    const { container } = renderForm();
+    const before = container.querySelectorAll('input[id^="email-"]').length;
+    fireEvent.click(screen.getByTestId('add-email-button'));
+    const after = container.querySelectorAll('input[id^="email-"]').length;
+    expect(after).toBe(before + 1);
+  });
+
+  test('should call Api2.updateSoftware with contact data and invoke onSaved on save', async () => {
+    const onSaved = vi.fn();
+    vi.spyOn(Api2, 'updateSoftware').mockResolvedValue({ data: updatedSoftware });
+
+    renderForm(software, onSaved);
+    const emailInput = screen.getByLabelText('Software Contact Email');
+    fireEvent.change(emailInput, { target: { value: 'jane@axos.com' } });
+    fireEvent.click(screen.getByTestId('button-save-contact-info'));
+
+    await waitFor(() => {
+      expect(Api2.updateSoftware).toHaveBeenCalledWith(
+        'sw-1',
+        expect.objectContaining({
+          contact: expect.objectContaining({
+            emails: ['jane@axos.com'],
+          }),
+        }),
+      );
+      expect(onSaved).toHaveBeenCalledWith(updatedSoftware);
+    });
+  });
+
+  test('should not call Api2.updateSoftware when Cancel is clicked', () => {
+    const updateSpy = vi.spyOn(Api2, 'updateSoftware');
+    renderForm();
+    fireEvent.click(screen.getByTestId('cancel-contact-info-link'));
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.tsx
+++ b/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.tsx
@@ -60,17 +60,31 @@ export function SoftwareVendorContactInfoForm({
   }
 
   async function handleSave() {
+    const trimmedAddress1 = addressLine1.trim();
+    const trimmedAddress2 = addressLine2.trim();
+    const trimmedCity = city.trim();
+    const trimmedZipCode = zipCode.trim();
+    const trimmedPhone = phone.trim();
+
+    const hasAddress = trimmedAddress1 || trimmedAddress2 || trimmedCity || state || trimmedZipCode;
+
+    const address = hasAddress
+      ? {
+          address1: trimmedAddress1 || undefined,
+          address2: trimmedAddress2 || undefined,
+          city: trimmedCity || undefined,
+          state: state || undefined,
+          zipCode: trimmedZipCode || undefined,
+          countryCode: 'US' as const,
+        }
+      : undefined;
+
     const contact: SoftwareContactInfo = {
       contactNames: contactNames.filter((n) => n.trim()),
-      address: {
-        address1: addressLine1.trim() || undefined,
-        address2: addressLine2.trim() || undefined,
-        city: city.trim() || undefined,
-        state: state || undefined,
-        zipCode: zipCode || undefined,
-        countryCode: 'US',
-      },
-      phone: phone ? { number: phone, extension: extension.trim() || undefined } : undefined,
+      address,
+      phone: trimmedPhone
+        ? { number: trimmedPhone, extension: extension.trim() || undefined }
+        : undefined,
       emails: emails.filter((e) => e.trim()),
       website: website.trim() || undefined,
     };

--- a/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.tsx
+++ b/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.tsx
@@ -59,6 +59,38 @@ export function SoftwareVendorContactInfoForm({
     setEmails((prev) => prev.map((e, i) => (i === index ? value : e)));
   }
 
+  function handleAddressLine1Change(e: React.ChangeEvent<HTMLInputElement>) {
+    setAddressLine1(e.target.value);
+  }
+
+  function handleAddressLine2Change(e: React.ChangeEvent<HTMLInputElement>) {
+    setAddressLine2(e.target.value);
+  }
+
+  function handleCityChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setCity(e.target.value);
+  }
+
+  function handleStateChange(options: ComboOption[]) {
+    setState(options[0]?.value ?? '');
+  }
+
+  function handleZipCodeChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setZipCode(e.target.value);
+  }
+
+  function handlePhoneChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setPhone(e.target.value);
+  }
+
+  function handleExtensionChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setExtension(e.target.value);
+  }
+
+  function handleWebsiteChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setWebsite(e.target.value);
+  }
+
   async function handleSave() {
     const trimmedAddress1 = addressLine1.trim();
     const trimmedAddress2 = addressLine2.trim();
@@ -126,27 +158,23 @@ export function SoftwareVendorContactInfoForm({
           </button>
           <Input
             id="address-line-1"
+            className="input-under-button"
             label="Software Contact Address Line 1"
             value={addressLine1}
-            onChange={(e) => setAddressLine1(e.target.value)}
+            onChange={handleAddressLine1Change}
           />
           <Input
             id="address-line-2"
             label="Software Contact Address Line 2"
             value={addressLine2}
-            onChange={(e) => setAddressLine2(e.target.value)}
+            onChange={handleAddressLine2Change}
           />
-          <Input
-            id="city"
-            label="Software Contact City"
-            value={city}
-            onChange={(e) => setCity(e.target.value)}
-          />
+          <Input id="city" label="Software Contact City" value={city} onChange={handleCityChange} />
           <UsStatesComboBox
             id="state"
             label="Software Contact State"
             selections={state ? [state] : []}
-            onUpdateSelection={(options: ComboOption[]) => setState(options[0]?.value ?? '')}
+            onUpdateSelection={handleStateChange}
           />
           <ZipCodeInput
             id="zip-code"
@@ -154,7 +182,7 @@ export function SoftwareVendorContactInfoForm({
             label="Software Contact Zip Code"
             ariaDescription="Example: 12345"
             value={zipCode}
-            onChange={(e) => setZipCode(e.target.value)}
+            onChange={handleZipCodeChange}
           />
         </div>
         <div className="form-col">
@@ -165,7 +193,7 @@ export function SoftwareVendorContactInfoForm({
                 label="Software Contact Phone"
                 ariaDescription="Example: 123-456-7890"
                 value={phone}
-                onChange={(e) => setPhone(e.target.value)}
+                onChange={handlePhoneChange}
               />
             </div>
             <div className="extension-col">
@@ -175,7 +203,7 @@ export function SoftwareVendorContactInfoForm({
                 ariaDescription="Up to 6 digits"
                 maxLength={6}
                 value={extension}
-                onChange={(e) => setExtension(e.target.value)}
+                onChange={handleExtensionChange}
               />
             </div>
           </div>
@@ -199,10 +227,11 @@ export function SoftwareVendorContactInfoForm({
           </button>
           <Input
             id="website"
+            className="input-under-button"
             label="Website"
             type="url"
             value={website}
-            onChange={(e) => setWebsite(e.target.value)}
+            onChange={handleWebsiteChange}
           />
         </div>
       </div>

--- a/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.tsx
+++ b/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { BankruptcySoftwareProfile, SoftwareContactInfo } from '@common/cams/bankruptcy-software';
+import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
+import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
+import Input from '@/lib/components/uswds/Input';
+import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
+import PhoneNumberInput from '@/lib/components/PhoneNumberInput';
+import ZipCodeInput from '@/lib/components/ZipCodeInput';
+import UsStatesComboBox from '@/lib/components/combobox/UsStatesComboBox';
+import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
+import Api2 from '@/lib/models/api2';
+import { ComboOption } from '@/lib/components/combobox/ComboBox';
+
+interface SoftwareVendorContactInfoFormProps {
+  software: BankruptcySoftwareProfile;
+  onSaved: (updated: BankruptcySoftwareProfile) => void;
+}
+
+export function SoftwareVendorContactInfoForm({
+  software,
+  onSaved,
+}: Readonly<SoftwareVendorContactInfoFormProps>) {
+  const { softwareId } = useParams();
+  const navigate = useNavigate();
+  const alert = useGlobalAlert();
+
+  const existingContact = software.contact;
+
+  const [contactNames, setContactNames] = useState<string[]>(
+    existingContact?.contactNames?.length ? existingContact.contactNames : [''],
+  );
+  const [addressLine1, setAddressLine1] = useState(existingContact?.address?.address1 ?? '');
+  const [addressLine2, setAddressLine2] = useState(existingContact?.address?.address2 ?? '');
+  const [city, setCity] = useState(existingContact?.address?.city ?? '');
+  const [state, setState] = useState(existingContact?.address?.state ?? '');
+  const [zipCode, setZipCode] = useState(existingContact?.address?.zipCode ?? '');
+  const [phone, setPhone] = useState(existingContact?.phone?.number ?? '');
+  const [extension, setExtension] = useState(existingContact?.phone?.extension ?? '');
+  const [emails, setEmails] = useState<string[]>(
+    existingContact?.emails?.length ? existingContact.emails : [''],
+  );
+  const [website, setWebsite] = useState(existingContact?.website ?? '');
+
+  function addContactName() {
+    setContactNames((prev) => [...prev, '']);
+  }
+
+  function updateContactName(index: number, value: string) {
+    setContactNames((prev) => prev.map((n, i) => (i === index ? value : n)));
+  }
+
+  function addEmail() {
+    setEmails((prev) => [...prev, '']);
+  }
+
+  function updateEmail(index: number, value: string) {
+    setEmails((prev) => prev.map((e, i) => (i === index ? value : e)));
+  }
+
+  async function handleSave() {
+    const contact: SoftwareContactInfo = {
+      contactNames: contactNames.filter((n) => n.trim()),
+      address: {
+        address1: addressLine1.trim() || undefined,
+        address2: addressLine2.trim() || undefined,
+        city: city.trim() || undefined,
+        state: state || undefined,
+        zipCode: zipCode || undefined,
+        countryCode: 'US',
+      },
+      phone: phone ? { number: phone, extension: extension.trim() || undefined } : undefined,
+      emails: emails.filter((e) => e.trim()),
+      website: website.trim() || undefined,
+    };
+
+    try {
+      const response = await Api2.updateSoftware(software.id, { contact });
+      const updated = response!.data;
+      onSaved(updated);
+      navigate(`/admin/bankruptcy-software/${softwareId}/overview`);
+      alert?.success('Vendor contact information updated successfully.');
+    } catch (error) {
+      getAppInsights()?.appInsights?.trackException({ exception: error as Error });
+      alert?.error('Failed to update vendor contact information. Please try again.');
+    }
+  }
+
+  return (
+    <MainContent data-testid="contact-info-form">
+      <DocumentTitle name="Add Software Vendor Contact Information" />
+      <h1>{software.name}</h1>
+      <h2>Add Software Vendor Contact Information</h2>
+      <div className="grid-row grid-gap-lg">
+        <div className="grid-col-6">
+          {contactNames.map((name, i) => (
+            <Input
+              key={i}
+              id={`contact-name-${i}`}
+              label={i === 0 ? 'Software Contact Name' : ''}
+              value={name}
+              onChange={(e) => updateContactName(i, e.target.value)}
+            />
+          ))}
+          <button
+            type="button"
+            className="usa-button usa-button--unstyled"
+            onClick={addContactName}
+            data-testid="add-contact-name-button"
+          >
+            + Add Another Contact Name
+          </button>
+          <Input
+            id="address-line-1"
+            label="Software Contact Address Line 1"
+            value={addressLine1}
+            onChange={(e) => setAddressLine1(e.target.value)}
+          />
+          <Input
+            id="address-line-2"
+            label="Software Contact Address Line 2"
+            value={addressLine2}
+            onChange={(e) => setAddressLine2(e.target.value)}
+          />
+          <Input
+            id="city"
+            label="Software Contact City"
+            value={city}
+            onChange={(e) => setCity(e.target.value)}
+          />
+          <UsStatesComboBox
+            id="state"
+            label="Software Contact State"
+            selections={state ? [state] : []}
+            onUpdateSelection={(options: ComboOption[]) => setState(options[0]?.value ?? '')}
+          />
+          <ZipCodeInput
+            id="zip-code"
+            label="Software Contact Zip Code"
+            ariaDescription="Example: 12345"
+            value={zipCode}
+            onChange={(e) => setZipCode(e.target.value)}
+          />
+        </div>
+        <div className="grid-col-6">
+          <PhoneNumberInput
+            id="phone"
+            label="Software Contact Phone"
+            ariaDescription="Example: 123-456-7890"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+          />
+          <Input
+            id="extension"
+            label="Extension"
+            ariaDescription="Up to 6 digits"
+            maxLength={6}
+            value={extension}
+            onChange={(e) => setExtension(e.target.value)}
+          />
+          {emails.map((email, i) => (
+            <Input
+              key={i}
+              id={`email-${i}`}
+              label={i === 0 ? 'Software Contact Email' : ''}
+              type="email"
+              value={email}
+              onChange={(e) => updateEmail(i, e.target.value)}
+            />
+          ))}
+          <button
+            type="button"
+            className="usa-button usa-button--unstyled"
+            onClick={addEmail}
+            data-testid="add-email-button"
+          >
+            + Add Another Email
+          </button>
+          <Input
+            id="website"
+            label="Website"
+            type="url"
+            value={website}
+            onChange={(e) => setWebsite(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="grid-row margin-top-4">
+        <div className="grid-col-12">
+          <Button id="save-contact-info" uswdsStyle={UswdsButtonStyle.Default} onClick={handleSave}>
+            Save
+          </Button>
+          <Link
+            to={`/admin/bankruptcy-software/${softwareId}/overview`}
+            className="usa-link margin-left-2"
+            data-testid="cancel-contact-info-link"
+          >
+            Cancel
+          </Link>
+        </div>
+      </div>
+    </MainContent>
+  );
+}

--- a/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.tsx
+++ b/user-interface/src/admin/bankruptcy-software/SoftwareVendorContactInfoForm.tsx
@@ -1,8 +1,8 @@
+import './SoftwareVendorContactInfoForm.scss';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import Icon from '@/lib/components/uswds/Icon';
 import { BankruptcySoftwareProfile, SoftwareContactInfo } from '@common/cams/bankruptcy-software';
-import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
-import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
 import Input from '@/lib/components/uswds/Input';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import PhoneNumberInput from '@/lib/components/PhoneNumberInput';
@@ -102,12 +102,11 @@ export function SoftwareVendorContactInfoForm({
   }
 
   return (
-    <MainContent data-testid="contact-info-form">
-      <DocumentTitle name="Add Software Vendor Contact Information" />
+    <div className="contact-info-form" data-testid="contact-info-form">
       <h1>{software.name}</h1>
       <h2>Add Software Vendor Contact Information</h2>
-      <div className="grid-row grid-gap-lg">
-        <div className="grid-col-6">
+      <div className="form-columns">
+        <div className="form-col">
           {contactNames.map((name, i) => (
             <Input
               key={i}
@@ -119,11 +118,11 @@ export function SoftwareVendorContactInfoForm({
           ))}
           <button
             type="button"
-            className="usa-button usa-button--unstyled"
+            className="usa-button usa-button--unstyled contact-add-button"
             onClick={addContactName}
             data-testid="add-contact-name-button"
           >
-            + Add Another Contact Name
+            <Icon name="add" /> Add Another Contact Name
           </button>
           <Input
             id="address-line-1"
@@ -151,28 +150,35 @@ export function SoftwareVendorContactInfoForm({
           />
           <ZipCodeInput
             id="zip-code"
+            className="zip-code-input"
             label="Software Contact Zip Code"
             ariaDescription="Example: 12345"
             value={zipCode}
             onChange={(e) => setZipCode(e.target.value)}
           />
         </div>
-        <div className="grid-col-6">
-          <PhoneNumberInput
-            id="phone"
-            label="Software Contact Phone"
-            ariaDescription="Example: 123-456-7890"
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-          />
-          <Input
-            id="extension"
-            label="Extension"
-            ariaDescription="Up to 6 digits"
-            maxLength={6}
-            value={extension}
-            onChange={(e) => setExtension(e.target.value)}
-          />
+        <div className="form-col">
+          <div className="phone-extension-row">
+            <div className="phone-col">
+              <PhoneNumberInput
+                id="phone"
+                label="Software Contact Phone"
+                ariaDescription="Example: 123-456-7890"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+              />
+            </div>
+            <div className="extension-col">
+              <Input
+                id="extension"
+                label="Extension"
+                ariaDescription="Up to 6 digits"
+                maxLength={6}
+                value={extension}
+                onChange={(e) => setExtension(e.target.value)}
+              />
+            </div>
+          </div>
           {emails.map((email, i) => (
             <Input
               key={i}
@@ -185,11 +191,11 @@ export function SoftwareVendorContactInfoForm({
           ))}
           <button
             type="button"
-            className="usa-button usa-button--unstyled"
+            className="usa-button usa-button--unstyled contact-add-button"
             onClick={addEmail}
             data-testid="add-email-button"
           >
-            + Add Another Email
+            <Icon name="add" /> Add Another Email
           </button>
           <Input
             id="website"
@@ -214,6 +220,6 @@ export function SoftwareVendorContactInfoForm({
           </Link>
         </div>
       </div>
-    </MainContent>
+    </div>
   );
 }

--- a/user-interface/src/admin/banks/BankDetail.scss
+++ b/user-interface/src/admin/banks/BankDetail.scss
@@ -1,14 +1,2 @@
 .bank-detail {
-  .back-link {
-    display: inline-flex;
-    align-items: center;
-    padding-top: 1rem;
-    padding-bottom: 0;
-
-    .usa-icon {
-      width: 1.25rem;
-      height: 1.25rem;
-      margin-right: 0.25rem;
-    }
-  }
 }

--- a/user-interface/src/admin/banks/BankDetail.test.tsx
+++ b/user-interface/src/admin/banks/BankDetail.test.tsx
@@ -61,6 +61,23 @@ describe('BankDetail', () => {
     });
   });
 
+  test('should cancel fetch when component unmounts', async () => {
+    let resolvePromise: (value: { data: BankProfile }) => void;
+    vi.spyOn(Api2, 'getBank').mockReturnValue(
+      new Promise((resolve) => {
+        resolvePromise = resolve;
+      }),
+    );
+
+    const { unmount } = renderComponent();
+    unmount();
+    resolvePromise!({ data: mockBank });
+
+    expect(
+      screen.queryByRole('heading', { name: 'Fifth Third Bank', level: 1 }),
+    ).not.toBeInTheDocument();
+  });
+
   test('should show error alert when fetch fails', async () => {
     vi.spyOn(Api2, 'getBank').mockRejectedValue(new Error('not found'));
     renderComponent();
@@ -75,6 +92,25 @@ describe('BankDetail', () => {
     fireEvent.click(editBtn);
     await waitFor(() => {
       expect(screen.getByTestId('modal-edit-bank-modal')).toHaveClass('is-visible');
+    });
+  });
+
+  test('should update bank name when edit modal calls onSuccess', async () => {
+    const updatedBank: BankProfile = { ...mockBank, name: 'Fifth Third Renamed' };
+    vi.spyOn(Api2, 'updateBank').mockResolvedValue({ data: updatedBank });
+
+    renderComponent();
+    const editBtn = await screen.findByTestId('button-edit-bank');
+    fireEvent.click(editBtn);
+
+    const nameInput = await screen.findByDisplayValue('Fifth Third Bank');
+    fireEvent.change(nameInput, { target: { value: 'Fifth Third Renamed' } });
+    fireEvent.click(screen.getByText('Update Bank'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Fifth Third Renamed', level: 1 }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/user-interface/src/admin/banks/BankDetail.tsx
+++ b/user-interface/src/admin/banks/BankDetail.tsx
@@ -1,7 +1,7 @@
 import '@/styles/left-navigation-pane.scss';
 import './BankDetail.scss';
 import { useEffect, useRef, useState } from 'react';
-import { Link, Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router-dom';
 import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
@@ -9,7 +9,7 @@ import { BankProfile } from '@common/cams/banks';
 import { EditBankModal, EditBankModalRef } from './EditBankModal';
 import { BankDetailNavigation } from './BankDetailNavigation';
 import { BankDetailOverview } from './BankDetailOverview';
-import Icon from '@/lib/components/uswds/Icon';
+import { BackLink } from '@/lib/components/cams/BackLink/BackLink';
 
 export function BankDetail() {
   const { bankId } = useParams();
@@ -50,10 +50,7 @@ export function BankDetail() {
 
   return (
     <div className="bank-detail" data-testid="bank-detail">
-      <Link to="/admin/banks" className="usa-link back-link" title="Back to Banks list">
-        <Icon name="navigate_before" />
-        Back to Banks
-      </Link>
+      <BackLink to="/admin/banks" label="Back to Banks" title="Back to Banks list" />
 
       {!isLoaded && <LoadingSpinner caption="Loading..." />}
 
@@ -71,6 +68,7 @@ export function BankDetail() {
           <div className="grid-row">
             <div className="grid-col-12">
               <h1>{bank.name}</h1>
+              <h2>Bank</h2>
             </div>
           </div>
           <div className="grid-row grid-gap-lg">

--- a/user-interface/src/admin/banks/BankDetail.tsx
+++ b/user-interface/src/admin/banks/BankDetail.tsx
@@ -48,6 +48,10 @@ export function BankDetail() {
     setBank(updated);
   }
 
+  function handleEditBank() {
+    editModalRef.current?.show();
+  }
+
   return (
     <div className="bank-detail" data-testid="bank-detail">
       <BackLink to="/admin/banks" label="Back to Banks" title="Back to Banks list" />
@@ -81,9 +85,7 @@ export function BankDetail() {
               <Routes>
                 <Route
                   path="overview"
-                  element={
-                    <BankDetailOverview bank={bank} onEdit={() => editModalRef.current?.show()} />
-                  }
+                  element={<BankDetailOverview bank={bank} onEdit={handleEditBank} />}
                 />
                 <Route path="*" element={<Navigate to="overview" replace />} />
               </Routes>

--- a/user-interface/src/admin/banks/BankDetailOverview.test.tsx
+++ b/user-interface/src/admin/banks/BankDetailOverview.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { BankDetailOverview } from './BankDetailOverview';
+import { BankProfile } from '@common/cams/banks';
+
+const bank: BankProfile = {
+  id: 'bank-1',
+  documentType: 'BANK_PROFILE',
+  name: 'Fifth Third Bank',
+  status: 'active',
+  updatedOn: '2024-01-01T00:00:00.000Z',
+  updatedBy: { id: 'user-1', name: 'User One' },
+};
+
+describe('BankDetailOverview', () => {
+  test('should render bank name and Active status', () => {
+    render(<BankDetailOverview bank={bank} onEdit={vi.fn()} />);
+    expect(screen.getByText('Fifth Third Bank')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  test('should render Inactive status when bank is inactive', () => {
+    render(<BankDetailOverview bank={{ ...bank, status: 'inactive' }} onEdit={vi.fn()} />);
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  test('should call onEdit when Edit button is clicked', () => {
+    const onEdit = vi.fn();
+    render(<BankDetailOverview bank={bank} onEdit={onEdit} />);
+    screen.getByTestId('button-edit-bank').click();
+    expect(onEdit).toHaveBeenCalled();
+  });
+});

--- a/user-interface/src/admin/banks/Banks.test.tsx
+++ b/user-interface/src/admin/banks/Banks.test.tsx
@@ -115,7 +115,7 @@ describe('Banks component', () => {
     });
   });
 
-  test('should render "+ Add Bank" button', async () => {
+  test('should render "Add Bank" button', async () => {
     renderComponent();
     await waitFor(() => {
       expect(screen.getByTestId('button-add-bank-button')).toBeInTheDocument();
@@ -130,7 +130,7 @@ describe('Banks component', () => {
     });
   });
 
-  test('should call modal show() when + Add Bank button is clicked', async () => {
+  test('should call modal show() when Add Bank button is clicked', async () => {
     renderComponent();
     const btn = await screen.findByTestId('button-add-bank-button');
     fireEvent.click(btn);

--- a/user-interface/src/admin/banks/Banks.tsx
+++ b/user-interface/src/admin/banks/Banks.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
+import Icon from '@/lib/components/uswds/Icon';
 import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import {
   CamsTable,
@@ -68,7 +69,7 @@ export function Banks() {
                 uswdsStyle={UswdsButtonStyle.Default}
                 onClick={() => addBankModalRef.current?.show()}
               >
-                + Add Bank
+                <Icon name="add" /> Add Bank
               </Button>
             </div>
           </div>

--- a/user-interface/src/admin/banks/Banks.tsx
+++ b/user-interface/src/admin/banks/Banks.tsx
@@ -40,6 +40,10 @@ export function Banks() {
     loadBanks().then(() => setIsLoaded(true));
   }, []);
 
+  function handleAddBankClick() {
+    addBankModalRef.current?.show();
+  }
+
   function handleBankAdded(bank: BankProfile) {
     setBanks((prev) => [...prev, bank].sort((a, b) => a.name.localeCompare(b.name)));
     getAppInsights().appInsights.trackEvent({
@@ -67,7 +71,7 @@ export function Banks() {
               <Button
                 id="add-bank-button"
                 uswdsStyle={UswdsButtonStyle.Default}
-                onClick={() => addBankModalRef.current?.show()}
+                onClick={handleAddBankClick}
               >
                 <Icon name="add" /> Add Bank
               </Button>

--- a/user-interface/src/admin/banks/EditBankModal.test.tsx
+++ b/user-interface/src/admin/banks/EditBankModal.test.tsx
@@ -161,4 +161,31 @@ describe('EditBankModal', () => {
       expect(screen.getByLabelText(/bank name/i)).toHaveValue('Fifth Third Bank');
     });
   });
+
+  test('should call hide on the modal ref', async () => {
+    renderComponent();
+    openModal();
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+    act(() => modalRef.current?.hide());
+    await waitFor(() => {
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
+    });
+  });
+
+  test('should set status to active when active radio is clicked', async () => {
+    renderComponent();
+    openModal();
+    await screen.findByLabelText(/bank name/i);
+
+    await userEvent.click(
+      screen.getByTestId(`button-radio-${MODAL_ID}-status-inactive-click-target`),
+    );
+    await userEvent.click(
+      screen.getByTestId(`button-radio-${MODAL_ID}-status-active-click-target`),
+    );
+
+    expect(screen.getByTestId(`radio-${MODAL_ID}-status-active`)).toBeChecked();
+  });
 });

--- a/user-interface/src/case-detail/panels/cards/DebtorCard.test.tsx
+++ b/user-interface/src/case-detail/panels/cards/DebtorCard.test.tsx
@@ -3,11 +3,11 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import DebtorCard from './DebtorCard';
 import { Debtor, DebtorAttorney } from '@common/cams/parties';
 import * as CommsLinkModule from '@/lib/components/cams/CommsLink/CommsLink';
-import { ContactInformation } from '@common/cams/contact';
+import { ContactWithPartialPhoneAndAddress } from '@common/cams/contact';
 
 beforeEach(() => {
   vi.spyOn(CommsLinkModule, 'default').mockImplementation(
-    ({ contact, mode }: { contact: Omit<ContactInformation, 'address'>; mode: string }) => (
+    ({ contact, mode }: { contact: ContactWithPartialPhoneAndAddress; mode: string }) => (
       <span data-testid={`comms-link-${mode}`}>{contact.phone?.number || contact.email}</span>
     ),
   );

--- a/user-interface/src/lib/components/NavigationTracker.test.tsx
+++ b/user-interface/src/lib/components/NavigationTracker.test.tsx
@@ -1,0 +1,76 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { NavigationTracker } from './NavigationTracker';
+import * as UseLandingPageAnalytics from '@/lib/hooks/UseLandingPageAnalytics';
+import { CASE_SEARCH_PATH, LOGIN_SUCCESS_PATH } from '@/login/login-library';
+import { act } from 'react';
+
+const mockTrackNavigation = vi.fn();
+
+function setupAnalyticsSpy() {
+  vi.spyOn(UseLandingPageAnalytics, 'useLandingPageAnalytics').mockReturnValue({
+    trackNavigation: mockTrackNavigation,
+    trackFirstSearch: vi.fn(),
+  });
+}
+
+function NavigatorHelper({ to }: { to: string }) {
+  const navigate = useNavigate();
+  return (
+    <button data-testid="navigate-btn" onClick={() => navigate(to)}>
+      Go
+    </button>
+  );
+}
+
+function renderTracker(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <NavigationTracker />
+      <Routes>
+        <Route path="*" element={<NavigatorHelper to="/case-detail/123" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('NavigationTracker', () => {
+  beforeEach(() => {
+    mockTrackNavigation.mockClear();
+    setupAnalyticsSpy();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should not track on first render (no previous path)', () => {
+    renderTracker(CASE_SEARCH_PATH);
+    expect(mockTrackNavigation).not.toHaveBeenCalled();
+  });
+
+  test('should track navigation away from CASE_SEARCH_PATH', () => {
+    const { getByTestId } = renderTracker(CASE_SEARCH_PATH);
+    act(() => getByTestId('navigate-btn').click());
+    expect(mockTrackNavigation).toHaveBeenCalledWith('/case-detail/123');
+  });
+
+  test('should only track first navigation away from CASE_SEARCH_PATH', () => {
+    const { getByTestId } = renderTracker(CASE_SEARCH_PATH);
+    act(() => getByTestId('navigate-btn').click());
+    act(() => getByTestId('navigate-btn').click());
+    expect(mockTrackNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  test('should track navigation away from LOGIN_SUCCESS_PATH', () => {
+    const { getByTestId } = renderTracker(LOGIN_SUCCESS_PATH);
+    act(() => getByTestId('navigate-btn').click());
+    expect(mockTrackNavigation).toHaveBeenCalledWith('/case-detail/123');
+  });
+
+  test('should not track navigation when previous path is not a landing page', () => {
+    const { getByTestId } = renderTracker('/some-other-path');
+    act(() => getByTestId('navigate-btn').click());
+    expect(mockTrackNavigation).not.toHaveBeenCalled();
+  });
+});

--- a/user-interface/src/lib/components/PhoneNumberInput.test.tsx
+++ b/user-interface/src/lib/components/PhoneNumberInput.test.tsx
@@ -96,5 +96,43 @@ describe('PhoneNumberInput', () => {
     await waitFor(() => {
       expect(alertSpy).toHaveBeenCalledWith(phoneNumber);
     });
+
+    await userEvent.click(screen.getByText('Reset Value'));
+    await waitFor(() => {
+      expect(screen.getByTestId(id)).toHaveValue(blank);
+    });
+  });
+
+  test('should support disable and focus imperatives', async () => {
+    const id = 'phone-disable-test';
+
+    const Wrapper = () => {
+      const ref = React.createRef<InputRef>();
+      return (
+        <>
+          <PhoneNumberInput onChange={vi.fn()} id={id} data-testid={id} ref={ref} />
+          <button onClick={() => ref.current?.disable(true)}>Disable</button>
+          <button onClick={() => ref.current?.disable(false)}>Enable</button>
+          <button onClick={() => ref.current?.focus()}>Focus</button>
+        </>
+      );
+    };
+
+    render(<Wrapper />);
+
+    await userEvent.click(screen.getByText('Disable'));
+    await waitFor(() => {
+      expect(screen.getByTestId(id)).toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByText('Enable'));
+    await waitFor(() => {
+      expect(screen.getByTestId(id)).not.toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByText('Focus'));
+    await waitFor(() => {
+      expect(screen.getByTestId(id)).toHaveFocus();
+    });
   });
 });

--- a/user-interface/src/lib/components/ZipCodeInput.test.tsx
+++ b/user-interface/src/lib/components/ZipCodeInput.test.tsx
@@ -48,4 +48,45 @@ describe('ZipCodeInput', () => {
     await userEvent.click(screen.getByText('Set Value'));
     await waitFor(() => expect(input).toHaveValue(zipFull));
   });
+
+  test('should support resetValue, getValue, disable, and focus imperatives', async () => {
+    const id = 'zip-imperative-test';
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    const Wrapper = () => {
+      const ref = React.createRef<InputRef>();
+      return (
+        <>
+          <ZipCodeInput id={id} data-testid={id} onChange={vi.fn()} ref={ref} />
+          <button onClick={() => ref.current?.setValue('123456789')}>Set Value</button>
+          <button onClick={() => ref.current?.resetValue()}>Reset Value</button>
+          <button onClick={() => window.alert(ref.current?.getValue())}>Get Value</button>
+          <button onClick={() => ref.current?.disable(true)}>Disable</button>
+          <button onClick={() => ref.current?.disable(false)}>Enable</button>
+          <button onClick={() => ref.current?.focus()}>Focus</button>
+        </>
+      );
+    };
+
+    render(<Wrapper />);
+    const input = screen.getByTestId(id) as HTMLInputElement;
+
+    await userEvent.click(screen.getByText('Set Value'));
+    await waitFor(() => expect(input).toHaveValue('12345-6789'));
+
+    await userEvent.click(screen.getByText('Get Value'));
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('12345-6789'));
+
+    await userEvent.click(screen.getByText('Reset Value'));
+    await waitFor(() => expect(input).toHaveValue(''));
+
+    await userEvent.click(screen.getByText('Disable'));
+    await waitFor(() => expect(input).toBeDisabled());
+
+    await userEvent.click(screen.getByText('Enable'));
+    await waitFor(() => expect(input).not.toBeDisabled());
+
+    await userEvent.click(screen.getByText('Focus'));
+    await waitFor(() => expect(input).toHaveFocus());
+  });
 });

--- a/user-interface/src/lib/components/cams/BackLink/BackLink.scss
+++ b/user-interface/src/lib/components/cams/BackLink/BackLink.scss
@@ -1,0 +1,12 @@
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  padding-top: 1rem;
+  padding-bottom: 0;
+
+  .usa-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 0.25rem;
+  }
+}

--- a/user-interface/src/lib/components/cams/BackLink/BackLink.tsx
+++ b/user-interface/src/lib/components/cams/BackLink/BackLink.tsx
@@ -1,0 +1,19 @@
+import './BackLink.scss';
+import { Link } from 'react-router-dom';
+import Icon from '@/lib/components/uswds/Icon';
+
+interface BackLinkProps {
+  to: string;
+  label: string;
+  title?: string;
+  testId?: string;
+}
+
+export function BackLink({ to, label, title, testId }: Readonly<BackLinkProps>) {
+  return (
+    <Link to={to} className="usa-link back-link" title={title} data-testid={testId ?? 'back-link'}>
+      <Icon name="navigate_before" />
+      {label}
+    </Link>
+  );
+}

--- a/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
+++ b/user-interface/src/lib/components/cams/CommsLink/CommsLink.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import './CommsLink.scss';
-import { ContactInformation } from '@common/cams/contact';
+import { ContactWithPartialPhoneAndAddress } from '@common/cams/contact';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
 import Validators from '@common/cams/validators';
 import { FIELD_VALIDATION_MESSAGES } from '@common/cams/validation-messages';
 import { EMAIL_REGEX, PHONE_REGEX } from '@common/cams/regex';
 
 type CommsLinkProps = {
-  contact: Omit<ContactInformation, 'address'>;
+  contact: ContactWithPartialPhoneAndAddress;
   mode: 'teams-chat' | 'teams-call' | 'phone-dialer' | 'email' | 'website';
   label?: string;
   icon?: string;

--- a/user-interface/src/lib/components/cams/FormattedContact.tsx
+++ b/user-interface/src/lib/components/cams/FormattedContact.tsx
@@ -1,10 +1,10 @@
 import './FormattedContact.scss';
 import React, { JSX } from 'react';
-import { ContactInformation } from '@common/cams/contact';
+import { ContactWithPartialPhoneAndAddress } from '@common/cams/contact';
 import CommsLink from '@/lib/components/cams/CommsLink/CommsLink';
 
 const formatCompanyName = (
-  contact: Partial<ContactInformation>,
+  contact: ContactWithPartialPhoneAndAddress,
   _showLinks: boolean,
   getTestId: (s: string) => string | undefined,
 ): React.ReactNode | undefined => {
@@ -19,7 +19,7 @@ const formatCompanyName = (
 };
 
 const formatAddress = (
-  contact: Partial<ContactInformation>,
+  contact: ContactWithPartialPhoneAndAddress,
   _showLinks: boolean,
   getTestId: (s: string) => string | undefined,
 ): React.ReactNode | undefined => {
@@ -70,7 +70,7 @@ const formatAddress = (
 };
 
 const formatPhone = (
-  contact: Partial<ContactInformation>,
+  contact: ContactWithPartialPhoneAndAddress,
   showLinks: boolean,
   getTestId: (s: string) => string | undefined,
 ): React.ReactNode | undefined => {
@@ -92,7 +92,7 @@ const formatPhone = (
 };
 
 const formatEmail = (
-  contact: Partial<ContactInformation>,
+  contact: ContactWithPartialPhoneAndAddress,
   showLinks: boolean,
   getTestId: (s: string) => string | undefined,
 ): React.ReactNode | undefined => {
@@ -106,7 +106,7 @@ const formatEmail = (
 };
 
 const formatWebsite = (
-  contact: Partial<ContactInformation>,
+  contact: ContactWithPartialPhoneAndAddress,
   showLinks: boolean,
   getTestId: (s: string) => string | undefined,
 ): React.ReactNode | undefined => {
@@ -121,7 +121,7 @@ const formatWebsite = (
 
 export type FormattedContactProps = {
   className?: string;
-  contact?: Partial<ContactInformation>;
+  contact?: ContactWithPartialPhoneAndAddress;
   showLinks?: boolean;
   testIdPrefix?: string;
 };

--- a/user-interface/src/lib/components/uswds/modal/Modal.test.tsx
+++ b/user-interface/src/lib/components/uswds/modal/Modal.test.tsx
@@ -618,6 +618,55 @@ describe('Test Modal component', () => {
   });
 });
 
+describe('Test Modal handleTab via action buttons', () => {
+  const modalId = 'tab-modal';
+
+  beforeEach(() => {
+    const modalRef = React.createRef<ModalRefType>();
+    const content = (
+      <div>
+        <Checkbox id="tab-test-checkbox" value={1} />
+      </div>
+    );
+    render(
+      <BrowserRouter>
+        <>
+          <OpenModalButton buttonIndex="tab-test" modalId={modalId} modalRef={modalRef}>
+            Open
+          </OpenModalButton>
+          <Modal
+            modalId={modalId}
+            ref={modalRef}
+            heading="Tab Test Modal"
+            content={content}
+            actionButtonGroup={{
+              modalId,
+              modalRef,
+              submitButton: { label: 'Submit', className: 'tab-submit', onClick: vi.fn() },
+              cancelButton: { label: 'Cancel', className: 'tab-cancel', onClick: vi.fn() },
+            }}
+          />
+        </>
+      </BrowserRouter>,
+    );
+    fireEvent.click(screen.getByTestId('open-modal-button_tab-test'));
+  });
+
+  test('should call handleTab when Tab is pressed on submit button', () => {
+    const submitButton = document.querySelector('.tab-submit') as HTMLElement;
+    const firstElement = document.querySelector('.usa-checkbox__label') as HTMLElement;
+    fireEvent.keyDown(submitButton, { key: 'Tab' });
+    expect(firstElement).toHaveFocus();
+  });
+
+  test('should call handleTab when Tab is pressed on cancel button', () => {
+    const cancelButton = document.querySelector('.tab-cancel') as HTMLElement;
+    const firstElement = document.querySelector('.usa-checkbox__label') as HTMLElement;
+    fireEvent.keyDown(cancelButton, { key: 'Tab' });
+    expect(firstElement).toHaveFocus();
+  });
+});
+
 describe('Test Modal component with force action set to true', () => {
   const modalId = 'test-modal';
 

--- a/user-interface/src/lib/models/api2.test.ts
+++ b/user-interface/src/lib/models/api2.test.ts
@@ -103,6 +103,7 @@ describe('_Api2 functions', async () => {
     await callApiFunction(api2.default.getTrusteeOversightAssignments, 'some-id', api);
     await callApiFunction(api2.default.getBanks, null, api);
     await callApiFunction(api2.default.getSoftwareList, null, api);
+    await callApiFunction(api2.default.getSoftware, 'sw-1', api);
   });
 
   test('should call api.put function when calling putPrivilegedIdentityUser', () => {
@@ -337,6 +338,7 @@ describe('_Api2 functions', async () => {
     ).rejects.toThrow(error);
     await expect(api2.default.getBanks()).rejects.toThrow(error);
     await expect(api2.default.getSoftwareList()).rejects.toThrow(error);
+    await expect(api2.default.getSoftware('sw-1')).rejects.toThrow(error);
     const mockOrder = MockData.getConsolidationOrder();
     await expect(
       api2.default.putConsolidationOrderApproval({
@@ -480,6 +482,22 @@ describe('_Api2 functions', async () => {
       .mockResolvedValue({ data: { id: 'software-id' } });
     api2.default.createSoftware({ name: 'Test Software' });
     expect(postSpy).toHaveBeenCalledWith('/bankruptcy-software', { name: 'Test Software' }, {});
+  });
+
+  test('should call api.get function when calling getSoftware', () => {
+    const getSpy = vi.spyOn(api.default, 'get').mockResolvedValue({ data: {} });
+    api2.default.getSoftware('sw-1');
+    expect(getSpy).toHaveBeenCalledWith('/bankruptcy-software/sw-1', {});
+  });
+
+  test('should call api.put function when calling updateSoftware', () => {
+    const putSpy = vi.spyOn(api.default, 'put').mockResolvedValue({ data: {} });
+    api2.default.updateSoftware('sw-1', { name: 'Updated', status: 'inactive' });
+    expect(putSpy).toHaveBeenCalledWith(
+      '/bankruptcy-software/sw-1',
+      { name: 'Updated', status: 'inactive' },
+      {},
+    );
   });
 
   test('should call api.get function when calling getBanks', () => {

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -553,6 +553,17 @@ async function createSoftware(data: { name: string }) {
   return api().post<BankruptcySoftwareProfile, { name: string }>('/bankruptcy-software', data);
 }
 
+async function getSoftware(softwareId: string) {
+  return api().get<BankruptcySoftwareProfile>(`/bankruptcy-software/${softwareId}`);
+}
+
+async function updateSoftware(
+  softwareId: string,
+  data: Partial<Pick<BankruptcySoftwareProfile, 'name' | 'status' | 'contact'>>,
+) {
+  return api().put<BankruptcySoftwareProfile>(`/bankruptcy-software/${softwareId}`, data);
+}
+
 async function getCaseTrusteeAppointment(caseId: string) {
   return api().get<CaseAppointment>(`/cases/${caseId}/trustee-appointment`);
 }
@@ -653,6 +664,8 @@ export const _Api2 = {
   updateBank,
   getSoftwareList,
   createSoftware,
+  getSoftware,
+  updateSoftware,
   getOversightStaff,
   postCaseReload,
   getCaseTrusteeAppointment,

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -44,6 +44,7 @@ import { TrusteeNote, TrusteeNoteInput } from '@common/cams/trustee-notes';
 import { TrusteeSearchResult } from '@common/cams/trustee-search';
 import { TrusteeUpcomingKeyDates } from '@common/cams/trustee-upcoming-key-dates';
 import { BankProfile } from '@common/cams/banks';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 import { CamsRole, OversightRoleType } from '@common/cams/roles';
 
 // Helper to generate a random ID
@@ -2822,6 +2823,40 @@ async function createSoftware(data: { name: string }) {
   };
 }
 
+async function getSoftware(softwareId: string) {
+  const mockUser = { id: 'system', name: 'System' };
+  const now = new Date().toISOString();
+  return {
+    data: {
+      id: softwareId,
+      documentType: 'BANKRUPTCY_SOFTWARE' as const,
+      name: 'Mock Software',
+      status: 'active' as const,
+      updatedOn: now,
+      updatedBy: mockUser,
+    },
+  };
+}
+
+async function updateSoftware(
+  softwareId: string,
+  data: Partial<Pick<BankruptcySoftwareProfile, 'name' | 'status' | 'contact'>>,
+) {
+  const mockUser = { id: 'system', name: 'System' };
+  const now = new Date().toISOString();
+  return {
+    data: {
+      id: softwareId,
+      documentType: 'BANKRUPTCY_SOFTWARE' as const,
+      name: data.name ?? 'Mock Software',
+      status: data.status ?? ('active' as const),
+      contact: data.contact,
+      updatedOn: now,
+      updatedBy: mockUser,
+    },
+  };
+}
+
 async function getBanks() {
   const mockUser = { id: 'system', name: 'System' };
   const now = new Date().toISOString();
@@ -3025,6 +3060,8 @@ const MockApi2 = {
   updateBank,
   getSoftwareList,
   createSoftware,
+  getSoftware,
+  updateSoftware,
   getUpcomingKeyDates,
   putUpcomingKeyDates,
   getTrusteeOversightAssignments,

--- a/user-interface/src/styles/left-navigation-pane.scss
+++ b/user-interface/src/styles/left-navigation-pane.scss
@@ -4,7 +4,7 @@
 
 .left-navigation-pane-container {
   flex-shrink: 0;
-  min-width: 150px;
+  min-width: 175px;
 
   .usa-sidenav__item {
     list-style-type: none;


### PR DESCRIPTION
# Purpose

Allow Office of Oversight administrators to view a full vendor profile, edit the vendor name and status, and add or update vendor contact information from the Bankruptcy Software admin page.

# Major Changes

* Added vendor detail page at `/admin/bankruptcy-software/:softwareId` with Overview nav and Trustees placeholder
* Two InfoCards on the overview: General Information (name, status with edit modal) and Vendor Contact Info. (formatted contact with full-page edit form)
* Edit Bankruptcy Software modal — pre-filled name/status inputs with warning messages about downstream impact
* Full-page contact info form with dynamic multi-name and multi-email fields, US state picker, auto-formatting phone and ZIP inputs
* Extended `BankruptcySoftwareProfile` with optional `SoftwareContactInfo` (aligns with `ContactInformation` from `@common/cams/contact` for use with existing `FormattedContact` component)
* Backend: `GET /bankruptcy-software/:softwareId` (strips contact for non-SuperUser) and `PUT /bankruptcy-software/:softwareId` (merge update with audit record)
* Vendor names on the list page are now clickable links to the detail page

# Testing/Validation

Implemented using TDD. 97 UI tests and 39 backend tests passing. Each layer (repository, use case, controller, function, UI components) independently tested. Manual verification against dev Cosmos instance confirms detail page loads, edit modal updates state without full reload, and contact form saves and navigates back.

# Notes

* `FormattedContact` (existing component) is used for the contact card display — `SoftwareContactInfo` maps to `Partial<ContactInformation>` at the component boundary
* Contact info is stripped from `GET /:softwareId` responses for non-SuperUser callers, consistent with the design decision established in Slice 1
* `updateSoftware` in the use case reads the current document, merges only the provided fields, and writes an audit record — same pattern as `updateBank` in CAMS-670
* The Trustees left-nav item is a non-link placeholder; Slice 4 (blocked on CAMS-671) will wire it up

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add bankruptcy software vendor detail view with editable general info and contact data, backed by new GET/PUT endpoints and repository methods, and wire it into the admin UI navigation.

New Features:
- Introduce bankruptcy software detail page with overview navigation and back link from the admin list.
- Allow admins to edit bankruptcy software name and status via an Edit Software modal.
- Add a full-page vendor contact information form supporting multiple contacts, emails, and address/phone details.
- Expose API methods in the UI layer to fetch a single bankruptcy software profile and update it, including contact info.

Enhancements:
- Extend bankruptcy software domain model with optional vendor contact information compatible with existing contact display components.
- Enforce role-based visibility of vendor contact information so non-SuperUsers receive profiles without contact data.
- Implement use case and Mongo repository operations to retrieve and update individual bankruptcy software records with audit logging.
- Update Azure Function routing and controller request handling to support GET/PUT by softwareId and validate updates.
- Make bankruptcy software names on the admin list clickable links to their detail pages.

Tests:
- Add backend tests covering controller routing, contact redaction, authorization and validation for updates, and repository/use case behavior for get/update operations.
- Add frontend tests for the new detail page, overview cards, navigation, edit modal, and contact info form, plus API wiring tests for new endpoints.