### PR TITLE
Fix trustee list links opening in new tab

### DIFF
--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -124,6 +124,9 @@ describe('TrusteesList Component', () => {
       'href',
       '/trustees/trustee-2',
     );
+
+    expect(screen.getByTestId('trustee-link-trustee-1')).not.toHaveAttribute('target', '_blank');
+    expect(screen.getByTestId('trustee-link-trustee-2')).not.toHaveAttribute('target', '_blank');
   });
 
   test('should fire analytics event when trustee link is clicked', async () => {

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -617,6 +617,7 @@ export default function TrusteesList() {
                             trusteeId={trustee.trusteeId}
                             dataTestId={`trustee-link-${trustee.trusteeId}`}
                             source="trustee-list"
+                            openNewTab={false}
                           />
                         ) : (
                           <span aria-hidden="true"></span>

--- a/user-interface/test/accessibility/trustee-appointment-form.test.ts
+++ b/user-interface/test/accessibility/trustee-appointment-form.test.ts
@@ -6,17 +6,16 @@ test.describe('Trustee Appointment Form', () => {
 
   let trusteeProfilePage;
 
-  test.beforeEach(async ({ page, context }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(getUrl('/trustees'));
     await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
 
     const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
     await expect(trusteeProfileLink).toBeVisible();
 
-    // Handle new tab opening (feature flag: open-trustee-profile-in-new-tab)
-    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
-    await newPage.waitForLoadState();
-    trusteeProfilePage = newPage;
+    await trusteeProfileLink.click();
+    await page.waitForLoadState();
+    trusteeProfilePage = page;
 
     await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
 

--- a/user-interface/test/accessibility/trustee-assistants.test.ts
+++ b/user-interface/test/accessibility/trustee-assistants.test.ts
@@ -6,17 +6,16 @@ test.describe('Trustee Assistants', () => {
 
   let trusteeProfilePage;
 
-  test.beforeEach(async ({ page, context }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(getUrl('/trustees'));
     await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
 
     const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
     await expect(trusteeProfileLink).toBeVisible();
 
-    // Handle new tab opening (feature flag: open-trustee-profile-in-new-tab)
-    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
-    await newPage.waitForLoadState();
-    trusteeProfilePage = newPage;
+    await trusteeProfileLink.click();
+    await page.waitForLoadState();
+    trusteeProfilePage = page;
 
     await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
   });

--- a/user-interface/test/accessibility/trustee-key-dates.test.ts
+++ b/user-interface/test/accessibility/trustee-key-dates.test.ts
@@ -6,17 +6,16 @@ test.describe('Trustee Key Dates', () => {
 
   let trusteeProfilePage;
 
-  test.beforeEach(async ({ page, context }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(getUrl('/trustees'));
     await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
 
     const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
     await expect(trusteeProfileLink).toBeVisible();
 
-    // Handle new tab opening (feature flag: open-trustee-profile-in-new-tab)
-    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
-    await newPage.waitForLoadState();
-    trusteeProfilePage = newPage;
+    await trusteeProfileLink.click();
+    await page.waitForLoadState();
+    trusteeProfilePage = page;
 
     await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
 

--- a/user-interface/test/accessibility/trustee.test.ts
+++ b/user-interface/test/accessibility/trustee.test.ts
@@ -24,21 +24,17 @@ test.describe('Trustees', () => {
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 
-  test('trustee profile should not have accessibility issues', async ({ page, context }) => {
+  test('trustee profile should not have accessibility issues', async ({ page }) => {
     const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
     await expect(trusteeProfileLink).toBeVisible();
 
-    // Handle new tab opening (feature flag: open-trustee-profile-in-new-tab)
-    const [trusteeProfilePage] = await Promise.all([
-      context.waitForEvent('page'),
-      trusteeProfileLink.click(),
-    ]);
-    await trusteeProfilePage.waitForLoadState();
+    await trusteeProfileLink.click();
+    await page.waitForLoadState();
 
-    await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
+    await expect(page.locator('.case-detail-header')).toBeVisible();
 
-    await trusteeProfilePage.waitForTimeout(ANALYZE_DELAY);
-    const accessibilityScanResults = await createAxeBuilder(trusteeProfilePage).analyze();
+    await page.waitForTimeout(ANALYZE_DELAY);
+    const accessibilityScanResults = await createAxeBuilder(page).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 });


### PR DESCRIPTION
# Purpose

Fix trustee list links opening in new tab

# Major Changes

Trustee name links in the list view were opening in a new tab due to the default openNewTab=true on TrusteeName. Pass openNewTab=false so clicking a trustee navigates in the same tab, fixing the E2E test that expected a URL change to /trustees/:id.

Also adds assertions to TrusteesList tests confirming links do not have target="_blank".

## Summary by Sourcery

Ensure trustee links in the list view navigate within the same tab instead of opening a new tab.

Bug Fixes:
- Prevent trustee list name links from opening in a new browser tab so navigation stays within the current tab.

Tests:
- Extend TrusteesList tests to assert trustee links do not render with target="_blank" attributes.