### PR TITLE
Fix React act() warnings and knip CI warnings

### DIFF
--- a/common/src/cams/test-utilities/dxtr-acms.mock.ts
+++ b/common/src/cams/test-utilities/dxtr-acms.mock.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { CourtDivisionDetails } from '../courts.js';
 
-export type AoDxtrCsRow = {
+type AoDxtrCsRow = {
   CS_CASEID: string;
   COURT_ID: string;
   CS_DIV: string;
@@ -12,7 +12,7 @@ export type AoDxtrCsRow = {
   CS_DATE_FILED: string;
 };
 
-export type AoDxtrPyRow = {
+type AoDxtrPyRow = {
   CS_CASEID: string;
   COURT_ID: string;
   PY_ROLE: string;
@@ -24,7 +24,7 @@ export type AoDxtrPyRow = {
   PY_ZIP: string;
 };
 
-export type AcmsCmmprRow = {
+type AcmsCmmprRow = {
   PROF_CODE: number;
   GROUP_DESIGNATOR: string;
   PROF_LAST_NAME: string;
@@ -34,7 +34,7 @@ export type AcmsCmmprRow = {
   EIN: string | null;
 };
 
-export type AcmsCmmapRow = {
+type AcmsCmmapRow = {
   RECORD_SEQ_NBR: number;
   CASE_DIV: string;
   CASE_YEAR: number;

--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,8 @@
     ".": {
       "entry": ["vitest.config.ts"],
       "ignore": [],
-      "ignoreFiles": ["test/migration/**", "ops/migrations/**"]
+      "ignoreFiles": ["test/migration/**", "ops/migrations/**"],
+      "ignoreDependencies": ["vitest"]
     },
     "backend": {
       "entry": [
@@ -78,6 +79,7 @@
     "pushd",
     "popd",
     "tsx",
+    "stryker",
 
     "playwright",
     "dot",
@@ -89,6 +91,7 @@
   ],
   "ignoreDependencies": [
     "@azure/cosmos",
+    "@stryker-mutator/core",
     "@azure/identity",
     "@azure/keyvault-secrets",
     "@uswds/uswds",

--- a/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.test.tsx
+++ b/user-interface/src/admin/bankruptcy-software/EditSoftwareModal.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { EditSoftwareModal, EditSoftwareModalRef } from './EditSoftwareModal';
 import Api2 from '@/lib/models/api2';
@@ -51,7 +51,9 @@ describe('EditSoftwareModal', () => {
 
   test('should open modal and pre-fill with current software values', async () => {
     renderModal(successSpy);
-    modalRef.current?.show();
+    act(() => {
+      modalRef.current?.show();
+    });
 
     await waitFor(() => {
       expect(screen.getByDisplayValue('Axos')).toBeInTheDocument();
@@ -61,7 +63,9 @@ describe('EditSoftwareModal', () => {
 
   test('should show validation error when name is blank', async () => {
     renderModal(successSpy);
-    modalRef.current?.show();
+    act(() => {
+      modalRef.current?.show();
+    });
 
     const nameInput = await screen.findByDisplayValue('Axos');
     fireEvent.change(nameInput, { target: { value: '' } });
@@ -77,7 +81,9 @@ describe('EditSoftwareModal', () => {
     vi.spyOn(Api2, 'updateSoftware').mockResolvedValue({ data: updatedSoftware });
 
     renderModal(successSpy);
-    modalRef.current?.show();
+    act(() => {
+      modalRef.current?.show();
+    });
 
     await screen.findByDisplayValue('Axos');
     const nameInput = screen.getByDisplayValue('Axos');
@@ -101,7 +107,9 @@ describe('EditSoftwareModal', () => {
     vi.spyOn(Api2, 'updateSoftware').mockRejectedValue(new Error('server error'));
 
     renderModal(successSpy);
-    modalRef.current?.show();
+    act(() => {
+      modalRef.current?.show();
+    });
 
     const nameInput = await screen.findByDisplayValue('Axos');
     fireEvent.change(nameInput, { target: { value: 'Changed' } });
@@ -117,15 +125,21 @@ describe('EditSoftwareModal', () => {
 
   test('should call hide on the modal ref', async () => {
     renderModal(successSpy);
-    modalRef.current?.show();
+    act(() => {
+      modalRef.current?.show();
+    });
     await screen.findByDisplayValue('Axos');
-    modalRef.current?.hide();
+    act(() => {
+      modalRef.current?.hide();
+    });
     expect(successSpy).not.toHaveBeenCalled();
   });
 
   test('should set status to active when active radio is clicked', async () => {
     renderModal(successSpy);
-    modalRef.current?.show();
+    act(() => {
+      modalRef.current?.show();
+    });
 
     await screen.findByDisplayValue('Axos');
     fireEvent.click(
@@ -140,7 +154,9 @@ describe('EditSoftwareModal', () => {
 
   test('should reset form and close modal on cancel', async () => {
     renderModal(successSpy);
-    modalRef.current?.show();
+    act(() => {
+      modalRef.current?.show();
+    });
 
     await screen.findByDisplayValue('Axos');
     const nameInput = screen.getByDisplayValue('Axos');

--- a/user-interface/src/case-detail/panels/case-notes/CaseNotes.test.tsx
+++ b/user-interface/src/case-detail/panels/case-notes/CaseNotes.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { vi, describe, test, expect, beforeEach } from 'vitest';
 import CaseNotes from './CaseNotes';
 import Api2 from '@/lib/models/api2';
@@ -125,9 +125,15 @@ describe('CaseNotes Adapter', () => {
       render(<CaseNotes caseId={caseId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onCreateNote(noteData);
-      await getNotesProps().onUpdateNote('note-id', noteData);
-      await getNotesProps().onDeleteNote('note-id');
+      await act(async () => {
+        await getNotesProps().onCreateNote(noteData);
+      });
+      await act(async () => {
+        await getNotesProps().onUpdateNote('note-id', noteData);
+      });
+      await act(async () => {
+        await getNotesProps().onDeleteNote('note-id');
+      });
 
       expect(postSpy).not.toHaveBeenCalled();
       expect(putSpy).not.toHaveBeenCalled();
@@ -146,7 +152,9 @@ describe('CaseNotes Adapter', () => {
       render(<CaseNotes caseId={caseId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onCreateNote(noteData);
+      await act(async () => {
+        await getNotesProps().onCreateNote(noteData);
+      });
 
       expect(postSpy).toHaveBeenCalledWith({
         caseId,
@@ -165,7 +173,9 @@ describe('CaseNotes Adapter', () => {
       render(<CaseNotes caseId={caseId} />);
       await waitFor(() => expect(getCaseNotesSpy).toHaveBeenCalledTimes(1));
 
-      await getNotesProps().onCreateNote(noteData);
+      await act(async () => {
+        await getNotesProps().onCreateNote(noteData);
+      });
 
       expect(getCaseNotesSpy).toHaveBeenCalledTimes(2);
     });
@@ -198,7 +208,9 @@ describe('CaseNotes Adapter', () => {
       render(<CaseNotes caseId={caseId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onUpdateNote(noteId, noteData);
+      await act(async () => {
+        await getNotesProps().onUpdateNote(noteId, noteData);
+      });
 
       expect(putSpy).toHaveBeenCalledWith({
         id: noteId,
@@ -218,7 +230,9 @@ describe('CaseNotes Adapter', () => {
       render(<CaseNotes caseId={caseId} />);
       await waitFor(() => expect(getCaseNotesSpy).toHaveBeenCalledTimes(1));
 
-      await getNotesProps().onUpdateNote(noteId, noteData);
+      await act(async () => {
+        await getNotesProps().onUpdateNote(noteId, noteData);
+      });
 
       expect(getCaseNotesSpy).toHaveBeenCalledTimes(2);
     });
@@ -246,7 +260,9 @@ describe('CaseNotes Adapter', () => {
       render(<CaseNotes caseId={caseId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onDeleteNote(noteId);
+      await act(async () => {
+        await getNotesProps().onDeleteNote(noteId);
+      });
 
       expect(deleteSpy).toHaveBeenCalledWith({
         id: noteId,
@@ -264,7 +280,9 @@ describe('CaseNotes Adapter', () => {
       render(<CaseNotes caseId={caseId} />);
       await waitFor(() => expect(getCaseNotesSpy).toHaveBeenCalledTimes(1));
 
-      await getNotesProps().onDeleteNote(noteId);
+      await act(async () => {
+        await getNotesProps().onDeleteNote(noteId);
+      });
 
       expect(getCaseNotesSpy).toHaveBeenCalledTimes(2);
     });

--- a/user-interface/src/lib/components/cams/Notes/NoteFormModal.test.tsx
+++ b/user-interface/src/lib/components/cams/Notes/NoteFormModal.test.tsx
@@ -105,10 +105,33 @@ vi.mock('@/lib/components/cams/RichTextEditor/RichTextEditor', async () => {
 
 const SUBMIT_BUTTON_ID = 'button-test-note-modal-submit-button';
 
+const DEFAULT_SHOW_OPTIONS: Parameters<NoteFormModalRef['show']>[0] = {
+  mode: 'create',
+  entityId: 'entity-123',
+  title: '',
+  content: '',
+  cacheKey: 'notes-entity-123',
+  openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+  initialTitle: '',
+  initialContent: '',
+};
+
 describe('NoteFormModal', () => {
   let modalRef: React.RefObject<NoteFormModalRef>;
   let mockOnSave: (noteData: NoteInput) => Promise<void>;
   let mockOnModalClosed: () => void;
+
+  function openNoteModal(overrides: Partial<Parameters<NoteFormModalRef['show']>[0]> = {}) {
+    act(() => {
+      modalRef.current?.show({ ...DEFAULT_SHOW_OPTIONS, ...overrides });
+    });
+  }
+
+  function closeNoteModal() {
+    act(() => {
+      modalRef.current?.hide();
+    });
+  }
 
   afterEach(() => {
     vi.useRealTimers();
@@ -134,18 +157,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: '',
-        content: '',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal();
 
     await waitFor(() => {
       expect(screen.getByText('Create Note')).toBeInTheDocument();
@@ -162,18 +174,14 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        id: 'note-456',
-        mode: 'edit',
-        entityId: 'entity-123',
-        title: 'Existing Note',
-        content: 'Existing content',
-        cacheKey: 'notes-entity-123-note-456',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: 'Existing Note',
-        initialContent: 'Existing content',
-      });
+    openNoteModal({
+      id: 'note-456',
+      mode: 'edit',
+      title: 'Existing Note',
+      content: 'Existing content',
+      cacheKey: 'notes-entity-123-note-456',
+      initialTitle: 'Existing Note',
+      initialContent: 'Existing content',
     });
 
     await waitFor(() => {
@@ -191,18 +199,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: '',
-        content: '',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal();
 
     await waitFor(() => {
       expect(screen.getByTestId('note-title-input')).toBeInTheDocument();
@@ -223,18 +220,7 @@ describe('NoteFormModal', () => {
     );
 
     const cacheKey = 'notes-entity-123';
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test',
-        content: '<p>Test</p>',
-        cacheKey,
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test', content: '<p>Test</p>', cacheKey });
 
     await waitFor(() => {
       expect(LocalFormCache.saveForm).toHaveBeenCalled();
@@ -258,18 +244,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test Note',
-        content: '<p>Test content</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test Note', content: '<p>Test content</p>' });
 
     await waitFor(() => {
       expect(screen.getByText('Create Note')).toBeInTheDocument();
@@ -306,18 +281,14 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        id: 'note-456',
-        mode: 'edit',
-        entityId: 'entity-123',
-        title: 'Updated Note',
-        content: '<p>Updated content</p>',
-        cacheKey: 'notes-entity-123-note-456',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: 'Original Note',
-        initialContent: '<p>Original content</p>',
-      });
+    openNoteModal({
+      id: 'note-456',
+      mode: 'edit',
+      title: 'Updated Note',
+      content: '<p>Updated content</p>',
+      cacheKey: 'notes-entity-123-note-456',
+      initialTitle: 'Original Note',
+      initialContent: '<p>Original content</p>',
     });
 
     await waitFor(() => {
@@ -356,18 +327,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: '',
-        content: '<p>Content only</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ content: '<p>Content only</p>' });
 
     await waitFor(() => {
       expect(screen.getByText('Create Note')).toBeInTheDocument();
@@ -393,18 +353,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Title only',
-        content: '',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Title only' });
 
     await waitFor(() => {
       expect(screen.getByText('Create Note')).toBeInTheDocument();
@@ -431,18 +380,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test Note',
-        content: '<p>Test content</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test Note', content: '<p>Test content</p>' });
 
     await waitFor(() => {
       expect(screen.getByText('Create Note')).toBeInTheDocument();
@@ -470,18 +408,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test Note',
-        content: '<p>Test content</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test Note', content: '<p>Test content</p>' });
 
     await waitFor(() => {
       expect(screen.getByText('Discard')).toBeInTheDocument();
@@ -508,18 +435,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test Note',
-        content: '<p>Test content</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test Note', content: '<p>Test content</p>' });
 
     await waitFor(() => {
       expect(screen.getByText('Create Note')).toBeInTheDocument();
@@ -600,18 +516,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test Note',
-        content: '<p>Test content</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test Note', content: '<p>Test content</p>' });
 
     const submitButton = screen.getByTestId(SUBMIT_BUTTON_ID);
     await waitFor(() => expect(submitButton).toBeEnabled());
@@ -632,17 +537,9 @@ describe('NoteFormModal', () => {
     render(<NoteFormModal modalId="test-note-modal" onSave={mockOnSave} ref={modalRef} />);
 
     // Pass undefined for title/content to exercise the ?? '' fallback in show()
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: undefined as unknown as string,
-        content: undefined as unknown as string,
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
+    openNoteModal({
+      title: undefined as unknown as string,
+      content: undefined as unknown as string,
     });
 
     expect(await screen.findByText('Create Note')).toBeInTheDocument();
@@ -656,24 +553,11 @@ describe('NoteFormModal', () => {
   test('should not throw when hide is called without onModalClosed', async () => {
     render(<NoteFormModal modalId="test-note-modal" onSave={mockOnSave} ref={modalRef} />);
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test',
-        content: '<p>Content</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test', content: '<p>Content</p>' });
 
     expect(await screen.findByText('Create Note')).toBeInTheDocument();
 
-    act(() => {
-      modalRef.current?.hide();
-    });
+    closeNoteModal();
   });
 
   test('should clear form cache when form key is set but both title and content are empty', async () => {
@@ -689,18 +573,7 @@ describe('NoteFormModal', () => {
     // Showing with empty title and content: Input.getValue() returns its initial
     // state (''), RichTextEditor.getHtml() returns '' for empty content —
     // so updateFormCache sees both as '' and hits saveFormData's else-if branch.
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: '',
-        content: '',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal();
 
     await waitFor(() => {
       expect(LocalFormCache.clearForm).toHaveBeenCalledWith('notes-entity-123');
@@ -721,18 +594,7 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test Note',
-        content: '<p>Test content</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test Note', content: '<p>Test content</p>' });
 
     const submitButton = screen.getByTestId(SUBMIT_BUTTON_ID);
     await waitFor(() => expect(submitButton).toBeEnabled());
@@ -770,26 +632,13 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    act(() => {
-      modalRef.current?.show({
-        mode: 'create',
-        entityId: 'entity-123',
-        title: 'Test Note',
-        content: '<p>Test content</p>',
-        cacheKey: 'notes-entity-123',
-        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-        initialTitle: '',
-        initialContent: '',
-      });
-    });
+    openNoteModal({ title: 'Test Note', content: '<p>Test content</p>' });
 
     await waitFor(() => {
       expect(screen.getByText('Create Note')).toBeInTheDocument();
     });
 
-    act(() => {
-      modalRef.current?.hide();
-    });
+    closeNoteModal();
 
     await waitFor(() => {
       expect(mockOnModalClosed).toHaveBeenCalled();

--- a/user-interface/src/lib/components/cams/Notes/NoteFormModal.test.tsx
+++ b/user-interface/src/lib/components/cams/Notes/NoteFormModal.test.tsx
@@ -134,15 +134,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: '',
-      content: '',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: '',
+        content: '',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -160,16 +162,18 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      id: 'note-456',
-      mode: 'edit',
-      entityId: 'entity-123',
-      title: 'Existing Note',
-      content: 'Existing content',
-      cacheKey: 'notes-entity-123-note-456',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: 'Existing Note',
-      initialContent: 'Existing content',
+    act(() => {
+      modalRef.current?.show({
+        id: 'note-456',
+        mode: 'edit',
+        entityId: 'entity-123',
+        title: 'Existing Note',
+        content: 'Existing content',
+        cacheKey: 'notes-entity-123-note-456',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: 'Existing Note',
+        initialContent: 'Existing content',
+      });
     });
 
     await waitFor(() => {
@@ -187,15 +191,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: '',
-      content: '',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: '',
+        content: '',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -217,15 +223,17 @@ describe('NoteFormModal', () => {
     );
 
     const cacheKey = 'notes-entity-123';
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test',
-      content: '<p>Test</p>',
-      cacheKey,
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test',
+        content: '<p>Test</p>',
+        cacheKey,
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -250,15 +258,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test Note',
-      content: '<p>Test content</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test Note',
+        content: '<p>Test content</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -296,16 +306,18 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      id: 'note-456',
-      mode: 'edit',
-      entityId: 'entity-123',
-      title: 'Updated Note',
-      content: '<p>Updated content</p>',
-      cacheKey: 'notes-entity-123-note-456',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: 'Original Note',
-      initialContent: '<p>Original content</p>',
+    act(() => {
+      modalRef.current?.show({
+        id: 'note-456',
+        mode: 'edit',
+        entityId: 'entity-123',
+        title: 'Updated Note',
+        content: '<p>Updated content</p>',
+        cacheKey: 'notes-entity-123-note-456',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: 'Original Note',
+        initialContent: '<p>Original content</p>',
+      });
     });
 
     await waitFor(() => {
@@ -344,15 +356,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: '',
-      content: '<p>Content only</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: '',
+        content: '<p>Content only</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -379,15 +393,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Title only',
-      content: '',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Title only',
+        content: '',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -415,15 +431,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test Note',
-      content: '<p>Test content</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test Note',
+        content: '<p>Test content</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -452,15 +470,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test Note',
-      content: '<p>Test content</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test Note',
+        content: '<p>Test content</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -488,15 +508,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test Note',
-      content: '<p>Test content</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test Note',
+        content: '<p>Test content</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -578,15 +600,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test Note',
-      content: '<p>Test content</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test Note',
+        content: '<p>Test content</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     const submitButton = screen.getByTestId(SUBMIT_BUTTON_ID);
@@ -608,15 +632,17 @@ describe('NoteFormModal', () => {
     render(<NoteFormModal modalId="test-note-modal" onSave={mockOnSave} ref={modalRef} />);
 
     // Pass undefined for title/content to exercise the ?? '' fallback in show()
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: undefined as unknown as string,
-      content: undefined as unknown as string,
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: undefined as unknown as string,
+        content: undefined as unknown as string,
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     expect(await screen.findByText('Create Note')).toBeInTheDocument();
@@ -630,20 +656,24 @@ describe('NoteFormModal', () => {
   test('should not throw when hide is called without onModalClosed', async () => {
     render(<NoteFormModal modalId="test-note-modal" onSave={mockOnSave} ref={modalRef} />);
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test',
-      content: '<p>Content</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test',
+        content: '<p>Content</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     expect(await screen.findByText('Create Note')).toBeInTheDocument();
 
-    expect(() => modalRef.current?.hide()).not.toThrow();
+    act(() => {
+      modalRef.current?.hide();
+    });
   });
 
   test('should clear form cache when form key is set but both title and content are empty', async () => {
@@ -659,15 +689,17 @@ describe('NoteFormModal', () => {
     // Showing with empty title and content: Input.getValue() returns its initial
     // state (''), RichTextEditor.getHtml() returns '' for empty content —
     // so updateFormCache sees both as '' and hits saveFormData's else-if branch.
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: '',
-      content: '',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: '',
+        content: '',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
@@ -689,15 +721,17 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test Note',
-      content: '<p>Test content</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test Note',
+        content: '<p>Test content</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     const submitButton = screen.getByTestId(SUBMIT_BUTTON_ID);
@@ -736,22 +770,26 @@ describe('NoteFormModal', () => {
       />,
     );
 
-    modalRef.current?.show({
-      mode: 'create',
-      entityId: 'entity-123',
-      title: 'Test Note',
-      content: '<p>Test content</p>',
-      cacheKey: 'notes-entity-123',
-      openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
-      initialTitle: '',
-      initialContent: '',
+    act(() => {
+      modalRef.current?.show({
+        mode: 'create',
+        entityId: 'entity-123',
+        title: 'Test Note',
+        content: '<p>Test content</p>',
+        cacheKey: 'notes-entity-123',
+        openModalButtonRef: { focus: vi.fn(), disableButton: vi.fn() },
+        initialTitle: '',
+        initialContent: '',
+      });
     });
 
     await waitFor(() => {
       expect(screen.getByText('Create Note')).toBeInTheDocument();
     });
 
-    modalRef.current?.hide();
+    act(() => {
+      modalRef.current?.hide();
+    });
 
     await waitFor(() => {
       expect(mockOnModalClosed).toHaveBeenCalled();

--- a/user-interface/src/lib/components/cams/SessionTimeoutManager/SessionTimeoutManager.test.tsx
+++ b/user-interface/src/lib/components/cams/SessionTimeoutManager/SessionTimeoutManager.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen } from '@testing-library/react';
+import { act, render, waitFor, screen } from '@testing-library/react';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import SessionTimeoutManager from './SessionTimeoutManager';
 import { SESSION_TIMEOUT, AUTH_EXPIRY_WARNING } from '@/login/session-timer';
@@ -93,7 +93,9 @@ describe('SessionTimeoutManager', () => {
     expect(modalWrapper).toHaveClass('is-hidden');
 
     // Dispatch the AUTH_EXPIRY_WARNING event
-    window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    });
 
     await waitFor(() => {
       expect(modalWrapper).toHaveClass('is-visible');
@@ -104,7 +106,9 @@ describe('SessionTimeoutManager', () => {
     renderWithContext();
 
     // Dispatch the SESSION_TIMEOUT event
-    window.dispatchEvent(new CustomEvent(SESSION_TIMEOUT));
+    act(() => {
+      window.dispatchEvent(new CustomEvent(SESSION_TIMEOUT));
+    });
 
     await waitFor(() => {
       expect(logoutSpy).toHaveBeenCalled();
@@ -117,7 +121,9 @@ describe('SessionTimeoutManager', () => {
     renderWithContext();
 
     // Dispatch AUTH_EXPIRY_WARNING to open the modal
-    window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    });
 
     await waitFor(() => {
       const modalWrapper = screen.getByTestId('modal-session-timeout-warning');
@@ -138,7 +144,9 @@ describe('SessionTimeoutManager', () => {
     renderWithContext();
 
     // Dispatch AUTH_EXPIRY_WARNING to open the modal
-    window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    });
 
     await waitFor(() => {
       const modalWrapper = screen.getByTestId('modal-session-timeout-warning');
@@ -172,7 +180,9 @@ describe('SessionTimeoutManager', () => {
     );
 
     // Dispatch AUTH_EXPIRY_WARNING to open the modal
-    window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    });
 
     await waitFor(() => {
       const modalWrapper = screen.getByTestId('modal-session-timeout-warning');
@@ -194,7 +204,9 @@ describe('SessionTimeoutManager', () => {
     renderWithContext();
 
     // Dispatch AUTH_EXPIRY_WARNING to open the modal
-    window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    });
 
     await waitFor(() => {
       const modalWrapper = screen.getByTestId('modal-session-timeout-warning');
@@ -212,7 +224,9 @@ describe('SessionTimeoutManager', () => {
     renderWithContext();
 
     // Dispatch AUTH_EXPIRY_WARNING to open the modal
-    window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_EXPIRY_WARNING));
+    });
 
     await waitFor(() => {
       const modalWrapper = screen.getByTestId('modal-session-timeout-warning');

--- a/user-interface/src/lib/components/cams/SessionTimeoutWarningModal/SessionTimeoutWarningModal.test.tsx
+++ b/user-interface/src/lib/components/cams/SessionTimeoutWarningModal/SessionTimeoutWarningModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { createRef } from 'react';
 import SessionTimeoutWarningModal, {
@@ -87,7 +87,9 @@ describe('SessionTimeoutWarningModal', () => {
     );
 
     // Call show() - should render timer
-    ref.current?.show();
+    act(() => {
+      ref.current?.show();
+    });
 
     await waitFor(() => {
       const timer = screen.queryByTestId('countdown-timer');
@@ -108,7 +110,9 @@ describe('SessionTimeoutWarningModal', () => {
     );
 
     // Open modal first time
-    ref.current?.show();
+    act(() => {
+      ref.current?.show();
+    });
 
     await waitFor(() => {
       const timer = screen.getByTestId('countdown-timer');
@@ -118,7 +122,9 @@ describe('SessionTimeoutWarningModal', () => {
     });
 
     // Call show() again - timer should reset to initial value
-    ref.current?.show();
+    act(() => {
+      ref.current?.show();
+    });
 
     await waitFor(() => {
       const timer = screen.getByTestId('countdown-timer');
@@ -140,7 +146,9 @@ describe('SessionTimeoutWarningModal', () => {
     );
 
     // Open modal first time
-    ref.current?.show();
+    act(() => {
+      ref.current?.show();
+    });
 
     await waitFor(() => {
       const timer = screen.getByTestId('countdown-timer');
@@ -150,10 +158,14 @@ describe('SessionTimeoutWarningModal', () => {
     });
 
     // Close the modal using hide()
-    ref.current?.hide();
+    act(() => {
+      ref.current?.hide();
+    });
 
     // Reopen the modal - timer should be reset
-    ref.current?.show();
+    act(() => {
+      ref.current?.show();
+    });
 
     await waitFor(() => {
       const timer = screen.getByTestId('countdown-timer');
@@ -176,7 +188,9 @@ describe('SessionTimeoutWarningModal', () => {
     );
 
     // Open the modal
-    ref.current?.show();
+    act(() => {
+      ref.current?.show();
+    });
 
     // Click Stay Logged In button
     const submitButton = screen.getByTestId('submit-button');
@@ -198,7 +212,9 @@ describe('SessionTimeoutWarningModal', () => {
     );
 
     // Open the modal
-    ref.current?.show();
+    act(() => {
+      ref.current?.show();
+    });
 
     // Click Log Out Now button
     const cancelButton = screen.getByTestId('cancel-button');
@@ -220,7 +236,9 @@ describe('SessionTimeoutWarningModal', () => {
     );
 
     // Open the modal
-    ref.current?.show();
+    act(() => {
+      ref.current?.show();
+    });
 
     await waitFor(() => {
       const timer = screen.getByTestId('countdown-timer');

--- a/user-interface/src/lib/components/uswds/DatePicker.tsx
+++ b/user-interface/src/lib/components/uswds/DatePicker.tsx
@@ -9,9 +9,9 @@ import React, {
   useEffect,
   type JSX,
 } from 'react';
-import Validators from 'common/src/cams/validators';
-import { ValidatorFunction } from 'common/src/cams/validation';
-import DateHelper, { DEFAULT_MIN_DATE } from 'common/src/date-helper';
+import Validators from '@common/cams/validators';
+import { ValidatorFunction } from '@common/cams/validation';
+import DateHelper, { DEFAULT_MIN_DATE } from '@common/date-helper';
 import Icon from './Icon';
 
 export type DatePickerProps = JSX.IntrinsicElements['input'] & {

--- a/user-interface/src/lib/components/uswds/DateRangePicker.tsx
+++ b/user-interface/src/lib/components/uswds/DateRangePicker.tsx
@@ -3,8 +3,8 @@ import { DateRange, DateRangePickerRef, InputRef } from '@/lib/type-declarations
 import DatePicker, { DatePickerProps } from './DatePicker';
 import './DateRangePicker.scss';
 import useDebounce from '@/lib/hooks/UseDebounce';
-import { ValidatorFunction } from 'common/src/cams/validation';
-import Validators from 'common/src/cams/validators';
+import { ValidatorFunction } from '@common/cams/validation';
+import Validators from '@common/cams/validators';
 import { DEFAULT_MIN_DATE } from '@common/date-helper';
 
 export const formatDateForVoiceOver = (dateString: string) => {

--- a/user-interface/src/lib/components/uswds/modal/RemovalModal.test.tsx
+++ b/user-interface/src/lib/components/uswds/modal/RemovalModal.test.tsx
@@ -83,7 +83,9 @@ describe('RemovalModal', () => {
     const submitButton = screen.getByTestId(
       `button-${defaultProps.modalId}-submit-button`,
     ) as HTMLButtonElement;
-    submitButton.click();
+    await act(async () => {
+      submitButton.click();
+    });
 
     await waitFor(() => {
       expect(mockOnDelete).toHaveBeenCalledTimes(1);
@@ -115,7 +117,9 @@ describe('RemovalModal', () => {
     const submitButton = screen.getByTestId(
       `button-${defaultProps.modalId}-submit-button`,
     ) as HTMLButtonElement;
-    submitButton.click();
+    await act(async () => {
+      submitButton.click();
+    });
 
     await waitFor(() => {
       expect(submitButton.disabled).toBe(true);
@@ -136,7 +140,9 @@ describe('RemovalModal', () => {
     const submitButton = screen.getByTestId(
       `button-${defaultProps.modalId}-submit-button`,
     ) as HTMLButtonElement;
-    submitButton.click();
+    await act(async () => {
+      submitButton.click();
+    });
 
     await waitFor(() => {
       expect(failingOnDelete).toHaveBeenCalled();
@@ -163,7 +169,9 @@ describe('RemovalModal', () => {
     const submitButton = screen.getByTestId(
       `button-${defaultProps.modalId}-submit-button`,
     ) as HTMLButtonElement;
-    submitButton.click();
+    await act(async () => {
+      submitButton.click();
+    });
 
     await waitFor(() => {
       expect(secondOnDelete).toHaveBeenCalledTimes(1);

--- a/user-interface/src/trustees/modals/UseTrusteeAssignments.test.ts
+++ b/user-interface/src/trustees/modals/UseTrusteeAssignments.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { vi, describe, test, expect, beforeEach } from 'vitest';
 import { useTrusteeAssignments } from './UseTrusteeAssignments';
 import Api2 from '@/lib/models/api2';
@@ -51,7 +51,9 @@ describe('useTrusteeAssignments', () => {
 
     expect(result.current.isLoading).toBe(false);
 
-    result.current.getTrusteeOversightAssignments('trustee-123');
+    act(() => {
+      result.current.getTrusteeOversightAssignments('trustee-123');
+    });
 
     await waitFor(() => {
       expect(result.current.assignments).toEqual(mockAssignments);
@@ -68,7 +70,9 @@ describe('useTrusteeAssignments', () => {
 
     const { result } = renderHook(() => useTrusteeAssignments());
 
-    result.current.getTrusteeOversightAssignments('trustee-123');
+    act(() => {
+      result.current.getTrusteeOversightAssignments('trustee-123');
+    });
 
     await waitFor(() => {
       expect(result.current.error).toBe(errorMessage);
@@ -91,7 +95,9 @@ describe('useTrusteeAssignments', () => {
 
     const { result } = renderHook(() => useTrusteeAssignments());
 
-    result.current.assignAttorneyToTrustee('trustee-123', 'attorney-123');
+    act(() => {
+      result.current.assignAttorneyToTrustee('trustee-123', 'attorney-123');
+    });
 
     await waitFor(() => {
       expect(result.current.assignments).toEqual([newAssignment]);
@@ -110,8 +116,10 @@ describe('useTrusteeAssignments', () => {
 
     let caughtError: Error | null = null;
 
-    result.current.assignAttorneyToTrustee('trustee-123', 'attorney-123').catch((err: Error) => {
-      caughtError = err;
+    act(() => {
+      result.current.assignAttorneyToTrustee('trustee-123', 'attorney-123').catch((err: Error) => {
+        caughtError = err;
+      });
     });
 
     await waitFor(() => {
@@ -130,14 +138,18 @@ describe('useTrusteeAssignments', () => {
     const { result } = renderHook(() => useTrusteeAssignments());
 
     // First set error state through a failed API call
-    result.current.getTrusteeOversightAssignments('trustee-123');
+    act(() => {
+      result.current.getTrusteeOversightAssignments('trustee-123');
+    });
 
     await waitFor(() => {
       expect(result.current.error).toBe(errorMessage);
     });
 
     // Then test clearing the error
-    result.current.clearError();
+    act(() => {
+      result.current.clearError();
+    });
 
     await waitFor(() => {
       expect(result.current.error).toBeNull();
@@ -152,7 +164,9 @@ describe('useTrusteeAssignments', () => {
 
     const { result } = renderHook(() => useTrusteeAssignments());
 
-    result.current.getTrusteeOversightAssignments('trustee-123');
+    act(() => {
+      result.current.getTrusteeOversightAssignments('trustee-123');
+    });
 
     await waitFor(() => {
       expect(result.current.assignments).toEqual([]);
@@ -168,7 +182,9 @@ describe('useTrusteeAssignments', () => {
 
     const { result } = renderHook(() => useTrusteeAssignments());
 
-    result.current.getTrusteeOversightAssignments('trustee-123');
+    act(() => {
+      result.current.getTrusteeOversightAssignments('trustee-123');
+    });
 
     await waitFor(() => {
       expect(result.current.error).toBe('Failed to fetch assignments');
@@ -186,8 +202,12 @@ describe('useTrusteeAssignments', () => {
 
     let caughtError: unknown = null;
 
-    result.current.assignAttorneyToTrustee('trustee-123', 'attorney-123').catch((err: unknown) => {
-      caughtError = err;
+    act(() => {
+      result.current
+        .assignAttorneyToTrustee('trustee-123', 'attorney-123')
+        .catch((err: unknown) => {
+          caughtError = err;
+        });
     });
 
     await waitFor(() => {

--- a/user-interface/src/trustees/panels/AppointmentCard.test.tsx
+++ b/user-interface/src/trustees/panels/AppointmentCard.test.tsx
@@ -281,6 +281,10 @@ describe('AppointmentCard', () => {
   });
 
   test('renders UpcomingKeyDates card for panel Ch7 appointment with TrusteeAdmin role', async () => {
+    vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+      [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
+    });
+
     renderWithProps({
       appointment: { ...mockAppointment, chapter: '7', appointmentType: 'panel' },
     });
@@ -291,6 +295,10 @@ describe('AppointmentCard', () => {
   });
 
   test('renders PastKeyDates card for panel Ch7 appointment with TrusteeAdmin role', async () => {
+    vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+      [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
+    });
+
     renderWithProps({
       appointment: { ...mockAppointment, chapter: '7', appointmentType: 'panel' },
     });

--- a/user-interface/src/trustees/panels/AppointmentCard.test.tsx
+++ b/user-interface/src/trustees/panels/AppointmentCard.test.tsx
@@ -280,31 +280,31 @@ describe('AppointmentCard', () => {
     expect(editButton).not.toBeInTheDocument();
   });
 
-  test('renders UpcomingKeyDates card for panel Ch7 appointment with TrusteeAdmin role', async () => {
-    vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-      [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
+  describe('when DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES flag is enabled', () => {
+    beforeEach(() => {
+      vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
+        [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
+      });
     });
 
-    renderWithProps({
-      appointment: { ...mockAppointment, chapter: '7', appointmentType: 'panel' },
+    test('renders UpcomingKeyDates card for panel Ch7 appointment with TrusteeAdmin role', async () => {
+      renderWithProps({
+        appointment: { ...mockAppointment, chapter: '7', appointmentType: 'panel' },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('upcoming-key-dates-card')).toBeInTheDocument();
+      });
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('upcoming-key-dates-card')).toBeInTheDocument();
-    });
-  });
+    test('renders PastKeyDates card for panel Ch7 appointment with TrusteeAdmin role', async () => {
+      renderWithProps({
+        appointment: { ...mockAppointment, chapter: '7', appointmentType: 'panel' },
+      });
 
-  test('renders PastKeyDates card for panel Ch7 appointment with TrusteeAdmin role', async () => {
-    vi.spyOn(featureFlagsHook, 'default').mockReturnValue({
-      [DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES]: true,
-    });
-
-    renderWithProps({
-      appointment: { ...mockAppointment, chapter: '7', appointmentType: 'panel' },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId('past-key-dates-card')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId('past-key-dates-card')).toBeInTheDocument();
+      });
     });
   });
 

--- a/user-interface/src/trustees/panels/trustee-notes/TrusteeNotes.test.tsx
+++ b/user-interface/src/trustees/panels/trustee-notes/TrusteeNotes.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { vi, describe, test, expect, beforeEach } from 'vitest';
 import TrusteeNotes from './TrusteeNotes';
 import Api2 from '@/lib/models/api2';
@@ -154,7 +154,9 @@ describe('TrusteeNotes Adapter', () => {
       render(<TrusteeNotes trusteeId={trusteeId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onCreateNote(noteData);
+      await act(async () => {
+        await getNotesProps().onCreateNote(noteData);
+      });
 
       expect(postSpy).toHaveBeenCalledWith({
         trusteeId,
@@ -175,7 +177,9 @@ describe('TrusteeNotes Adapter', () => {
 
       expect(getTrusteeNotesSpy).toHaveBeenCalledTimes(1);
 
-      await getNotesProps().onCreateNote(noteData);
+      await act(async () => {
+        await getNotesProps().onCreateNote(noteData);
+      });
 
       expect(getTrusteeNotesSpy).toHaveBeenCalledTimes(2);
     });
@@ -187,7 +191,9 @@ describe('TrusteeNotes Adapter', () => {
       render(<TrusteeNotes trusteeId={trusteeId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onCreateNote(noteData);
+      await act(async () => {
+        await getNotesProps().onCreateNote(noteData);
+      });
 
       expect(postSpy).not.toHaveBeenCalled();
     });
@@ -220,7 +226,9 @@ describe('TrusteeNotes Adapter', () => {
       render(<TrusteeNotes trusteeId={trusteeId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onUpdateNote(noteId, noteData);
+      await act(async () => {
+        await getNotesProps().onUpdateNote(noteId, noteData);
+      });
 
       expect(putSpy).toHaveBeenCalledWith({
         id: noteId,
@@ -242,7 +250,9 @@ describe('TrusteeNotes Adapter', () => {
 
       expect(getTrusteeNotesSpy).toHaveBeenCalledTimes(1);
 
-      await getNotesProps().onUpdateNote(noteId, noteData);
+      await act(async () => {
+        await getNotesProps().onUpdateNote(noteId, noteData);
+      });
 
       expect(getTrusteeNotesSpy).toHaveBeenCalledTimes(2);
     });
@@ -254,7 +264,9 @@ describe('TrusteeNotes Adapter', () => {
       render(<TrusteeNotes trusteeId={trusteeId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onUpdateNote(noteId, noteData);
+      await act(async () => {
+        await getNotesProps().onUpdateNote(noteId, noteData);
+      });
 
       expect(putSpy).not.toHaveBeenCalled();
     });
@@ -282,7 +294,9 @@ describe('TrusteeNotes Adapter', () => {
       render(<TrusteeNotes trusteeId={trusteeId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onDeleteNote(noteId);
+      await act(async () => {
+        await getNotesProps().onDeleteNote(noteId);
+      });
 
       expect(deleteSpy).toHaveBeenCalledWith({
         id: noteId,
@@ -302,7 +316,9 @@ describe('TrusteeNotes Adapter', () => {
 
       expect(getTrusteeNotesSpy).toHaveBeenCalledTimes(1);
 
-      await getNotesProps().onDeleteNote(noteId);
+      await act(async () => {
+        await getNotesProps().onDeleteNote(noteId);
+      });
 
       expect(getTrusteeNotesSpy).toHaveBeenCalledTimes(2);
     });
@@ -314,7 +330,9 @@ describe('TrusteeNotes Adapter', () => {
       render(<TrusteeNotes trusteeId={trusteeId} />);
       await waitFor(() => expect(MockNotes).toHaveBeenCalled());
 
-      await getNotesProps().onDeleteNote(noteId);
+      await act(async () => {
+        await getNotesProps().onDeleteNote(noteId);
+      });
 
       expect(deleteSpy).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
# Bug

Several unit test files produced `not wrapped in act(...)` warnings in CI logs due to React state updates occurring outside the testing library's act() scope. Two AppointmentCard tests were failing silently because a feature flag was never mocked to true, preventing the components under test from rendering. The knip dependency checker also flagged unused exports, unlisted dependencies, and missing binary entries.

# Purpose

Eliminate noisy act() warnings from CI test output and fix two broken unit tests, so CI logs reflect only genuine failures and all tests pass cleanly.

# Major Changes

* Wrapped imperative modal ref calls (`.show()` / `.hide()`), `window.dispatchEvent()` calls, and async handler invocations in `act()` across 9 test files
* Fixed two AppointmentCard tests by mocking `DISPLAY_CHPT7_PANEL_UPCOMING_KEY_DATES` to `true` so `UpcomingKeyDates` and `PastKeyDates` components actually render
* Removed `export` from 4 locally-scoped types in `dxtr-acms.mock.ts` that were not used outside the file
* Switched bare `common/src/` imports in `DatePicker` and `DateRangePicker` to the `@common` alias used everywhere else in the codebase
* Added `stryker` binary and `@stryker-mutator/core` to knip ignore lists; scoped `vitest` ignore to the root workspace

# Testing/Validation

All 3084 tests pass (10 pre-existing failures on main confirmed unrelated). Knip, lint, and typecheck all pass clean after changes.

# Notes

The act() warnings fall into three patterns:
1. **Imperative ref calls** (`.show()` / `.hide()`) — wrapped in synchronous `act()`
2. **`window.dispatchEvent()`** — wrapped in synchronous `act()` since event handlers synchronously update React state
3. **Async handler calls that trigger re-fetch** — wrapped in `await act(async () => { await handler(...) })`

The AppointmentCard fix was non-obvious: the feature flag defaults to `false` when `FEATURE_FLAG_SDK_KEY` is empty (as in CI), so the child components are never mounted and `waitFor` times out looking for their test IDs.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Resolve React testing warnings and CI noise by updating tests, feature flag usage, and shared config.

Bug Fixes:
- Ensure AppointmentCard key date tests render gated components by enabling the relevant feature flag in test setup.

Enhancements:
- Align DatePicker and DateRangePicker imports to use the shared @common alias instead of direct common/src paths.
- Limit type visibility in dxtr-acms test utilities by making internal row types file-local instead of exported.

Build:
- Update knip configuration to ignore specific Stryker-related entries and scope vitest ignores at the workspace level to eliminate false-positive dependency warnings.

Tests:
- Wrap imperative modal calls, window events, and async handlers in React testing act() across multiple modal, hook, and notes adapter tests to prevent unscoped state update warnings.
- Adjust RemovalModal tests to perform submit interactions within act() to better reflect React update semantics.