### PR TITLE
CAMS-741 Improve district/division dropdown display and add auto-upgrade to All

### DIFF
--- a/common/src/cams/sanitization.test.ts
+++ b/common/src/cams/sanitization.test.ts
@@ -333,15 +333,7 @@ describe('String sanitization functions', () => {
         { value: 'deep' },
       );
       expect(() => sanitizeDeep(deepObject)).toThrow(SanitizationError);
-      expect(() => sanitizeDeep(deepObject)).toThrow('Max depth exceeded');
-      try {
-        sanitizeDeep(deepObject);
-        expect.fail('Should have thrown');
-      } catch (err) {
-        expect(err).toBeInstanceOf(SanitizationError);
-        expect((err as SanitizationError).message).toMatch(/Max depth exceeded:/);
-        expect((err as SanitizationError).message).toMatch(/>/);
-      }
+      expect(() => sanitizeDeep(deepObject)).toThrow(/Max depth exceeded:.*>/s);
     });
 
     test('should throw SanitizationError when max key count exceeded', () => {
@@ -349,15 +341,7 @@ describe('String sanitization functions', () => {
         Array.from({ length: 1100 }, (_, i) => [`key${i}`, `value${i}`]),
       );
       expect(() => sanitizeDeep({ data: largeObject })).toThrow(SanitizationError);
-      expect(() => sanitizeDeep({ data: largeObject })).toThrow('Max key count exceeded');
-      try {
-        sanitizeDeep({ data: largeObject });
-        expect.fail('Should have thrown');
-      } catch (err) {
-        expect(err).toBeInstanceOf(SanitizationError);
-        expect((err as SanitizationError).message).toMatch(/Max key count exceeded:/);
-        expect((err as SanitizationError).message).toMatch(/>/);
-      }
+      expect(() => sanitizeDeep({ data: largeObject })).toThrow(/Max key count exceeded:.*>/s);
     });
 
     test('should sanitize deep structures with maxObjectDepth default of 50', () => {

--- a/knip.json
+++ b/knip.json
@@ -67,7 +67,8 @@
     "dev-tools/.venv-docs/bin/python3",
     "python3",
     "podman",
-    "podman-compose"
+    "podman-compose",
+    "stryker"
   ],
   "ignoreDependencies": [
     "@azure/cosmos",
@@ -99,6 +100,7 @@
     "launchdarkly-react-client-sdk",
     "react-router-dom",
     "common",
-    "globals"
+    "globals",
+    "@stryker-mutator/core"
   ]
 }

--- a/user-interface/src/lib/utils/court-utils.ts
+++ b/user-interface/src/lib/utils/court-utils.ts
@@ -337,7 +337,7 @@ export function getDistrictDivisionComboOptions(
       options.push({
         value: `${district.courtId}|${div.courtDivisionCode}`,
         label: `${district.courtName} (${div.courtDivisionName})`,
-        selectedLabel: `${div.courtDivisionName}`,
+        selectedLabel: `${district.courtName} (${div.courtDivisionName})`,
       });
     }
   }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -11,6 +11,7 @@ import { TrusteeDistrictFilterRef } from './trusteeDistrictFilter.types';
 import React from 'react';
 import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 import { FeatureFlagSet } from '@common/feature-flags';
+import { ComboOption } from '@/lib/components/combobox/ComboBoxAlt';
 
 const mockDistricts: CourtDivisionDetails[] = [
   {
@@ -55,6 +56,7 @@ function renderFilter(
   overrides: Partial<{
     ref: React.RefObject<TrusteeDistrictFilterRef>;
     onExpandedChange: (expanded: boolean) => void;
+    combinedDistrictDivisionOptions: ComboOption[];
   }> = {},
 ) {
   const mockHandleFilterDistrict = vi.fn();
@@ -68,7 +70,7 @@ function renderFilter(
       handleFilterChapter={mockHandleFilterChapter}
       handleFilterName={mockHandleFilterName}
       handleFilterDivision={mockHandleFilterDivision}
-      combinedDistrictDivisionOptions={[]}
+      combinedDistrictDivisionOptions={overrides.combinedDistrictDivisionOptions ?? []}
       onExpandedChange={overrides.onExpandedChange}
     />,
   );
@@ -82,7 +84,8 @@ function renderFilter(
 
 describe('TrusteeDistrictFilter Component', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
     vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
       'trustee-district-division': false,
     } as FeatureFlagSet);
@@ -90,13 +93,8 @@ describe('TrusteeDistrictFilter Component', () => {
     vi.spyOn(Api2, 'getCourts').mockResolvedValue(mockResponse);
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   test('should render collapsed by default and expand when toggle button clicked, loading districts from API', async () => {
     const user = userEvent.setup();
-    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
     renderFilter();
 
@@ -119,7 +117,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
   test('should display unique districts by courtId', async () => {
     const user = userEvent.setup();
-    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
     renderFilter();
 
@@ -203,7 +200,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
   test('should call handleFilterDistrict when selection changes', async () => {
     const user = userEvent.setup();
-    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
     const { mockHandleFilterDistrict } = renderFilter();
 
@@ -238,7 +234,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
   test('should show selected districts as pills when collapsed', async () => {
     const user = userEvent.setup();
-    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
     renderFilter();
 
@@ -343,7 +338,6 @@ describe('TrusteeDistrictFilter Component', () => {
   test('should display error message when API fails', async () => {
     const user = userEvent.setup();
     vi.spyOn(Api2, 'getCourts').mockRejectedValue(new Error('API Error'));
-    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
     renderFilter();
 
@@ -363,8 +357,6 @@ describe('TrusteeDistrictFilter Component', () => {
   });
 
   test('should handle empty user session gracefully', async () => {
-    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
-
     const { mockHandleFilterDistrict } = renderFilter();
 
     await waitFor(() => {
@@ -378,7 +370,6 @@ describe('TrusteeDistrictFilter Component', () => {
   test('should call onExpandedChange callback when toggling between collapsed and expanded states', async () => {
     const user = userEvent.setup();
     const mockOnExpandedChange = vi.fn();
-    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
     renderFilter({ onExpandedChange: mockOnExpandedChange });
 
@@ -491,7 +482,6 @@ describe('TrusteeDistrictFilter Component', () => {
   describe('Name Filter', () => {
     test('renders name input inside accordion when expanded', async () => {
       const user = userEvent.setup();
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderFilter();
 
@@ -505,7 +495,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
     test('does not show Clear button when name input is empty', async () => {
       const user = userEvent.setup();
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderFilter();
 
@@ -522,7 +511,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
     test('shows Clear button when name input has text', async () => {
       const user = userEvent.setup();
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderFilter();
 
@@ -542,7 +530,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
     test('Clear button click empties input and calls handleFilterName with empty string', async () => {
       const user = userEvent.setup();
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       const { mockHandleFilterName } = renderFilter();
 
@@ -562,7 +549,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
     test('typing calls handleFilterName with current value', async () => {
       const user = userEvent.setup();
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       const { mockHandleFilterName } = renderFilter();
 
@@ -579,10 +565,83 @@ describe('TrusteeDistrictFilter Component', () => {
     });
   });
 
+  describe('Upgrade Announcement (districtDivisionEnabled)', () => {
+    const combinedOptions: ComboOption[] = [
+      {
+        value: 'NYSB|ALL',
+        label: 'Southern District of New York (All)',
+        selectedLabel: 'Southern District of New York (All)',
+      },
+      {
+        value: 'NYSB|081',
+        label: 'Southern District of New York (Manhattan)',
+        selectedLabel: 'Southern District of New York (Manhattan)',
+      },
+      {
+        value: 'NYSB|087',
+        label: 'Southern District of New York (White Plains)',
+        selectedLabel: 'Southern District of New York (White Plains)',
+      },
+    ];
+
+    beforeEach(() => {
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': true,
+      } as FeatureFlagSet);
+    });
+
+    test('announces the All label when selecting the last remaining division upgrades the selection', async () => {
+      const user = userEvent.setup();
+
+      renderFilter({ combinedDistrictDivisionOptions: combinedOptions });
+
+      // Wait for districts to load from API
+      await waitFor(() => expect(Api2.getCourts).toHaveBeenCalled());
+
+      // Expand the filter
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      // Open the District (Division) combobox and select Manhattan
+      const combobox = await screen.findByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combobox);
+      await user.click(await screen.findByRole('option', { name: /manhattan/i }));
+
+      // Select White Plains — all divisions for NYSB are now selected, upgrade fires
+      await user.click(await screen.findByRole('option', { name: /white plains/i }));
+
+      await waitFor(() => {
+        const liveRegion = document.querySelector('[aria-live="polite"][aria-atomic="true"]');
+        expect(liveRegion).toHaveTextContent('Southern District of New York (All)');
+      });
+    });
+
+    test('aria-live span is empty when no upgrade has occurred', async () => {
+      const user = userEvent.setup();
+
+      renderFilter({ combinedDistrictDivisionOptions: combinedOptions });
+
+      await waitFor(() => expect(Api2.getCourts).toHaveBeenCalled());
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      // Select only one division — not all, so no upgrade
+      const combobox = await screen.findByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combobox);
+      await user.click(await screen.findByRole('option', { name: /manhattan/i }));
+
+      // The announcement span should remain empty
+      const liveRegion = screen.getByRole('region', { name: /trustee filter controls/i });
+      const spans = liveRegion.querySelectorAll('[aria-live="polite"]');
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toHaveTextContent('');
+    });
+  });
+
   describe('Chapter Filter', () => {
     test('should render chapter combobox when accordion is expanded', async () => {
       const user = userEvent.setup();
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderFilter();
 
@@ -600,7 +659,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
     test('should call handleFilterChapter when a chapter is selected', async () => {
       const user = userEvent.setup();
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       const { mockHandleFilterChapter } = renderFilter();
 
@@ -633,7 +691,6 @@ describe('TrusteeDistrictFilter Component', () => {
 
     test('should render chapter pill when chapter is selected and accordion is collapsed', async () => {
       const user = userEvent.setup();
-      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       renderFilter();
 

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -30,6 +30,8 @@ const TrusteeDistrictFilter_ = (
   const flags = useFeatureFlags();
   const districtDivisionEnabled = !!flags[TRUSTEE_DISTRICT_DIVISION];
   const [nameSearch, setNameSearch] = useState('');
+  const [upgradeAnnouncement, setUpgradeAnnouncement] = useState('');
+  const previousDivisionValuesRef = useRef<Set<string>>(new Set());
   const store: TrusteeDistrictFilterStore = useTrusteeDistrictFilterStoreReact();
   const controls: TrusteeDistrictFilterControls = useTrusteeDistrictFilterControlsReact();
 
@@ -91,6 +93,25 @@ const TrusteeDistrictFilter_ = (
     }
   }, [store.districts, onCourtsLoaded]);
 
+  // Announce when individual division selections are auto-upgraded to an All option.
+  // Reset to '' first so NVDA always sees a content change even if the same district upgrades twice.
+  useEffect(() => {
+    const currentValues = new Set(store.selectedDivisions.map((d) => d.value));
+    const newAllSelections = store.selectedDivisions.filter(
+      (d) => d.value.endsWith('|ALL') && !previousDivisionValuesRef.current.has(d.value),
+    );
+    previousDivisionValuesRef.current = currentValues;
+    if (newAllSelections.length > 0) {
+      const labels = newAllSelections.map((d) => d.label).join(', ');
+      setUpgradeAnnouncement('');
+      requestAnimationFrame(() => {
+        setUpgradeAnnouncement(`${labels}`);
+      });
+    } else {
+      setUpgradeAnnouncement('');
+    }
+  }, [store.selectedDivisions]);
+
   const defaultDivisionValues = new Set((store.defaultDivisions ?? []).map((d) => d.value));
   const orderedCombinedOptions = districtDivisionEnabled
     ? separateDefaultOptions(props.combinedDistrictDivisionOptions, defaultDivisionValues)
@@ -109,6 +130,7 @@ const TrusteeDistrictFilter_ = (
     chapterFilterRef: controls.chapterFilterRef,
     divisionFilterRef: controls.divisionFilterRef,
     nameSearch,
+    upgradeAnnouncement,
     districtsToComboOptions: useCase.districtsToComboOptions,
     chaptersToComboOptions: useCase.chaptersToComboOptions,
     handleFilterChange: useCase.handleFilterChange,

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -102,6 +102,9 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
 
   return (
     <section className="trustee-district-filter" aria-label="Trustee filter controls">
+      <span className="screen-reader-only" aria-live="polite" aria-atomic="true">
+        {viewModel.upgradeAnnouncement}
+      </span>
       <AccordionGroup>
         <Accordion id="district-filter" onExpand={() => viewModel.handleToggleExpanded()}>
           <span>Filters</span>

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -45,6 +45,7 @@ export interface TrusteeDistrictFilterViewModel {
   chapterFilterRef: React.RefObject<ComboBoxRef | null>;
   divisionFilterRef: React.RefObject<ComboBoxRef | null>;
   nameSearch: string;
+  upgradeAnnouncement: string;
 
   districtsToComboOptions(districts: CourtDivisionDetails[]): ComboOption[];
   chaptersToComboOptions(): ComboOption[];

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -6,6 +6,7 @@ import {
 import MockData from '@common/cams/test-utilities/mock-data';
 import trusteeDistrictFilterUseCase, {
   resolveCombinedSelections,
+  autoUpgradeToAll,
   getUserDivisionCodes,
 } from './trusteeDistrictFilterUseCase';
 import { MockInstance } from 'vitest';
@@ -853,6 +854,114 @@ describe('trustee district filter use case tests', () => {
         { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
       ]);
     });
+  });
+});
+
+describe('autoUpgradeToAll', () => {
+  const nysbDistricts = [
+    {
+      officeName: 'Manhattan',
+      officeCode: '081',
+      courtId: 'NYSB',
+      courtName: 'Southern District of New York',
+      courtDivisionCode: '081',
+      courtDivisionName: 'Manhattan',
+      groupDesignator: 'NY',
+      regionId: '02',
+      regionName: 'New York Region',
+      state: 'NY',
+    },
+    {
+      officeName: 'White Plains',
+      officeCode: '087',
+      courtId: 'NYSB',
+      courtName: 'Southern District of New York',
+      courtDivisionCode: '087',
+      courtDivisionName: 'White Plains',
+      groupDesignator: 'NY',
+      regionId: '02',
+      regionName: 'New York Region',
+      state: 'NY',
+    },
+  ];
+
+  const vtbDistricts = [
+    {
+      officeName: 'Rutland',
+      officeCode: '088',
+      courtId: 'VTB',
+      courtName: 'District of Vermont',
+      courtDivisionCode: '088',
+      courtDivisionName: 'Rutland',
+      groupDesignator: 'VT',
+      regionId: '01',
+      regionName: 'Boston Region',
+      state: 'VT',
+    },
+  ];
+
+  const allDistricts = [...nysbDistricts, ...vtbDistricts];
+
+  test('returns selections unchanged when not all divisions are selected', () => {
+    const selections: ComboOption[] = [
+      { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+    ];
+    expect(autoUpgradeToAll(selections, allDistricts)).toEqual(selections);
+  });
+
+  test('upgrades to ALL when all divisions in a district are individually selected', () => {
+    const selections: ComboOption[] = [
+      { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+      { value: 'NYSB|087', label: 'Southern District of New York (White Plains)' },
+    ];
+    const result = autoUpgradeToAll(selections, allDistricts);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe('NYSB|ALL');
+    expect(result[0].label).toBe('Southern District of New York (All)');
+    expect(result[0].selectedLabel).toBe('Southern District of New York (All)');
+  });
+
+  test('does not upgrade a district that is only partially selected', () => {
+    const selections: ComboOption[] = [
+      { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+    ];
+    const result = autoUpgradeToAll(selections, allDistricts);
+    expect(result).toEqual(selections);
+    expect(result.find((s) => s.value === 'NYSB|ALL')).toBeUndefined();
+  });
+
+  test('upgrades only the fully-selected district, leaves others unchanged', () => {
+    const selections: ComboOption[] = [
+      { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+      { value: 'NYSB|087', label: 'Southern District of New York (White Plains)' },
+      { value: 'VTB|088', label: 'District of Vermont (Rutland)' },
+    ];
+    const result = autoUpgradeToAll(selections, allDistricts);
+    // VTB has only one division, so it gets upgraded too
+    // NYSB gets upgraded since both divisions selected
+    expect(result.find((s) => s.value === 'NYSB|ALL')).toBeDefined();
+    expect(result.find((s) => s.value === 'VTB|ALL')).toBeDefined();
+    expect(result.find((s) => s.value === 'NYSB|081')).toBeUndefined();
+    expect(result.find((s) => s.value === 'NYSB|087')).toBeUndefined();
+    expect(result.find((s) => s.value === 'VTB|088')).toBeUndefined();
+  });
+
+  test('returns selections unchanged when ALL already selected', () => {
+    const selections: ComboOption[] = [
+      { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+    ];
+    expect(autoUpgradeToAll(selections, allDistricts)).toEqual(selections);
+  });
+
+  test('returns empty array when given empty selections', () => {
+    expect(autoUpgradeToAll([], allDistricts)).toEqual([]);
+  });
+
+  test('returns selections unchanged when no districts provided', () => {
+    const selections: ComboOption[] = [
+      { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
+    ];
+    expect(autoUpgradeToAll(selections, [])).toEqual(selections);
   });
 });
 

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.test.ts
@@ -14,13 +14,9 @@ import { CourtDivisionDetails } from '@common/cams/courts';
 import { CamsSession } from '@common/cams/session';
 import Api2 from '@/lib/models/api2';
 import LocalStorage from '@/lib/utils/local-storage';
+import * as AppInsights from '@/lib/hooks/UseApplicationInsights';
 
 const mockTrackEvent = vi.fn();
-vi.mock('@/lib/hooks/UseApplicationInsights', () => ({
-  getAppInsights: () => ({
-    appInsights: { trackEvent: mockTrackEvent },
-  }),
-}));
 
 describe('trustee district filter use case tests', () => {
   let setSelectedDistrictsSpy: MockInstance<(val: ComboOption[]) => void>;
@@ -132,6 +128,10 @@ describe('trustee district filter use case tests', () => {
   );
 
   beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(AppInsights, 'getAppInsights').mockReturnValue({
+      appInsights: { trackEvent: mockTrackEvent },
+    } as unknown as ReturnType<typeof AppInsights.getAppInsights>);
     mockStore.defaultDistricts = [];
     mockStore.defaultDivisions = [];
     mockStore.setSelectedDistricts = vi.fn();
@@ -146,10 +146,6 @@ describe('trustee district filter use case tests', () => {
     previousDistrictsRef.current = undefined;
     previousChaptersRef.current = undefined;
     previousDivisionsRef.current = undefined;
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe('districtsToComboOptions', () => {
@@ -798,61 +794,19 @@ describe('trustee district filter use case tests', () => {
       expect(mockOnFilterDivision).toHaveBeenCalledWith([]);
     });
 
-    test('adding ALL option removes specific divisions for that court', () => {
+    test('auto-upgrades to ALL when all divisions in a district are individually selected', () => {
       const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
-      previousDivisionsRef.current = [
-        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
-      ];
-
       const selections: ComboOption[] = [
         { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
-        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
+        { value: 'NYSB|087', label: 'Southern District of New York (White Plains)' },
       ];
 
       useCase.handleFilterCombined(selections);
 
-      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([
-        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
-      ]);
-    });
-
-    test('adding specific division removes ALL option for that court', () => {
-      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
-      previousDivisionsRef.current = [
-        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
-      ];
-
-      const selections: ComboOption[] = [
-        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
-        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
-      ];
-
-      useCase.handleFilterCombined(selections);
-
-      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([
-        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
-      ]);
-    });
-
-    test('mutual exclusion does not affect selections from a different court', () => {
-      const setSelectedDivisionsSpy = vi.spyOn(mockStore, 'setSelectedDivisions');
-      previousDivisionsRef.current = [
-        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
-        { value: 'VTB|ALL', label: 'District of Vermont (All)' },
-      ];
-
-      const selections: ComboOption[] = [
-        { value: 'NYSB|081', label: 'Southern District of New York (Manhattan)' },
-        { value: 'VTB|ALL', label: 'District of Vermont (All)' },
-        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
-      ];
-
-      useCase.handleFilterCombined(selections);
-
-      expect(setSelectedDivisionsSpy).toHaveBeenCalledWith([
-        { value: 'VTB|ALL', label: 'District of Vermont (All)' },
-        { value: 'NYSB|ALL', label: 'Southern District of New York (All)' },
-      ]);
+      const stored = setSelectedDivisionsSpy.mock.calls[0][0];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].value).toBe('NYSB|ALL');
+      expect(mockOnFilterDivision).toHaveBeenCalledWith(stored);
     });
   });
 });

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -21,9 +21,11 @@ export function autoUpgradeToAll(
   districts: CourtDivisionDetails[],
 ): ComboOption[] {
   const allDivisionsByDistrict = new Map<string, Set<string>>();
+  const courtNameById = new Map<string, string>();
   for (const court of districts) {
     if (!allDivisionsByDistrict.has(court.courtId)) {
       allDivisionsByDistrict.set(court.courtId, new Set());
+      courtNameById.set(court.courtId, court.courtName);
     }
     allDivisionsByDistrict.get(court.courtId)!.add(court.courtDivisionCode);
   }
@@ -49,9 +51,9 @@ export function autoUpgradeToAll(
     ) {
       result = result.filter((s) => {
         const [sCourt, sCode] = s.value.split('|');
-        return !(sCourt === courtId && sCode !== 'ALL');
+        return sCourt !== courtId || sCode === 'ALL';
       });
-      const courtName = districts.find((d) => d.courtId === courtId)?.courtName ?? courtId;
+      const courtName = courtNameById.get(courtId) ?? courtId;
       result.push({
         value: `${courtId}|ALL`,
         label: `${courtName} (All)`,

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -16,6 +16,52 @@ import {
 } from '@/lib/utils/court-utils';
 import { AppointmentChapterType, formatChapterType } from '@common/cams/trustees';
 
+export function autoUpgradeToAll(
+  selections: ComboOption[],
+  districts: CourtDivisionDetails[],
+): ComboOption[] {
+  const allDivisionsByDistrict = new Map<string, Set<string>>();
+  for (const court of districts) {
+    if (!allDivisionsByDistrict.has(court.courtId)) {
+      allDivisionsByDistrict.set(court.courtId, new Set());
+    }
+    allDivisionsByDistrict.get(court.courtId)!.add(court.courtDivisionCode);
+  }
+
+  const selectedSpecificByDistrict = new Map<string, Set<string>>();
+  for (const sel of selections) {
+    const [courtId, code] = sel.value.split('|');
+    if (code !== 'ALL') {
+      if (!selectedSpecificByDistrict.has(courtId)) {
+        selectedSpecificByDistrict.set(courtId, new Set());
+      }
+      selectedSpecificByDistrict.get(courtId)!.add(code);
+    }
+  }
+
+  let result = [...selections];
+  for (const [courtId, selectedCodes] of selectedSpecificByDistrict.entries()) {
+    const allCodes = allDivisionsByDistrict.get(courtId);
+    if (
+      allCodes &&
+      selectedCodes.size === allCodes.size &&
+      [...selectedCodes].every((c) => allCodes.has(c))
+    ) {
+      result = result.filter((s) => {
+        const [sCourt, sCode] = s.value.split('|');
+        return !(sCourt === courtId && sCode !== 'ALL');
+      });
+      const courtName = districts.find((d) => d.courtId === courtId)?.courtName ?? courtId;
+      result.push({
+        value: `${courtId}|ALL`,
+        label: `${courtName} (All)`,
+        selectedLabel: `${courtName} (All)`,
+      });
+    }
+  }
+  return result;
+}
+
 export function resolveCombinedSelections(
   previous: ComboOption[],
   next: ComboOption[],
@@ -205,7 +251,8 @@ const trusteeDistrictFilterUseCase = (
   const handleFilterCombined = (selections: ComboOption[]) => {
     const previous = previousDivisionsRef.current ?? [];
     const resolved = resolveCombinedSelections(previous, selections);
-    handleFilterDivision(resolved);
+    const upgraded = autoUpgradeToAll(resolved, store.districts);
+    handleFilterDivision(upgraded);
   };
 
   const handleFilterChange = (districts: ComboOption[]) => {


### PR DESCRIPTION
# Bug

When a division was selected in the District (Division) dropdown, the input field showed only the division name (e.g., "Juneau") instead of the full district and division (e.g., "District of Alaska (Juneau)"), making it inconsistent with the pill display.

# Purpose

Improve clarity in the trustee filter by showing both district and division name when a selection is made, and automatically upgrading to the district-level "All" option when a user has individually selected every division in a district.

# Major Changes

* Updated `getDistrictDivisionComboOptions` in `court-utils.ts` to use the full `"District (Division)"` format for `selectedLabel` (was division name only)
* Added `autoUpgradeToAll` function in `trusteeDistrictFilterUseCase.ts` — when all individual divisions for a district are selected, the selection is automatically replaced with the `|ALL` form
* Wired `autoUpgradeToAll` into `handleFilterCombined` so the upgrade fires on every user selection change
* Added `stryker` binary and `@stryker-mutator/core` package to knip ignore lists to suppress false-positive warnings
* Fixed `vitest/no-conditional-expect` lint violations in `sanitization.test.ts` inherited from main

# Testing/Validation

Implemented using TDD. Unit tests added for `autoUpgradeToAll` covering: partial selection (no upgrade), full selection (upgrades to ALL), multi-district scenarios, already-ALL selected, and empty inputs. Integration test added to `handleFilterCombined` verifying the full pipeline stores the `|ALL` form when all divisions are selected. Existing 54 tests in the use case file continue to pass.

Post-implementation spec review was performed and findings addressed: moved `vi.restoreAllMocks()` to `beforeEach`, replaced `vi.mock` with `vi.spyOn` for `UseApplicationInsights`, removed duplicate mutual-exclusion tests that re-tested `resolveCombinedSelections` through the use-case wrapper.

# Notes

`autoUpgradeToAll` runs after `resolveCombinedSelections` in `handleFilterCombined`. This ordering matters: `resolveCombinedSelections` handles the mutual-exclusion (selecting ALL removes specifics, selecting a specific removes ALL), then `autoUpgradeToAll` handles the implicit upgrade when all specifics are checked individually.

The `selectedLabel` fix is a one-line change in `court-utils.ts` — the full label was already being set as the dropdown option `label`, just not carried through to `selectedLabel` which drives what the combobox input displays after selection.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve trustee district/division selection UX and keep division selections consistent by auto-upgrading full-division selections to district-level "All" options.

Enhancements:
- Show full "District (Division)" text in the district/division dropdown input for selected divisions.
- Automatically replace fully selected sets of divisions with their corresponding district-level "All" option when handling combined trustee filters.

Tests:
- Add unit tests for the auto-upgrade-to-All behavior across partial, full, multi-district, already-All, and empty selection scenarios.
- Add an integration test for the combined filter handler to verify that fully selected divisions are stored as the district-level All option.
- Simplify sanitization error tests to use single regex-based expectations and resolve conditional-expect lint violations.

Chores:
- Refactor application insights mocking in trustee district filter tests to use spies and shared setup.