### PR TITLE
CAMS-741: Fix incorrect ComboBox import in test file

### DIFF
--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -11,7 +11,7 @@ import { TrusteeDistrictFilterRef } from './trusteeDistrictFilter.types';
 import React from 'react';
 import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 import { FeatureFlagSet } from '@common/feature-flags';
-import { ComboOption } from '@/lib/components/combobox/ComboBoxAlt';
+import { ComboOption } from '@/lib/components/combobox/ComboBox';
 
 const mockDistricts: CourtDivisionDetails[] = [
   {


### PR DESCRIPTION
Update TrusteeDistrictFilter.test.tsx to import ComboOption from ComboBox instead of the non-existent ComboBoxAlt module. This resolves a TypeScript compilation error.

Jira ticket: CAMS-741

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Bug Fixes:
- Resolve TypeScript compilation error in TrusteeDistrictFilter.test by importing ComboOption from the existing ComboBox module instead of a non-existent alternative.