### PR TITLE
CAMS-741: Fix screen reader labels for trustee filters on hover

### DIFF
--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -2461,4 +2461,30 @@ describe('ComboBox', () => {
       expect(selectedItem).toHaveAttribute('aria-label', expect.stringContaining(', selected'));
     });
   });
+
+  describe('Accessibility', () => {
+    it('should hide internal label from screen readers when hideInternalLabel is true', () => {
+      renderWithProps({ hideInternalLabel: true });
+
+      const label = document.querySelector(`#${comboboxId}-label`);
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('should not hide internal label when hideInternalLabel is false', () => {
+      renderWithProps({ hideInternalLabel: false });
+
+      const label = document.querySelector(`#${comboboxId}-label`);
+      expect(label).toBeInTheDocument();
+      expect(label).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('should not hide internal label when hideInternalLabel is not provided', () => {
+      renderWithProps();
+
+      const label = document.querySelector(`#${comboboxId}-label`);
+      expect(label).toBeInTheDocument();
+      expect(label).not.toHaveAttribute('aria-hidden');
+    });
+  });
 });

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -35,6 +35,7 @@ export interface ComboBoxProps extends Omit<InputProps, 'onChange' | 'onFocus' |
   label?: string;
   ariaLabelPrefix?: string;
   ariaDescription?: string;
+  hideInternalLabel?: boolean;
   autoComplete?: 'off';
   icon?: string;
   options: ComboOption[];
@@ -66,6 +67,7 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
     wrapPills,
     ariaLabelPrefix,
     ariaDescription,
+    hideInternalLabel,
     options: _options,
     selections,
     singularLabel,
@@ -568,6 +570,7 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
           className="usa-label"
           id={comboBoxId + '-label'}
           htmlFor={`${comboBoxId}-combo-box-input`}
+          aria-hidden={hideInternalLabel ? 'true' : undefined}
         >
           {label} {otherProps.required && <span className="required-form-field">*</span>}
         </label>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -82,6 +82,15 @@ function renderFilter(
   };
 }
 
+async function openFiltersPanel(user: ReturnType<typeof userEvent.setup>) {
+  await waitFor(() => {
+    expect(screen.getByText('Filters')).toBeInTheDocument();
+  });
+
+  const toggleButton = screen.getByRole('button', { name: /filters/i });
+  await user.click(toggleButton);
+}
+
 describe('TrusteeDistrictFilter Component', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -722,13 +731,7 @@ describe('TrusteeDistrictFilter Component', () => {
       const user = userEvent.setup();
 
       renderFilter();
-
-      await waitFor(() => {
-        expect(screen.getByText('Filters')).toBeInTheDocument();
-      });
-
-      const toggleButton = screen.getByRole('button', { name: /filters/i });
-      await user.click(toggleButton);
+      await openFiltersPanel(user);
 
       await waitFor(() => {
         expect(screen.getByLabelText('District')).toBeInTheDocument();
@@ -748,13 +751,7 @@ describe('TrusteeDistrictFilter Component', () => {
       const user = userEvent.setup();
 
       renderFilter();
-
-      await waitFor(() => {
-        expect(screen.getByText('Filters')).toBeInTheDocument();
-      });
-
-      const toggleButton = screen.getByRole('button', { name: /filters/i });
-      await user.click(toggleButton);
+      await openFiltersPanel(user);
 
       await waitFor(() => {
         expect(screen.getByLabelText('District')).toBeInTheDocument();
@@ -783,13 +780,7 @@ describe('TrusteeDistrictFilter Component', () => {
       ];
 
       renderFilter({ combinedDistrictDivisionOptions: combinedOptions });
-
-      await waitFor(() => {
-        expect(screen.getByText('Filters')).toBeInTheDocument();
-      });
-
-      const toggleButton = screen.getByRole('button', { name: /filters/i });
-      await user.click(toggleButton);
+      await openFiltersPanel(user);
 
       await waitFor(() => {
         expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -716,4 +716,96 @@ describe('TrusteeDistrictFilter Component', () => {
       });
     });
   });
+
+  describe('Accessibility - Filter Labels', () => {
+    test('should have visible external labels for screen readers', async () => {
+      const user = userEvent.setup();
+
+      renderFilter();
+
+      await waitFor(() => {
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('District')).toBeInTheDocument();
+      });
+
+      // External labels should be visible to screen readers (no aria-hidden)
+      const districtLabel = screen.getByText('District', { selector: '.filter-control-label' });
+      expect(districtLabel).toBeInTheDocument();
+      expect(districtLabel).not.toHaveAttribute('aria-hidden');
+
+      const chapterLabel = screen.getByText('Chapter', { selector: '.filter-control-label' });
+      expect(chapterLabel).toBeInTheDocument();
+      expect(chapterLabel).not.toHaveAttribute('aria-hidden');
+    });
+
+    test('should hide internal ComboBox labels to prevent duplicate announcements', async () => {
+      const user = userEvent.setup();
+
+      renderFilter();
+
+      await waitFor(() => {
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('District')).toBeInTheDocument();
+      });
+
+      // Internal ComboBox labels should be hidden from screen readers
+      const districtInternalLabel = document.querySelector('#district-combobox-label');
+      expect(districtInternalLabel).toBeInTheDocument();
+      expect(districtInternalLabel).toHaveAttribute('aria-hidden', 'true');
+
+      const chapterInternalLabel = document.querySelector('#chapter-combobox-label');
+      expect(chapterInternalLabel).toBeInTheDocument();
+      expect(chapterInternalLabel).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    test('should have visible external label for District (Division) when feature flag is enabled', async () => {
+      const user = userEvent.setup();
+
+      vi.spyOn(FeatureFlagHook, 'default').mockReturnValue({
+        'trustee-district-division': true,
+      } as FeatureFlagSet);
+
+      const combinedOptions: ComboOption[] = [
+        { value: 'NYSB-081', label: 'Southern District of New York - Manhattan' },
+        { value: 'NYSB-087', label: 'Southern District of New York - White Plains' },
+      ];
+
+      renderFilter({ combinedDistrictDivisionOptions: combinedOptions });
+
+      await waitFor(() => {
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('District (Division)')).toBeInTheDocument();
+      });
+
+      // External label should be visible to screen readers (no aria-hidden)
+      const districtDivisionLabel = screen.getByText('District (Division)', {
+        selector: '.filter-control-label',
+      });
+      expect(districtDivisionLabel).toBeInTheDocument();
+      expect(districtDivisionLabel).not.toHaveAttribute('aria-hidden');
+
+      // Internal ComboBox label should be hidden from screen readers
+      const internalLabel = document.querySelector('#district-division-combobox-label');
+      expect(internalLabel).toBeInTheDocument();
+      expect(internalLabel).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
 });

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -19,13 +19,12 @@ function renderDistrictFilter(
     return (
       <div className="filter-control">
         <div className="filter-control-header">
-          <span className="filter-control-label" aria-hidden="true">
-            District (Division)
-          </span>
+          <span className="filter-control-label">District (Division)</span>
         </div>
         <ComboBox
           id="district-division-combobox"
           label="District (Division)"
+          hideInternalLabel={true}
           options={viewModel.combinedDistrictDivisionOptions}
           selections={viewModel.selectedDivisions}
           onUpdateSelection={viewModel.handleFilterCombined}
@@ -45,13 +44,12 @@ function renderDistrictFilter(
   return (
     <div className="filter-control">
       <div className="filter-control-header">
-        <span className="filter-control-label" aria-hidden="true">
-          District
-        </span>
+        <span className="filter-control-label">District</span>
       </div>
       <ComboBox
         id="district-combobox"
         label="District"
+        hideInternalLabel={true}
         options={viewModel.districtsToComboOptions(viewModel.districts)}
         selections={viewModel.selectedDistricts}
         onUpdateSelection={viewModel.handleFilterChange}
@@ -138,13 +136,12 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
 
               <div className="filter-control">
                 <div className="filter-control-header">
-                  <span className="filter-control-label" aria-hidden="true">
-                    Chapter
-                  </span>
+                  <span className="filter-control-label">Chapter</span>
                 </div>
                 <ComboBox
                   id="chapter-combobox"
                   label="Chapter"
+                  hideInternalLabel={true}
                   ariaLabelPrefix="Chapter"
                   options={viewModel.chaptersToComboOptions()}
                   selections={viewModel.selectedChapters}


### PR DESCRIPTION
Remove aria-hidden from District, District (Division), and Chapter filter labels so screen readers can announce them on hover. Add hideInternalLabel prop to ComboBox to prevent duplicate label announcements when external labels are used. Include comprehensive accessibility tests covering both ComboBox component and trustee filter integration.

Jira ticket: CAMS-741

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve accessibility of trustee filter ComboBox labels to ensure correct screen reader behavior.

New Features:
- Add a hideInternalLabel prop to the ComboBox component to control whether its internal label is exposed to screen readers.

Bug Fixes:
- Ensure trustee District, District (Division), and Chapter filter labels are readable by screen readers by making external labels accessible and hiding internal ComboBox labels to avoid duplicate announcements.

Tests:
- Add accessibility-focused tests for ComboBox hideInternalLabel behavior and trustee filter labels, including District (Division) behavior under the feature flag.