### PR TITLE
CAMS-671 Change trustee software assignment from name to ID

### DIFF
--- a/backend/express/server.ts
+++ b/backend/express/server.ts
@@ -443,7 +443,21 @@ export function createApp(): Application {
     }
   };
 
+  const handleBankruptcySoftwareName = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const context = await ContextCreator.applicationContextCreator(req);
+      const controller = new BankruptcySoftwareController(context);
+      const softwareId = context.request.params.softwareId as string;
+      const camsResponse = await controller.handleGetName(context, softwareId);
+      sendCamsResponse(res, camsResponse as CamsHttpResponseInit);
+      await finalizeDeferrable(context);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   app.get('/api/bankruptcy-software/:softwareId/history', handleBankruptcySoftwareHistory);
+  app.get('/api/bankruptcy-software/:softwareId/name', handleBankruptcySoftwareName);
   app.get('/api/bankruptcy-software', handleBankruptcySoftware);
   app.get('/api/bankruptcy-software/:softwareId', handleBankruptcySoftware);
   app.post('/api/bankruptcy-software', handleBankruptcySoftware);

--- a/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
+++ b/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
@@ -28,13 +28,6 @@ export default async function handler(
   }
 }
 
-app.http('bankruptcy-software', {
-  methods: ['GET', 'POST', 'PUT'],
-  authLevel: 'anonymous',
-  handler,
-  route: 'bankruptcy-software/{softwareId?}',
-});
-
 async function nameHandler(
   request: HttpRequest,
   invocationContext: InvocationContext,
@@ -57,6 +50,13 @@ async function nameHandler(
     return toAzureError(logger, MODULE_NAME, error);
   }
 }
+
+app.http('bankruptcy-software', {
+  methods: ['GET', 'POST', 'PUT'],
+  authLevel: 'anonymous',
+  handler,
+  route: 'bankruptcy-software/{softwareId?}',
+});
 
 app.http('bankruptcy-software-name', {
   methods: ['GET'],

--- a/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
+++ b/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.ts
@@ -34,3 +34,33 @@ app.http('bankruptcy-software', {
   handler,
   route: 'bankruptcy-software/{softwareId?}',
 });
+
+async function nameHandler(
+  request: HttpRequest,
+  invocationContext: InvocationContext,
+): Promise<HttpResponseInit> {
+  const logger = ContextCreator.getLogger(invocationContext);
+
+  try {
+    const context = await ContextCreator.applicationContextCreator({
+      invocationContext,
+      logger,
+      request,
+    });
+
+    context.session = await ContextCreator.getApplicationContextSession(context);
+    const controller = new BankruptcySoftwareController(context);
+    const softwareId = request.params.softwareId;
+    const response = await controller.handleGetName(context, softwareId);
+    return toAzureSuccess(response as CamsHttpResponseInit);
+  } catch (error) {
+    return toAzureError(logger, MODULE_NAME, error);
+  }
+}
+
+app.http('bankruptcy-software-name', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  handler: nameHandler,
+  route: 'bankruptcy-software/{softwareId}/name',
+});

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
@@ -601,7 +601,7 @@ describe('TrusteesMongoRepository', () => {
           email: 'test@example.com',
         },
         banks: ['Bank 1', 'Bank 2'],
-        software: 'Software 1',
+        softwareId: 'sw-1',
       };
 
       const updatedTrusteeDocument = {

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
@@ -133,6 +133,31 @@ describe('BankruptcySoftwareController', () => {
     });
   });
 
+  describe('handleGetName', () => {
+    test('should return 200 with software name for valid ID', async () => {
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftware').mockResolvedValue(
+        mockSoftware[0],
+      );
+
+      const result = await controller.handleGetName(context, 'sw-1');
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.data).toEqual({ name: 'Axos' });
+    });
+
+    test('should not require SuperUser role', async () => {
+      context.session.user.roles = [CamsRole.TrialAttorney];
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftware').mockResolvedValue(
+        mockSoftware[0],
+      );
+
+      const result = await controller.handleGetName(context, 'sw-1');
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.data).toEqual({ name: 'Axos' });
+    });
+  });
+
   describe('handlePut', () => {
     test('should return 200 with updated software for SuperUser', async () => {
       context.request.params = { softwareId: 'sw-1' };

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.test.ts
@@ -134,7 +134,7 @@ describe('BankruptcySoftwareController', () => {
   });
 
   describe('handleGetName', () => {
-    test('should return 200 with software name for valid ID', async () => {
+    test('should return 200 with only the software name', async () => {
       vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftware').mockResolvedValue(
         mockSoftware[0],
       );
@@ -145,7 +145,7 @@ describe('BankruptcySoftwareController', () => {
       expect(result.body.data).toEqual({ name: 'Axos' });
     });
 
-    test('should not require SuperUser role', async () => {
+    test('should succeed for non-SuperUser role', async () => {
       context.session.user.roles = [CamsRole.TrialAttorney];
       vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftware').mockResolvedValue(
         mockSoftware[0],
@@ -154,7 +154,21 @@ describe('BankruptcySoftwareController', () => {
       const result = await controller.handleGetName(context, 'sw-1');
 
       expect(result.statusCode).toBe(200);
+    });
+
+    test('should not expose contact info even when underlying data has it', async () => {
+      const softwareWithContact = {
+        ...mockSoftware[0],
+        contact: { contactNames: ['Jane Doe'], emails: ['jane@axos.com'] },
+      };
+      vi.spyOn(BankruptcySoftwareUseCase.prototype, 'getSoftware').mockResolvedValue(
+        softwareWithContact,
+      );
+
+      const result = await controller.handleGetName(context, 'sw-1');
+
       expect(result.body.data).toEqual({ name: 'Axos' });
+      expect(result.body.data).not.toHaveProperty('contact');
     });
   });
 

--- a/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
+++ b/backend/lib/controllers/bankruptcy-software/bankruptcy-software.controller.ts
@@ -38,6 +38,17 @@ export class BankruptcySoftwareController {
     return httpSuccess({ statusCode: HttpStatusCodes.METHOD_NOT_ALLOWED }) as CamsHttpResponseInit;
   }
 
+  async handleGetName(
+    context: ApplicationContext,
+    softwareId: string,
+  ): Promise<CamsHttpResponseInit<{ name: string }>> {
+    const software = await this.useCase.getSoftware(softwareId);
+    return httpSuccess({
+      statusCode: HttpStatusCodes.OK,
+      body: { meta: { self: context.request.url }, data: { name: software.name } },
+    });
+  }
+
   async handleGetOne(
     context: ApplicationContext,
     softwareId: string,

--- a/backend/lib/use-cases/dataflows/migrate-trustee-software-field.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustee-software-field.test.ts
@@ -124,6 +124,127 @@ describe('migrateTrusteeSoftwareField', () => {
     expect(updateSpy).toHaveBeenCalled();
   });
 
+  test('should migrate bank names to bank IDs using software associatedBanks', async () => {
+    const trustee = MockData.getTrustee({
+      softwareId: 'sw-axos',
+      banks: ['Fifth Third', 'Key Bank'],
+    });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([
+      {
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-fifth-third', bankName: 'Fifth Third', status: 'active' },
+          { bankId: 'bank-key', bankName: 'Key Bank', status: 'active' },
+        ],
+      },
+    ]);
+    const updateSpy = vi
+      .spyOn(MockMongoRepository.prototype, 'updateTrustee')
+      .mockResolvedValue(trustee);
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.migrated).toBe(1);
+    expect(updateSpy).toHaveBeenCalledWith(
+      trustee.trusteeId,
+      expect.objectContaining({ banks: ['bank-fifth-third', 'bank-key'] }),
+      expect.objectContaining({ id: 'system-migration' }),
+    );
+  });
+
+  test('should skip bank migration when banks already look like IDs', async () => {
+    const trustee = MockData.getTrustee({ softwareId: 'sw-axos', banks: ['bank-fifth-third'] });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([
+      {
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-fifth-third', bankName: 'Fifth Third', status: 'active' },
+        ],
+      },
+    ]);
+    const updateSpy = vi.spyOn(MockMongoRepository.prototype, 'updateTrustee');
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.skipped).toBe(1);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test('should log warning when bank name cannot be resolved to ID', async () => {
+    const trustee = MockData.getTrustee({ softwareId: 'sw-axos', banks: ['Unknown Bank'] });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([
+      {
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-fifth-third', bankName: 'Fifth Third', status: 'active' },
+        ],
+      },
+    ]);
+    const updateSpy = vi.spyOn(MockMongoRepository.prototype, 'updateTrustee');
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.notFound).toBe(1);
+    expect(result.details[0]).toContain('Unknown Bank');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test('should migrate both software and banks in a single pass', async () => {
+    const trustee = MockData.getTrustee();
+    Object.assign(trustee, { software: 'Axos', softwareId: undefined, banks: ['Fifth Third'] });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([
+      {
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-fifth-third', bankName: 'Fifth Third', status: 'active' },
+        ],
+      },
+    ]);
+    const updateSpy = vi
+      .spyOn(MockMongoRepository.prototype, 'updateTrustee')
+      .mockResolvedValue(trustee);
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.migrated).toBe(1);
+    expect(updateSpy).toHaveBeenCalledWith(
+      trustee.trusteeId,
+      expect.objectContaining({
+        softwareId: 'sw-axos',
+        banks: ['bank-fifth-third'],
+      }),
+      expect.objectContaining({ id: 'system-migration' }),
+    );
+  });
+
   test('should handle errors for individual trustees without stopping', async () => {
     const trustee1 = MockData.getTrustee();
     Object.assign(trustee1, { software: 'Axos', softwareId: undefined });

--- a/backend/lib/use-cases/dataflows/migrate-trustee-software-field.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustee-software-field.test.ts
@@ -1,0 +1,153 @@
+import { vi } from 'vitest';
+import { migrateTrusteeSoftwareField } from './migrate-trustee-software-field';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
+import { ApplicationContext } from '../../adapters/types/basic';
+import MockData from '@common/cams/test-utilities/mock-data';
+
+describe('migrateTrusteeSoftwareField', () => {
+  let context: ApplicationContext;
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should migrate trustee with matching software name to softwareId', async () => {
+    const trustee = MockData.getTrustee();
+    Object.assign(trustee, { software: 'Axos', softwareId: undefined });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([
+      {
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      },
+    ]);
+    const updateSpy = vi
+      .spyOn(MockMongoRepository.prototype, 'updateTrustee')
+      .mockResolvedValue(trustee);
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.migrated).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.notFound).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(updateSpy).toHaveBeenCalledWith(
+      trustee.trusteeId,
+      expect.objectContaining({ softwareId: 'sw-axos' }),
+      expect.objectContaining({ id: 'system-migration' }),
+    );
+  });
+
+  test('should skip trustees that already have softwareId', async () => {
+    const trustee = MockData.getTrustee({ softwareId: 'sw-existing' });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([]);
+    const updateSpy = vi.spyOn(MockMongoRepository.prototype, 'updateTrustee');
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.skipped).toBe(1);
+    expect(result.migrated).toBe(0);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test('should skip trustees with no software field', async () => {
+    const trustee = MockData.getTrustee();
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([]);
+    const updateSpy = vi.spyOn(MockMongoRepository.prototype, 'updateTrustee');
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.skipped).toBe(1);
+    expect(result.migrated).toBe(0);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test('should log warning when software name does not match any vendor', async () => {
+    const trustee = MockData.getTrustee();
+    Object.assign(trustee, { software: 'UnknownSoftware', softwareId: undefined });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([
+      {
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      },
+    ]);
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.notFound).toBe(1);
+    expect(result.migrated).toBe(0);
+    expect(result.details[0]).toContain('UnknownSoftware');
+  });
+
+  test('should match software names case-insensitively', async () => {
+    const trustee = MockData.getTrustee();
+    Object.assign(trustee, { software: 'axos', softwareId: undefined });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([
+      {
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      },
+    ]);
+    const updateSpy = vi
+      .spyOn(MockMongoRepository.prototype, 'updateTrustee')
+      .mockResolvedValue(trustee);
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.migrated).toBe(1);
+    expect(updateSpy).toHaveBeenCalled();
+  });
+
+  test('should handle errors for individual trustees without stopping', async () => {
+    const trustee1 = MockData.getTrustee();
+    Object.assign(trustee1, { software: 'Axos', softwareId: undefined });
+    const trustee2 = MockData.getTrustee();
+    Object.assign(trustee2, { software: 'Axos', softwareId: undefined });
+
+    vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee1, trustee2]);
+    vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue([
+      {
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      },
+    ]);
+    vi.spyOn(MockMongoRepository.prototype, 'updateTrustee')
+      .mockRejectedValueOnce(new Error('DB write failed'))
+      .mockResolvedValueOnce(trustee2);
+
+    const result = await migrateTrusteeSoftwareField(context);
+
+    expect(result.errors).toBe(1);
+    expect(result.migrated).toBe(1);
+  });
+});

--- a/backend/lib/use-cases/dataflows/migrate-trustee-software-field.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustee-software-field.ts
@@ -1,0 +1,92 @@
+import { ApplicationContext } from '../../adapters/types/basic';
+import factory from '../../factory';
+import { Trustee } from '@common/cams/trustees';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+
+const MODULE_NAME = 'MIGRATE-TRUSTEE-SOFTWARE-FIELD';
+
+export interface MigrationResult {
+  migrated: number;
+  skipped: number;
+  notFound: number;
+  errors: number;
+  details: string[];
+}
+
+export async function migrateTrusteeSoftwareField(
+  context: ApplicationContext,
+): Promise<MigrationResult> {
+  const { logger } = context;
+  const trusteesRepository = factory.getTrusteesRepository(context);
+  const softwareRepository = factory.getBankruptcySoftwareRepository(context);
+
+  const result: MigrationResult = {
+    migrated: 0,
+    skipped: 0,
+    notFound: 0,
+    errors: 0,
+    details: [],
+  };
+
+  logger.info(MODULE_NAME, 'Starting trustee software field migration (software → softwareId)');
+
+  const softwareList = await softwareRepository.getSoftwareList();
+  const softwareByName = new Map<string, BankruptcySoftwareProfile>();
+  for (const sw of softwareList) {
+    softwareByName.set(sw.name.toLowerCase(), sw);
+  }
+
+  const trustees = await trusteesRepository.listTrustees();
+
+  for (const trustee of trustees) {
+    try {
+      if (trustee.softwareId) {
+        result.skipped++;
+        continue;
+      }
+
+      const legacySoftware = (trustee as Trustee & { software?: string }).software;
+      if (!legacySoftware) {
+        result.skipped++;
+        continue;
+      }
+
+      const matchedSoftware = softwareByName.get(legacySoftware.toLowerCase());
+      if (!matchedSoftware) {
+        result.notFound++;
+        result.details.push(`Trustee ${trustee.trusteeId}: software "${legacySoftware}" not found`);
+        logger.warn(
+          MODULE_NAME,
+          `Trustee ${trustee.trusteeId}: software "${legacySoftware}" not found in software collection`,
+        );
+        continue;
+      }
+
+      const userReference = { id: 'system-migration', name: 'System Migration' };
+      await trusteesRepository.updateTrustee(
+        trustee.trusteeId,
+        { ...trustee, softwareId: matchedSoftware.id, software: undefined } as Trustee,
+        userReference,
+      );
+
+      result.migrated++;
+      result.details.push(
+        `Trustee ${trustee.trusteeId}: "${legacySoftware}" → softwareId "${matchedSoftware.id}"`,
+      );
+    } catch (e) {
+      result.errors++;
+      result.details.push(`Trustee ${trustee.trusteeId}: ERROR - ${(e as Error).message}`);
+      logger.error(
+        MODULE_NAME,
+        `Failed to migrate trustee ${trustee.trusteeId}: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  logger.info(
+    MODULE_NAME,
+    `Migration complete. Migrated: ${result.migrated}, Skipped: ${result.skipped}, Not Found: ${result.notFound}, Errors: ${result.errors}`,
+  );
+
+  return result;
+}

--- a/backend/lib/use-cases/dataflows/migrate-trustee-software-field.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustee-software-field.ts
@@ -1,7 +1,10 @@
 import { ApplicationContext } from '../../adapters/types/basic';
 import factory from '../../factory';
 import { Trustee } from '@common/cams/trustees';
-import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
+import {
+  BankruptcySoftwareProfile,
+  SoftwareBankAssociation,
+} from '@common/cams/bankruptcy-software';
 
 const MODULE_NAME = 'MIGRATE-TRUSTEE-SOFTWARE-FIELD';
 
@@ -11,6 +14,21 @@ export interface MigrationResult {
   notFound: number;
   errors: number;
   details: string[];
+}
+
+function buildBankNameToIdMap(
+  associatedBanks: SoftwareBankAssociation[] | undefined,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const bank of associatedBanks ?? []) {
+    map.set(bank.bankName.toLowerCase(), bank.bankId);
+  }
+  return map;
+}
+
+function banksNeedMigration(banks: string[] | undefined, bankIdSet: Set<string>): boolean {
+  if (!banks || banks.length === 0) return false;
+  return banks.some((bank) => !bankIdSet.has(bank));
 }
 
 export async function migrateTrusteeSoftwareField(
@@ -28,51 +46,102 @@ export async function migrateTrusteeSoftwareField(
     details: [],
   };
 
-  logger.info(MODULE_NAME, 'Starting trustee software field migration (software → softwareId)');
+  logger.info(MODULE_NAME, 'Starting trustee software and bank field migration');
 
   const softwareList = await softwareRepository.getSoftwareList();
   const softwareByName = new Map<string, BankruptcySoftwareProfile>();
+  const softwareById = new Map<string, BankruptcySoftwareProfile>();
   for (const sw of softwareList) {
     softwareByName.set(sw.name.toLowerCase(), sw);
+    softwareById.set(sw.id, sw);
   }
 
   const trustees = await trusteesRepository.listTrustees();
 
   for (const trustee of trustees) {
     try {
-      if (trustee.softwareId) {
-        result.skipped++;
-        continue;
-      }
-
       const legacySoftware = (trustee as Trustee & { software?: string }).software;
-      if (!legacySoftware) {
+      let softwareIdToSet: string | undefined = trustee.softwareId;
+      let needsSoftwareMigration = false;
+
+      if (!trustee.softwareId && legacySoftware) {
+        const matchedSoftware = softwareByName.get(legacySoftware.toLowerCase());
+        if (!matchedSoftware) {
+          result.notFound++;
+          result.details.push(
+            `Trustee ${trustee.trusteeId}: software "${legacySoftware}" not found`,
+          );
+          logger.warn(
+            MODULE_NAME,
+            `Trustee ${trustee.trusteeId}: software "${legacySoftware}" not found in software collection`,
+          );
+          continue;
+        }
+        softwareIdToSet = matchedSoftware.id;
+        needsSoftwareMigration = true;
+      }
+
+      const software = softwareIdToSet ? softwareById.get(softwareIdToSet) : undefined;
+      const bankNameMap = buildBankNameToIdMap(software?.associatedBanks);
+      const bankIdSet = new Set(software?.associatedBanks?.map((b) => b.bankId) ?? []);
+      const needsBankMigration = banksNeedMigration(trustee.banks, bankIdSet);
+
+      if (!needsSoftwareMigration && !needsBankMigration) {
         result.skipped++;
         continue;
       }
 
-      const matchedSoftware = softwareByName.get(legacySoftware.toLowerCase());
-      if (!matchedSoftware) {
-        result.notFound++;
-        result.details.push(`Trustee ${trustee.trusteeId}: software "${legacySoftware}" not found`);
-        logger.warn(
-          MODULE_NAME,
-          `Trustee ${trustee.trusteeId}: software "${legacySoftware}" not found in software collection`,
-        );
-        continue;
+      let migratedBanks = trustee.banks;
+      if (needsBankMigration && trustee.banks) {
+        const resolved: string[] = [];
+        let allResolved = true;
+        for (const bankName of trustee.banks) {
+          const bankId = bankNameMap.get(bankName.toLowerCase());
+          if (bankId) {
+            resolved.push(bankId);
+          } else {
+            allResolved = false;
+            result.notFound++;
+            result.details.push(
+              `Trustee ${trustee.trusteeId}: bank "${bankName}" not found in software's associated banks`,
+            );
+            logger.warn(
+              MODULE_NAME,
+              `Trustee ${trustee.trusteeId}: bank "${bankName}" not found in associated banks for software ${softwareIdToSet}`,
+            );
+          }
+        }
+        if (!allResolved) {
+          continue;
+        }
+        migratedBanks = resolved;
       }
 
       const userReference = { id: 'system-migration', name: 'System Migration' };
+      const updatedFields: Record<string, unknown> = { ...trustee };
+      if (needsSoftwareMigration) {
+        updatedFields.softwareId = softwareIdToSet;
+        updatedFields.software = undefined;
+      }
+      if (needsBankMigration) {
+        updatedFields.banks = migratedBanks;
+      }
+
       await trusteesRepository.updateTrustee(
         trustee.trusteeId,
-        { ...trustee, softwareId: matchedSoftware.id, software: undefined } as Trustee,
+        updatedFields as Trustee,
         userReference,
       );
 
       result.migrated++;
-      result.details.push(
-        `Trustee ${trustee.trusteeId}: "${legacySoftware}" → softwareId "${matchedSoftware.id}"`,
-      );
+      const details: string[] = [];
+      if (needsSoftwareMigration) {
+        details.push(`software "${legacySoftware}" → softwareId "${softwareIdToSet}"`);
+      }
+      if (needsBankMigration) {
+        details.push(`banks migrated to IDs`);
+      }
+      result.details.push(`Trustee ${trustee.trusteeId}: ${details.join(', ')}`);
     } catch (e) {
       result.errors++;
       result.details.push(`Trustee ${trustee.trusteeId}: ERROR - ${(e as Error).message}`);

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -7,6 +7,7 @@ import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repo
 import { getCamsUserReference } from '@common/cams/session';
 import { BadRequestError } from '../../common-errors/bad-request';
 import { CamsError } from '../../common-errors/cams-error';
+import { NotFoundError } from '../../common-errors/not-found-error';
 import { FIELD_VALIDATION_MESSAGES } from '@common/cams/validation-messages';
 import { CourtsUseCase } from '../courts/courts';
 import { CourtDivisionDetails } from '@common/cams/courts';
@@ -564,6 +565,38 @@ describe('TrusteesUseCase tests', () => {
           after: 'New Software',
         }),
       );
+    });
+
+    test('should throw BadRequestError when softwareId does not exist', async () => {
+      const updateData = { softwareId: 'sw-nonexistent' };
+
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockRejectedValue(
+        new NotFoundError('BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY', {
+          message: 'No matching item found.',
+        }),
+      );
+
+      await expect(trusteesUseCase.updateTrustee(context, trusteeId, updateData)).rejects.toThrow(
+        BadRequestError,
+      );
+    });
+
+    test('should let operational errors bubble up from validateSoftwareExists', async () => {
+      const updateData = { softwareId: 'sw-123' };
+      const operationalError = new CamsError('BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY', {
+        status: 500,
+        message: 'Unable to retrieve bankruptcy software.',
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockRejectedValue(
+        operationalError,
+      );
+
+      const thrownError = await getTheThrownError(() =>
+        trusteesUseCase.updateTrustee(context, trusteeId, updateData),
+      );
+      expect(thrownError).not.toBeInstanceOf(BadRequestError);
+      expect(thrownError.isCamsError).toBe(true);
     });
 
     test('should not create history when no fields change', async () => {

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -508,9 +508,28 @@ describe('TrusteesUseCase tests', () => {
 
     test('should update trustee and create banks history when banks change', async () => {
       const updatedBy = getCamsUserReference(context.session.user);
-      const newBanks = ['Bank A', 'Bank B'];
+      const trusteeWithSoftware = MockData.getTrustee({
+        softwareId: 'sw-axos',
+        banks: ['bank-old'],
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithSoftware);
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-old', bankName: 'Old Bank', status: 'active' },
+          { bankId: 'bank-a', bankName: 'Bank A', status: 'active' },
+          { bankId: 'bank-b', bankName: 'Bank B', status: 'active' },
+        ],
+      });
+
+      const newBanks = ['bank-a', 'bank-b'];
       const updateData = { banks: newBanks };
-      const updatedTrustee = { ...existingTrustee, banks: newBanks };
+      const updatedTrustee = { ...trusteeWithSoftware, banks: newBanks };
 
       const updateTrusteeSpy = vi
         .spyOn(MockMongoRepository.prototype, 'updateTrustee')
@@ -521,15 +540,12 @@ describe('TrusteesUseCase tests', () => {
 
       await trusteesUseCase.updateTrustee(context, trusteeId, updateData);
       expect(updateTrusteeSpy).toHaveBeenCalledWith(trusteeId, updatedTrustee, updatedBy);
-      expect(updateTrusteeSpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({ updatedBy: context.session.user }),
-      );
       expect(historyCreateSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           documentType: 'AUDIT_BANKS',
           trusteeId,
-          before: existingTrustee.banks,
-          after: newBanks,
+          before: ['Old Bank'],
+          after: ['Bank A', 'Bank B'],
         }),
       );
     });
@@ -597,6 +613,101 @@ describe('TrusteesUseCase tests', () => {
       );
       expect(thrownError).not.toBeInstanceOf(BadRequestError);
       expect(thrownError.isCamsError).toBe(true);
+    });
+
+    test('should throw BadRequestError when banks are set without softwareId', async () => {
+      const trusteeWithoutSoftware = MockData.getTrustee();
+      delete trusteeWithoutSoftware.softwareId;
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithoutSoftware);
+
+      const updateData = { banks: ['bank-1'] };
+
+      await expect(trusteesUseCase.updateTrustee(context, trusteeId, updateData)).rejects.toThrow(
+        BadRequestError,
+      );
+    });
+
+    test('should throw BadRequestError when bank ID is not in software associatedBanks', async () => {
+      const trusteeWithSoftware = MockData.getTrustee({ softwareId: 'sw-axos' });
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithSoftware);
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [{ bankId: 'bank-1', bankName: 'Fifth Third', status: 'active' }],
+      });
+
+      const updateData = { banks: ['bank-999'] };
+
+      await expect(trusteesUseCase.updateTrustee(context, trusteeId, updateData)).rejects.toThrow(
+        BadRequestError,
+      );
+    });
+
+    test('should allow banks that are in software associatedBanks', async () => {
+      const trusteeWithSoftware = MockData.getTrustee({ softwareId: 'sw-axos' });
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithSoftware);
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-1', bankName: 'Fifth Third', status: 'active' },
+          { bankId: 'bank-2', bankName: 'Key Bank', status: 'active' },
+        ],
+      });
+
+      const updateData = { banks: ['bank-1', 'bank-2'] };
+      const updatedTrustee = { ...trusteeWithSoftware, banks: ['bank-1', 'bank-2'] };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+
+      const result = await trusteesUseCase.updateTrustee(context, trusteeId, updateData);
+      expect(result.banks).toEqual(['bank-1', 'bank-2']);
+    });
+
+    test('should resolve bank names in audit history when banks change', async () => {
+      const trusteeWithSoftware = MockData.getTrustee({
+        softwareId: 'sw-axos',
+        banks: ['bank-1'],
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithSoftware);
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+        id: 'sw-axos',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-1', bankName: 'Fifth Third', status: 'active' },
+          { bankId: 'bank-2', bankName: 'Key Bank', status: 'active' },
+        ],
+      });
+
+      const updateData = { banks: ['bank-1', 'bank-2'] };
+      const updatedTrustee = { ...trusteeWithSoftware, banks: ['bank-1', 'bank-2'] };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+      const historyCreateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
+        .mockResolvedValue();
+
+      await trusteesUseCase.updateTrustee(context, trusteeId, updateData);
+
+      expect(historyCreateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: 'AUDIT_BANKS',
+          trusteeId,
+          before: ['Fifth Third'],
+          after: ['Fifth Third', 'Key Bank'],
+        }),
+      );
     });
 
     test('should not create history when no fields change', async () => {

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -533,11 +533,11 @@ describe('TrusteesUseCase tests', () => {
       );
     });
 
-    test('should update trustee and create software history when software changes', async () => {
+    test('should update trustee and create software history with resolved names when softwareId changes', async () => {
       const updatedBy = getCamsUserReference(context.session.user);
-      const newSoftware = 'New Software System';
-      const updateData = { software: newSoftware };
-      const updatedTrustee = { ...existingTrustee, software: newSoftware };
+      const newSoftwareId = 'sw-new';
+      const updateData = { softwareId: newSoftwareId };
+      const updatedTrustee = { ...existingTrustee, softwareId: newSoftwareId };
 
       const updateTrusteeSpy = vi
         .spyOn(MockMongoRepository.prototype, 'updateTrustee')
@@ -545,18 +545,23 @@ describe('TrusteesUseCase tests', () => {
       const historyCreateSpy = vi
         .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
         .mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+        id: newSoftwareId,
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'New Software',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      });
 
       await trusteesUseCase.updateTrustee(context, trusteeId, updateData);
       expect(updateTrusteeSpy).toHaveBeenCalledWith(trusteeId, updatedTrustee, updatedBy);
-      expect(updateTrusteeSpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({ updatedBy: context.session.user }),
-      );
       expect(historyCreateSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           documentType: 'AUDIT_SOFTWARE',
           trusteeId,
-          before: existingTrustee.software,
-          after: newSoftware,
+          before: undefined,
+          after: 'New Software',
         }),
       );
     });
@@ -639,12 +644,12 @@ describe('TrusteesUseCase tests', () => {
           email: null,
           phone: null,
         },
-        software: null,
+        softwareId: null,
         banks: undefined,
       };
       const updatedTrustee = { ...existingTrustee, name: 'Updated Name' };
       delete updatedTrustee.internal;
-      delete updatedTrustee.software;
+      delete updatedTrustee.softwareId;
       delete updatedTrustee.banks;
 
       const mongoMock = vi
@@ -661,10 +666,10 @@ describe('TrusteesUseCase tests', () => {
       );
       const patchedArg = (mongoMock.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
       expect(patchedArg).not.toHaveProperty('internal');
-      expect(patchedArg).not.toHaveProperty('software');
+      expect(patchedArg).not.toHaveProperty('softwareId');
       expect(patchedArg).not.toHaveProperty('banks');
       expect(result).toEqual(updatedTrustee);
-      expect(result.software).toBeUndefined();
+      expect(result.softwareId).toBeUndefined();
       expect(result.banks).toBeUndefined();
     });
 
@@ -717,7 +722,7 @@ describe('TrusteesUseCase tests', () => {
         expect.any(Object),
       );
       expect(result).toEqual(updatedTrustee);
-      expect(result.software).toBeUndefined();
+      expect(result.softwareId).toBeUndefined();
       expect(result.banks).toBeUndefined();
     });
 

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -627,6 +627,7 @@ describe('TrusteesUseCase tests', () => {
       );
     });
 
+    // bank-999 is not in sw-axos's associatedBanks, so loadAndValidateSoftware rejects it
     test('should throw BadRequestError when bank ID is not in software associatedBanks', async () => {
       const trusteeWithSoftware = MockData.getTrustee({ softwareId: 'sw-axos' });
       vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithSoftware);

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -7,6 +7,7 @@ import {
 } from '../gateways.types';
 import { getCamsUserReference } from '@common/cams/session';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
+import { isCamsError } from '../../common-errors/cams-error';
 import factory from '../../factory';
 import { ValidationSpec, validateObject, flatten, ValidatorResult } from '@common/cams/validation';
 import { BadRequestError } from '../../common-errors/bad-request';
@@ -414,10 +415,13 @@ export class TrusteesUseCase {
       factory.getBankruptcySoftwareRepository(context);
     try {
       await softwareRepository.findSoftwareById(softwareId);
-    } catch {
-      throw new BadRequestError(MODULE_NAME, {
-        message: `Software with ID '${softwareId}' does not exist.`,
-      });
+    } catch (error) {
+      if (isCamsError(error) && error.status === 404) {
+        throw new BadRequestError(MODULE_NAME, {
+          message: `Software with ID '${softwareId}' does not exist.`,
+        });
+      }
+      throw error;
     }
   }
 
@@ -430,8 +434,11 @@ export class TrusteesUseCase {
     try {
       const software = await softwareRepository.findSoftwareById(softwareId);
       return software.name;
-    } catch {
-      return softwareId;
+    } catch (error) {
+      if (isCamsError(error) && error.status === 404) {
+        return softwareId;
+      }
+      throw error;
     }
   }
 }

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -38,6 +38,7 @@ import { deepEqual } from '@common/object-equality';
 import { normalizeForUndefined } from '@common/normalization';
 import V from '@common/cams/validators';
 import { Address, ContactInformation, PhoneNumber } from '@common/cams/contact';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 const MODULE_NAME = 'TRUSTEES-USE-CASE';
 
@@ -85,12 +86,14 @@ export class TrusteesUseCase {
   private readonly trusteesRepository: TrusteesRepository;
   private readonly trusteeAssistantsRepository: TrusteeAssistantsRepository;
   private readonly trusteeAppointmentsRepository: TrusteeAppointmentsRepository;
+  private readonly softwareRepository: BankruptcySoftwareRepository;
   private readonly courtsUseCase: CourtsUseCase;
 
   constructor(context: ApplicationContext) {
     this.trusteesRepository = factory.getTrusteesRepository(context);
     this.trusteeAssistantsRepository = factory.getTrusteeAssistantsRepository(context);
     this.trusteeAppointmentsRepository = factory.getTrusteeAppointmentsRepository(context);
+    this.softwareRepository = factory.getBankruptcySoftwareRepository(context);
     this.courtsUseCase = new CourtsUseCase();
   }
 
@@ -287,17 +290,11 @@ export class TrusteesUseCase {
 
       this.checkValidation(validateObject(specToValidate, patchedTrustee));
 
-      if (trustee.softwareId) {
-        await this.validateSoftwareExists(context, trustee.softwareId);
-      }
-
-      if (patchedTrustee.banks && patchedTrustee.banks.length > 0) {
-        await this.validateBanksForSoftware(
-          context,
-          patchedTrustee.banks,
-          patchedTrustee.softwareId,
-        );
-      }
+      const software = await this.loadAndValidateSoftware(
+        trustee.softwareId,
+        patchedTrustee.banks,
+        patchedTrustee.softwareId,
+      );
 
       const updatedTrustee = await this.trusteesRepository.updateTrustee(
         trusteeId,
@@ -305,110 +302,14 @@ export class TrusteesUseCase {
         userReference,
       );
 
-      if (existingTrustee.name !== updatedTrustee.name) {
-        await this.trusteesRepository.createTrusteeHistory(
-          createAuditRecord(
-            {
-              documentType: 'AUDIT_NAME',
-              trusteeId,
-              before: existingTrustee.name,
-              after: updatedTrustee.name,
-            },
-            userReference,
-          ),
-        );
-        const trace = context.observability.startTrace(context.invocationId);
-        const isMigrated = !!(
-          updatedTrustee.legacy?.truIds && updatedTrustee.legacy.truIds.length > 0
-        );
-        context.observability.completeTrace(trace, 'Trustee Name Edited', {
-          success: true,
-          properties: { isMigrated: String(isMigrated) },
-          measurements: {},
-        });
-      }
-
-      if (!deepEqual(existingTrustee.public, updatedTrustee.public)) {
-        await this.trusteesRepository.createTrusteeHistory(
-          createAuditRecord(
-            {
-              documentType: 'AUDIT_PUBLIC_CONTACT',
-              trusteeId,
-              before: existingTrustee.public,
-              after: updatedTrustee.public,
-            },
-            userReference,
-          ),
-        );
-      }
-
-      if (!deepEqual(existingTrustee.internal, updatedTrustee.internal)) {
-        await this.trusteesRepository.createTrusteeHistory(
-          createAuditRecord(
-            {
-              documentType: 'AUDIT_INTERNAL_CONTACT',
-              trusteeId,
-              before: normalizeForUndefined(existingTrustee.internal),
-              after: normalizeForUndefined(updatedTrustee.internal),
-            },
-            userReference,
-          ),
-        );
-      }
-
-      if (!deepEqual(existingTrustee.banks, updatedTrustee.banks)) {
-        const softwareIdForBanks = updatedTrustee.softwareId || existingTrustee.softwareId;
-        const bankNames = softwareIdForBanks
-          ? await this.resolveBankNames(context, softwareIdForBanks)
-          : new Map<string, string>();
-        const beforeNames = existingTrustee.banks?.map((id) => bankNames.get(id) ?? id);
-        const afterNames = updatedTrustee.banks?.map((id) => bankNames.get(id) ?? id);
-        await this.trusteesRepository.createTrusteeHistory(
-          createAuditRecord(
-            {
-              documentType: 'AUDIT_BANKS',
-              trusteeId,
-              before: beforeNames,
-              after: afterNames,
-            },
-            userReference,
-          ),
-        );
-      }
-
-      if (existingTrustee.softwareId !== updatedTrustee.softwareId) {
-        const beforeName = existingTrustee.softwareId
-          ? await this.resolveSoftwareName(context, existingTrustee.softwareId)
-          : undefined;
-        const afterName = updatedTrustee.softwareId
-          ? await this.resolveSoftwareName(context, updatedTrustee.softwareId)
-          : undefined;
-        await this.trusteesRepository.createTrusteeHistory(
-          createAuditRecord(
-            {
-              documentType: 'AUDIT_SOFTWARE',
-              trusteeId,
-              before: beforeName,
-              after: afterName,
-            },
-            userReference,
-          ),
-        );
-      }
-
-      if (!deepEqual(existingTrustee.zoomInfo, updatedTrustee.zoomInfo)) {
-        await this.trusteesRepository.createTrusteeHistory(
-          createAuditRecord(
-            {
-              documentType: 'AUDIT_ZOOM_INFO',
-              trusteeId,
-              before: existingTrustee.zoomInfo,
-              after: updatedTrustee.zoomInfo,
-            },
-            userReference,
-          ),
-        );
-      }
+      await this.recordAuditHistory(
+        context,
+        trusteeId,
+        existingTrustee,
+        updatedTrustee,
+        userReference,
+        software,
+      );
 
       return updatedTrustee;
     } catch (originalError) {
@@ -421,14 +322,25 @@ export class TrusteesUseCase {
     }
   }
 
-  private async validateSoftwareExists(
-    context: ApplicationContext,
-    softwareId: string,
-  ): Promise<void> {
-    const softwareRepository: BankruptcySoftwareRepository =
-      factory.getBankruptcySoftwareRepository(context);
+  private async loadAndValidateSoftware(
+    incomingSoftwareId: string | undefined | null,
+    banks: string[] | undefined,
+    effectiveSoftwareId: string | undefined,
+  ): Promise<BankruptcySoftwareProfile | undefined> {
+    if (!incomingSoftwareId && (!banks || banks.length === 0)) return undefined;
+
+    if (banks && banks.length > 0 && !effectiveSoftwareId) {
+      throw new BadRequestError(MODULE_NAME, {
+        message: 'A software vendor must be assigned before adding banks.',
+      });
+    }
+
+    const softwareId = incomingSoftwareId || effectiveSoftwareId;
+    if (!softwareId) return undefined;
+
+    let software: BankruptcySoftwareProfile;
     try {
-      await softwareRepository.findSoftwareById(softwareId);
+      software = await this.softwareRepository.findSoftwareById(softwareId);
     } catch (error) {
       if (isCamsError(error) && error.status === 404) {
         throw new BadRequestError(MODULE_NAME, {
@@ -437,64 +349,133 @@ export class TrusteesUseCase {
       }
       throw error;
     }
+
+    if (banks && banks.length > 0) {
+      const validBankIds = new Set(software.associatedBanks?.map((b) => b.bankId) ?? []);
+      const invalidBanks = banks.filter((id) => !validBankIds.has(id));
+      if (invalidBanks.length > 0) {
+        throw new BadRequestError(MODULE_NAME, {
+          message: `Banks [${invalidBanks.join(', ')}] are not associated with the selected software.`,
+        });
+      }
+    }
+
+    return software;
   }
 
-  private async resolveSoftwareName(
+  private async recordAuditHistory(
     context: ApplicationContext,
-    softwareId: string,
-  ): Promise<string> {
-    const softwareRepository: BankruptcySoftwareRepository =
-      factory.getBankruptcySoftwareRepository(context);
+    trusteeId: string,
+    before: Trustee,
+    after: Trustee,
+    userReference: ReturnType<typeof getCamsUserReference>,
+    software: BankruptcySoftwareProfile | undefined,
+  ): Promise<void> {
+    if (before.name !== after.name) {
+      await this.trusteesRepository.createTrusteeHistory(
+        createAuditRecord(
+          { documentType: 'AUDIT_NAME', trusteeId, before: before.name, after: after.name },
+          userReference,
+        ),
+      );
+      const trace = context.observability.startTrace(context.invocationId);
+      const isMigrated = !!(after.legacy?.truIds && after.legacy.truIds.length > 0);
+      context.observability.completeTrace(trace, 'Trustee Name Edited', {
+        success: true,
+        properties: { isMigrated: String(isMigrated) },
+        measurements: {},
+      });
+    }
+
+    if (!deepEqual(before.public, after.public)) {
+      await this.trusteesRepository.createTrusteeHistory(
+        createAuditRecord(
+          {
+            documentType: 'AUDIT_PUBLIC_CONTACT',
+            trusteeId,
+            before: before.public,
+            after: after.public,
+          },
+          userReference,
+        ),
+      );
+    }
+
+    if (!deepEqual(before.internal, after.internal)) {
+      await this.trusteesRepository.createTrusteeHistory(
+        createAuditRecord(
+          {
+            documentType: 'AUDIT_INTERNAL_CONTACT',
+            trusteeId,
+            before: normalizeForUndefined(before.internal),
+            after: normalizeForUndefined(after.internal),
+          },
+          userReference,
+        ),
+      );
+    }
+
+    if (!deepEqual(before.banks, after.banks)) {
+      const bankNames = this.buildBankNameMap(software, after.softwareId || before.softwareId);
+      const beforeNames = before.banks?.map((id) => bankNames.get(id) ?? id);
+      const afterNames = after.banks?.map((id) => bankNames.get(id) ?? id);
+      await this.trusteesRepository.createTrusteeHistory(
+        createAuditRecord(
+          { documentType: 'AUDIT_BANKS', trusteeId, before: beforeNames, after: afterNames },
+          userReference,
+        ),
+      );
+    }
+
+    if (before.softwareId !== after.softwareId) {
+      const beforeName = before.softwareId
+        ? await this.resolveSoftwareName(before.softwareId)
+        : undefined;
+      const afterName = after.softwareId ? (software?.name ?? after.softwareId) : undefined;
+      await this.trusteesRepository.createTrusteeHistory(
+        createAuditRecord(
+          { documentType: 'AUDIT_SOFTWARE', trusteeId, before: beforeName, after: afterName },
+          userReference,
+        ),
+      );
+    }
+
+    if (!deepEqual(before.zoomInfo, after.zoomInfo)) {
+      await this.trusteesRepository.createTrusteeHistory(
+        createAuditRecord(
+          {
+            documentType: 'AUDIT_ZOOM_INFO',
+            trusteeId,
+            before: before.zoomInfo,
+            after: after.zoomInfo,
+          },
+          userReference,
+        ),
+      );
+    }
+  }
+
+  private buildBankNameMap(
+    software: BankruptcySoftwareProfile | undefined,
+    softwareId: string | undefined,
+  ): Map<string, string> {
+    if (!software || !softwareId) return new Map();
+    const nameMap = new Map<string, string>();
+    for (const bank of software.associatedBanks ?? []) {
+      nameMap.set(bank.bankId, bank.bankName);
+    }
+    return nameMap;
+  }
+
+  private async resolveSoftwareName(softwareId: string): Promise<string> {
     try {
-      const software = await softwareRepository.findSoftwareById(softwareId);
+      const software = await this.softwareRepository.findSoftwareById(softwareId);
       return software.name;
     } catch (error) {
       if (isCamsError(error) && error.status === 404) {
         return softwareId;
       }
       throw error;
-    }
-  }
-
-  private async validateBanksForSoftware(
-    context: ApplicationContext,
-    bankIds: string[],
-    softwareId: string | undefined,
-  ): Promise<void> {
-    if (!softwareId) {
-      throw new BadRequestError(MODULE_NAME, {
-        message: 'A software vendor must be assigned before adding banks.',
-      });
-    }
-
-    const softwareRepository: BankruptcySoftwareRepository =
-      factory.getBankruptcySoftwareRepository(context);
-    const software = await softwareRepository.findSoftwareById(softwareId);
-    const validBankIds = new Set(software.associatedBanks?.map((b) => b.bankId) ?? []);
-
-    const invalidBanks = bankIds.filter((id) => !validBankIds.has(id));
-    if (invalidBanks.length > 0) {
-      throw new BadRequestError(MODULE_NAME, {
-        message: `Banks [${invalidBanks.join(', ')}] are not associated with the selected software.`,
-      });
-    }
-  }
-
-  private async resolveBankNames(
-    context: ApplicationContext,
-    softwareId: string,
-  ): Promise<Map<string, string>> {
-    const softwareRepository: BankruptcySoftwareRepository =
-      factory.getBankruptcySoftwareRepository(context);
-    try {
-      const software = await softwareRepository.findSoftwareById(softwareId);
-      const nameMap = new Map<string, string>();
-      for (const bank of software.associatedBanks ?? []) {
-        nameMap.set(bank.bankId, bank.bankName);
-      }
-      return nameMap;
-    } catch {
-      return new Map();
     }
   }
 }

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -291,6 +291,14 @@ export class TrusteesUseCase {
         await this.validateSoftwareExists(context, trustee.softwareId);
       }
 
+      if (patchedTrustee.banks && patchedTrustee.banks.length > 0) {
+        await this.validateBanksForSoftware(
+          context,
+          patchedTrustee.banks,
+          patchedTrustee.softwareId,
+        );
+      }
+
       const updatedTrustee = await this.trusteesRepository.updateTrustee(
         trusteeId,
         patchedTrustee,
@@ -349,13 +357,19 @@ export class TrusteesUseCase {
       }
 
       if (!deepEqual(existingTrustee.banks, updatedTrustee.banks)) {
+        const softwareIdForBanks = updatedTrustee.softwareId || existingTrustee.softwareId;
+        const bankNames = softwareIdForBanks
+          ? await this.resolveBankNames(context, softwareIdForBanks)
+          : new Map<string, string>();
+        const beforeNames = existingTrustee.banks?.map((id) => bankNames.get(id) ?? id);
+        const afterNames = updatedTrustee.banks?.map((id) => bankNames.get(id) ?? id);
         await this.trusteesRepository.createTrusteeHistory(
           createAuditRecord(
             {
               documentType: 'AUDIT_BANKS',
               trusteeId,
-              before: existingTrustee.banks,
-              after: updatedTrustee.banks,
+              before: beforeNames,
+              after: afterNames,
             },
             userReference,
           ),
@@ -439,6 +453,48 @@ export class TrusteesUseCase {
         return softwareId;
       }
       throw error;
+    }
+  }
+
+  private async validateBanksForSoftware(
+    context: ApplicationContext,
+    bankIds: string[],
+    softwareId: string | undefined,
+  ): Promise<void> {
+    if (!softwareId) {
+      throw new BadRequestError(MODULE_NAME, {
+        message: 'A software vendor must be assigned before adding banks.',
+      });
+    }
+
+    const softwareRepository: BankruptcySoftwareRepository =
+      factory.getBankruptcySoftwareRepository(context);
+    const software = await softwareRepository.findSoftwareById(softwareId);
+    const validBankIds = new Set(software.associatedBanks?.map((b) => b.bankId) ?? []);
+
+    const invalidBanks = bankIds.filter((id) => !validBankIds.has(id));
+    if (invalidBanks.length > 0) {
+      throw new BadRequestError(MODULE_NAME, {
+        message: `Banks [${invalidBanks.join(', ')}] are not associated with the selected software.`,
+      });
+    }
+  }
+
+  private async resolveBankNames(
+    context: ApplicationContext,
+    softwareId: string,
+  ): Promise<Map<string, string>> {
+    const softwareRepository: BankruptcySoftwareRepository =
+      factory.getBankruptcySoftwareRepository(context);
+    try {
+      const software = await softwareRepository.findSoftwareById(softwareId);
+      const nameMap = new Map<string, string>();
+      for (const bank of software.associatedBanks ?? []) {
+        nameMap.set(bank.bankId, bank.bankName);
+      }
+      return nameMap;
+    } catch {
+      return new Map();
     }
   }
 }

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -3,6 +3,7 @@ import {
   TrusteesRepository,
   TrusteeAssistantsRepository,
   TrusteeAppointmentsRepository,
+  BankruptcySoftwareRepository,
 } from '../gateways.types';
 import { getCamsUserReference } from '@common/cams/session';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
@@ -75,7 +76,7 @@ const trusteeSpec: ValidationSpec<TrusteeInput> = {
   public: [V.optional(V.spec(contactInformationSpec))],
   internal: [V.optional(V.spec(internalContactInformationSpec))],
   banks: [V.optional(V.arrayOf(V.length(1, 100)))],
-  software: [V.optional(V.length(0, 100))],
+  softwareId: [V.optional(V.length(1, 50))],
   zoomInfo: [V.optional(V.nullable(V.spec(zoomInfoSpec)))],
 };
 
@@ -285,6 +286,10 @@ export class TrusteesUseCase {
 
       this.checkValidation(validateObject(specToValidate, patchedTrustee));
 
+      if (trustee.softwareId) {
+        await this.validateSoftwareExists(context, trustee.softwareId);
+      }
+
       const updatedTrustee = await this.trusteesRepository.updateTrustee(
         trusteeId,
         patchedTrustee,
@@ -356,14 +361,20 @@ export class TrusteesUseCase {
         );
       }
 
-      if (existingTrustee.software !== updatedTrustee.software) {
+      if (existingTrustee.softwareId !== updatedTrustee.softwareId) {
+        const beforeName = existingTrustee.softwareId
+          ? await this.resolveSoftwareName(context, existingTrustee.softwareId)
+          : undefined;
+        const afterName = updatedTrustee.softwareId
+          ? await this.resolveSoftwareName(context, updatedTrustee.softwareId)
+          : undefined;
         await this.trusteesRepository.createTrusteeHistory(
           createAuditRecord(
             {
               documentType: 'AUDIT_SOFTWARE',
               trusteeId,
-              before: existingTrustee.software,
-              after: updatedTrustee.software,
+              before: beforeName,
+              after: afterName,
             },
             userReference,
           ),
@@ -392,6 +403,35 @@ export class TrusteesUseCase {
           message: `Failed to update trustee with ID ${trusteeId}.`,
         },
       });
+    }
+  }
+
+  private async validateSoftwareExists(
+    context: ApplicationContext,
+    softwareId: string,
+  ): Promise<void> {
+    const softwareRepository: BankruptcySoftwareRepository =
+      factory.getBankruptcySoftwareRepository(context);
+    try {
+      await softwareRepository.findSoftwareById(softwareId);
+    } catch {
+      throw new BadRequestError(MODULE_NAME, {
+        message: `Software with ID '${softwareId}' does not exist.`,
+      });
+    }
+  }
+
+  private async resolveSoftwareName(
+    context: ApplicationContext,
+    softwareId: string,
+  ): Promise<string> {
+    const softwareRepository: BankruptcySoftwareRepository =
+      factory.getBankruptcySoftwareRepository(context);
+    try {
+      const software = await softwareRepository.findSoftwareById(softwareId);
+      return software.name;
+    } catch {
+      return softwareId;
     }
   }
 }

--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -580,8 +580,8 @@ function getTrustee(override: Partial<Trustee> = {}): Trustee {
   if (sanitizedOverride.banks === null) {
     sanitizedOverride.banks = undefined;
   }
-  if (sanitizedOverride.software === null) {
-    sanitizedOverride.software = undefined;
+  if (sanitizedOverride.softwareId === null) {
+    sanitizedOverride.softwareId = undefined;
   }
 
   // Create a properly typed result
@@ -598,7 +598,7 @@ function getTrustee(override: Partial<Trustee> = {}): Trustee {
     // Optional fields with proper types
     internal: sanitizedOverride.internal || trusteeInput.internal,
     banks: sanitizedOverride.banks,
-    software: sanitizedOverride.software,
+    softwareId: sanitizedOverride.softwareId,
     zoomInfo: sanitizedOverride.zoomInfo,
     legacy: sanitizedOverride.legacy,
     ...override,

--- a/common/src/cams/trustees.ts
+++ b/common/src/cams/trustees.ts
@@ -108,7 +108,7 @@ export function formatTrusteeListName(
 
 type TrusteeOptionalFields = {
   banks?: string[];
-  software?: string;
+  softwareId?: string;
   zoomInfo?: ZoomInfo;
 };
 
@@ -153,7 +153,7 @@ export type TrusteePatchBody = Omit<Partial<Person>, 'middleName'> & {
       })
     | null;
   banks?: string[] | null;
-  software?: string | null;
+  softwareId?: string | null;
   zoomInfo?: ZoomInfo | null;
 };
 

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -565,6 +565,10 @@ async function getSoftware(softwareId: string) {
   return api().get<BankruptcySoftwareProfile>(`/bankruptcy-software/${softwareId}`);
 }
 
+async function getSoftwareName(softwareId: string) {
+  return api().get<{ name: string }>(`/bankruptcy-software/${softwareId}/name`);
+}
+
 async function updateSoftware(
   softwareId: string,
   data: Partial<Pick<BankruptcySoftwareProfile, 'name' | 'status' | 'contact'>>,
@@ -696,6 +700,7 @@ export const _Api2 = {
   getSoftwareList,
   createSoftware,
   getSoftware,
+  getSoftwareName,
   updateSoftware,
   addAssociatedBank,
   updateBankAssociationStatus,

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -63,6 +63,7 @@ export default function TrusteeDetailScreen() {
   const [navState, setNavState] = useState<number>(mapTrusteeDetailNavState(location.pathname));
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [softwareOptions, setSoftwareOptions] = useState<ComboOption[]>([]);
+  const [softwareProfiles, setSoftwareProfiles] = useState<BankruptcySoftwareProfile[]>([]);
   const navigate = useNavigate();
   const globalAlert = useGlobalAlert();
   const featureFlags = useFeatureFlags();
@@ -97,10 +98,9 @@ export default function TrusteeDetailScreen() {
       try {
         const response = await Api2.getSoftwareList();
         if (response?.data) {
-          const transformedOptions = transformSoftwareList(
-            response.data as BankruptcySoftwareProfile[],
-          );
-          setSoftwareOptions(transformedOptions);
+          const profiles = response.data as BankruptcySoftwareProfile[];
+          setSoftwareProfiles(profiles);
+          setSoftwareOptions(transformSoftwareList(profiles));
         }
       } catch (e) {
         console.log('Failed to fetch software options', (e as Error).message);
@@ -168,6 +168,7 @@ export default function TrusteeDetailScreen() {
               onEditZoomInfo={openEditZoomInfo}
               showSoftwareBankInfo={showSoftwareBankInfo}
               softwareOptions={softwareOptions}
+              softwareProfiles={softwareProfiles}
             />
           </div>
         </div>
@@ -216,6 +217,7 @@ export default function TrusteeDetailScreen() {
           softwareId={trustee.softwareId}
           trusteeId={trustee.trusteeId}
           softwareOptions={softwareOptions}
+          softwareProfiles={softwareProfiles}
         />
       ),
     },

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -51,7 +51,7 @@ function TrusteeHeader({ trustee, isLoading, subHeading, children }: TrusteeHead
 
 const transformSoftwareList = (items: BankruptcySoftwareProfile[]): ComboOption[] => {
   return items.map((item) => ({
-    value: item.name,
+    value: item.id,
     label: item.name,
   }));
 };
@@ -167,6 +167,7 @@ export default function TrusteeDetailScreen() {
               onEditOtherInformation={openEditOtherInformation}
               onEditZoomInfo={openEditZoomInfo}
               showSoftwareBankInfo={showSoftwareBankInfo}
+              softwareOptions={softwareOptions}
             />
           </div>
         </div>
@@ -212,7 +213,7 @@ export default function TrusteeDetailScreen() {
       content: (
         <TrusteeOtherInfoForm
           banks={trustee.banks}
-          software={trustee.software}
+          softwareId={trustee.softwareId}
           trusteeId={trustee.trusteeId}
           softwareOptions={softwareOptions}
         />

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.scss
@@ -9,13 +9,6 @@
         position: relative;
         width: 100%;
         max-width: 400px;
-
-        .remove-bank-button {
-          position: absolute;
-          top: 0;
-          line-height: 1.3;
-          right: 0;
-        }
       }
     }
     .form-column .field-group.bank-field:not(:has(~ .field-group.bank-field)) {
@@ -26,10 +19,6 @@
     display: inline-block;
     width: 100%;
     max-width: 400px;
-  }
-  .remove-bank-button {
-    margin-left: 1rem;
-    color: $secondary-dark;
   }
   .add-bank-button {
     margin-bottom: 1.5rem;

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
@@ -29,14 +29,14 @@ describe('TrusteeOtherInfoForm', () => {
   };
 
   const mockSoftwareOptions = [
-    { value: 'Axos', label: 'Axos' },
-    { value: 'BlueStylus', label: 'BlueStylus' },
-    { value: 'BSS 13Software', label: 'BSS 13Software' },
-    { value: 'Epiq', label: 'Epiq' },
-    { value: 'Satori', label: 'Satori' },
-    { value: 'Stretto', label: 'Stretto' },
-    { value: 'TrusteSolutions', label: 'TrusteSolutions' },
-    { value: 'Verita Title XI', label: 'Verita Title XI' },
+    { value: 'sw-axos', label: 'Axos' },
+    { value: 'sw-bluestylus', label: 'BlueStylus' },
+    { value: 'sw-bss13', label: 'BSS 13Software' },
+    { value: 'sw-epiq', label: 'Epiq' },
+    { value: 'sw-satori', label: 'Satori' },
+    { value: 'sw-stretto', label: 'Stretto' },
+    { value: 'sw-trustesolutions', label: 'TrusteSolutions' },
+    { value: 'sw-verita', label: 'Verita Title XI' },
   ];
 
   let patchTrusteeSpy: Mock<
@@ -352,13 +352,10 @@ describe('TrusteeOtherInfoForm', () => {
   );
 
   test('updates software value when a software option is selected from ComboBox', async () => {
-    const initialSoftware = 'Axos';
-    const newSoftware = 'Stretto';
-
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        software={initialSoftware}
+        softwareId="sw-axos"
         softwareOptions={mockSoftwareOptions}
       />,
     );
@@ -366,7 +363,7 @@ describe('TrusteeOtherInfoForm', () => {
     // Verify initial software selection is displayed in the input
     await waitFor(() => {
       const input = document.querySelector('#trustee-software-combo-box-input') as HTMLInputElement;
-      expect(input).toHaveValue(initialSoftware);
+      expect(input).toHaveValue('Axos');
     });
 
     // Open the ComboBox dropdown
@@ -379,19 +376,19 @@ describe('TrusteeOtherInfoForm', () => {
     });
 
     // Select Stretto option - find it by its data-value attribute
-    const strettoOption = document.querySelector('[data-value="Stretto"]') as HTMLLIElement;
+    const strettoOption = document.querySelector('[data-value="sw-stretto"]') as HTMLLIElement;
     expect(strettoOption).toBeInTheDocument();
     await userEvent.click(strettoOption);
 
     // Submit the form to verify the software state was updated
     await userEvent.click(screen.getByTestId('button-submit-button'));
 
-    // Verify API was called with the new software value
+    // Verify API was called with the new softwareId value
     await waitFor(() => {
       expect(patchTrusteeSpy).toHaveBeenCalledWith(
         TEST_TRUSTEE_ID,
         expect.objectContaining({
-          software: newSoftware,
+          softwareId: 'sw-stretto',
         }),
       );
     });
@@ -403,12 +400,10 @@ describe('TrusteeOtherInfoForm', () => {
   });
 
   test('clears software value when ComboBox clear button is clicked', async () => {
-    const initialSoftware = 'Epiq';
-
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        software={initialSoftware}
+        softwareId="sw-epiq"
         softwareOptions={mockSoftwareOptions}
       />,
     );
@@ -416,7 +411,7 @@ describe('TrusteeOtherInfoForm', () => {
     // Verify initial software selection is displayed in the input
     await waitFor(() => {
       const input = document.querySelector('#trustee-software-combo-box-input') as HTMLInputElement;
-      expect(input).toHaveValue(initialSoftware);
+      expect(input).toHaveValue('Epiq');
     });
 
     const clearButton = document.querySelector('#trustee-software-clear-all') as HTMLButtonElement;
@@ -429,7 +424,7 @@ describe('TrusteeOtherInfoForm', () => {
       expect(patchTrusteeSpy).toHaveBeenCalledWith(
         TEST_TRUSTEE_ID,
         expect.objectContaining({
-          software: null,
+          softwareId: null,
         }),
       );
     });

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
@@ -8,11 +8,40 @@ import { Trustee } from '@common/cams/trustees';
 import { ResponseBody } from '@common/api/response';
 import MockData from '@common/cams/test-utilities/mock-data';
 import TestingUtilities, { CamsUserEvent } from '@/lib/testing/testing-utilities';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 describe('TrusteeOtherInfoForm', () => {
   const TEST_TRUSTEE_ID = 'trustee-123';
-  const TEST_BANKS = ['Bank of America', 'Chase', 'Wells Fargo'];
-  const TRUSTEE = MockData.getTrustee({ id: TEST_TRUSTEE_ID, banks: TEST_BANKS });
+
+  const mockSoftwareProfiles: BankruptcySoftwareProfile[] = [
+    {
+      id: 'sw-axos',
+      documentType: 'BANKRUPTCY_SOFTWARE',
+      name: 'Axos',
+      status: 'active',
+      updatedOn: '2024-01-01T00:00:00.000Z',
+      updatedBy: { id: 'user-1', name: 'User One' },
+      associatedBanks: [
+        { bankId: 'bank-fifth-third', bankName: 'Fifth Third Bank', status: 'active' },
+        { bankId: 'bank-key', bankName: 'Key Bank', status: 'active' },
+        { bankId: 'bank-inactive', bankName: 'Inactive Bank', status: 'inactive' },
+      ],
+    },
+    {
+      id: 'sw-stretto',
+      documentType: 'BANKRUPTCY_SOFTWARE',
+      name: 'Stretto',
+      status: 'active',
+      updatedOn: '2024-01-01T00:00:00.000Z',
+      updatedBy: { id: 'user-1', name: 'User One' },
+      associatedBanks: [{ bankId: 'bank-chase', bankName: 'Chase', status: 'active' }],
+    },
+  ];
+
+  const mockSoftwareOptions = [
+    { value: 'sw-axos', label: 'Axos' },
+    { value: 'sw-stretto', label: 'Stretto' },
+  ];
 
   const mockGlobalAlert = {
     success: vi.fn(),
@@ -28,21 +57,12 @@ describe('TrusteeOtherInfoForm', () => {
     redirectTo: vi.fn(),
   };
 
-  const mockSoftwareOptions = [
-    { value: 'sw-axos', label: 'Axos' },
-    { value: 'sw-bluestylus', label: 'BlueStylus' },
-    { value: 'sw-bss13', label: 'BSS 13Software' },
-    { value: 'sw-epiq', label: 'Epiq' },
-    { value: 'sw-satori', label: 'Satori' },
-    { value: 'sw-stretto', label: 'Stretto' },
-    { value: 'sw-trustesolutions', label: 'TrusteSolutions' },
-    { value: 'sw-verita', label: 'Verita Title XI' },
-  ];
-
   let patchTrusteeSpy: Mock<
     (trusteeId: string, trustee: unknown) => Promise<ResponseBody<Trustee>>
   >;
   let userEvent: CamsUserEvent;
+
+  const TRUSTEE = MockData.getTrustee({ id: TEST_TRUSTEE_ID, banks: ['bank-fifth-third'] });
 
   beforeEach(() => {
     userEvent = TestingUtilities.setupUserEvent();
@@ -51,12 +71,10 @@ describe('TrusteeOtherInfoForm', () => {
     vi.spyOn(UseGlobalAlertModule, 'useGlobalAlert').mockReturnValue(mockGlobalAlert);
     vi.spyOn(useCamsNavigatorModule, 'default').mockReturnValue(mockNavigate);
 
-    // Create a spy on the patchTrustee method of the API
     patchTrusteeSpy = vi.fn().mockResolvedValue({
       data: TRUSTEE,
     });
 
-    // Get the API instance and spy on its methods
     vi.spyOn(Api2, 'patchTrustee').mockImplementation(patchTrusteeSpy);
   });
 
@@ -64,159 +82,173 @@ describe('TrusteeOtherInfoForm', () => {
     vi.restoreAllMocks();
   });
 
-  test('renders the form with initial bank fields', async () => {
+  test('renders bank disabled message when no software is selected', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('bank-disabled-message')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('bank-disabled-message')).toHaveTextContent(
+      'Trustee bank with a software requires a software to be entered',
+    );
+    expect(screen.queryByTestId('button-add-bank-button')).not.toBeInTheDocument();
+  });
+
+  test('shows bank ComboBox when software is selected', async () => {
+    render(
+      <TrusteeOtherInfoForm
+        trusteeId={TEST_TRUSTEE_ID}
+        softwareId="sw-axos"
+        softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
     await waitFor(() => {
       expect(screen.getByTestId('trustee-other-info-form')).toBeInTheDocument();
     });
-
-    // Check all initial bank fields are rendered
-    TEST_BANKS.forEach((bank, index) => {
-      expect(screen.getByTestId(`trustee-banks-${index}`)).toHaveValue(bank);
-    });
-
-    // Check that "Remove Bank" button is present for all banks except the first one
-    // Count bank inputs instead of remove buttons since we're using test IDs
-    expect(screen.getByTestId('trustee-banks-1')).toBeInTheDocument();
-    expect(screen.getByTestId('trustee-banks-2')).toBeInTheDocument();
-
-    // Check that "Add another bank" button is present
+    expect(screen.queryByTestId('bank-disabled-message')).not.toBeInTheDocument();
     expect(screen.getByTestId('button-add-bank-button')).toBeInTheDocument();
   });
 
-  test('renders the form with empty bank field when no banks are provided', async () => {
+  test('pre-populates bank selections from props', async () => {
     render(
-      <TrusteeOtherInfoForm trusteeId={TEST_TRUSTEE_ID} softwareOptions={mockSoftwareOptions} />,
+      <TrusteeOtherInfoForm
+        trusteeId={TEST_TRUSTEE_ID}
+        softwareId="sw-axos"
+        banks={['bank-fifth-third']}
+        softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
+      />,
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('trustee-other-info-form')).toBeInTheDocument();
+      const input = document.querySelector('#trustee-banks-0-combo-box-input') as HTMLInputElement;
+      expect(input).toHaveValue('Fifth Third Bank');
     });
-    expect(screen.getByTestId('trustee-banks-0')).toHaveValue('');
-    expect(screen.queryByText('Remove Bank')).not.toBeInTheDocument();
   });
 
-  test('adds a bank when "Add another bank" is clicked', async () => {
+  test('adds a bank dropdown when "Add another bank" is clicked', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
+        softwareId="sw-axos"
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
-    // Initial number of banks - verify they exist
-    TEST_BANKS.forEach((_, index) => {
-      expect(screen.getByTestId(`trustee-banks-${index}`)).toBeInTheDocument();
-    });
-
-    // Click the "Add another bank" button
     await userEvent.click(screen.getByTestId('button-add-bank-button'));
 
-    // Check a new bank field was added
-    expect(screen.getByTestId(`trustee-banks-${TEST_BANKS.length}`)).toHaveValue('');
+    expect(document.querySelector('#trustee-banks-0-combo-box-input')).toBeInTheDocument();
+    expect(document.querySelector('#trustee-banks-1-combo-box-input')).toBeInTheDocument();
   });
 
-  test('removes a bank when "Remove Bank" is clicked', async () => {
+  test('removes a bank dropdown when "Remove bank" is clicked', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
+        softwareId="sw-axos"
+        banks={['bank-fifth-third', 'bank-key']}
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
-    // Initial banks should exist
-    TEST_BANKS.forEach((_, index) => {
-      expect(screen.getByTestId(`trustee-banks-${index}`)).toBeInTheDocument();
-    });
+    expect(document.querySelector('#trustee-banks-1-combo-box-input')).toBeInTheDocument();
 
-    // Click the first "Remove Bank" button (which removes the second bank)
     await userEvent.click(screen.getByTestId('button-remove-bank-1-button'));
 
-    // Check that a bank was removed - the last bank should no longer exist
-    expect(screen.queryByTestId(`trustee-banks-${TEST_BANKS.length - 1}`)).not.toBeInTheDocument();
-    // But the first bank should still exist
-    expect(screen.getByTestId('trustee-banks-0')).toBeInTheDocument();
+    expect(document.querySelector('#trustee-banks-1-combo-box-input')).not.toBeInTheDocument();
+    expect(document.querySelector('#trustee-banks-0-combo-box-input')).toBeInTheDocument();
   });
 
-  test('updates bank value when input changes', async () => {
+  test('clears banks when software vendor changes', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
+        softwareId="sw-axos"
+        banks={['bank-fifth-third']}
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
-    const updatedBankName = 'Updated Bank Name';
-    const bankInput = screen.getByTestId('trustee-banks-0');
+    // Verify bank is initially populated
+    await waitFor(() => {
+      const input = document.querySelector('#trustee-banks-0-combo-box-input') as HTMLInputElement;
+      expect(input).toHaveValue('Fifth Third Bank');
+    });
 
-    await userEvent.clear(bankInput);
-    await userEvent.type(bankInput, updatedBankName);
+    // Change software selection
+    const expandButton = document.querySelector('#trustee-software-expand') as HTMLButtonElement;
+    await userEvent.click(expandButton);
 
-    expect(bankInput).toHaveValue(updatedBankName);
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    const strettoOption = document.querySelector('[data-value="sw-stretto"]') as HTMLLIElement;
+    await userEvent.click(strettoOption);
+
+    // Banks should be cleared - the old bank input should be gone
+    await waitFor(() => {
+      const bankInput = document.querySelector(
+        '#trustee-banks-0-combo-box-input',
+      ) as HTMLInputElement;
+      // After software change, banks are cleared but one empty row shows
+      expect(bankInput?.value || '').toBe('');
+    });
   });
 
-  test('submits the form with updated banks', async () => {
+  test('submits bank IDs to the API', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
+        softwareId="sw-axos"
+        banks={['bank-fifth-third', 'bank-key']}
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
-    // Update first bank name
-    const updatedBankName = 'Updated Bank Name';
-    const bankInput = screen.getByTestId('trustee-banks-0');
-    await userEvent.clear(bankInput);
-    await userEvent.type(bankInput, updatedBankName);
-
-    // Submit the form
     await userEvent.click(screen.getByTestId('button-submit-button'));
 
-    // Wait for the async operation to complete
     await waitFor(() => {
       expect(patchTrusteeSpy).toHaveBeenCalledWith(
         TEST_TRUSTEE_ID,
         expect.objectContaining({
-          banks: expect.arrayContaining([updatedBankName, TEST_BANKS[1], TEST_BANKS[2]]),
+          banks: ['bank-fifth-third', 'bank-key'],
+          softwareId: 'sw-axos',
         }),
       );
     });
-
-    // Check that navigation occurred
-    await waitFor(() => {
-      expect(mockNavigate.navigateTo).toHaveBeenCalledWith(`/trustees/${TEST_TRUSTEE_ID}`);
-    });
   });
 
-  test('filters out empty banks when submitting', async () => {
+  test('sends null banks when no banks are selected', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={['Bank One', '', 'Bank Three']}
+        softwareId="sw-axos"
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
-    // Submit the form
     await userEvent.click(screen.getByTestId('button-submit-button'));
 
-    // Wait for the async operation to complete
     await waitFor(() => {
       expect(patchTrusteeSpy).toHaveBeenCalledWith(
         TEST_TRUSTEE_ID,
         expect.objectContaining({
-          banks: ['Bank One', 'Bank Three'],
+          banks: null,
+          softwareId: 'sw-axos',
         }),
       );
     });
@@ -229,15 +261,14 @@ describe('TrusteeOtherInfoForm', () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
+        softwareId="sw-axos"
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
-    // Submit the form
     await userEvent.click(screen.getByTestId('button-submit-button'));
 
-    // Wait for the async operation to complete
     await waitFor(() => {
       expect(mockGlobalAlert.error).toHaveBeenCalledWith(
         `Failed to update trustee information: ${errorMessage}`,
@@ -245,34 +276,21 @@ describe('TrusteeOtherInfoForm', () => {
     });
   });
 
-  test('changes the Save button text when submitting', async () => {
+  test('navigates to trustee page when cancel is clicked', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
-    // Submit button should initially show "Save"
-    expect(screen.getByTestId('button-submit-button')).toHaveTextContent('Save');
+    await userEvent.click(screen.getByTestId('button-cancel-button'));
 
-    // Click the submit button
-    await userEvent.click(screen.getByTestId('button-submit-button'));
-
-    // Wait for the async operation to complete and verify the API was called
-    await waitFor(() => {
-      expect(patchTrusteeSpy).toHaveBeenCalled();
-    });
-
-    // The button text should return to "Save" after the operation completes
-    await waitFor(() => {
-      expect(screen.getByTestId('button-submit-button')).toHaveTextContent('Save');
-    });
+    expect(mockNavigate.navigateTo).toHaveBeenCalledWith(`/trustees/${TEST_TRUSTEE_ID}`);
   });
 
   test('disables submit button during form submission', async () => {
-    // Mock the API call to be slow so we can test the disabled state
     patchTrusteeSpy.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -285,50 +303,23 @@ describe('TrusteeOtherInfoForm', () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
+        softwareId="sw-axos"
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
     const submitButton = screen.getByTestId('button-submit-button');
-
-    // Submit button should initially be enabled
     expect(submitButton).not.toBeDisabled();
-    expect(submitButton).toHaveTextContent('Save');
 
-    // Click the submit button
     await userEvent.click(submitButton);
 
-    // Button should be disabled and show "Saving..." during submission
     expect(submitButton).toBeDisabled();
     expect(submitButton).toHaveTextContent('Saving…');
 
-    // Wait for the API call to complete
-    await waitFor(() => {
-      expect(patchTrusteeSpy).toHaveBeenCalled();
-    });
-
-    // Button should be re-enabled after submission completes
     await waitFor(() => {
       expect(submitButton).not.toBeDisabled();
-      expect(submitButton).toHaveTextContent('Save');
     });
-  });
-
-  test('navigates to trustee page when cancel is clicked', async () => {
-    render(
-      <TrusteeOtherInfoForm
-        trusteeId={TEST_TRUSTEE_ID}
-        banks={TEST_BANKS}
-        softwareOptions={mockSoftwareOptions}
-      />,
-    );
-
-    // Click the cancel button
-    await userEvent.click(screen.getByTestId('button-cancel-button'));
-
-    // Check that navigation occurred to the correct page
-    expect(mockNavigate.navigateTo).toHaveBeenCalledWith(`/trustees/${TEST_TRUSTEE_ID}`);
   });
 
   test.each([[''], ['   ']])(
@@ -337,8 +328,8 @@ describe('TrusteeOtherInfoForm', () => {
       render(
         <TrusteeOtherInfoForm
           trusteeId={trusteeId}
-          banks={TEST_BANKS}
           softwareOptions={mockSoftwareOptions}
+          softwareProfiles={mockSoftwareProfiles}
         />,
       );
 
@@ -351,68 +342,40 @@ describe('TrusteeOtherInfoForm', () => {
     },
   );
 
-  test('updates software value when a software option is selected from ComboBox', async () => {
+  test('filters inactive banks from dropdown options', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
         softwareId="sw-axos"
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
 
-    // Verify initial software selection is displayed in the input
-    await waitFor(() => {
-      const input = document.querySelector('#trustee-software-combo-box-input') as HTMLInputElement;
-      expect(input).toHaveValue('Axos');
-    });
-
-    // Open the ComboBox dropdown
-    const expandButton = document.querySelector('#trustee-software-expand') as HTMLButtonElement;
+    // Open the bank ComboBox dropdown
+    const expandButton = document.querySelector('#trustee-banks-0-expand') as HTMLButtonElement;
     await userEvent.click(expandButton);
 
-    // Wait for dropdown to open and find the Stretto option
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
 
-    // Select Stretto option - find it by its data-value attribute
-    const strettoOption = document.querySelector('[data-value="sw-stretto"]') as HTMLLIElement;
-    expect(strettoOption).toBeInTheDocument();
-    await userEvent.click(strettoOption);
-
-    // Submit the form to verify the software state was updated
-    await userEvent.click(screen.getByTestId('button-submit-button'));
-
-    // Verify API was called with the new softwareId value
-    await waitFor(() => {
-      expect(patchTrusteeSpy).toHaveBeenCalledWith(
-        TEST_TRUSTEE_ID,
-        expect.objectContaining({
-          softwareId: 'sw-stretto',
-        }),
-      );
-    });
-
-    // Check that navigation occurred
-    await waitFor(() => {
-      expect(mockNavigate.navigateTo).toHaveBeenCalledWith(`/trustees/${TEST_TRUSTEE_ID}`);
-    });
+    // Active banks should be visible
+    expect(document.querySelector('[data-value="bank-fifth-third"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-value="bank-key"]')).toBeInTheDocument();
+    // Inactive bank should NOT be visible
+    expect(document.querySelector('[data-value="bank-inactive"]')).not.toBeInTheDocument();
   });
 
-  test('clears software value when ComboBox clear button is clicked', async () => {
+  test('clears software sends null softwareId', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
-        softwareId="sw-epiq"
+        softwareId="sw-axos"
         softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
       />,
     );
-
-    // Verify initial software selection is displayed in the input
-    await waitFor(() => {
-      const input = document.querySelector('#trustee-software-combo-box-input') as HTMLInputElement;
-      expect(input).toHaveValue('Epiq');
-    });
 
     const clearButton = document.querySelector('#trustee-software-clear-all') as HTMLButtonElement;
     expect(clearButton).toBeInTheDocument();
@@ -427,10 +390,6 @@ describe('TrusteeOtherInfoForm', () => {
           softwareId: null,
         }),
       );
-    });
-
-    await waitFor(() => {
-      expect(mockNavigate.navigateTo).toHaveBeenCalledWith(`/trustees/${TEST_TRUSTEE_ID}`);
     });
   });
 });

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
@@ -82,7 +82,7 @@ describe('TrusteeOtherInfoForm', () => {
     vi.restoreAllMocks();
   });
 
-  test('renders bank disabled message when no software is selected', async () => {
+  test('renders disabled bank ComboBox when no software is selected', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
@@ -92,15 +92,17 @@ describe('TrusteeOtherInfoForm', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('bank-disabled-message')).toBeInTheDocument();
+      const bankInput = document.querySelector(
+        '#trustee-banks-0-combo-box-input',
+      ) as HTMLInputElement;
+      expect(bankInput).toBeInTheDocument();
+      expect(bankInput).toBeDisabled();
     });
-    expect(screen.getByTestId('bank-disabled-message')).toHaveTextContent(
-      'Trustee bank with a software requires a software to be entered',
-    );
-    expect(screen.queryByTestId('button-add-bank-button')).not.toBeInTheDocument();
+    expect(screen.getByTestId('button-add-bank-button')).toBeDisabled();
+    expect(screen.getByTestId('button-submit-button')).toBeDisabled();
   });
 
-  test('shows bank ComboBox when software is selected', async () => {
+  test('enables bank ComboBox and add button when software is selected', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
@@ -111,10 +113,12 @@ describe('TrusteeOtherInfoForm', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('trustee-other-info-form')).toBeInTheDocument();
+      const bankInput = document.querySelector(
+        '#trustee-banks-0-combo-box-input',
+      ) as HTMLInputElement;
+      expect(bankInput).not.toBeDisabled();
     });
-    expect(screen.queryByTestId('bank-disabled-message')).not.toBeInTheDocument();
-    expect(screen.getByTestId('button-add-bank-button')).toBeInTheDocument();
+    expect(screen.getByTestId('button-add-bank-button')).not.toBeDisabled();
   });
 
   test('pre-populates bank selections from props', async () => {
@@ -150,7 +154,7 @@ describe('TrusteeOtherInfoForm', () => {
     expect(document.querySelector('#trustee-banks-1-combo-box-input')).toBeInTheDocument();
   });
 
-  test('removes a bank dropdown when "Remove bank" is clicked', async () => {
+  test('filters out cleared banks on submit', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
@@ -161,12 +165,20 @@ describe('TrusteeOtherInfoForm', () => {
       />,
     );
 
-    expect(document.querySelector('#trustee-banks-1-combo-box-input')).toBeInTheDocument();
+    const clearButton = document.querySelector('#trustee-banks-1-clear-all') as HTMLButtonElement;
+    await userEvent.click(clearButton);
 
-    await userEvent.click(screen.getByTestId('button-remove-bank-1-button'));
+    await userEvent.click(screen.getByTestId('button-submit-button'));
 
-    expect(document.querySelector('#trustee-banks-1-combo-box-input')).not.toBeInTheDocument();
-    expect(document.querySelector('#trustee-banks-0-combo-box-input')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(patchTrusteeSpy).toHaveBeenCalledWith(
+        TEST_TRUSTEE_ID,
+        expect.objectContaining({
+          banks: ['bank-fifth-third'],
+          softwareId: 'sw-axos',
+        }),
+      );
+    });
   });
 
   test('clears banks when software vendor changes', async () => {
@@ -231,7 +243,7 @@ describe('TrusteeOtherInfoForm', () => {
     });
   });
 
-  test('sends null banks when no banks are selected', async () => {
+  test('disables save when software is selected but no bank is chosen', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
@@ -241,17 +253,7 @@ describe('TrusteeOtherInfoForm', () => {
       />,
     );
 
-    await userEvent.click(screen.getByTestId('button-submit-button'));
-
-    await waitFor(() => {
-      expect(patchTrusteeSpy).toHaveBeenCalledWith(
-        TEST_TRUSTEE_ID,
-        expect.objectContaining({
-          banks: null,
-          softwareId: 'sw-axos',
-        }),
-      );
-    });
+    expect(screen.getByTestId('button-submit-button')).toBeDisabled();
   });
 
   test('shows error message when API call fails', async () => {
@@ -262,6 +264,7 @@ describe('TrusteeOtherInfoForm', () => {
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
         softwareId="sw-axos"
+        banks={['bank-fifth-third']}
         softwareOptions={mockSoftwareOptions}
         softwareProfiles={mockSoftwareProfiles}
       />,
@@ -304,6 +307,7 @@ describe('TrusteeOtherInfoForm', () => {
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
         softwareId="sw-axos"
+        banks={['bank-fifth-third']}
         softwareOptions={mockSoftwareOptions}
         softwareProfiles={mockSoftwareProfiles}
       />,
@@ -328,6 +332,8 @@ describe('TrusteeOtherInfoForm', () => {
       render(
         <TrusteeOtherInfoForm
           trusteeId={trusteeId}
+          softwareId="sw-axos"
+          banks={['bank-fifth-third']}
           softwareOptions={mockSoftwareOptions}
           softwareProfiles={mockSoftwareProfiles}
         />,
@@ -367,11 +373,12 @@ describe('TrusteeOtherInfoForm', () => {
     expect(document.querySelector('[data-value="bank-inactive"]')).not.toBeInTheDocument();
   });
 
-  test('clears software sends null softwareId', async () => {
+  test('disables bank and save when software is cleared', async () => {
     render(
       <TrusteeOtherInfoForm
         trusteeId={TEST_TRUSTEE_ID}
         softwareId="sw-axos"
+        banks={['bank-fifth-third']}
         softwareOptions={mockSoftwareOptions}
         softwareProfiles={mockSoftwareProfiles}
       />,
@@ -381,15 +388,12 @@ describe('TrusteeOtherInfoForm', () => {
     expect(clearButton).toBeInTheDocument();
     await userEvent.click(clearButton);
 
-    await userEvent.click(screen.getByTestId('button-submit-button'));
-
     await waitFor(() => {
-      expect(patchTrusteeSpy).toHaveBeenCalledWith(
-        TEST_TRUSTEE_ID,
-        expect.objectContaining({
-          softwareId: null,
-        }),
-      );
+      const bankInput = document.querySelector(
+        '#trustee-banks-0-combo-box-input',
+      ) as HTMLInputElement;
+      expect(bankInput).toBeDisabled();
     });
+    expect(screen.getByTestId('button-submit-button')).toBeDisabled();
   });
 });

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
@@ -11,7 +11,7 @@ import React, { useState } from 'react';
 type TrusteeOtherInfoFormProps = {
   trusteeId: string;
   banks?: string[];
-  software?: string;
+  softwareId?: string;
   softwareOptions: ComboOption[];
 };
 
@@ -21,7 +21,7 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
   const initialBanks = props.banks?.filter((b) => b.trim() !== '') ?? [];
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [banks, setBanks] = useState<string[]>(initialBanks.length > 0 ? initialBanks : ['']);
-  const [software, setSoftware] = useState<string>(props.software ?? '');
+  const [softwareId, setSoftwareId] = useState<string>(props.softwareId ?? '');
 
   const navigate = useCamsNavigator();
 
@@ -51,7 +51,7 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
 
   const handleSoftwareChange = (selections: ComboOption[]) => {
     const selectedValue = selections.length > 0 ? selections[0].value : '';
-    setSoftware(selectedValue);
+    setSoftwareId(selectedValue);
   };
 
   async function handleSubmit(event?: React.MouseEvent<HTMLButtonElement>): Promise<void> {
@@ -69,7 +69,7 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
     try {
       const response = await Api2.patchTrustee(trusteeId, {
         banks: banks.filter((bank) => bank.trim() !== ''),
-        software: software || null,
+        softwareId: softwareId || null,
       });
       if (response?.data) {
         navigate.navigateTo(`/trustees/${trusteeId}`);
@@ -90,6 +90,18 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
       <form data-testid="trustee-other-info-form">
         <div className="form-container">
           <div className="form-column">
+            <div className="field-group">
+              <ComboBox
+                id="trustee-software"
+                className="trustee-software-input"
+                name="software"
+                label="Bankruptcy Software"
+                options={softwareOptions}
+                selections={softwareOptions.filter((option) => option.value === softwareId)}
+                onUpdateSelection={handleSoftwareChange}
+                autoComplete="off"
+              />
+            </div>
             {banks.map((bank, index) => {
               return (
                 <div className="field-group bank-field" key={`bank-${index}`}>
@@ -126,18 +138,6 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
               <Icon name="add_circle" />
               Add another bank
             </Button>
-            <div className="field-group">
-              <ComboBox
-                id="trustee-software"
-                className="trustee-software-input"
-                name="software"
-                label="Bankruptcy Software"
-                options={softwareOptions}
-                selections={softwareOptions.filter((option) => option.value === software)}
-                onUpdateSelection={handleSoftwareChange}
-                autoComplete="off"
-              />
-            </div>
           </div>
         </div>
         <div className="usa-button-group">

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
@@ -1,36 +1,47 @@
 import './TrusteeOtherInfoForm.scss';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import Icon from '@/lib/components/uswds/Icon';
-import Input from '@/lib/components/uswds/Input';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import Api2 from '@/lib/models/api2';
 import useCamsNavigator from '@/lib/hooks/UseCamsNavigator';
 import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import React, { useState } from 'react';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 type TrusteeOtherInfoFormProps = {
   trusteeId: string;
   banks?: string[];
   softwareId?: string;
   softwareOptions: ComboOption[];
+  softwareProfiles: BankruptcySoftwareProfile[];
 };
 
 function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
   const globalAlert = useGlobalAlert();
-  const { trusteeId, softwareOptions } = props;
+  const { trusteeId, softwareOptions, softwareProfiles } = props;
   const initialBanks = props.banks?.filter((b) => b.trim() !== '') ?? [];
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [banks, setBanks] = useState<string[]>(initialBanks.length > 0 ? initialBanks : ['']);
+  const [banks, setBanks] = useState<string[]>(
+    initialBanks.length > 0 ? initialBanks : props.softwareId ? [''] : [],
+  );
   const [softwareId, setSoftwareId] = useState<string>(props.softwareId ?? '');
 
   const navigate = useCamsNavigator();
 
-  const handleBankChange = (index: number, value: string) => {
+  const selectedSoftware = softwareProfiles.find((p) => p.id === softwareId);
+  const availableBanks: ComboOption[] =
+    selectedSoftware?.associatedBanks
+      ?.filter((b) => b.status === 'active')
+      .map((b) => ({ value: b.bankId, label: b.bankName })) ?? [];
+
+  const handleBankChange = (index: number, selections: ComboOption[]) => {
     const newBanks = [...banks];
-    if (index < newBanks.length) {
-      newBanks[index] = value;
-      setBanks(newBanks);
+    if (selections.length > 0) {
+      newBanks[index] = selections[0].value;
+    } else {
+      newBanks[index] = '';
     }
+    setBanks(newBanks);
   };
 
   const handleBankRemove = (index: number) => {
@@ -44,13 +55,14 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
   };
 
   const handleBankAdd = () => {
-    setBanks((current) => {
-      return [...current, ''];
-    });
+    setBanks((current) => [...current, '']);
   };
 
   const handleSoftwareChange = (selections: ComboOption[]) => {
     const selectedValue = selections.length > 0 ? selections[0].value : '';
+    if (selectedValue !== softwareId) {
+      setBanks(selectedValue ? [''] : []);
+    }
     setSoftwareId(selectedValue);
   };
 
@@ -59,7 +71,6 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
       event.preventDefault();
     }
 
-    // Guard clause: prevent submission if trusteeId is missing
     if (!trusteeId || trusteeId.trim() === '') {
       globalAlert?.error('Cannot save trustee information: Trustee ID is missing');
       return;
@@ -67,8 +78,9 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
 
     setIsSubmitting(true);
     try {
+      const filteredBanks = banks.filter((bank) => bank.trim() !== '');
       const response = await Api2.patchTrustee(trusteeId, {
-        banks: banks.filter((bank) => bank.trim() !== ''),
+        banks: filteredBanks.length > 0 ? filteredBanks : null,
         softwareId: softwareId || null,
       });
       if (response?.data) {
@@ -84,6 +96,8 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
   function handleCancel(_event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void {
     navigate.navigateTo(`/trustees/${trusteeId}`);
   }
+
+  const bankDisabled = !softwareId;
 
   return (
     <div className="other-info-trustee-form-screen">
@@ -102,42 +116,55 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
                 autoComplete="off"
               />
             </div>
-            {banks.map((bank, index) => {
-              return (
-                <div className="field-group bank-field" key={`bank-${index}`}>
-                  <div className="bank-field-input">
-                    <Input
-                      id={`trustee-banks-${index}`}
-                      className="trustee-bank-input"
-                      name={`bank-${index}`}
-                      value={bank}
-                      label="Bank"
-                      onChange={(e) => handleBankChange(index, e.target.value)}
-                      autoComplete="off"
-                    />
-                    {index > 0 && (
-                      <Button
-                        id={`remove-bank-${index}-button`}
-                        className="remove-bank-button"
-                        uswdsStyle={UswdsButtonStyle.Unstyled}
-                        onClick={handleBankRemove(index)}
-                      >
-                        Remove bank
-                      </Button>
-                    )}
+            {bankDisabled && (
+              <div className="bank-disabled-message" data-testid="bank-disabled-message">
+                Trustee bank with a software requires a software to be entered.
+              </div>
+            )}
+            {!bankDisabled &&
+              banks.map((bankId, index) => {
+                const selectedBankIds = banks.filter((_, i) => i !== index && banks[i] !== '');
+                const filteredOptions = availableBanks.filter(
+                  (opt) => !selectedBankIds.includes(opt.value),
+                );
+                return (
+                  <div className="field-group bank-field" key={`bank-${index}`}>
+                    <div className="bank-field-input">
+                      <ComboBox
+                        id={`trustee-banks-${index}`}
+                        className="trustee-bank-input"
+                        name={`bank-${index}`}
+                        label="Bank"
+                        options={filteredOptions}
+                        selections={availableBanks.filter((opt) => opt.value === bankId)}
+                        onUpdateSelection={(selections) => handleBankChange(index, selections)}
+                        autoComplete="off"
+                      />
+                      {index > 0 && (
+                        <Button
+                          id={`remove-bank-${index}-button`}
+                          className="remove-bank-button"
+                          uswdsStyle={UswdsButtonStyle.Unstyled}
+                          onClick={handleBankRemove(index)}
+                        >
+                          Remove bank
+                        </Button>
+                      )}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-            <Button
-              id="add-bank-button"
-              className="add-bank-button"
-              onClick={handleBankAdd}
-              uswdsStyle={UswdsButtonStyle.Unstyled}
-            >
-              <Icon name="add_circle" />
-              Add another bank
-            </Button>
+                );
+              })}
+            {!bankDisabled && (
+              <Button
+                id="add-bank-button"
+                className="add-bank-button"
+                onClick={handleBankAdd}
+                uswdsStyle={UswdsButtonStyle.Unstyled}
+              >
+                <Icon name="add_circle" />
+                Add another bank
+              </Button>
+            )}
           </div>
         </div>
         <div className="usa-button-group">

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
@@ -44,16 +44,6 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
     setBanks(newBanks);
   };
 
-  const handleBankRemove = (index: number) => {
-    return (_: React.MouseEvent<HTMLButtonElement>) => {
-      setBanks((current) => {
-        const updated = [...current];
-        updated.splice(index, 1);
-        return updated;
-      });
-    };
-  };
-
   const handleBankAdd = () => {
     setBanks((current) => [...current, '']);
   };
@@ -98,6 +88,8 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
   }
 
   const bankDisabled = !softwareId;
+  const hasBankSelected = banks.some((b) => b.trim() !== '');
+  const saveDisabled = isSubmitting || !softwareId || !hasBankSelected;
 
   return (
     <div className="other-info-trustee-form-screen">
@@ -117,8 +109,20 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
               />
             </div>
             {bankDisabled && (
-              <div className="bank-disabled-message" data-testid="bank-disabled-message">
-                Trustee bank with a software requires a software to be entered.
+              <div className="field-group bank-field">
+                <div className="bank-field-input">
+                  <ComboBox
+                    id="trustee-banks-0"
+                    className="trustee-bank-input"
+                    name="bank-0"
+                    label="Bank"
+                    options={[]}
+                    selections={[]}
+                    onUpdateSelection={() => {}}
+                    autoComplete="off"
+                    disabled={true}
+                  />
+                </div>
               </div>
             )}
             {!bankDisabled &&
@@ -140,35 +144,24 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
                         onUpdateSelection={(selections) => handleBankChange(index, selections)}
                         autoComplete="off"
                       />
-                      {index > 0 && (
-                        <Button
-                          id={`remove-bank-${index}-button`}
-                          className="remove-bank-button"
-                          uswdsStyle={UswdsButtonStyle.Unstyled}
-                          onClick={handleBankRemove(index)}
-                        >
-                          Remove bank
-                        </Button>
-                      )}
                     </div>
                   </div>
                 );
               })}
-            {!bankDisabled && (
-              <Button
-                id="add-bank-button"
-                className="add-bank-button"
-                onClick={handleBankAdd}
-                uswdsStyle={UswdsButtonStyle.Unstyled}
-              >
-                <Icon name="add_circle" />
-                Add another bank
-              </Button>
-            )}
+            <Button
+              id="add-bank-button"
+              className="add-bank-button"
+              onClick={handleBankAdd}
+              uswdsStyle={UswdsButtonStyle.Unstyled}
+              disabled={bankDisabled}
+            >
+              <Icon name="add_circle" />
+              Add another bank
+            </Button>
           </div>
         </div>
         <div className="usa-button-group">
-          <Button id="submit-button" onClick={handleSubmit} disabled={isSubmitting}>
+          <Button id="submit-button" onClick={handleSubmit} disabled={saveDisabled}>
             {isSubmitting ? 'Saving…' : 'Save'}
           </Button>
           <Button

--- a/user-interface/src/trustees/panels/OtherInformationCard.tsx
+++ b/user-interface/src/trustees/panels/OtherInformationCard.tsx
@@ -2,11 +2,13 @@ import './OtherInformationCard.scss';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 interface OtherInformationCardProps {
   banks?: string[];
   softwareId?: string;
   softwareOptions: ComboOption[];
+  softwareProfiles: BankruptcySoftwareProfile[];
   onEdit: () => void;
 }
 
@@ -14,12 +16,20 @@ export default function OtherInformationCard({
   banks,
   softwareId,
   softwareOptions,
+  softwareProfiles,
   onEdit,
 }: Readonly<OtherInformationCardProps>) {
   const softwareName = softwareId
     ? (softwareOptions.find((opt) => opt.value === softwareId)?.label ?? 'Unknown software')
     : undefined;
-  const hasData = (banks && banks.length > 0) || softwareName;
+
+  const selectedSoftware = softwareProfiles.find((p) => p.id === softwareId);
+  const bankNameMap = new Map(
+    selectedSoftware?.associatedBanks?.map((b) => [b.bankId, b.bankName]) ?? [],
+  );
+
+  const resolvedBanks = banks?.map((id) => bankNameMap.get(id) ?? id);
+  const hasData = (resolvedBanks && resolvedBanks.length > 0) || softwareName;
 
   return (
     <div className="other-information-card-container">
@@ -39,18 +49,18 @@ export default function OtherInformationCard({
               </Button>
             </div>
             {!hasData && <div data-testid="no-other-information">No information added.</div>}
-            {banks &&
-              banks.length > 0 &&
-              banks.map((bank, index) => (
-                <div key={index} className="trustee-bank" data-testid={`trustee-bank-${index}`}>
-                  Bank: {bank}
-                </div>
-              ))}
             {softwareName && (
               <div className="trustee-software" data-testid="trustee-software">
                 Software: {softwareName}
               </div>
             )}
+            {resolvedBanks &&
+              resolvedBanks.length > 0 &&
+              resolvedBanks.map((bank, index) => (
+                <div key={index} className="trustee-bank" data-testid={`trustee-bank-${index}`}>
+                  Bank: {bank}
+                </div>
+              ))}
           </div>
         </div>
       </div>

--- a/user-interface/src/trustees/panels/OtherInformationCard.tsx
+++ b/user-interface/src/trustees/panels/OtherInformationCard.tsx
@@ -1,19 +1,25 @@
 import './OtherInformationCard.scss';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
+import { ComboOption } from '@/lib/components/combobox/ComboBox';
 
 interface OtherInformationCardProps {
   banks?: string[];
-  software?: string;
+  softwareId?: string;
+  softwareOptions: ComboOption[];
   onEdit: () => void;
 }
 
 export default function OtherInformationCard({
   banks,
-  software,
+  softwareId,
+  softwareOptions,
   onEdit,
 }: Readonly<OtherInformationCardProps>) {
-  const hasData = (banks && banks.length > 0) || software;
+  const softwareName = softwareId
+    ? (softwareOptions.find((opt) => opt.value === softwareId)?.label ?? 'Unknown software')
+    : undefined;
+  const hasData = (banks && banks.length > 0) || softwareName;
 
   return (
     <div className="other-information-card-container">
@@ -40,9 +46,9 @@ export default function OtherInformationCard({
                   Bank: {bank}
                 </div>
               ))}
-            {software && (
+            {softwareName && (
               <div className="trustee-software" data-testid="trustee-software">
-                Software: {software}
+                Software: {softwareName}
               </div>
             )}
           </div>

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.test.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.test.tsx
@@ -59,6 +59,7 @@ function renderWithProps(props?: Partial<TrusteeDetailProfileProps>) {
     onAddAssistant: mockOnAddAssistant,
     onEditAssistant: mockOnEditAssistant,
     softwareOptions: [],
+    softwareProfiles: [],
   };
 
   const renderProps = { ...defaultProps, ...props };

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.test.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.test.tsx
@@ -58,6 +58,7 @@ function renderWithProps(props?: Partial<TrusteeDetailProfileProps>) {
     onEditZoomInfo: onEditZoomInfo,
     onAddAssistant: mockOnAddAssistant,
     onEditAssistant: mockOnEditAssistant,
+    softwareOptions: [],
   };
 
   const renderProps = { ...defaultProps, ...props };
@@ -358,13 +359,16 @@ describe('TrusteeDetailProfile', () => {
     expect(mockOnEditOtherInformation).toHaveBeenCalledTimes(1);
   });
 
-  test('should render software information when software is present', () => {
+  test('should render software information when softwareId is present', () => {
     const trusteeWithSoftware = {
       ...mockTrustee,
-      software: 'BestCase Trustee Software v2.1',
+      softwareId: 'sw-bestcase',
     };
 
-    renderWithProps({ trustee: trusteeWithSoftware });
+    renderWithProps({
+      trustee: trusteeWithSoftware,
+      softwareOptions: [{ value: 'sw-bestcase', label: 'BestCase Trustee Software v2.1' }],
+    });
 
     expect(screen.getByTestId('trustee-software')).toHaveTextContent(
       'Software: BestCase Trustee Software v2.1',

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.tsx
@@ -8,6 +8,7 @@ import OtherInformationCard from './OtherInformationCard';
 import ContactInformationCard from './ContactInformationCard';
 import TrusteeAssistantCard from './TrusteeAssistantCard';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 export interface TrusteeDetailProfileProps {
   trustee: Trustee;
@@ -19,6 +20,7 @@ export interface TrusteeDetailProfileProps {
   onEditZoomInfo: () => void;
   showSoftwareBankInfo?: boolean;
   softwareOptions: ComboOption[];
+  softwareProfiles: BankruptcySoftwareProfile[];
 }
 
 export default function TrusteeDetailProfile({
@@ -31,6 +33,7 @@ export default function TrusteeDetailProfile({
   onEditZoomInfo,
   showSoftwareBankInfo = true,
   softwareOptions,
+  softwareProfiles,
 }: Readonly<TrusteeDetailProfileProps>) {
   return (
     <div className="right-side-screen-content">
@@ -90,6 +93,7 @@ export default function TrusteeDetailProfile({
                 banks={trustee.banks}
                 softwareId={trustee.softwareId}
                 softwareOptions={softwareOptions}
+                softwareProfiles={softwareProfiles}
                 onEdit={onEditOtherInformation}
               />
             )}

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.tsx
@@ -7,6 +7,7 @@ import MeetingOfCreditorsInfoCard from './MeetingOfCreditorsInfoCard';
 import OtherInformationCard from './OtherInformationCard';
 import ContactInformationCard from './ContactInformationCard';
 import TrusteeAssistantCard from './TrusteeAssistantCard';
+import { ComboOption } from '@/lib/components/combobox/ComboBox';
 
 export interface TrusteeDetailProfileProps {
   trustee: Trustee;
@@ -17,6 +18,7 @@ export interface TrusteeDetailProfileProps {
   onEditOtherInformation: () => void;
   onEditZoomInfo: () => void;
   showSoftwareBankInfo?: boolean;
+  softwareOptions: ComboOption[];
 }
 
 export default function TrusteeDetailProfile({
@@ -28,6 +30,7 @@ export default function TrusteeDetailProfile({
   onEditOtherInformation,
   onEditZoomInfo,
   showSoftwareBankInfo = true,
+  softwareOptions,
 }: Readonly<TrusteeDetailProfileProps>) {
   return (
     <div className="right-side-screen-content">
@@ -85,7 +88,8 @@ export default function TrusteeDetailProfile({
             {showSoftwareBankInfo && (
               <OtherInformationCard
                 banks={trustee.banks}
-                software={trustee.software}
+                softwareId={trustee.softwareId}
+                softwareOptions={softwareOptions}
                 onEdit={onEditOtherInformation}
               />
             )}


### PR DESCRIPTION
# Purpose

Enable referential integrity for trustee software assignments by storing the software vendor ID instead of a name string. This is Slice 1 of the "Assign Software and Bank to Trustee" feature, laying the data model foundation for cascading bank selection in Slice 2.

# Major Changes

* Changed trustee data model from `software: string` (name) to `softwareId: string` (ID reference) across common types, backend, and frontend
* Backend use case validates that the softwareId exists in the software collection before saving
* Audit records resolve and store the human-readable software name (not the ID) for readability
* Frontend ComboBox uses software IDs as values and resolves names for display
* Software field moved above bank field in the edit form per Figma design
* Added one-time migration script to convert existing `software` name values to `softwareId` references

# Testing/Validation

Implemented using TDD. Backend use case tests verify ID validation, null clearing, and audit name resolution. Frontend form tests verify ID-based selection, clearing, and API payload shape. Migration script tested with 6 unit tests covering: successful migration, skip already-migrated, skip no-software, unresolvable names, case-insensitive matching, and error resilience.

# Notes

* The migration script (`migrate-trustee-software-field.ts`) matches software names case-insensitively and logs warnings for unresolvable names without stopping the migration.
* The `OtherInformationCard` now receives `softwareOptions` to resolve the display name from the ID. If an ID doesn't match any option (e.g., deleted software), it shows "Unknown software" as a fallback.
* The `TrusteeSoftwareHistory` audit type continues to use `string` for before/after values — it stores resolved names, not IDs.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Change trustee software association to use software IDs instead of names across backend, shared types, and UI, including validation, display updates, and data migration.

New Features:
- Add validation to ensure referenced bankruptcy software IDs exist before updating trustees.
- Introduce a migration script to convert existing trustee software name values to softwareId references while logging any unmapped cases.

Enhancements:
- Refine trustee audit history to store human-readable software names derived from software IDs.
- Update trustee UI to use software IDs for selection while resolving and displaying software names, including a fallback for unknown software.
- Reorder the trustee other information form so the software selector appears above bank fields.
- Extend trustee detail components to accept shared software option lists for consistent name resolution.

Tests:
- Expand backend tests to cover softwareId-based updates, validation, and audit history behavior.
- Update frontend tests to validate softwareId-based selection, clearing, and API payloads for trustee software.
- Add unit tests for the trustee software migration script covering successful migrations, skips, not-found software, and error handling.