### PR TITLE
Fix e2e test timing for trustee link click

### DIFF
--- a/test/e2e/playwright/trustees.spec.ts
+++ b/test/e2e/playwright/trustees.spec.ts
@@ -43,6 +43,7 @@ test.describe('Trustees', () => {
 
     // Only proceed if there are trustees in the table
     if ((await firstTrusteeLink.count()) > 0) {
+      await expect(firstTrusteeLink).toBeVisible(timeoutOption);
       await firstTrusteeLink.click();
 
       // Verify we navigated to the trustee detail page


### PR DESCRIPTION
Add explicit wait for trustee link visibility before clicking. The test was timing out because it checked count() > 0 but didn't wait for the link to become actionable before attempting to click. This race condition caused intermittent failures when the link existed but wasn't yet clickable.

# Looking to create a bug?

Please go to the `Preview` tab and select the appropriate template. **Otherwise, please delete this section.**

* [Bug](?expand=1&template=bug.md)

# Purpose

Describe the reason why this was developed.

# Major Changes

Describe what has changed.

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Notes

Optional - capture notes for nuances or future work that could be done.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Bug Fixes:
- Prevent intermittent timeouts in the trustees E2E test by waiting for the trustee link to be visible before clicking.