### PR TITLE
Fix trustee list links to navigate in same tab

### DIFF
--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -617,6 +617,7 @@ export default function TrusteesList() {
                             trusteeId={trustee.trusteeId}
                             dataTestId={`trustee-link-${trustee.trusteeId}`}
                             source="trustee-list"
+                            openNewTab={false}
                           />
                         ) : (
                           <span aria-hidden="true"></span>


### PR DESCRIPTION
Set openNewTab={false} for TrusteeName in trustees list. Users expect list navigation to happen in the same tab, not open new tabs. This fixes the Playwright e2e test that expects same-tab navigation when clicking a trustee name from the list.

Jira ticket: CAMS-618

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Bug Fixes:
- Align trustee name link behaviour with user expectations and existing tests by disabling new-tab navigation from the trustees list.