### PR TITLE
Warm up downstream handler modules in beforeAll

### DIFF
--- a/backend/function-apps/dataflows/downstream/acms-cams-transition.test.ts
+++ b/backend/function-apps/dataflows/downstream/acms-cams-transition.test.ts
@@ -47,6 +47,10 @@ vi.mock('@azure/functions', async () => {
 // ─── Staff assignment handler ─────────────────────────────────────────────────
 
 describe('staffAssignmentHandler', () => {
+  beforeAll(async () => {
+    await import('./staff-assignment-downstream');
+  });
+
   beforeEach(() => {
     mockRequest.input.mockReset().mockReturnThis();
     mockRequest.query.mockReset().mockResolvedValue({});
@@ -164,6 +168,10 @@ describe('staffAssignmentHandler', () => {
 // ─── Trustee appointment handler ──────────────────────────────────────────────
 
 describe('trusteeAppointmentHandler', () => {
+  beforeAll(async () => {
+    await import('./trustee-appointment-downstream');
+  });
+
   beforeEach(() => {
     mockRequest.input.mockReset().mockReturnThis();
     mockRequest.query.mockReset().mockResolvedValue({});


### PR DESCRIPTION
# Purpose

Fix tests breaking staging ADO

# Major Changes

The mssql module cold-loads ~2s on first import inside a vitest worker. With no vi.resetModules() between tests, this cost landed on the first test in the staffAssignmentHandler and trusteeAppointmentHandler describe blocks, causing timeouts in CI. A beforeAll pre-imports each downstream module so the cold-load happens outside any individual test's timeout window. The cascade failure on the second test (query called 2 times) was a symptom of the first test being killed mid-execution.

## Summary by Sourcery

Warm up downstream handler modules in tests to avoid per-test cold-load timeouts.

Tests:
- Pre-import staff assignment downstream module in a beforeAll hook to shift its initial load cost outside individual test timeouts.
- Pre-import trustee appointment downstream module in a beforeAll hook to prevent timeouts on the first test case.