### PR TITLE
Fix protobufjs lock file version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17102,9 +17102,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
# Purpose

Resolve a version mismatch in the lock file for `protobufjs` that was causing inconsistency between the declared and resolved package versions.

# Major Changes

* Updated `package-lock.json` to pin `protobufjs` to `7.6.2` with the correct resolved URL and integrity hash

# Testing/Validation

No application code changed. Lock file only — verified by `npm install` producing a clean tree.

# Notes

The previous lock file entry had a mismatched integrity hash for `7.6.1`. This bumps to `7.6.2` which resolves the mismatch.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Build:
- Update package-lock.json to pin protobufjs to version 7.6.2 with the correct resolved URL and integrity metadata.