### PR TITLE
CAMS-752 Sync bank status to software associations

### DIFF
--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.test.ts
@@ -245,6 +245,59 @@ describe('BankruptcySoftwareMongoRepository', () => {
     });
   });
 
+  describe('findSoftwareByBankId', () => {
+    test('should return software profiles that have the given bankId in associatedBanks', async () => {
+      const bankId = 'bank-1';
+      const mockProfiles: BankruptcySoftwareProfile[] = [
+        {
+          id: 'sw-1',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'Axos',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+          associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'active' }],
+        },
+        {
+          id: 'sw-2',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'BlueStylus',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+          associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'active' }],
+        },
+      ];
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue(mockProfiles);
+
+      const result = await repo.findSoftwareByBankId(bankId);
+
+      expect(result).toEqual(mockProfiles);
+    });
+
+    test('should return empty array when no software profiles match the bankId', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]);
+
+      const result = await repo.findSoftwareByBankId('nonexistent-bank');
+
+      expect(result).toEqual([]);
+    });
+
+    test('should throw CamsError when find fails', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockRejectedValue(
+        new Error('connection error'),
+      );
+
+      await expect(repo.findSoftwareByBankId('bank-1')).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to retrieve bankruptcy software by bank.',
+          status: 500,
+          module: 'BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
   describe('updateSoftware', () => {
     test('should replace document and return the updated software', async () => {
       const updated: BankruptcySoftwareProfile = {

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
@@ -14,6 +14,8 @@ const COLLECTION_NAME = 'bankruptcy-software';
 
 const { using, orderBy } = QueryBuilder;
 const doc = using<BankruptcySoftwareProfile>();
+// QueryBuilder does not support dot-notation into embedded arrays with typed keys;
+// use Record<string, unknown> to bypass the type constraint
 const docNested = using<Record<string, unknown>>();
 
 export class BankruptcySoftwareMongoRepository

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
@@ -14,6 +14,7 @@ const COLLECTION_NAME = 'bankruptcy-software';
 
 const { using, orderBy } = QueryBuilder;
 const doc = using<BankruptcySoftwareProfile>();
+const docNested = using<Record<string, unknown>>();
 
 export class BankruptcySoftwareMongoRepository
   extends BaseMongoRepository
@@ -72,7 +73,7 @@ export class BankruptcySoftwareMongoRepository
   async findSoftwareByBankId(bankId: string): Promise<BankruptcySoftwareProfile[]> {
     const query = QueryBuilder.and(
       doc('documentType').equals('BANKRUPTCY_SOFTWARE'),
-      (doc('associatedBanks.bankId') as unknown as ReturnType<typeof doc>).equals(bankId),
+      docNested('associatedBanks.bankId').equals(bankId),
     );
     try {
       return await this.getAdapter<BankruptcySoftwareProfile>().find(query);

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
@@ -69,6 +69,22 @@ export class BankruptcySoftwareMongoRepository
     }
   }
 
+  async findSoftwareByBankId(bankId: string): Promise<BankruptcySoftwareProfile[]> {
+    const query = QueryBuilder.and(
+      doc('documentType').equals('BANKRUPTCY_SOFTWARE'),
+      doc('associatedBanks.bankId' as keyof BankruptcySoftwareProfile).equals(bankId),
+    );
+    try {
+      return await this.getAdapter<BankruptcySoftwareProfile>().find(query);
+    } catch (originalError) {
+      throw getCamsError(
+        originalError,
+        MODULE_NAME,
+        'Unable to retrieve bankruptcy software by bank.',
+      );
+    }
+  }
+
   async updateSoftware(
     id: string,
     update: BankruptcySoftwareProfile,

--- a/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/bankruptcy-software.mongo.repository.ts
@@ -72,7 +72,7 @@ export class BankruptcySoftwareMongoRepository
   async findSoftwareByBankId(bankId: string): Promise<BankruptcySoftwareProfile[]> {
     const query = QueryBuilder.and(
       doc('documentType').equals('BANKRUPTCY_SOFTWARE'),
-      doc('associatedBanks.bankId' as keyof BankruptcySoftwareProfile).equals(bankId),
+      (doc('associatedBanks.bankId') as unknown as ReturnType<typeof doc>).equals(bankId),
     );
     try {
       return await this.getAdapter<BankruptcySoftwareProfile>().find(query);

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -113,6 +113,10 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
+  findSoftwareByBankId(_bankId: string): Promise<BankruptcySoftwareProfile[]> {
+    throw new Error('Method not implemented.');
+  }
+
   updateSoftware(
     _id: string,
     _update: BankruptcySoftwareProfile,

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
@@ -7,6 +7,8 @@ import {
   BankruptcySoftwareAuditHistory,
   BankruptcySoftwareProfile,
 } from '@common/cams/bankruptcy-software';
+import { BankProfile } from '@common/cams/banks';
+import { BadRequestError } from '../../common-errors/bad-request';
 
 describe('BankruptcySoftwareUseCase', () => {
   let context: ApplicationContext;
@@ -331,6 +333,82 @@ describe('BankruptcySoftwareUseCase', () => {
           after: updated,
         }),
       );
+    });
+
+    const activeBank: BankProfile = {
+      id: 'bank-1',
+      documentType: 'BANK_PROFILE',
+      name: 'Chase',
+      status: 'active',
+      updatedOn: '2024-01-01T00:00:00.000Z',
+      updatedBy: { id: 'user-1', name: 'User One' },
+    };
+
+    const inactiveBank: BankProfile = { ...activeBank, status: 'inactive' };
+
+    test('should throw BadRequestError when attempting to reactivate association for an inactive bank', async () => {
+      const softwareWithInactiveBank: BankruptcySoftwareProfile = {
+        ...baseSoftware,
+        associatedBanks: [{ bankId: 'bank-1', bankName: 'Chase', status: 'inactive' }],
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue(
+        softwareWithInactiveBank,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(inactiveBank);
+      const updateSpy = vi.spyOn(MockMongoRepository.prototype, 'updateSoftware');
+
+      const error = await useCase
+        .updateSoftware('sw-1', { updateBankAssociation: { bankId: 'bank-1', status: 'active' } })
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(BadRequestError);
+      expect(error.message).toBe('Cannot reactivate association: the bank profile is inactive.');
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    test('should allow reactivating association when bank profile is active', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+        ...baseSoftware,
+        associatedBanks: [{ bankId: 'bank-1', bankName: 'Chase', status: 'inactive' }],
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(activeBank);
+      vi.spyOn(MockMongoRepository.prototype, 'updateSoftware').mockResolvedValue(baseSoftware);
+      vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord').mockResolvedValue();
+
+      await expect(
+        useCase.updateSoftware('sw-1', {
+          updateBankAssociation: { bankId: 'bank-1', status: 'active' },
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    test('should allow setting association to inactive regardless of bank profile status', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue(baseSoftware);
+      const getBankSpy = vi.spyOn(MockMongoRepository.prototype, 'getBank');
+      vi.spyOn(MockMongoRepository.prototype, 'updateSoftware').mockResolvedValue({
+        ...baseSoftware,
+        associatedBanks: [{ bankId: 'bank-1', bankName: 'Chase', status: 'inactive' }],
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord').mockResolvedValue();
+
+      await useCase.updateSoftware('sw-1', {
+        updateBankAssociation: { bankId: 'bank-1', status: 'inactive' },
+      });
+
+      expect(getBankSpy).not.toHaveBeenCalled();
+    });
+
+    test('should release banksRepo even if getBank throws', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockRejectedValue(new Error('db error'));
+      const releaseSpy = vi.spyOn(MockMongoRepository.prototype, 'release');
+
+      await expect(
+        useCase.updateSoftware('sw-1', {
+          updateBankAssociation: { bankId: 'bank-1', status: 'active' },
+        }),
+      ).rejects.toThrow();
+
+      expect(releaseSpy).toHaveBeenCalled();
     });
   });
 

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
@@ -94,6 +94,19 @@ export class BankruptcySoftwareUseCase {
   }
 
   async updateSoftware(id: string, update: SoftwareUpdate): Promise<BankruptcySoftwareProfile> {
+    if ('updateBankAssociation' in update && update.updateBankAssociation.status === 'active') {
+      const banksRepo = factory.getBanksRepository(this.context);
+      try {
+        const bankProfile = await banksRepo.getBank(update.updateBankAssociation.bankId);
+        if (bankProfile.status === 'inactive') {
+          throw new BadRequestError(MODULE_NAME, {
+            message: 'Cannot reactivate association: the bank profile is inactive.',
+          });
+        }
+      } finally {
+        banksRepo.release();
+      }
+    }
     try {
       const userRef = getCamsUserReference(this.context.session.user);
       const current = await this.repository.findSoftwareById(id);

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -286,6 +286,37 @@ describe('BanksUseCase', () => {
       expect(auditSoftwareSpy).not.toHaveBeenCalled();
     });
 
+    test('should log error and still return updated bank when findSoftwareByBankId throws during cascade', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankProfile = { ...existing, status: 'inactive' };
+
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId').mockRejectedValue(
+        new Error('lookup error'),
+      );
+      const releaseSpy = vi.spyOn(MockMongoRepository.prototype, 'release');
+      const loggerSpy = vi.spyOn(context.logger, 'error');
+
+      const result = await useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'inactive' });
+
+      expect(result).toEqual(updated);
+      expect(loggerSpy).toHaveBeenCalledWith(
+        'BANKS-USE-CASE',
+        'Failed to load software profiles for bank inactivation cascade.',
+        expect.objectContaining({ bankId: 'bank-1' }),
+      );
+      expect(releaseSpy).toHaveBeenCalled();
+    });
+
     test('should log error and continue when a profile update fails during cascade', async () => {
       const existing: BankProfile = {
         id: 'bank-1',

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -239,6 +239,27 @@ describe('BanksUseCase', () => {
       expect(findSoftwareSpy).not.toHaveBeenCalled();
     });
 
+    test('should not cascade when already-inactive bank is updated without status change', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'inactive',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankProfile = { ...existing, name: 'Alpha Bank Renamed' };
+
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+      const findSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId');
+
+      await useCase.updateBank('bank-1', { name: 'Alpha Bank Renamed', status: 'inactive' });
+
+      expect(findSoftwareSpy).not.toHaveBeenCalled();
+    });
+
     test('should handle cascade when no software profiles are associated (empty result)', async () => {
       const existing: BankProfile = {
         id: 'bank-1',

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -4,6 +4,7 @@ import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { BanksUseCase } from './banks';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import { BankAuditHistory, BankProfile } from '@common/cams/banks';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 describe('BanksUseCase', () => {
   let context: ApplicationContext;
@@ -105,6 +106,7 @@ describe('BanksUseCase', () => {
       const auditSpy = vi
         .spyOn(MockMongoRepository.prototype, 'createBankAuditRecord')
         .mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId').mockResolvedValue([]);
 
       const result = await useCase.updateBank('bank-1', {
         name: 'Alpha Bank Updated',
@@ -142,6 +144,163 @@ describe('BanksUseCase', () => {
       await expect(useCase.updateBank('bank-1', { name: 'New', status: 'active' })).rejects.toThrow(
         expect.objectContaining({ message: 'Unable to update bank.', status: 500 }),
       );
+    });
+
+    test('should inactivate all software associations and create audit records when bank is set to inactive', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankProfile = { ...existing, status: 'inactive' };
+
+      const profile1: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'active' }],
+      };
+      const profile2: BankruptcySoftwareProfile = {
+        id: 'sw-2',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'BlueStylus',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'active' }],
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId').mockResolvedValue([
+        profile1,
+        profile2,
+      ]);
+      const updateSoftwareSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'updateSoftware')
+        .mockResolvedValue(profile1);
+      const auditSoftwareSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord')
+        .mockResolvedValue();
+
+      await useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'inactive' });
+
+      expect(updateSoftwareSpy).toHaveBeenCalledTimes(2);
+      expect(updateSoftwareSpy).toHaveBeenCalledWith(
+        'sw-1',
+        expect.objectContaining({
+          associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'inactive' }],
+        }),
+      );
+      expect(updateSoftwareSpy).toHaveBeenCalledWith(
+        'sw-2',
+        expect.objectContaining({
+          associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'inactive' }],
+        }),
+      );
+      expect(auditSoftwareSpy).toHaveBeenCalledTimes(2);
+      expect(auditSoftwareSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+          softwareId: 'sw-1',
+          before: profile1,
+          after: expect.objectContaining({
+            associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'inactive' }],
+          }),
+        }),
+      );
+    });
+
+    test('should not cascade when bank is set to active', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'inactive',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankProfile = { ...existing, status: 'active' };
+
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+      const findSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId');
+
+      await useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'active' });
+
+      expect(findSoftwareSpy).not.toHaveBeenCalled();
+    });
+
+    test('should handle cascade when no software profiles are associated (empty result)', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankProfile = { ...existing, status: 'inactive' };
+
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId').mockResolvedValue([]);
+      const updateSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'updateSoftware');
+      const auditSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord');
+
+      await expect(
+        useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'inactive' }),
+      ).resolves.not.toThrow();
+
+      expect(updateSoftwareSpy).not.toHaveBeenCalled();
+      expect(auditSoftwareSpy).not.toHaveBeenCalled();
+    });
+
+    test('should release softwareRepo even if cascade throws', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankProfile = { ...existing, status: 'inactive' };
+      const profile: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'active' }],
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId').mockResolvedValue([profile]);
+      vi.spyOn(MockMongoRepository.prototype, 'updateSoftware').mockRejectedValue(
+        new Error('write error'),
+      );
+      const releaseSpy = vi.spyOn(MockMongoRepository.prototype, 'release');
+
+      await expect(
+        useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'inactive' }),
+      ).rejects.toThrow(
+        expect.objectContaining({ message: 'Unable to cascade bank inactivation to software.' }),
+      );
+
+      expect(releaseSpy).toHaveBeenCalled();
     });
   });
 

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -286,6 +286,42 @@ describe('BanksUseCase', () => {
       expect(auditSoftwareSpy).not.toHaveBeenCalled();
     });
 
+    test('should skip profiles where the bank association is already inactive', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankProfile = { ...existing, status: 'inactive' };
+      const alreadyInactiveProfile: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [{ bankId: 'bank-1', bankName: 'Alpha Bank', status: 'inactive' }],
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId').mockResolvedValue([
+        alreadyInactiveProfile,
+      ]);
+      const updateSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'updateSoftware');
+      const auditSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord');
+
+      const result = await useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'inactive' });
+
+      expect(result).toEqual(updated);
+      expect(updateSoftwareSpy).not.toHaveBeenCalled();
+      expect(auditSoftwareSpy).not.toHaveBeenCalled();
+    });
+
     test('should log error and still return updated bank when findSoftwareByBankId throws during cascade', async () => {
       const existing: BankProfile = {
         id: 'bank-1',

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -265,7 +265,7 @@ describe('BanksUseCase', () => {
       expect(auditSoftwareSpy).not.toHaveBeenCalled();
     });
 
-    test('should release softwareRepo even if cascade throws', async () => {
+    test('should log error and continue when a profile update fails during cascade', async () => {
       const existing: BankProfile = {
         id: 'bank-1',
         documentType: 'BANK_PROFILE',
@@ -293,13 +293,16 @@ describe('BanksUseCase', () => {
         new Error('write error'),
       );
       const releaseSpy = vi.spyOn(MockMongoRepository.prototype, 'release');
+      const loggerSpy = vi.spyOn(context.logger, 'error');
 
-      await expect(
-        useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'inactive' }),
-      ).rejects.toThrow(
-        expect.objectContaining({ message: 'Unable to cascade bank inactivation to software.' }),
+      const result = await useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'inactive' });
+
+      expect(result).toEqual(updated);
+      expect(loggerSpy).toHaveBeenCalledWith(
+        'BANKS-USE-CASE',
+        'Failed to cascade bank inactivation to software profile.',
+        expect.objectContaining({ bankId: 'bank-1', softwareId: 'sw-1' }),
       );
-
       expect(releaseSpy).toHaveBeenCalled();
     });
   });

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -70,41 +70,55 @@ export class BanksUseCase {
     }
 
     if (input.status === 'inactive') {
-      const softwareRepo = factory.getBankruptcySoftwareRepository(this.context);
-      try {
-        const affectedProfiles = await softwareRepo.findSoftwareByBankId(id);
-        for (const profile of affectedProfiles) {
-          const updatedProfile: BankruptcySoftwareProfile = {
-            ...profile,
-            associatedBanks: profile.associatedBanks.map((b) =>
-              b.bankId === id ? { ...b, status: 'inactive' } : b,
-            ),
-          };
-          await softwareRepo.updateSoftware(profile.id, updatedProfile);
-          await softwareRepo.createSoftwareAuditRecord(
-            createAuditRecord(
-              {
-                documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
-                softwareId: profile.id,
-                before: profile,
-                after: updatedProfile,
-              },
-              userRef,
-            ),
-          );
-        }
-      } catch (originalError) {
-        throw getCamsError(
-          originalError,
-          MODULE_NAME,
-          'Unable to cascade bank inactivation to software.',
-        );
-      } finally {
-        softwareRepo.release();
-      }
+      await this.cascadeBankInactivationToSoftware(id, userRef);
     }
 
     return updated;
+  }
+
+  private async cascadeBankInactivationToSoftware(
+    bankId: string,
+    userRef: ReturnType<typeof getCamsUserReference>,
+  ): Promise<void> {
+    const softwareRepo = factory.getBankruptcySoftwareRepository(this.context);
+    try {
+      const affectedProfiles = await softwareRepo.findSoftwareByBankId(bankId);
+      for (const profile of affectedProfiles) {
+        const updatedProfile = this.inactivateBankAssociation(profile, bankId);
+        await softwareRepo.updateSoftware(profile.id, updatedProfile);
+        await softwareRepo.createSoftwareAuditRecord(
+          createAuditRecord(
+            {
+              documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+              softwareId: profile.id,
+              before: profile,
+              after: updatedProfile,
+            },
+            userRef,
+          ),
+        );
+      }
+    } catch (originalError) {
+      throw getCamsError(
+        originalError,
+        MODULE_NAME,
+        'Unable to cascade bank inactivation to software.',
+      );
+    } finally {
+      softwareRepo.release();
+    }
+  }
+
+  private inactivateBankAssociation(
+    profile: BankruptcySoftwareProfile,
+    bankId: string,
+  ): BankruptcySoftwareProfile {
+    return {
+      ...profile,
+      associatedBanks: profile.associatedBanks.map((b) =>
+        b.bankId === bankId ? { ...b, status: 'inactive' } : b,
+      ),
+    };
   }
 
   async getBankHistory(bankId: string): Promise<BankAuditHistory[]> {

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -111,10 +111,13 @@ export class BanksUseCase {
         }
       }
     } catch (originalError) {
-      throw getCamsError(
-        originalError,
+      this.context.logger.error(
         MODULE_NAME,
-        'Unable to cascade bank inactivation to software.',
+        'Failed to load software profiles for bank inactivation cascade.',
+        {
+          bankId,
+          error: (originalError as Error).message,
+        },
       );
     } finally {
       softwareRepo.release();

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -69,7 +69,7 @@ export class BanksUseCase {
       throw getCamsError(originalError, MODULE_NAME, 'Unable to update bank.');
     }
 
-    if (input.status === 'inactive') {
+    if (updated.status === 'inactive' && existing.status !== 'inactive') {
       await this.cascadeBankInactivationToSoftware(id, userRef);
     }
 

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -84,19 +84,31 @@ export class BanksUseCase {
     try {
       const affectedProfiles = await softwareRepo.findSoftwareByBankId(bankId);
       for (const profile of affectedProfiles) {
-        const updatedProfile = this.inactivateBankAssociation(profile, bankId);
-        await softwareRepo.updateSoftware(profile.id, updatedProfile);
-        await softwareRepo.createSoftwareAuditRecord(
-          createAuditRecord(
+        try {
+          const updatedProfile = this.inactivateBankAssociation(profile, bankId);
+          await softwareRepo.updateSoftware(profile.id, updatedProfile);
+          await softwareRepo.createSoftwareAuditRecord(
+            createAuditRecord(
+              {
+                documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+                softwareId: profile.id,
+                before: profile,
+                after: updatedProfile,
+              },
+              userRef,
+            ),
+          );
+        } catch (profileError) {
+          this.context.logger.error(
+            MODULE_NAME,
+            'Failed to cascade bank inactivation to software profile.',
             {
-              documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+              bankId,
               softwareId: profile.id,
-              before: profile,
-              after: updatedProfile,
+              error: (profileError as Error).message,
             },
-            userRef,
-          ),
-        );
+          );
+        }
       }
     } catch (originalError) {
       throw getCamsError(

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -82,7 +82,9 @@ export class BanksUseCase {
   ): Promise<void> {
     const softwareRepo = factory.getBankruptcySoftwareRepository(this.context);
     try {
-      const affectedProfiles = await softwareRepo.findSoftwareByBankId(bankId);
+      const affectedProfiles = (await softwareRepo.findSoftwareByBankId(bankId)).filter((p) =>
+        p.associatedBanks.some((b) => b.bankId === bankId && b.status === 'active'),
+      );
       for (const profile of affectedProfiles) {
         try {
           const updatedProfile = this.inactivateBankAssociation(profile, bankId);

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -1,4 +1,5 @@
 import { BankAuditHistory, BankProfile } from '@common/cams/banks';
+import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 import { TrusteeSummary } from '@common/cams/trustees';
 import { createAuditRecord } from '@common/cams/auditable';
 import { getCamsUserReference } from '@common/cams/session';
@@ -49,8 +50,9 @@ export class BanksUseCase {
       updatedBy: userRef,
     };
 
+    let updated: BankProfile;
     try {
-      const updated = await this.repository.updateBank(id, bankData);
+      updated = await this.repository.updateBank(id, bankData);
 
       await this.repository.createBankAuditRecord(
         createAuditRecord(
@@ -63,11 +65,46 @@ export class BanksUseCase {
           userRef,
         ),
       );
-
-      return updated;
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME, 'Unable to update bank.');
     }
+
+    if (input.status === 'inactive') {
+      const softwareRepo = factory.getBankruptcySoftwareRepository(this.context);
+      try {
+        const affectedProfiles = await softwareRepo.findSoftwareByBankId(id);
+        for (const profile of affectedProfiles) {
+          const updatedProfile: BankruptcySoftwareProfile = {
+            ...profile,
+            associatedBanks: profile.associatedBanks.map((b) =>
+              b.bankId === id ? { ...b, status: 'inactive' } : b,
+            ),
+          };
+          await softwareRepo.updateSoftware(profile.id, updatedProfile);
+          await softwareRepo.createSoftwareAuditRecord(
+            createAuditRecord(
+              {
+                documentType: 'AUDIT_BANKRUPTCY_SOFTWARE',
+                softwareId: profile.id,
+                before: profile,
+                after: updatedProfile,
+              },
+              userRef,
+            ),
+          );
+        }
+      } catch (originalError) {
+        throw getCamsError(
+          originalError,
+          MODULE_NAME,
+          'Unable to cascade bank inactivation to software.',
+        );
+      } finally {
+        softwareRepo.release();
+      }
+    }
+
+    return updated;
   }
 
   async getBankHistory(bankId: string): Promise<BankAuditHistory[]> {

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -324,6 +324,7 @@ export interface BanksRepository extends Releasable {
 export interface BankruptcySoftwareRepository extends Releasable {
   getSoftwareList(): Promise<BankruptcySoftwareProfile[]>;
   findSoftwareById(id: string): Promise<BankruptcySoftwareProfile>;
+  findSoftwareByBankId(bankId: string): Promise<BankruptcySoftwareProfile[]>;
   createSoftware(
     software: Creatable<BankruptcySoftwareProfile>,
   ): Promise<BankruptcySoftwareProfile>;

--- a/user-interface/src/admin/bankruptcy-software/AssociatedBanksTable.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/AssociatedBanksTable.test.tsx
@@ -326,4 +326,38 @@ describe('AssociatedBanksTable', () => {
     });
     expect(screen.getByText('5')).toBeInTheDocument();
   });
+
+  test('should hide Edit Status button when bank profile is inactive', async () => {
+    const associations: SoftwareBankAssociation[] = [
+      { bankId: 'bank-4', bankName: 'Citibank', status: 'inactive' },
+    ];
+    renderTable(associations, mockBanks);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Citibank (opens in new tab)' }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Edit Status' })).not.toBeInTheDocument();
+  });
+
+  test('should show Edit Status button when bank profile is active', async () => {
+    const associations: SoftwareBankAssociation[] = [
+      { bankId: 'bank-1', bankName: 'Chase Bank', status: 'active' },
+    ];
+    renderTable(associations, mockBanks);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Edit Status' })).toBeInTheDocument();
+    });
+  });
+
+  test('should show Edit Status button only for associations with active bank profiles', async () => {
+    const associations: SoftwareBankAssociation[] = [
+      { bankId: 'bank-1', bankName: 'Chase Bank', status: 'active' },
+      { bankId: 'bank-4', bankName: 'Citibank', status: 'inactive' },
+    ];
+    renderTable(associations, mockBanks);
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Edit Status' })).toHaveLength(1);
+    });
+  });
 });

--- a/user-interface/src/admin/bankruptcy-software/AssociatedBanksTable.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/AssociatedBanksTable.test.tsx
@@ -67,14 +67,11 @@ function renderTable(
 
 describe('AssociatedBanksTable', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.spyOn(Api2, 'getSoftwareBankTrustees').mockResolvedValue({
       data: [],
       pagination: { count: 0, totalCount: 0, currentPage: 1, totalPages: 0, limit: 1 },
     } as never);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   test('should render table with associations showing bank name as link and status text', async () => {
@@ -119,26 +116,27 @@ describe('AssociatedBanksTable', () => {
     expect(onEditStatus).toHaveBeenCalledWith('bank-1', 'Chase Bank', 'active');
   });
 
-  test('should exclude already-associated banks from dropdown', async () => {
+  test('should exclude already-associated and inactive banks from dropdown', async () => {
     renderTable();
 
     await waitFor(() => {
       expect(screen.getByRole('combobox')).toBeInTheDocument();
     });
-  });
 
-  test('should exclude inactive banks from dropdown', async () => {
-    // All banks are already associated — inactive bank-4 should not appear
-    const allAssociated: SoftwareBankAssociation[] = [
-      { bankId: 'bank-1', bankName: 'Chase Bank', status: 'active' },
-      { bankId: 'bank-2', bankName: 'Wells Fargo', status: 'active' },
-      { bankId: 'bank-3', bankName: 'Bank of America', status: 'active' },
-    ];
-    renderTable(allAssociated, mockBanks);
+    const combobox = screen.getByRole('combobox');
+    await userEvent.click(combobox);
 
+    // Bank of America (bank-3) is active and not associated — should appear
     await waitFor(() => {
-      expect(screen.getByTestId('button-add-bank-button')).toBeDisabled();
+      expect(screen.getByText('Bank of America')).toBeInTheDocument();
     });
+
+    // Chase Bank (bank-1) and Wells Fargo (bank-2) are already associated — should not appear
+    expect(screen.queryByRole('option', { name: 'Chase Bank' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Wells Fargo' })).not.toBeInTheDocument();
+
+    // Citibank (bank-4) is inactive — should not appear
+    expect(screen.queryByRole('option', { name: 'Citibank' })).not.toBeInTheDocument();
   });
 
   test('should disable Add Bank button when no available banks', async () => {
@@ -327,15 +325,41 @@ describe('AssociatedBanksTable', () => {
     expect(screen.getByText('5')).toBeInTheDocument();
   });
 
+  test('should render trustee count as a link when count is greater than zero', async () => {
+    vi.spyOn(Api2, 'getSoftwareBankTrustees').mockResolvedValue({
+      data: [],
+      pagination: { count: 0, totalCount: 7, currentPage: 1, totalPages: 1, limit: 1 },
+    } as never);
+
+    renderTable([mockAssociations[0]]);
+
+    await waitFor(() => {
+      expect(screen.getByText('7')).toBeInTheDocument();
+    });
+
+    const link = screen.getByRole('link', { name: '7 opens in a new tab' });
+    expect(link).toHaveAttribute('href', '/admin/bankruptcy-software/sw-1/banks/bank-1/trustees');
+  });
+
+  test('should render trustee count as plain text when count is zero', async () => {
+    renderTable([mockAssociations[0]]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trustee-count-bank-1')).toBeInTheDocument();
+    });
+
+    const countElement = screen.getByTestId('trustee-count-bank-1');
+    expect(countElement).toHaveTextContent('0');
+    expect(countElement.querySelector('a')).not.toBeInTheDocument();
+  });
+
   test('should hide Edit Status button when bank profile is inactive', async () => {
     const associations: SoftwareBankAssociation[] = [
       { bankId: 'bank-4', bankName: 'Citibank', status: 'inactive' },
     ];
     renderTable(associations, mockBanks);
     await waitFor(() => {
-      expect(
-        screen.getByRole('link', { name: 'Citibank (opens in new tab)' }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Citibank (opens in new tab)' })).toBeInTheDocument();
     });
     expect(screen.queryByRole('button', { name: 'Edit Status' })).not.toBeInTheDocument();
   });

--- a/user-interface/src/admin/bankruptcy-software/AssociatedBanksTable.tsx
+++ b/user-interface/src/admin/bankruptcy-software/AssociatedBanksTable.tsx
@@ -90,6 +90,7 @@ export function AssociatedBanksTable({
   const availableBanks: ComboOption[] = allBanks
     .filter((bank) => bank.status === 'active' && !associatedBankIds.has(bank.id))
     .map((bank) => ({ value: bank.id, label: bank.name }));
+  const bankProfileMap = new Map(allBanks.map((b) => [b.id, b]));
 
   function handleSelectionChange(options: ComboOption[]) {
     setSelectedBank(options.length > 0 ? options[0] : null);
@@ -168,15 +169,17 @@ export function AssociatedBanksTable({
                   {association.status === 'active' ? 'Active' : 'Inactive'}
                 </CamsTableCell>
                 <CamsTableCell data-cell="" className="text-right">
-                  <Button
-                    id={`edit-status-${association.bankId}`}
-                    uswdsStyle={UswdsButtonStyle.Unstyled}
-                    onClick={() =>
-                      onEditStatus(association.bankId, association.bankName, association.status)
-                    }
-                  >
-                    <IconLabel icon="edit" label="Edit Status" />
-                  </Button>
+                  {bankProfileMap.get(association.bankId)?.status === 'active' && (
+                    <Button
+                      id={`edit-status-${association.bankId}`}
+                      uswdsStyle={UswdsButtonStyle.Unstyled}
+                      onClick={() =>
+                        onEditStatus(association.bankId, association.bankName, association.status)
+                      }
+                    >
+                      <IconLabel icon="edit" label="Edit Status" />
+                    </Button>
+                  )}
                 </CamsTableCell>
               </CamsTableRow>
             );

--- a/user-interface/src/admin/bankruptcy-software/EditBankAssociationStatusModal.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditBankAssociationStatusModal.test.tsx
@@ -19,7 +19,7 @@ describe('EditBankAssociationStatusModal', () => {
 
   function renderComponent() {
     modalRef = React.createRef<EditBankAssociationStatusModalRef>();
-    onSave = vi.fn<EditBankAssociationStatusModalProps['onSave']>();
+    onSave = vi.fn<EditBankAssociationStatusModalProps['onSave']>().mockResolvedValue(undefined);
     render(<EditBankAssociationStatusModal ref={modalRef} modalId={MODAL_ID} onSave={onSave} />);
   }
 
@@ -144,5 +144,47 @@ describe('EditBankAssociationStatusModal', () => {
     await waitFor(() => {
       expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
     });
+  });
+
+  test('should disable both buttons while onSave is in progress', async () => {
+    onSave = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<EditBankAssociationStatusModal ref={modalRef} modalId={MODAL_ID} onSave={onSave} />);
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    await userEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(SUBMIT_BTN)).toBeDisabled();
+      expect(screen.getByTestId(CANCEL_BTN)).toBeDisabled();
+    });
+  });
+
+  test('should re-enable buttons after onSave resolves', async () => {
+    onSave = vi.fn().mockResolvedValue(undefined);
+    render(<EditBankAssociationStatusModal ref={modalRef} modalId={MODAL_ID} onSave={onSave} />);
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    await userEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(SUBMIT_BTN)).not.toBeDisabled();
+      expect(screen.getByTestId(CANCEL_BTN)).not.toBeDisabled();
+    });
+  });
+
+  test('should not close modal when cancel is clicked during save', async () => {
+    onSave = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<EditBankAssociationStatusModal ref={modalRef} modalId={MODAL_ID} onSave={onSave} />);
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    await userEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => expect(screen.getByTestId(CANCEL_BTN)).toBeDisabled());
+    await userEvent.click(screen.getByTestId(CANCEL_BTN));
+
+    expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
   });
 });

--- a/user-interface/src/admin/bankruptcy-software/EditBankAssociationStatusModal.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditBankAssociationStatusModal.test.tsx
@@ -16,6 +16,7 @@ describe('EditBankAssociationStatusModal', () => {
   let modalRef: React.RefObject<EditBankAssociationStatusModalRef | null>;
   let onSave: EditBankAssociationStatusModalProps['onSave'];
   let userEvent: CamsUserEvent;
+  let alertSpy: ReturnType<typeof TestingUtilities.spyOnGlobalAlert>;
 
   function renderComponent() {
     modalRef = React.createRef<EditBankAssociationStatusModalRef>();
@@ -28,7 +29,7 @@ describe('EditBankAssociationStatusModal', () => {
   }
 
   beforeEach(() => {
-    TestingUtilities.spyOnGlobalAlert();
+    alertSpy = TestingUtilities.spyOnGlobalAlert();
     userEvent = TestingUtilities.setupUserEvent();
   });
 
@@ -169,6 +170,23 @@ describe('EditBankAssociationStatusModal', () => {
     await userEvent.click(screen.getByTestId(SUBMIT_BTN));
 
     await waitFor(() => {
+      expect(screen.getByTestId(SUBMIT_BTN)).not.toBeDisabled();
+      expect(screen.getByTestId(CANCEL_BTN)).not.toBeDisabled();
+    });
+  });
+
+  test('should show error alert and re-enable buttons when onSave rejects', async () => {
+    onSave = vi.fn().mockRejectedValue(new Error('API failure'));
+    render(<EditBankAssociationStatusModal ref={modalRef} modalId={MODAL_ID} onSave={onSave} />);
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    await userEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(alertSpy.error).toHaveBeenCalledWith(
+        'Failed to save bank association status. Please try again.',
+      );
       expect(screen.getByTestId(SUBMIT_BTN)).not.toBeDisabled();
       expect(screen.getByTestId(CANCEL_BTN)).not.toBeDisabled();
     });

--- a/user-interface/src/admin/bankruptcy-software/EditBankAssociationStatusModal.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditBankAssociationStatusModal.tsx
@@ -11,7 +11,7 @@ export type EditBankAssociationStatusModalRef = {
 
 export type EditBankAssociationStatusModalProps = {
   modalId: string;
-  onSave: (bankId: string, bankName: string, status: 'active' | 'inactive') => void;
+  onSave: (bankId: string, bankName: string, status: 'active' | 'inactive') => Promise<void>;
 };
 
 export const EditBankAssociationStatusModal = forwardRef<
@@ -22,6 +22,7 @@ export const EditBankAssociationStatusModal = forwardRef<
   const [bankId, setBankId] = useState('');
   const [bankName, setBankName] = useState('');
   const [status, setStatus] = useState<'active' | 'inactive'>('active');
+  const [isPending, setIsPending] = useState(false);
 
   useImperativeHandle(ref, () => ({
     show(id: string, name: string, currentStatus: 'active' | 'inactive') {
@@ -35,11 +36,13 @@ export const EditBankAssociationStatusModal = forwardRef<
     },
   }));
 
-  function handleSubmit() {
-    onSave(bankId, bankName, status);
+  async function handleSubmit() {
+    setIsPending(true);
+    await onSave(bankId, bankName, status).finally(() => setIsPending(false));
   }
 
   function handleCancel() {
+    if (isPending) return;
     modalRef.current?.hide();
   }
 
@@ -50,10 +53,12 @@ export const EditBankAssociationStatusModal = forwardRef<
       label: 'Save',
       onClick: handleSubmit,
       closeOnClick: false,
+      disabled: isPending,
     },
     cancelButton: {
       label: 'Cancel',
       onClick: handleCancel,
+      disabled: isPending,
     },
   };
 

--- a/user-interface/src/admin/bankruptcy-software/EditBankAssociationStatusModal.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditBankAssociationStatusModal.tsx
@@ -3,6 +3,7 @@ import Modal from '@/lib/components/uswds/modal/Modal';
 import Radio from '@/lib/components/uswds/Radio';
 import { RadioGroup } from '@/lib/components/uswds/RadioGroup';
 import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
+import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 
 export type EditBankAssociationStatusModalRef = {
   show: (bankId: string, bankName: string, currentStatus: 'active' | 'inactive') => void;
@@ -19,6 +20,7 @@ export const EditBankAssociationStatusModal = forwardRef<
   EditBankAssociationStatusModalProps
 >(function EditBankAssociationStatusModal({ modalId, onSave }, ref) {
   const modalRef = useRef<ModalRefType>(null);
+  const alert = useGlobalAlert();
   const [bankId, setBankId] = useState('');
   const [bankName, setBankName] = useState('');
   const [status, setStatus] = useState<'active' | 'inactive'>('active');
@@ -38,7 +40,13 @@ export const EditBankAssociationStatusModal = forwardRef<
 
   async function handleSubmit() {
     setIsPending(true);
-    await onSave(bankId, bankName, status).finally(() => setIsPending(false));
+    try {
+      await onSave(bankId, bankName, status);
+    } catch {
+      alert?.error('Failed to save bank association status. Please try again.');
+    } finally {
+      setIsPending(false);
+    }
   }
 
   function handleCancel() {

--- a/user-interface/src/admin/banks/EditBankModal.test.tsx
+++ b/user-interface/src/admin/banks/EditBankModal.test.tsx
@@ -191,4 +191,52 @@ describe('EditBankModal', () => {
 
     expect(screen.getByTestId(`radio-${MODAL_ID}-status-active`)).toBeChecked();
   });
+
+  test('should disable both buttons while save is in progress', async () => {
+    vi.spyOn(Api2, 'updateBank').mockReturnValue(new Promise(() => {}));
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    await userEvent.clear(screen.getByLabelText(/bank name/i));
+    await userEvent.type(screen.getByLabelText(/bank name/i), 'Updated Name');
+    await userEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(SUBMIT_BTN)).toBeDisabled();
+      expect(screen.getByTestId(CANCEL_BTN)).toBeDisabled();
+    });
+  });
+
+  test('should re-enable buttons after a failed save', async () => {
+    vi.spyOn(Api2, 'updateBank').mockRejectedValue(new Error('server error'));
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    await userEvent.clear(screen.getByLabelText(/bank name/i));
+    await userEvent.type(screen.getByLabelText(/bank name/i), 'Updated Name');
+    await userEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(SUBMIT_BTN)).not.toBeDisabled();
+      expect(screen.getByTestId(CANCEL_BTN)).not.toBeDisabled();
+    });
+  });
+
+  test('should not close modal when cancel is clicked during save', async () => {
+    vi.spyOn(Api2, 'updateBank').mockReturnValue(new Promise(() => {}));
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    await userEvent.clear(screen.getByLabelText(/bank name/i));
+    await userEvent.type(screen.getByLabelText(/bank name/i), 'Updated Name');
+    await userEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => expect(screen.getByTestId(CANCEL_BTN)).toBeDisabled());
+    await userEvent.click(screen.getByTestId(CANCEL_BTN));
+
+    expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+  });
 });

--- a/user-interface/src/admin/banks/EditBankModal.tsx
+++ b/user-interface/src/admin/banks/EditBankModal.tsx
@@ -29,6 +29,7 @@ export const EditBankModal = forwardRef<EditBankModalRef, EditBankModalProps>(
     const [name, setName] = useState('');
     const [status, setStatus] = useState<'active' | 'inactive'>('active');
     const [nameError, setNameError] = useState<string | null>(null);
+    const [isPending, setIsPending] = useState(false);
 
     function resetForm() {
       setName(bank.name);
@@ -53,7 +54,7 @@ export const EditBankModal = forwardRef<EditBankModalRef, EditBankModalProps>(
         return;
       }
       setNameError(null);
-
+      setIsPending(true);
       try {
         const response = await Api2.updateBank(bank.id, { name: trimmed, status });
         const updated = response.data;
@@ -63,10 +64,13 @@ export const EditBankModal = forwardRef<EditBankModalRef, EditBankModalProps>(
       } catch (error) {
         getAppInsights()?.appInsights?.trackException({ exception: error as Error });
         alert?.error('Failed to update bank. Please try again.');
+      } finally {
+        setIsPending(false);
       }
     }
 
     function handleCancel() {
+      if (isPending) return;
       resetForm();
       modalRef.current?.hide();
     }
@@ -78,10 +82,12 @@ export const EditBankModal = forwardRef<EditBankModalRef, EditBankModalProps>(
         label: 'Save',
         onClick: handleSubmit,
         closeOnClick: false,
+        disabled: isPending,
       },
       cancelButton: {
         label: 'Cancel',
         onClick: handleCancel,
+        disabled: isPending,
       },
     };
 

--- a/user-interface/src/lib/components/uswds/modal/Modal.tsx
+++ b/user-interface/src/lib/components/uswds/modal/Modal.tsx
@@ -98,6 +98,7 @@ function Modal_(props: ModalProps, ref: React.Ref<ModalRefType>) {
   }
 
   function cancelBtnClick(e: React.MouseEvent<HTMLButtonElement>) {
+    if (props.actionButtonGroup.cancelButton?.disabled) return;
     if (props.actionButtonGroup.cancelButton?.onClick) {
       props.actionButtonGroup.cancelButton.onClick(e);
     }
@@ -279,6 +280,7 @@ function Modal_(props: ModalProps, ref: React.Ref<ModalRefType>) {
                           uswdsStyle:
                             props.actionButtonGroup.cancelButton?.uswdsStyle ??
                             UswdsButtonStyle.Unstyled,
+                          disabled: props.actionButtonGroup.cancelButton?.disabled ?? false,
                         }
                       : undefined
                   }

--- a/user-interface/src/lib/components/uswds/modal/SubmitCancelButtonGroup.tsx
+++ b/user-interface/src/lib/components/uswds/modal/SubmitCancelButtonGroup.tsx
@@ -22,6 +22,7 @@ export type SubmitCancelBtnProps = {
     onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>;
     className?: string;
     uswdsStyle?: UswdsButtonStyle;
+    disabled?: boolean;
   };
 };
 
@@ -68,6 +69,7 @@ function SubmitCancelButtonGroup_(
             className={cancelButtonClassName}
             onClick={cancelButton.onClick ?? close}
             onKeyDown={cancelButton.onKeyDown}
+            disabled={cancelButton.disabled ?? false}
           >
             {cancelButton.label.length > 0 ? cancelButton.label : 'Go back'}
           </Button>


### PR DESCRIPTION
# Bug

When a bank profile was marked inactive, software profiles that referenced that bank retained active association statuses. There was also no guard preventing an API caller from manually reactivating a bank association while the bank remained inactive, and the UI showed the Edit Status button regardless of the bank's profile status.

# Purpose

Ensure that bank inactivation is consistently reflected across associated software profiles — automatically at the data layer, enforced at the API layer, and communicated clearly in the UI.

# Major Changes

- **Cascade (backend):** When a bank is set to inactive, all `SoftwareBankAssociation` entries referencing that bank are automatically set to inactive across every `BankruptcySoftwareProfile`, and an audit record is created per affected profile. No cascade occurs when a bank is set to active.
- **Guard (backend):** `BankruptcySoftwareUseCase.updateSoftware` now rejects any attempt to set a bank association status to `active` when the referenced bank profile is inactive, returning a 400 Bad Request. Setting an association to `inactive` is always permitted.
- **UI:** The Edit Status button in `AssociatedBanksTable` is hidden when the associated bank's profile status is inactive, preventing admins from attempting an action the API would reject.

# Testing/Validation

Implemented using TDD. All three changes are covered by unit tests:

- Cascade: 4 tests covering multi-profile fan-out, no cascade on active, empty result no-op, and `release()` called even when cascade throws
- Guard: 4 tests covering inactive bank rejects with correct message, active bank allows, setting to inactive skips bank lookup, and `release()` called on error
- UI: 3 tests covering hide when profile inactive, show when profile active, and mixed-row rendering

# Notes

- Cross-domain lookup pattern (use case → factory → repository) is consistent with `getTrusteesByBank` in the same codebase
- The `findSoftwareByBankId` query uses a `QueryBuilder` dot-notation cast (`'associatedBanks.bankId' as keyof BankruptcySoftwareProfile`) — a known limitation of the QueryBuilder for embedded array fields
- UI uses `bankProfileMap` (a `Map` keyed by bank id) derived from the existing `allBanks` prop — no new props or API calls needed
- Safe default: if a `bankId` is not found in `allBanks`, the Edit Status button is hidden

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Ensure bank inactivation is consistently enforced and communicated across bankruptcy software associations and admin UI workflows.

Bug Fixes:
- Prevent reactivation of software–bank associations when the underlying bank profile is inactive.
- Ensure software associations are automatically inactivated when a bank profile is set to inactive, avoiding stale active links.

Enhancements:
- Add repository support and use-case logic to fan out bank inactivation to all affected bankruptcy software profiles with auditing and error-tolerant logging.
- Update admin UI modals to handle in-progress saves by disabling submit/cancel actions and preventing accidental closure during pending requests.
- Hide the Edit Status control for software–bank associations whose bank profiles are inactive and refine trustee count display behavior in the associations table.

Tests:
- Expand backend unit tests to cover bank inactivation cascading, association reactivation guards, and repository queries by bank ID.
- Add frontend tests for association table filtering, trustee count link rendering, and button state behavior in bank and association status modals.