### PR TITLE
CAMS-618: Fix trustee link styling on trustee tab

### DIFF
--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
@@ -14,6 +14,11 @@
     gap: 1.5rem;
     flex-wrap: wrap;
   }
+
+  // Ensure underline shows through IconLabel component in all trustee links
+  .usa-link .cams-icon-label span {
+    text-decoration: underline;
+  }
 }
 
 .past-trustees-section {

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.tsx
@@ -10,6 +10,7 @@ import FormattedContact from '@/lib/components/cams/FormattedContact';
 import ContactInformationCard from '@/trustees/panels/ContactInformationCard';
 import MeetingOfCreditorsInfoCard from '@/trustees/panels/MeetingOfCreditorsInfoCard';
 import useFeatureFlags, { TRUSTEE_APPOINTMENT_HISTORY_ENABLED } from '@/lib/hooks/UseFeatureFlags';
+import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
 
 const appointedDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
@@ -62,11 +63,11 @@ function PastTrusteesSection({ history, onTrusteeClick }: Readonly<PastTrusteesS
                     href={`/trustees/${item.trusteeId}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="usa-link usa-link--external"
+                    className="usa-link"
                     aria-label={`${item.trusteeName}, opens in new tab`}
                     onClick={() => onTrusteeClick?.(item)}
                   >
-                    {item.trusteeName}
+                    <IconLabel label={item.trusteeName} icon="launch" location="left" />
                   </a>
                 ) : (
                   item.trusteeId

--- a/user-interface/src/case-detail/panels/TrusteeName.tsx
+++ b/user-interface/src/case-detail/panels/TrusteeName.tsx
@@ -30,6 +30,7 @@ export function TrusteeName({ trusteeName, trusteeId, openNewTab = false }: Trus
   return (
     <Link
       to={`/trustees/${trusteeId}`}
+      className="usa-link"
       data-testid="case-detail-trustee-link"
       aria-label={`View trustee profile for ${trusteeName}${openNewTab ? ' (opens in new tab)' : ''}`}
       target={openNewTab ? '_blank' : undefined}


### PR DESCRIPTION
# Purpose

Fix two styling issues on the case details trustee tab to ensure proper link styling and icon placement consistency.

# Major Changes

- Added `className="usa-link"` to TrusteeName Link component for underline styling
- Imported and used IconLabel component in Past Trustees table with `location="left"` for consistent icon placement
- Added CSS rule to ensure underline shows through IconLabel nested spans

# Testing/Validation

- [ ] Verify trustee name link in Public Contact Info card has underline
- [ ] Verify trustee name links in Past Trustees table have underlines
- [ ] Verify external link icons appear at the beginning of trustee names in Past Trustees table (not at the end)
- [ ] Verify links open trustee profile in new tab
- [ ] All unit tests pass (CaseDetailTrusteePanel and TrusteeName components)

# Notes

Changes ensure consistent USWDS link styling (underlines) and icon placement (beginning of name) across both the Public Contact Info card and Past Trustees table.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application