### PR TITLE
CAMS-746 - Fix data verification crash from bloated trustee-match-verification response (1 of 3)

### DIFF
--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.test.ts
@@ -177,6 +177,34 @@ describe('TrusteeMatchVerificationMongoRepository', () => {
     });
   });
 
+  describe('search', () => {
+    test('should return documents sorted by createdOn ascending', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([sampleVerification]);
+
+      const result = await repository.search({ status: ['pending'] });
+
+      expect(result).toEqual([sampleVerification]);
+      expect(MongoCollectionAdapter.prototype.find).toHaveBeenCalledWith(
+        expect.objectContaining({ conjunction: 'AND' }),
+        expect.objectContaining({
+          fields: expect.arrayContaining([
+            expect.objectContaining({ field: { name: 'createdOn' }, direction: 'ASCENDING' }),
+          ]),
+        }),
+      );
+    });
+
+    test('should wrap errors', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockRejectedValue(
+        new Error('Database failure'),
+      );
+
+      await expect(repository.search({ status: ['pending'] })).rejects.toThrow(
+        'Failed to find trustee match verification records.',
+      );
+    });
+  });
+
   describe('upsertVerification', () => {
     test('should call replaceOne with upsert = true', async () => {
       vi.spyOn(MongoCollectionAdapter.prototype, 'replaceOne').mockResolvedValue({

--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.test.ts
@@ -138,44 +138,6 @@ describe('TrusteeMatchVerificationMongoRepository', () => {
     });
   });
 
-  describe('search', () => {
-    test('should return all TRUSTEE_MATCH_VERIFICATION documents when no predicate', async () => {
-      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([sampleVerification]);
-
-      const result = await repository.search();
-
-      expect(result).toEqual([sampleVerification]);
-      expect(MongoCollectionAdapter.prototype.find).toHaveBeenCalledWith(
-        expect.objectContaining({ conjunction: 'AND' }),
-        expect.objectContaining({
-          fields: expect.arrayContaining([
-            expect.objectContaining({ field: { name: 'createdOn' }, direction: 'ASCENDING' }),
-          ]),
-        }),
-      );
-    });
-
-    test('should filter by status when predicate is provided', async () => {
-      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([sampleVerification]);
-
-      await repository.search({ status: ['pending'] });
-
-      const query = (MongoCollectionAdapter.prototype.find as ReturnType<typeof vi.spyOn>).mock
-        .calls[0][0];
-      expect(JSON.stringify(query)).toContain('pending');
-    });
-
-    test('should wrap errors', async () => {
-      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockRejectedValue(
-        new Error('Database error'),
-      );
-
-      await expect(repository.search()).rejects.toThrow(
-        'Failed to find trustee match verification records.',
-      );
-    });
-  });
-
   describe('update', () => {
     test('should merge partial updates, persist, and return the merged document', async () => {
       vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockResolvedValue(sampleVerification);

--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
@@ -17,7 +17,7 @@ import {
 const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-MONGO-REPOSITORY';
 const COLLECTION_NAME = 'trustee-match-verification';
 
-const { using, and, orderBy } = QueryBuilder;
+const { using, and } = QueryBuilder;
 
 export class TrusteeMatchVerificationMongoRepository
   extends BaseMongoRepository
@@ -82,25 +82,6 @@ export class TrusteeMatchVerificationMongoRepository
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         message: `Failed to upsert trustee match verification for case ${doc.caseId}.`,
-      });
-    }
-  }
-
-  async search(predicate?: { status?: OrderStatus[] }): Promise<TrusteeMatchVerification[]> {
-    try {
-      const doc = using<TrusteeMatchVerification>();
-      const conditions = [doc('documentType').equals(TRUSTEE_MATCH_VERIFICATION_DOCUMENT_TYPE)];
-      if (predicate?.status?.length) {
-        conditions.push(doc('status').contains(predicate.status));
-      }
-      const query = and(...conditions);
-      return await this.getAdapter<TrusteeMatchVerification>().find(
-        query,
-        orderBy(['createdOn', 'ASCENDING']),
-      );
-    } catch (originalError) {
-      throw getCamsErrorWithStack(originalError, MODULE_NAME, {
-        message: 'Failed to find trustee match verification records.',
       });
     }
   }

--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
@@ -1,13 +1,9 @@
 import { ApplicationContext } from '../../types/basic';
 import { getCamsErrorWithStack } from '../../../common-errors/error-utilities';
 import { NotFoundError } from '../../../common-errors/not-found-error';
-import {
-  CamsPaginationResponse,
-  TrusteeMatchVerificationRepository,
-} from '../../../use-cases/gateways.types';
+import { TrusteeMatchVerificationRepository } from '../../../use-cases/gateways.types';
 import { BaseMongoRepository } from './utils/base-mongo-repository';
 import QueryBuilder from '../../../query/query-builder';
-import QueryPipeline from '../../../query/query-pipeline';
 import { OrderStatus } from '@common/cams/orders';
 import {
   TRUSTEE_MATCH_VERIFICATION_DOCUMENT_TYPE,
@@ -86,25 +82,18 @@ export class TrusteeMatchVerificationMongoRepository
     }
   }
 
-  async searchPaginated(
-    predicate: { status?: OrderStatus[] },
-    limit: number,
-    offset: number,
-  ): Promise<CamsPaginationResponse<TrusteeMatchVerification>> {
-    const { match, sort, ascending, paginate, pipeline, source } = QueryPipeline;
+  async search(predicate: { status?: OrderStatus[] }): Promise<TrusteeMatchVerification[]> {
+    const { orderBy } = QueryBuilder;
     try {
       const doc = using<TrusteeMatchVerification>();
-      const [createdOnField] = source<TrusteeMatchVerification>().fields('createdOn');
       const conditions = [doc('documentType').equals(TRUSTEE_MATCH_VERIFICATION_DOCUMENT_TYPE)];
       if (predicate?.status?.length) {
         conditions.push(doc('status').contains(predicate.status));
       }
-      const spec = pipeline(
-        match(and(...conditions)),
-        sort(ascending(createdOnField)),
-        paginate(offset, limit),
+      return await this.getAdapter<TrusteeMatchVerification>().find(
+        and(...conditions),
+        orderBy<TrusteeMatchVerification>(['createdOn', 'ASCENDING']),
       );
-      return await this.getAdapter<TrusteeMatchVerification>().paginate(spec);
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         message: 'Failed to find trustee match verification records.',

--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
@@ -1,9 +1,13 @@
 import { ApplicationContext } from '../../types/basic';
 import { getCamsErrorWithStack } from '../../../common-errors/error-utilities';
 import { NotFoundError } from '../../../common-errors/not-found-error';
-import { TrusteeMatchVerificationRepository } from '../../../use-cases/gateways.types';
+import {
+  CamsPaginationResponse,
+  TrusteeMatchVerificationRepository,
+} from '../../../use-cases/gateways.types';
 import { BaseMongoRepository } from './utils/base-mongo-repository';
 import QueryBuilder from '../../../query/query-builder';
+import QueryPipeline from '../../../query/query-pipeline';
 import { OrderStatus } from '@common/cams/orders';
 import {
   TRUSTEE_MATCH_VERIFICATION_DOCUMENT_TYPE,
@@ -94,6 +98,32 @@ export class TrusteeMatchVerificationMongoRepository
         query,
         orderBy(['createdOn', 'ASCENDING']),
       );
+    } catch (originalError) {
+      throw getCamsErrorWithStack(originalError, MODULE_NAME, {
+        message: 'Failed to find trustee match verification records.',
+      });
+    }
+  }
+
+  async searchPaginated(
+    predicate: { status?: OrderStatus[] },
+    limit: number,
+    offset: number,
+  ): Promise<CamsPaginationResponse<TrusteeMatchVerification>> {
+    const { match, sort, ascending, paginate, pipeline, source } = QueryPipeline;
+    try {
+      const doc = using<TrusteeMatchVerification>();
+      const [createdOnField] = source<TrusteeMatchVerification>().fields('createdOn');
+      const conditions = [doc('documentType').equals(TRUSTEE_MATCH_VERIFICATION_DOCUMENT_TYPE)];
+      if (predicate?.status?.length) {
+        conditions.push(doc('status').contains(predicate.status));
+      }
+      const spec = pipeline(
+        match(and(...conditions)),
+        sort(ascending(createdOnField)),
+        paginate(offset, limit),
+      );
+      return await this.getAdapter<TrusteeMatchVerification>().paginate(spec);
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         message: 'Failed to find trustee match verification records.',

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
@@ -70,7 +70,9 @@ describe('TrusteeMatchVerificationController', () => {
   function mockVerificationRepo(orders: TrusteeMatchVerification[]) {
     vi.spyOn(factory, 'getTrusteeMatchVerificationRepository').mockReturnValue(
       Object.assign(new MockMongoRepository(), {
-        search: vi.fn().mockResolvedValue(orders),
+        searchPaginated: vi
+          .fn()
+          .mockResolvedValue({ data: orders, metadata: { total: orders.length } }),
       }),
     );
   }
@@ -173,7 +175,9 @@ describe('TrusteeMatchVerificationController', () => {
     test('should throw a CamsError when the repository throws', async () => {
       const error = new Error('Database failure');
       vi.spyOn(factory, 'getTrusteeMatchVerificationRepository').mockReturnValue(
-        Object.assign(new MockMongoRepository(), { search: vi.fn().mockRejectedValue(error) }),
+        Object.assign(new MockMongoRepository(), {
+          searchPaginated: vi.fn().mockRejectedValue(error),
+        }),
       );
 
       const controller = new TrusteeMatchVerificationController();

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
@@ -124,47 +124,24 @@ describe('TrusteeMatchVerificationController', () => {
     expect(response.statusCode).toBe(404);
   });
 
-  describe('GET', () => {
-    test('should return verification orders enriched with trustee contact and appointment data', async () => {
+  describe('GET list', () => {
+    test('should return verification orders without enriched appointments', async () => {
       mockVerificationRepo([sampleOrder]);
-      mockEnrichmentRepos();
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
 
       expect(response.body.data).toHaveLength(1);
       const candidate = response.body.data[0].matchCandidates[0];
-      expect(candidate.address).toEqual(mockTrustee.public.address);
-      expect(candidate.phone).toEqual(mockTrustee.public.phone);
-      expect(candidate.email).toEqual(mockTrustee.public.email);
-      expect(candidate.appointments).toEqual(mockAppointments);
-    });
-
-    test('should return original candidate when enrichment fails', async () => {
-      mockVerificationRepo([sampleOrder]);
-      vi.spyOn(factory, 'getTrusteesRepository').mockReturnValue(
-        Object.assign(new MockMongoRepository(), {
-          read: vi.fn().mockRejectedValue(new Error('Trustee not found')),
-        }),
-      );
-      vi.spyOn(factory, 'getTrusteeAppointmentsRepository').mockReturnValue(
-        Object.assign(new MockMongoRepository(), {
-          getTrusteeAppointments: vi.fn().mockResolvedValue([]),
-        }),
-      );
-
-      const controller = new TrusteeMatchVerificationController();
-      const response = await controller.handleRequest(context);
-
-      expect(response.body.data).toHaveLength(1);
-      const candidate = response.body.data[0].matchCandidates[0];
-      expect(candidate.address).toBeUndefined();
+      expect(candidate.trusteeId).toBe('trustee-001');
+      expect(candidate.trusteeName).toBe('John Doe');
       expect(candidate.appointments).toBeUndefined();
     });
 
     test('should return empty array when repository returns no documents', async () => {
       mockVerificationRepo([]);
-      mockEnrichmentRepos();
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
@@ -184,6 +161,29 @@ describe('TrusteeMatchVerificationController', () => {
       const expectedError = getCamsError(error, 'TRUSTEE-MATCH-VERIFICATION-CONTROLLER');
 
       await expect(controller.handleRequest(context)).rejects.toThrow(expectedError.message);
+    });
+  });
+
+  describe('GET by ID', () => {
+    test('should return a single enriched verification with appointments', async () => {
+      context.request.params = { id: 'case-001:john doe' };
+      vi.spyOn(factory, 'getTrusteeMatchVerificationRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          findById: vi.fn().mockResolvedValue(sampleOrder),
+        }),
+      );
+      mockEnrichmentRepos();
+
+      const controller = new TrusteeMatchVerificationController();
+      const response = await controller.handleRequest(context);
+
+      const data = response.body.data as TrusteeMatchVerification;
+      expect(data.id).toBe('case-001:john doe');
+      const candidate = data.matchCandidates[0];
+      expect(candidate.address).toEqual(mockTrustee.public.address);
+      expect(candidate.phone).toEqual(mockTrustee.public.phone);
+      expect(candidate.email).toEqual(mockTrustee.public.email);
+      expect(candidate.appointments).toEqual(mockAppointments);
     });
   });
 
@@ -295,7 +295,15 @@ describe('TrusteeMatchVerificationController', () => {
     await expect(controller.handleRequest(context)).rejects.toThrow('Unsupported method.');
   });
 
-  describe('GET - manual trustee name resolution', () => {
+  describe('GET by ID - manual trustee name resolution', () => {
+    function mockFindById(order: TrusteeMatchVerification) {
+      vi.spyOn(factory, 'getTrusteeMatchVerificationRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          findById: vi.fn().mockResolvedValue(order),
+        }),
+      );
+    }
+
     test('should resolve trustee name when manually selected trustee is not in candidates', async () => {
       const approvedOrder: TrusteeMatchVerification = {
         ...sampleOrder,
@@ -313,8 +321,8 @@ describe('TrusteeMatchVerificationController', () => {
         ],
       };
 
-      mockVerificationRepo([approvedOrder]);
-      mockEnrichmentRepos();
+      context.request.params = { id: approvedOrder.id };
+      mockFindById(approvedOrder);
 
       const manualTrustee = {
         trusteeId: 'manual-trustee-999',
@@ -340,13 +348,19 @@ describe('TrusteeMatchVerificationController', () => {
           }),
         }),
       );
+      vi.spyOn(factory, 'getTrusteeAppointmentsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          getTrusteeAppointments: vi.fn().mockResolvedValue(mockAppointments),
+        }),
+      );
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
+      const data = response.body.data as TrusteeMatchVerification;
 
-      expect(response.body.data).toHaveLength(1);
-      expect(response.body.data[0].resolvedTrusteeId).toBe('manual-trustee-999');
-      expect(response.body.data[0].resolvedTrusteeName).toBe('Manually Selected Trustee');
+      expect(data.resolvedTrusteeId).toBe('manual-trustee-999');
+      expect(data.resolvedTrusteeName).toBe('Manually Selected Trustee');
     });
 
     test('should fallback to trusteeId when manual trustee name resolution fails', async () => {
@@ -357,28 +371,27 @@ describe('TrusteeMatchVerificationController', () => {
         matchCandidates: [],
       };
 
-      mockVerificationRepo([approvedOrder]);
+      context.request.params = { id: approvedOrder.id };
+      mockFindById(approvedOrder);
 
       vi.spyOn(factory, 'getTrusteesRepository').mockReturnValue(
         Object.assign(new MockMongoRepository(), {
           read: vi.fn().mockRejectedValue(new Error('Trustee not found')),
         }),
       );
-
       vi.spyOn(factory, 'getTrusteeAppointmentsRepository').mockReturnValue(
         Object.assign(new MockMongoRepository(), {
           getTrusteeAppointments: vi.fn().mockResolvedValue([]),
         }),
       );
-
       vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
+      const data = response.body.data as TrusteeMatchVerification;
 
-      expect(response.body.data).toHaveLength(1);
-      expect(response.body.data[0].resolvedTrusteeId).toBe('manual-trustee-999');
-      expect(response.body.data[0].resolvedTrusteeName).toBeUndefined();
+      expect(data.resolvedTrusteeId).toBe('manual-trustee-999');
+      expect(data.resolvedTrusteeName).toBeUndefined();
     });
 
     test('should not attempt name resolution when resolvedTrusteeName is already provided', async () => {
@@ -390,24 +403,15 @@ describe('TrusteeMatchVerificationController', () => {
         matchCandidates: [],
       };
 
-      mockVerificationRepo([approvedOrder]);
+      context.request.params = { id: approvedOrder.id };
+      mockFindById(approvedOrder);
       mockEnrichmentRepos();
-
-      const readSpy = vi.spyOn(factory, 'getTrusteesRepository').mockReturnValue(
-        Object.assign(new MockMongoRepository(), {
-          read: vi.fn(),
-        }),
-      );
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
+      const data = response.body.data as TrusteeMatchVerification;
 
-      expect(response.body.data).toHaveLength(1);
-      expect(response.body.data[0].resolvedTrusteeName).toBe('Already Resolved Name');
-
-      // Should not call read for manual trustee
-      const repo = readSpy.mock.results[0].value;
-      expect(repo.read).not.toHaveBeenCalledWith('manual-trustee-999');
+      expect(data.resolvedTrusteeName).toBe('Already Resolved Name');
     });
 
     test('should not attempt name resolution when resolvedTrusteeId is in candidates', async () => {
@@ -427,19 +431,19 @@ describe('TrusteeMatchVerificationController', () => {
         ],
       };
 
-      mockVerificationRepo([approvedOrder]);
+      context.request.params = { id: approvedOrder.id };
+      mockFindById(approvedOrder);
       mockEnrichmentRepos();
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
+      const data = response.body.data as TrusteeMatchVerification;
 
-      expect(response.body.data).toHaveLength(1);
-      expect(response.body.data[0].resolvedTrusteeId).toBe('trustee-001');
-      // Should use candidate's trusteeName, not resolve separately
+      expect(data.resolvedTrusteeId).toBe('trustee-001');
     });
   });
 
-  describe('GET - court name enrichment', () => {
+  describe('GET list - court name enrichment', () => {
     test('should enrich verification order with court name from court lookup', async () => {
       const orderWithoutCourtName: TrusteeMatchVerification = {
         ...sampleOrder,
@@ -447,7 +451,7 @@ describe('TrusteeMatchVerificationController', () => {
       };
 
       mockVerificationRepo([orderWithoutCourtName]);
-      mockEnrichmentRepos();
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
@@ -465,7 +469,7 @@ describe('TrusteeMatchVerificationController', () => {
       };
 
       mockVerificationRepo([orderWithComplexCaseId]);
-      mockEnrichmentRepos();
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
@@ -483,7 +487,7 @@ describe('TrusteeMatchVerificationController', () => {
       };
 
       mockVerificationRepo([orderWithInvalidCaseId]);
-      mockEnrichmentRepos();
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
@@ -500,7 +504,7 @@ describe('TrusteeMatchVerificationController', () => {
       };
 
       mockVerificationRepo([orderWithUnknownCourt]);
-      mockEnrichmentRepos();
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
@@ -70,9 +70,7 @@ describe('TrusteeMatchVerificationController', () => {
   function mockVerificationRepo(orders: TrusteeMatchVerification[]) {
     vi.spyOn(factory, 'getTrusteeMatchVerificationRepository').mockReturnValue(
       Object.assign(new MockMongoRepository(), {
-        searchPaginated: vi
-          .fn()
-          .mockResolvedValue({ data: orders, metadata: { total: orders.length } }),
+        search: vi.fn().mockResolvedValue(orders),
       }),
     );
   }
@@ -153,7 +151,7 @@ describe('TrusteeMatchVerificationController', () => {
       const error = new Error('Database failure');
       vi.spyOn(factory, 'getTrusteeMatchVerificationRepository').mockReturnValue(
         Object.assign(new MockMongoRepository(), {
-          searchPaginated: vi.fn().mockRejectedValue(error),
+          search: vi.fn().mockRejectedValue(error),
         }),
       );
 

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
@@ -405,13 +405,23 @@ describe('TrusteeMatchVerificationController', () => {
 
       context.request.params = { id: approvedOrder.id };
       mockFindById(approvedOrder);
-      mockEnrichmentRepos();
+      const readSpy = vi.fn();
+      vi.spyOn(factory, 'getTrusteesRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), { read: readSpy }),
+      );
+      vi.spyOn(factory, 'getTrusteeAppointmentsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          getTrusteeAppointments: vi.fn().mockResolvedValue([]),
+        }),
+      );
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
 
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
       const data = response.body.data as TrusteeMatchVerification;
 
       expect(data.resolvedTrusteeName).toBe('Already Resolved Name');
+      expect(readSpy).not.toHaveBeenCalledWith('manual-trustee-999');
     });
 
     test('should not attempt name resolution when resolvedTrusteeId is in candidates', async () => {

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
@@ -8,7 +8,6 @@ import { TrusteeMatchVerification } from '@common/cams/trustee-match-verificatio
 import { TrusteeMatchVerificationUseCase } from '../../use-cases/trustee-match-verification/trustee-match-verification.use-case';
 import HttpStatusCodes from '@common/api/http-status-codes';
 import { CamsRole } from '@common/cams/roles';
-import { calculatePagination } from '../pagination';
 
 const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-CONTROLLER';
 
@@ -44,22 +43,14 @@ export class TrusteeMatchVerificationController {
     context: ApplicationContext,
   ): Promise<CamsHttpResponseInit<TrusteeMatchVerification[]>> {
     const useCase = new TrusteeMatchVerificationUseCase();
-    const result = await useCase.getVerifications(context, {
+    const data = await useCase.getVerifications(context, {
       statusParam: context.request.query.status as string | undefined,
-      limit: parseInt(context.request.query.limit as string) || undefined,
-      offset: parseInt(context.request.query.offset as string) || undefined,
     });
 
     return httpSuccess({
       body: {
         meta: { self: context.request.url },
-        pagination: calculatePagination(
-          result.data.length,
-          result.totalCount,
-          result.limit,
-          result.offset,
-        ),
-        data: result.data,
+        data,
       },
     });
   }

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
@@ -12,6 +12,9 @@ import { CamsRole } from '@common/cams/roles';
 import { CourtsUseCase } from '../../use-cases/courts/courts';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import { getCaseIdParts } from '@common/cams/cases';
+import { OrderStatus } from '@common/cams/orders';
+import { DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET } from '@common/api/search';
+import { calculatePagination } from '../pagination';
 
 const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-CONTROLLER';
 
@@ -40,15 +43,29 @@ export class TrusteeMatchVerificationController {
   private async getVerificationOrders(
     context: ApplicationContext,
   ): Promise<CamsHttpResponseInit<TrusteeMatchVerification[]>> {
+    const statusParam = context.request.query.status as string | undefined;
+    const status: OrderStatus[] = statusParam
+      ? (statusParam.split(',') as OrderStatus[])
+      : ['pending'];
+
+    const parsedLimit = parseInt(context.request.query.limit as string);
+    const limit =
+      Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : DEFAULT_SEARCH_LIMIT;
+
+    const parsedOffset = parseInt(context.request.query.offset as string);
+    const offset =
+      Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : DEFAULT_SEARCH_OFFSET;
+
     const repo = factory.getTrusteeMatchVerificationRepository(context);
-    const data = await repo.search();
+    const result = await repo.searchPaginated({ status }, limit, offset);
+    const totalCount = result.metadata?.total ?? 0;
 
     const trusteesRepo = factory.getTrusteesRepository(context);
     const appointmentsRepo = factory.getTrusteeAppointmentsRepository(context);
     const courts = await new CourtsUseCase().getCourts(context);
 
     const enriched = await Promise.all(
-      data.map((verification) =>
+      result.data.map((verification) =>
         this.enrichVerification(verification, trusteesRepo, appointmentsRepo, courts),
       ),
     );
@@ -56,6 +73,7 @@ export class TrusteeMatchVerificationController {
     return httpSuccess({
       body: {
         meta: { self: context.request.url },
+        pagination: calculatePagination(enriched.length, totalCount, limit, offset),
         data: enriched,
       },
     });

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
@@ -21,13 +21,19 @@ const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-CONTROLLER';
 export class TrusteeMatchVerificationController {
   async handleRequest(
     context: ApplicationContext,
-  ): Promise<CamsHttpResponseInit<TrusteeMatchVerification[] | undefined>> {
+  ): Promise<
+    CamsHttpResponseInit<TrusteeMatchVerification | TrusteeMatchVerification[] | undefined>
+  > {
     if (!context.featureFlags['trustee-verification-enabled']) {
       return { statusCode: 404 };
     }
 
     try {
       if (context.request.method === 'GET') {
+        const id = context.request.params['id'];
+        if (id) {
+          return await this.getVerificationById(context, id);
+        }
         return await this.getVerificationOrders(context);
       } else if (context.request.method === 'PATCH') {
         return await this.handlePatch(context);
@@ -60,97 +66,34 @@ export class TrusteeMatchVerificationController {
     const result = await repo.searchPaginated({ status }, limit, offset);
     const totalCount = result.metadata?.total ?? 0;
 
-    const trusteesRepo = factory.getTrusteesRepository(context);
-    const appointmentsRepo = factory.getTrusteeAppointmentsRepository(context);
     const courts = await new CourtsUseCase().getCourts(context);
-
-    const enriched = await Promise.all(
-      result.data.map((verification) =>
-        this.enrichVerification(verification, trusteesRepo, appointmentsRepo, courts),
-      ),
-    );
+    const data = result.data.map((verification) => {
+      const courtName = this.resolveCourtName(verification, courts) ?? verification.courtName;
+      return { ...verification, courtName };
+    });
 
     return httpSuccess({
       body: {
         meta: { self: context.request.url },
-        pagination: calculatePagination(enriched.length, totalCount, limit, offset),
-        data: enriched,
+        pagination: calculatePagination(data.length, totalCount, limit, offset),
+        data,
       },
     });
   }
 
-  private async enrichVerification(
-    verification: TrusteeMatchVerification,
-    trusteesRepo: ReturnType<typeof factory.getTrusteesRepository>,
-    appointmentsRepo: ReturnType<typeof factory.getTrusteeAppointmentsRepository>,
-    courts: CourtDivisionDetails[],
-  ): Promise<TrusteeMatchVerification> {
-    const enrichedCandidates = await Promise.all(
-      verification.matchCandidates.map(async (candidate) => {
-        try {
-          const [trustee, appointments] = await Promise.all([
-            trusteesRepo.read(candidate.trusteeId),
-            appointmentsRepo.getTrusteeAppointments(candidate.trusteeId),
-          ]);
-          const enrichedAppointments = appointments.map((appt) => {
-            const court = this.findCourt(courts, appt.divisionCode, appt.courtId);
-            return {
-              ...appt,
-              courtName: court?.courtName,
-              courtDivisionName: court?.courtDivisionName,
-            };
-          });
-          return {
-            ...candidate,
-            address: trustee.public.address,
-            phone: trustee.public.phone,
-            email: trustee.public.email,
-            appointments: enrichedAppointments,
-          };
-        } catch {
-          return candidate;
-        }
-      }),
-    );
+  private async getVerificationById(
+    context: ApplicationContext,
+    id: string,
+  ): Promise<CamsHttpResponseInit<TrusteeMatchVerification>> {
+    const useCase = new TrusteeMatchVerificationUseCase();
+    const enriched = await useCase.getEnrichedVerification(context, id);
 
-    const resolvedTrusteeName = await this.resolveManualTrusteeName(
-      verification,
-      trusteesRepo,
-      enrichedCandidates,
-    );
-
-    const courtName = this.resolveCourtName(verification, courts) ?? verification.courtName;
-
-    return {
-      ...verification,
-      matchCandidates: enrichedCandidates,
-      resolvedTrusteeName,
-      courtName,
-    };
-  }
-
-  private async resolveManualTrusteeName(
-    verification: TrusteeMatchVerification,
-    trusteesRepo: ReturnType<typeof factory.getTrusteesRepository>,
-    enrichedCandidates: Array<{ trusteeId: string }>,
-  ): Promise<string | undefined> {
-    // For approved records where the resolved trustee was manually selected (not a candidate),
-    // fetch their name so the UI can display it instead of the raw trustee ID.
-    let resolvedTrusteeName = verification.resolvedTrusteeName;
-    const isApprovedWithUnresolvedName =
-      verification.status === 'approved' && verification.resolvedTrusteeId && !resolvedTrusteeName;
-    const notAlreadyInCandidates = !enrichedCandidates.find(
-      (c) => c.trusteeId === verification.resolvedTrusteeId,
-    );
-    if (isApprovedWithUnresolvedName && notAlreadyInCandidates) {
-      try {
-        const resolved = await trusteesRepo.read(verification.resolvedTrusteeId);
-        resolvedTrusteeName = resolved.name;
-      } catch {
-        // name unavailable — UI falls back to trustee ID
-      }
-    }
-    return resolvedTrusteeName;
+    return httpSuccess({
+      body: {
+        meta: { self: context.request.url },
+        data: enriched,
+      },
+    });
   }
 
   private resolveCourtName(

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
@@ -4,16 +4,10 @@ import { getCamsError } from '../../common-errors/error-utilities';
 import { BadRequestError } from '../../common-errors/bad-request';
 import { UnauthorizedError } from '../../common-errors/unauthorized-error';
 import { finalizeDeferrable } from '../../deferrable/finalize-deferrable';
-import factory from '../../factory';
 import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
 import { TrusteeMatchVerificationUseCase } from '../../use-cases/trustee-match-verification/trustee-match-verification.use-case';
 import HttpStatusCodes from '@common/api/http-status-codes';
 import { CamsRole } from '@common/cams/roles';
-import { CourtsUseCase } from '../../use-cases/courts/courts';
-import { CourtDivisionDetails } from '@common/cams/courts';
-import { getCaseIdParts } from '@common/cams/cases';
-import { OrderStatus } from '@common/cams/orders';
-import { DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET } from '@common/api/search';
 import { calculatePagination } from '../pagination';
 
 const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-CONTROLLER';
@@ -49,34 +43,23 @@ export class TrusteeMatchVerificationController {
   private async getVerificationOrders(
     context: ApplicationContext,
   ): Promise<CamsHttpResponseInit<TrusteeMatchVerification[]>> {
-    const statusParam = context.request.query.status as string | undefined;
-    const status: OrderStatus[] = statusParam
-      ? (statusParam.split(',') as OrderStatus[])
-      : ['pending'];
-
-    const parsedLimit = parseInt(context.request.query.limit as string);
-    const limit =
-      Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : DEFAULT_SEARCH_LIMIT;
-
-    const parsedOffset = parseInt(context.request.query.offset as string);
-    const offset =
-      Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : DEFAULT_SEARCH_OFFSET;
-
-    const repo = factory.getTrusteeMatchVerificationRepository(context);
-    const result = await repo.searchPaginated({ status }, limit, offset);
-    const totalCount = result.metadata?.total ?? 0;
-
-    const courts = await new CourtsUseCase().getCourts(context);
-    const data = result.data.map((verification) => {
-      const courtName = this.resolveCourtName(verification, courts) ?? verification.courtName;
-      return { ...verification, courtName };
+    const useCase = new TrusteeMatchVerificationUseCase();
+    const result = await useCase.getVerifications(context, {
+      statusParam: context.request.query.status as string | undefined,
+      limit: parseInt(context.request.query.limit as string) || undefined,
+      offset: parseInt(context.request.query.offset as string) || undefined,
     });
 
     return httpSuccess({
       body: {
         meta: { self: context.request.url },
-        pagination: calculatePagination(data.length, totalCount, limit, offset),
-        data,
+        pagination: calculatePagination(
+          result.data.length,
+          result.totalCount,
+          result.limit,
+          result.offset,
+        ),
+        data: result.data,
       },
     });
   }
@@ -94,40 +77,6 @@ export class TrusteeMatchVerificationController {
         data: enriched,
       },
     });
-  }
-
-  private resolveCourtName(
-    verification: TrusteeMatchVerification,
-    courts: CourtDivisionDetails[],
-  ): string | undefined {
-    // Enrich court name so the UI can display it without needing the USTP courts list.
-    // Includes division name (e.g. "Southern District of New York - Manhattan").
-    try {
-      const { divisionCode } = getCaseIdParts(verification.caseId);
-      const court = this.findCourt(courts, divisionCode, verification.courtId);
-      if (!court) return undefined;
-      return court.courtDivisionName
-        ? `${court.courtName} - ${court.courtDivisionName}`
-        : court.courtName;
-    } catch {
-      const court = this.findCourt(courts, undefined, verification.courtId);
-      if (!court) return undefined;
-      return court.courtDivisionName
-        ? `${court.courtName} - ${court.courtDivisionName}`
-        : court.courtName;
-    }
-  }
-
-  private findCourt(
-    courts: CourtDivisionDetails[],
-    divisionCode?: string,
-    courtId?: string,
-  ): CourtDivisionDetails | undefined {
-    if (divisionCode) {
-      const byDivision = courts.find((c) => c.courtDivisionCode === divisionCode);
-      if (byDivision) return byDivision;
-    }
-    return courts.find((c) => c.courtId === courtId);
   }
 
   private async handlePatch(context: ApplicationContext): Promise<CamsHttpResponseInit<undefined>> {

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -225,6 +225,10 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
+  searchPaginated(..._ignore): Promise<CamsPaginationResponse<any>> {
+    throw new Error('Method not implemented.');
+  }
+
   searchCases(..._ignore): Promise<CamsPaginationResponse<SyncedCase>> {
     throw new Error('Method not implemented.');
   }

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -651,11 +651,7 @@ export interface TrusteeMatchVerificationRepository extends Releasable {
   getVerification(caseId: string): Promise<TrusteeMatchVerification | null>;
   findById(id: string): Promise<TrusteeMatchVerification>;
   upsertVerification(doc: TrusteeMatchVerification): Promise<void>;
-  searchPaginated(
-    predicate: { status?: OrderStatus[] },
-    limit: number,
-    offset: number,
-  ): Promise<CamsPaginationResponse<TrusteeMatchVerification>>;
+  search(predicate: { status?: OrderStatus[] }): Promise<TrusteeMatchVerification[]>;
   update(id: string, updates: Partial<TrusteeMatchVerification>): Promise<TrusteeMatchVerification>;
 }
 

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -651,7 +651,6 @@ export interface TrusteeMatchVerificationRepository extends Releasable {
   getVerification(caseId: string): Promise<TrusteeMatchVerification | null>;
   findById(id: string): Promise<TrusteeMatchVerification>;
   upsertVerification(doc: TrusteeMatchVerification): Promise<void>;
-  search(predicate?: { status?: OrderStatus[] }): Promise<TrusteeMatchVerification[]>;
   searchPaginated(
     predicate: { status?: OrderStatus[] },
     limit: number,

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -652,6 +652,11 @@ export interface TrusteeMatchVerificationRepository extends Releasable {
   findById(id: string): Promise<TrusteeMatchVerification>;
   upsertVerification(doc: TrusteeMatchVerification): Promise<void>;
   search(predicate?: { status?: OrderStatus[] }): Promise<TrusteeMatchVerification[]>;
+  searchPaginated(
+    predicate: { status?: OrderStatus[] },
+    limit: number,
+    offset: number,
+  ): Promise<CamsPaginationResponse<TrusteeMatchVerification>>;
   update(id: string, updates: Partial<TrusteeMatchVerification>): Promise<TrusteeMatchVerification>;
 }
 

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.test.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.test.ts
@@ -7,6 +7,7 @@ import { TrusteeMatchVerification } from '@common/cams/trustee-match-verificatio
 import { NotFoundError } from '../../common-errors/not-found-error';
 import factory from '../../factory';
 import { ObservabilityGateway } from '../../use-cases/gateways.types';
+import { CourtsUseCase } from '../courts/courts';
 
 describe('TrusteeMatchVerificationUseCase', () => {
   let context: ApplicationContext;
@@ -103,6 +104,41 @@ describe('TrusteeMatchVerificationUseCase', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('getVerifications', () => {
+    let mockSearch: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockSearch = vi.fn().mockResolvedValue([sampleVerification]);
+      vi.spyOn(factory, 'getTrusteeMatchVerificationRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          findById: mockFindById,
+          update: mockUpdate,
+          search: mockSearch,
+        }),
+      );
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue([]);
+    });
+
+    test('defaults to pending status when no statusParam provided', async () => {
+      await useCase.getVerifications(context, {});
+
+      expect(mockSearch).toHaveBeenCalledWith({ status: ['pending'] });
+    });
+
+    test('parses comma-separated statuses from statusParam', async () => {
+      await useCase.getVerifications(context, { statusParam: 'approved,rejected' });
+
+      expect(mockSearch).toHaveBeenCalledWith({ status: ['approved', 'rejected'] });
+    });
+
+    test('returns data from repository', async () => {
+      const result = await useCase.getVerifications(context, {});
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('verification-1');
+    });
   });
 
   describe('approveVerification', () => {

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
@@ -3,6 +3,7 @@ import { getCamsError } from '../../common-errors/error-utilities';
 import { NotFoundError } from '../../common-errors/not-found-error';
 import factory from '../../factory';
 import { getCamsUserReference } from '@common/cams/session';
+import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
 
 const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-USE-CASE';
 
@@ -166,6 +167,62 @@ export class TrusteeMatchVerificationUseCase {
         properties: { action: 'approve' },
         measurements: {},
       });
+      throw getCamsError(originalError, MODULE_NAME);
+    }
+  }
+
+  async getEnrichedVerification(
+    context: ApplicationContext,
+    id: string,
+  ): Promise<TrusteeMatchVerification> {
+    try {
+      const repo = factory.getTrusteeMatchVerificationRepository(context);
+      const trusteesRepo = factory.getTrusteesRepository(context);
+      const appointmentsRepo = factory.getTrusteeAppointmentsRepository(context);
+
+      const verification = await repo.findById(id);
+
+      const enrichedCandidates = await Promise.all(
+        verification.matchCandidates.map(async (candidate) => {
+          try {
+            const [trustee, appointments] = await Promise.all([
+              trusteesRepo.read(candidate.trusteeId),
+              appointmentsRepo.getTrusteeAppointments(candidate.trusteeId),
+            ]);
+            return {
+              ...candidate,
+              address: trustee.public.address,
+              phone: trustee.public.phone,
+              email: trustee.public.email,
+              appointments,
+            };
+          } catch {
+            return candidate;
+          }
+        }),
+      );
+
+      let resolvedTrusteeName = verification.resolvedTrusteeName;
+      if (
+        verification.status === 'approved' &&
+        verification.resolvedTrusteeId &&
+        !resolvedTrusteeName &&
+        !enrichedCandidates.find((c) => c.trusteeId === verification.resolvedTrusteeId)
+      ) {
+        try {
+          const resolved = await trusteesRepo.read(verification.resolvedTrusteeId);
+          resolvedTrusteeName = resolved.name;
+        } catch {
+          // name unavailable — UI falls back to trustee ID
+        }
+      }
+
+      return {
+        ...verification,
+        matchCandidates: enrichedCandidates,
+        resolvedTrusteeName,
+      };
+    } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);
     }
   }

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
@@ -5,8 +5,6 @@ import factory from '../../factory';
 import { getCamsUserReference } from '@common/cams/session';
 import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
 import { OrderStatus } from '@common/cams/orders';
-import { CamsPaginationResponse } from '../gateways.types';
-import { DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET } from '@common/api/search';
 import { CourtsUseCase } from '../courts/courts';
 import { getCaseIdParts } from '@common/cams/cases';
 import { CourtDivisionDetails } from '@common/cams/courts';
@@ -16,22 +14,13 @@ const VALID_STATUSES: OrderStatus[] = ['pending', 'approved', 'rejected'];
 
 export type VerificationListParams = {
   statusParam?: string;
-  limit?: number;
-  offset?: number;
-};
-
-export type VerificationListResult = {
-  data: TrusteeMatchVerification[];
-  totalCount: number;
-  limit: number;
-  offset: number;
 };
 
 export class TrusteeMatchVerificationUseCase {
   async getVerifications(
     context: ApplicationContext,
     params: VerificationListParams,
-  ): Promise<VerificationListResult> {
+  ): Promise<TrusteeMatchVerification[]> {
     try {
       const parsedStatuses = (params.statusParam ?? '')
         .split(',')
@@ -39,26 +28,14 @@ export class TrusteeMatchVerificationUseCase {
         .filter((s) => VALID_STATUSES.includes(s));
       const status: OrderStatus[] = parsedStatuses.length > 0 ? parsedStatuses : ['pending'];
 
-      const limit =
-        params.limit !== undefined && params.limit > 0 ? params.limit : DEFAULT_SEARCH_LIMIT;
-      const offset =
-        params.offset !== undefined && params.offset >= 0 ? params.offset : DEFAULT_SEARCH_OFFSET;
-
       const repo = factory.getTrusteeMatchVerificationRepository(context);
-      const result: CamsPaginationResponse<TrusteeMatchVerification> = await repo.searchPaginated(
-        { status },
-        limit,
-        offset,
-      );
-      const totalCount = result.metadata?.total ?? 0;
+      const results = await repo.search({ status });
 
       const courts = await new CourtsUseCase().getCourts(context);
-      const data = result.data.map((verification) => ({
+      return results.map((verification) => ({
         ...verification,
         courtName: this.resolveCourtName(verification, courts) ?? verification.courtName,
       }));
-
-      return { data, totalCount, limit, offset };
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);
     }

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
@@ -4,10 +4,88 @@ import { NotFoundError } from '../../common-errors/not-found-error';
 import factory from '../../factory';
 import { getCamsUserReference } from '@common/cams/session';
 import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import { OrderStatus } from '@common/cams/orders';
+import { CamsPaginationResponse } from '../gateways.types';
+import { DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET } from '@common/api/search';
+import { CourtsUseCase } from '../courts/courts';
+import { getCaseIdParts } from '@common/cams/cases';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
 const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-USE-CASE';
+const VALID_STATUSES: OrderStatus[] = ['pending', 'approved', 'rejected'];
+
+export type VerificationListParams = {
+  statusParam?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type VerificationListResult = {
+  data: TrusteeMatchVerification[];
+  totalCount: number;
+  limit: number;
+  offset: number;
+};
 
 export class TrusteeMatchVerificationUseCase {
+  async getVerifications(
+    context: ApplicationContext,
+    params: VerificationListParams,
+  ): Promise<VerificationListResult> {
+    try {
+      const parsedStatuses = (params.statusParam ?? '')
+        .split(',')
+        .map((s) => s.trim() as OrderStatus)
+        .filter((s) => VALID_STATUSES.includes(s));
+      const status: OrderStatus[] = parsedStatuses.length > 0 ? parsedStatuses : ['pending'];
+
+      const limit =
+        params.limit !== undefined && params.limit > 0 ? params.limit : DEFAULT_SEARCH_LIMIT;
+      const offset =
+        params.offset !== undefined && params.offset >= 0 ? params.offset : DEFAULT_SEARCH_OFFSET;
+
+      const repo = factory.getTrusteeMatchVerificationRepository(context);
+      const result: CamsPaginationResponse<TrusteeMatchVerification> = await repo.searchPaginated(
+        { status },
+        limit,
+        offset,
+      );
+      const totalCount = result.metadata?.total ?? 0;
+
+      const courts = await new CourtsUseCase().getCourts(context);
+      const data = result.data.map((verification) => ({
+        ...verification,
+        courtName: this.resolveCourtName(verification, courts) ?? verification.courtName,
+      }));
+
+      return { data, totalCount, limit, offset };
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME);
+    }
+  }
+
+  private resolveCourtName(
+    verification: TrusteeMatchVerification,
+    courts: CourtDivisionDetails[],
+  ): string | undefined {
+    try {
+      const { divisionCode } = getCaseIdParts(verification.caseId);
+      const court = courts.find(
+        (c) => c.courtDivisionCode === divisionCode || c.courtId === verification.courtId,
+      );
+      if (!court) return undefined;
+      return court.courtDivisionName
+        ? `${court.courtName} - ${court.courtDivisionName}`
+        : court.courtName;
+    } catch {
+      const court = courts.find((c) => c.courtId === verification.courtId);
+      if (!court) return undefined;
+      return court.courtDivisionName
+        ? `${court.courtName} - ${court.courtDivisionName}`
+        : court.courtName;
+    }
+  }
+
   async rejectVerification(
     context: ApplicationContext,
     id: string,

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -10,7 +10,6 @@ import { orderType, orderStatusType } from '@/lib/utils/labels';
 import { ConsolidationOrderAccordion } from './consolidation/ConsolidationOrderAccordion';
 import { ConsolidationOrder, Order, OrderStatus, TransferOrder } from '@common/cams/orders';
 import {
-  DataVerificationItem,
   DataVerificationItemType,
   isConsolidationOrder,
   isTransferOrder,
@@ -52,7 +51,6 @@ export default function DataVerificationScreen() {
   const statusFilter = statusSelections.map((s) => s.value as OrderStatus);
   const [regionsMap, setRegionsMap] = useState<Map<string, string>>(new Map());
   const [courts, setCourts] = useState<Array<CourtDivisionDetails>>([]);
-  const [orderList, setOrderList] = useState<Array<DataVerificationItem>>([]);
   const [isOrderListLoading, setIsOrderListLoading] = useState(true);
   const alertRef = useRef<AlertRefType>(null);
   const [reviewOrderAlert, setReviewOrderAlert] = useState<AlertDetails>({
@@ -73,11 +71,7 @@ export default function DataVerificationScreen() {
 
   function handleTransferOrderUpdate(alertDetails: AlertDetails, updatedOrder?: TransferOrder) {
     if (updatedOrder) {
-      setOrderList(
-        orderList.map((order) => {
-          return order.id === updatedOrder.id ? updatedOrder : order;
-        }),
-      );
+      setOrders((prev) => prev.map((o) => (o.id === updatedOrder.id ? updatedOrder : o)));
     }
 
     setReviewOrderAlert(alertDetails);
@@ -86,16 +80,12 @@ export default function DataVerificationScreen() {
 
   function handleConsolidationOrderUpdate(
     alertDetails: AlertDetails,
-    orders?: ConsolidationOrder[],
+    newOrders?: ConsolidationOrder[],
     deletedOrder?: ConsolidationOrder,
   ) {
-    // update the orders list
-    if (deletedOrder && orders) {
-      const newOrderList = orderList.filter((o) => o.id !== deletedOrder.id);
-      newOrderList.push(...orders);
-      setOrderList(newOrderList);
+    if (deletedOrder && newOrders) {
+      setOrders((prev) => [...prev.filter((o) => o.id !== deletedOrder.id), ...newOrders]);
     }
-    // display alert
     setReviewOrderAlert(alertDetails);
     alertRef.current?.show();
   }
@@ -104,9 +94,7 @@ export default function DataVerificationScreen() {
     alertDetails: AlertDetails,
     updatedOrder: TrusteeMatchVerification,
   ) {
-    setOrderList((prev) =>
-      prev.map((order) => (order.id === updatedOrder.id ? updatedOrder : order)),
-    );
+    setVerifications((prev) => prev.map((v) => (v.id === updatedOrder.id ? updatedOrder : v)));
     setReviewOrderAlert(alertDetails);
     alertRef.current?.show();
   }
@@ -138,6 +126,10 @@ export default function DataVerificationScreen() {
     featureFlags[TRUSTEE_VERIFICATION_ENABLED],
   ]);
 
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [verifications, setVerifications] = useState<TrusteeMatchVerification[]>([]);
+  const verificationStatusParam = statusFilter.length > 0 ? statusFilter.join(',') : undefined;
+
   useEffect(() => {
     if (!showDataVerification) return;
 
@@ -146,20 +138,12 @@ export default function DataVerificationScreen() {
 
     async function loadOrders() {
       try {
-        const [ordersResponse, verificationResponse] = await Promise.all([
-          Api2.getOrders(),
-          featureFlags[TRUSTEE_VERIFICATION_ENABLED]
-            ? Api2.getTrusteeMatchVerifications()
-            : Promise.resolve({ data: [] as TrusteeMatchVerification[] }),
-        ]);
+        const ordersResponse = await Api2.getOrders();
         if (cancelled) return;
-        setOrderList([
-          ...(ordersResponse as ResponseBody<Order[]>).data,
-          ...(verificationResponse as ResponseBody<TrusteeMatchVerification[]>).data,
-        ]);
+        setOrders((ordersResponse as ResponseBody<Order[]>).data);
       } catch {
         if (cancelled) return;
-        setOrderList([]);
+        setOrders([]);
       }
 
       if (cancelled) return;
@@ -189,11 +173,39 @@ export default function DataVerificationScreen() {
     return () => {
       cancelled = true;
     };
-    // featureFlags object and showDataVerification are intentionally omitted: we only want to
-    // re-fetch when the trustee-verification flag toggles. showDataVerification is always true
-    // for authenticated users by the time this effect runs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [featureFlags[TRUSTEE_VERIFICATION_ENABLED]]);
+  }, []);
+
+  useEffect(() => {
+    if (!showDataVerification || !featureFlags[TRUSTEE_VERIFICATION_ENABLED]) {
+      setVerifications([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadVerifications() {
+      try {
+        const response = await Api2.getTrusteeMatchVerifications({
+          status: verificationStatusParam,
+        });
+        if (cancelled) return;
+        setVerifications((response as ResponseBody<TrusteeMatchVerification[]>).data);
+      } catch {
+        if (cancelled) return;
+        setVerifications([]);
+      }
+    }
+
+    loadVerifications();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [featureFlags[TRUSTEE_VERIFICATION_ENABLED], verificationStatusParam]);
+
+  const orderList = [...orders, ...verifications];
 
   let visibleItemCount = 0;
   let pendingItemCount = 0;
@@ -226,10 +238,14 @@ export default function DataVerificationScreen() {
     })
     .map((order) => {
       const noFiltersSelected = typeFilter.length === 0 && statusFilter.length === 0;
+      const statusMismatch =
+        statusFilter.length > 0 &&
+        !isTrusteeMatchVerification(order) &&
+        !statusFilter.includes(order.status);
       const isHidden =
         noFiltersSelected ||
         (typeFilter.length > 0 && !typeFilter.includes(order.orderType)) ||
-        (statusFilter.length > 0 && !statusFilter.includes(order.status));
+        statusMismatch;
       if (!isHidden) {
         visibleItemCount++;
       }

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -28,13 +28,10 @@ import Api2 from '@/lib/models/api2';
 import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
 import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
 import { ResponseBody } from '@common/api/response';
-import { Pagination as PaginationModel } from '@common/api/pagination';
-import { DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET, SearchPredicate } from '@common/api/search';
 import { CamsRole } from '@common/cams/roles';
 import LocalStorage from '@/lib/utils/local-storage';
 import { sortByCourtLocation } from '@/lib/utils/court-utils';
 import { Stop } from '@/lib/components/Stop';
-import { Pagination } from '@/lib/components/uswds/Pagination';
 
 export default function DataVerificationScreen() {
   const featureFlags = useFeatureFlags();
@@ -131,13 +128,6 @@ export default function DataVerificationScreen() {
 
   const [orders, setOrders] = useState<Order[]>([]);
   const [verifications, setVerifications] = useState<TrusteeMatchVerification[]>([]);
-  const [verificationPagination, setVerificationPagination] = useState<
-    PaginationModel | undefined
-  >();
-  const [verificationPredicate, setVerificationPredicate] = useState<SearchPredicate>({
-    limit: DEFAULT_SEARCH_LIMIT,
-    offset: DEFAULT_SEARCH_OFFSET,
-  });
   const verificationStatusParam = statusFilter.length > 0 ? statusFilter.join(',') : undefined;
 
   useEffect(() => {
@@ -187,18 +177,8 @@ export default function DataVerificationScreen() {
   }, []);
 
   useEffect(() => {
-    setVerificationPredicate((prev) =>
-      prev.offset === DEFAULT_SEARCH_OFFSET
-        ? prev
-        : { limit: DEFAULT_SEARCH_LIMIT, offset: DEFAULT_SEARCH_OFFSET },
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [verificationStatusParam]);
-
-  useEffect(() => {
     if (!showDataVerification || !featureFlags[TRUSTEE_VERIFICATION_ENABLED]) {
       setVerifications([]);
-      setVerificationPagination(undefined);
       return;
     }
 
@@ -208,17 +188,13 @@ export default function DataVerificationScreen() {
       try {
         const response = await Api2.getTrusteeMatchVerifications({
           status: verificationStatusParam,
-          limit: verificationPredicate.limit,
-          offset: verificationPredicate.offset,
         });
         if (cancelled) return;
         const body = response as ResponseBody<TrusteeMatchVerification[]>;
         setVerifications(body.data);
-        setVerificationPagination(body.pagination);
       } catch {
         if (cancelled) return;
         setVerifications([]);
-        setVerificationPagination(undefined);
       }
     }
 
@@ -228,7 +204,7 @@ export default function DataVerificationScreen() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [featureFlags[TRUSTEE_VERIFICATION_ENABLED], verificationStatusParam, verificationPredicate]);
+  }, [featureFlags[TRUSTEE_VERIFICATION_ENABLED], verificationStatusParam]);
 
   const orderList = [...orders, ...verifications];
 
@@ -434,15 +410,6 @@ export default function DataVerificationScreen() {
                       </div>
                     </div>
                     <AccordionGroup>{...accordionItems}</AccordionGroup>
-                    {verificationPagination &&
-                      verificationPagination.totalPages &&
-                      verificationPagination.totalPages > 1 && (
-                        <Pagination<SearchPredicate>
-                          paginationValues={verificationPagination}
-                          searchPredicate={verificationPredicate}
-                          retrievePage={setVerificationPredicate}
-                        />
-                      )}
                   </>
                 )}
               </section>

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -28,10 +28,13 @@ import Api2 from '@/lib/models/api2';
 import DocumentTitle from '@/lib/components/cams/DocumentTitle/DocumentTitle';
 import { MainContent } from '@/lib/components/cams/MainContent/MainContent';
 import { ResponseBody } from '@common/api/response';
+import { Pagination as PaginationModel } from '@common/api/pagination';
+import { DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET, SearchPredicate } from '@common/api/search';
 import { CamsRole } from '@common/cams/roles';
 import LocalStorage from '@/lib/utils/local-storage';
 import { sortByCourtLocation } from '@/lib/utils/court-utils';
 import { Stop } from '@/lib/components/Stop';
+import { Pagination } from '@/lib/components/uswds/Pagination';
 
 export default function DataVerificationScreen() {
   const featureFlags = useFeatureFlags();
@@ -128,6 +131,13 @@ export default function DataVerificationScreen() {
 
   const [orders, setOrders] = useState<Order[]>([]);
   const [verifications, setVerifications] = useState<TrusteeMatchVerification[]>([]);
+  const [verificationPagination, setVerificationPagination] = useState<
+    PaginationModel | undefined
+  >();
+  const [verificationPredicate, setVerificationPredicate] = useState<SearchPredicate>({
+    limit: DEFAULT_SEARCH_LIMIT,
+    offset: DEFAULT_SEARCH_OFFSET,
+  });
   const verificationStatusParam = statusFilter.length > 0 ? statusFilter.join(',') : undefined;
 
   useEffect(() => {
@@ -177,8 +187,18 @@ export default function DataVerificationScreen() {
   }, []);
 
   useEffect(() => {
+    setVerificationPredicate((prev) =>
+      prev.offset === DEFAULT_SEARCH_OFFSET
+        ? prev
+        : { limit: DEFAULT_SEARCH_LIMIT, offset: DEFAULT_SEARCH_OFFSET },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [verificationStatusParam]);
+
+  useEffect(() => {
     if (!showDataVerification || !featureFlags[TRUSTEE_VERIFICATION_ENABLED]) {
       setVerifications([]);
+      setVerificationPagination(undefined);
       return;
     }
 
@@ -188,12 +208,17 @@ export default function DataVerificationScreen() {
       try {
         const response = await Api2.getTrusteeMatchVerifications({
           status: verificationStatusParam,
+          limit: verificationPredicate.limit,
+          offset: verificationPredicate.offset,
         });
         if (cancelled) return;
-        setVerifications((response as ResponseBody<TrusteeMatchVerification[]>).data);
+        const body = response as ResponseBody<TrusteeMatchVerification[]>;
+        setVerifications(body.data);
+        setVerificationPagination(body.pagination);
       } catch {
         if (cancelled) return;
         setVerifications([]);
+        setVerificationPagination(undefined);
       }
     }
 
@@ -203,7 +228,7 @@ export default function DataVerificationScreen() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [featureFlags[TRUSTEE_VERIFICATION_ENABLED], verificationStatusParam]);
+  }, [featureFlags[TRUSTEE_VERIFICATION_ENABLED], verificationStatusParam, verificationPredicate]);
 
   const orderList = [...orders, ...verifications];
 
@@ -409,6 +434,15 @@ export default function DataVerificationScreen() {
                       </div>
                     </div>
                     <AccordionGroup>{...accordionItems}</AccordionGroup>
+                    {verificationPagination &&
+                      verificationPagination.totalPages &&
+                      verificationPagination.totalPages > 1 && (
+                        <Pagination<SearchPredicate>
+                          paginationValues={verificationPagination}
+                          searchPredicate={verificationPredicate}
+                          retrievePage={setVerificationPredicate}
+                        />
+                      )}
                   </>
                 )}
               </section>

--- a/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.tsx
+++ b/user-interface/src/data-verification/consolidation/ConsolidationCasesTable.tsx
@@ -215,18 +215,20 @@ function ConsolidationCaseTable_(
                 >
                   {onSelect && <td></td>}
                   <td colSpan={5} className="measure-6">
-                    <div>
-                      <Button
-                        id={`assign-lead-${id}-${idx}`}
-                        uswdsStyle={setLeadCaseStyle(bCase.caseId)}
-                        className="mark-as-lead-button"
-                        role="switch"
-                        aria-checked={bCase.caseId === leadCaseId}
-                        onClick={() => handleLeadCaseButton(bCase)}
-                      >
-                        {setLeadCaseButtonLabels(bCase.caseId)}
-                      </Button>
-                    </div>
+                    {onMarkLead && (
+                      <div>
+                        <Button
+                          id={`assign-lead-${id}-${idx}`}
+                          uswdsStyle={setLeadCaseStyle(bCase.caseId)}
+                          className="mark-as-lead-button"
+                          role="switch"
+                          aria-checked={bCase.caseId === leadCaseId}
+                          onClick={() => handleLeadCaseButton(bCase)}
+                        >
+                          {setLeadCaseButtonLabels(bCase.caseId)}
+                        </Button>
+                      </div>
+                    )}
                     {!bCase.docketEntries && <>No docket entries</>}
                     {bCase.docketEntries &&
                       bCase.docketEntries.map((docketEntry, idx) => {

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -239,6 +239,28 @@ export interface TrusteeMatchVerificationAccordionProps {
   onOrderUpdate: (alertDetails: AlertDetails, order: TrusteeMatchVerification) => void;
 }
 
+function enrichWithCourtNames(
+  detail: TrusteeMatchVerification,
+  courts: CourtDivisionDetails[],
+): TrusteeMatchVerification {
+  return {
+    ...detail,
+    matchCandidates: detail.matchCandidates.map((candidate) => ({
+      ...candidate,
+      appointments: candidate.appointments?.map((appt) => {
+        const court = courts.find(
+          (c) => c.courtDivisionCode === appt.divisionCode || c.courtId === appt.courtId,
+        );
+        return {
+          ...appt,
+          courtName: appt.courtName ?? court?.courtName,
+          courtDivisionName: appt.courtDivisionName ?? court?.courtDivisionName,
+        };
+      }),
+    })),
+  };
+}
+
 export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificationAccordionProps) {
   const { order, hidden, statusType, orderType, fieldHeaders, courts = [], onOrderUpdate } = props;
   const [isProcessing, setIsProcessing] = useState(false);
@@ -256,22 +278,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
     try {
       const response = await Api2.getTrusteeMatchVerificationDetail(order.id);
       const detail = (response as ResponseBody<TrusteeMatchVerification>).data;
-      setEnrichedOrder({
-        ...detail,
-        matchCandidates: detail.matchCandidates.map((candidate) => ({
-          ...candidate,
-          appointments: candidate.appointments?.map((appt) => {
-            const court = courts.find(
-              (c) => c.courtDivisionCode === appt.divisionCode || c.courtId === appt.courtId,
-            );
-            return {
-              ...appt,
-              courtName: appt.courtName ?? court?.courtName,
-              courtDivisionName: appt.courtDivisionName ?? court?.courtDivisionName,
-            };
-          }),
-        })),
-      });
+      setEnrichedOrder(enrichWithCourtNames(detail, courts));
     } catch {
       setEnrichedOrder(null);
     } finally {
@@ -542,128 +549,133 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
                 </div>
               </div>
 
-              {isLoadingDetail && <LoadingSpinner caption="Loading candidate details..." />}
-              {!isLoadingDetail && viewMode === 'pending-with-candidate' && preselected && (
-                <div className="trustee-match-candidate-section" data-testid="candidate-info">
-                  {isMultipleMatch ? (
-                    <>
-                      <h3>CAMS Strongest Match</h3>
-                      <CandidateTable
-                        candidates={[candidatesToShow[0]]}
-                        onApprove={openConfirmation}
-                        isProcessing={isProcessing}
-                      />
-                      <h3>Other Potential Matches</h3>
-                      <p className="other-matches-subtext">
-                        Results are ordered from strongest to weakest match. If you don&apos;t find
-                        the trustee you&apos;re looking for{' '}
-                        <button
-                          type="button"
-                          onClick={openSearch}
-                          className="search-trustee-link search-trustee-inline-link"
-                        >
-                          search here.
-                        </button>
-                      </p>
-                      <p className="other-matches-count" data-testid="other-matches-count">
-                        {candidatesToShow.slice(1).length} matches
-                      </p>
-                      <CandidateTable
-                        candidates={candidatesToShow
-                          .slice(1)
-                          .slice(
-                            (otherMatchesPage - 1) * OTHER_MATCHES_PAGE_SIZE,
-                            otherMatchesPage * OTHER_MATCHES_PAGE_SIZE,
+              {isLoadingDetail ? (
+                <LoadingSpinner caption="Loading candidate details..." />
+              ) : (
+                <>
+                  {viewMode === 'pending-with-candidate' && preselected && (
+                    <div className="trustee-match-candidate-section" data-testid="candidate-info">
+                      {isMultipleMatch ? (
+                        <>
+                          <h3>CAMS Strongest Match</h3>
+                          <CandidateTable
+                            candidates={[candidatesToShow[0]]}
+                            onApprove={openConfirmation}
+                            isProcessing={isProcessing}
+                          />
+                          <h3>Other Potential Matches</h3>
+                          <p className="other-matches-subtext">
+                            Results are ordered from strongest to weakest match. If you don&apos;t
+                            find the trustee you&apos;re looking for{' '}
+                            <button
+                              type="button"
+                              onClick={openSearch}
+                              className="search-trustee-link search-trustee-inline-link"
+                            >
+                              search here.
+                            </button>
+                          </p>
+                          <p className="other-matches-count" data-testid="other-matches-count">
+                            {candidatesToShow.slice(1).length} matches
+                          </p>
+                          <CandidateTable
+                            candidates={candidatesToShow
+                              .slice(1)
+                              .slice(
+                                (otherMatchesPage - 1) * OTHER_MATCHES_PAGE_SIZE,
+                                otherMatchesPage * OTHER_MATCHES_PAGE_SIZE,
+                              )}
+                            onApprove={openConfirmation}
+                            isProcessing={isProcessing}
+                          />
+                          {candidatesToShow.slice(1).length > OTHER_MATCHES_PAGE_SIZE && (
+                            <OtherMatchesPagination
+                              currentPage={otherMatchesPage}
+                              totalPages={Math.ceil(
+                                candidatesToShow.slice(1).length / OTHER_MATCHES_PAGE_SIZE,
+                              )}
+                              onPageChange={setOtherMatchesPage}
+                            />
                           )}
-                        onApprove={openConfirmation}
-                        isProcessing={isProcessing}
-                      />
-                      {candidatesToShow.slice(1).length > OTHER_MATCHES_PAGE_SIZE && (
-                        <OtherMatchesPagination
-                          currentPage={otherMatchesPage}
-                          totalPages={Math.ceil(
-                            candidatesToShow.slice(1).length / OTHER_MATCHES_PAGE_SIZE,
-                          )}
-                          onPageChange={setOtherMatchesPage}
-                        />
+                        </>
+                      ) : (
+                        <>
+                          <h3>CAMS Strongest Match</h3>
+                          <CandidateTable
+                            candidates={candidatesToShow}
+                            onApprove={openConfirmation}
+                            isProcessing={isProcessing}
+                          />
+                          <TrusteeSearchLink
+                            linkMessage="There are no other suggested matches in CAMS."
+                            linkLabel="Search for a different trustee"
+                            onClick={openSearch}
+                          />
+                        </>
                       )}
-                    </>
-                  ) : (
+                    </div>
+                  )}
+                  {viewMode === 'readonly-with-candidate' && preselected && (
                     <>
-                      <h3>CAMS Strongest Match</h3>
-                      <CandidateTable
-                        candidates={candidatesToShow}
-                        onApprove={openConfirmation}
-                        isProcessing={isProcessing}
-                      />
-                      <TrusteeSearchLink
-                        linkMessage="There are no other suggested matches in CAMS."
-                        linkLabel="Search for a different trustee"
-                        onClick={openSearch}
-                      />
+                      {isMultipleMatch ? (
+                        <>
+                          <h3>CAMS Strongest Match</h3>
+                          <CandidateTable candidates={[candidatesToShow[0]]} />
+                          <h3>Other Potential Matches</h3>
+                          <p className="other-matches-subtext">
+                            Results are ordered from strongest to weakest match. If you don&apos;t
+                            find the trustee you&apos;re looking for{' '}
+                            <button
+                              type="button"
+                              onClick={openSearch}
+                              className="search-trustee-link search-trustee-inline-link"
+                            >
+                              search here.
+                            </button>
+                          </p>
+                          <p className="other-matches-count" data-testid="other-matches-count">
+                            {candidatesToShow.slice(1).length} matches
+                          </p>
+                          <CandidateTable
+                            candidates={candidatesToShow
+                              .slice(1)
+                              .slice(
+                                (otherMatchesPage - 1) * OTHER_MATCHES_PAGE_SIZE,
+                                otherMatchesPage * OTHER_MATCHES_PAGE_SIZE,
+                              )}
+                          />
+                          {candidatesToShow.slice(1).length > OTHER_MATCHES_PAGE_SIZE && (
+                            <OtherMatchesPagination
+                              currentPage={otherMatchesPage}
+                              totalPages={Math.ceil(
+                                candidatesToShow.slice(1).length / OTHER_MATCHES_PAGE_SIZE,
+                              )}
+                              onPageChange={setOtherMatchesPage}
+                            />
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          <h3>CAMS Strongest Match</h3>
+                          <CandidateTable candidates={candidatesToShow} />
+                          <TrusteeSearchLink
+                            linkMessage="There are no other suggested matches in CAMS."
+                            linkLabel="Search for a different trustee."
+                            onClick={openSearch}
+                          />
+                        </>
+                      )}
                     </>
                   )}
-                </div>
-              )}
-              {!isLoadingDetail && viewMode === 'readonly-with-candidate' && preselected && (
-                <>
-                  {isMultipleMatch ? (
-                    <>
-                      <h3>CAMS Strongest Match</h3>
-                      <CandidateTable candidates={[candidatesToShow[0]]} />
-                      <h3>Other Potential Matches</h3>
-                      <p className="other-matches-subtext">
-                        Results are ordered from strongest to weakest match. If you don&apos;t find
-                        the trustee you&apos;re looking for{' '}
-                        <button
-                          type="button"
-                          onClick={openSearch}
-                          className="search-trustee-link search-trustee-inline-link"
-                        >
-                          search here.
-                        </button>
-                      </p>
-                      <p className="other-matches-count" data-testid="other-matches-count">
-                        {candidatesToShow.slice(1).length} matches
-                      </p>
-                      <CandidateTable
-                        candidates={candidatesToShow
-                          .slice(1)
-                          .slice(
-                            (otherMatchesPage - 1) * OTHER_MATCHES_PAGE_SIZE,
-                            otherMatchesPage * OTHER_MATCHES_PAGE_SIZE,
-                          )}
-                      />
-                      {candidatesToShow.slice(1).length > OTHER_MATCHES_PAGE_SIZE && (
-                        <OtherMatchesPagination
-                          currentPage={otherMatchesPage}
-                          totalPages={Math.ceil(
-                            candidatesToShow.slice(1).length / OTHER_MATCHES_PAGE_SIZE,
-                          )}
-                          onPageChange={setOtherMatchesPage}
-                        />
-                      )}
-                    </>
-                  ) : (
-                    <>
-                      <h3>CAMS Strongest Match</h3>
-                      <CandidateTable candidates={candidatesToShow} />
-                      <TrusteeSearchLink
-                        linkMessage="There are no other suggested matches in CAMS."
-                        linkLabel="Search for a different trustee."
-                        onClick={openSearch}
-                      />
-                    </>
+                  {viewMode === 'no-candidates' && (
+                    <TrusteeSearchLink
+                      className="no-candidates-message"
+                      linkMessage="There are no suggested matches in CAMS."
+                      linkLabel="Search for a trustee"
+                      onClick={openSearch}
+                    />
                   )}
                 </>
-              )}
-              {!isLoadingDetail && viewMode === 'no-candidates' && (
-                <TrusteeSearchLink
-                  className="no-candidates-message"
-                  linkMessage="There are no suggested matches in CAMS."
-                  linkLabel="Search for a trustee"
-                  onClick={openSearch}
-                />
               )}
             </>
           )}

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -22,6 +22,8 @@ import TrusteeMatchConfirmationModal, {
 } from './TrusteeMatchConfirmationModal';
 import TrusteeSearchModal, { TrusteeSearchModalImperative } from './TrusteeSearchModal';
 import { TrusteeSearchResult } from '@common/cams/trustee-search';
+import { ResponseBody } from '@common/api/response';
+import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 
 type TrusteeSearchLinkProps = {
   linkLabel: string;
@@ -241,10 +243,41 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
   const { order, hidden, statusType, orderType, fieldHeaders, courts = [], onOrderUpdate } = props;
   const [isProcessing, setIsProcessing] = useState(false);
   const [otherMatchesPage, setOtherMatchesPage] = useState(1);
+  const [enrichedOrder, setEnrichedOrder] = useState<TrusteeMatchVerification | null>(null);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
   const OTHER_MATCHES_PAGE_SIZE = 5;
   const rejectionModalRef = useRef<TrusteeMatchRejectionModalImperative>(null);
   const confirmationModalRef = useRef<TrusteeMatchConfirmationModalImperative>(null);
   const searchModalRef = useRef<TrusteeSearchModalImperative>(null);
+
+  async function handleExpand(_id: string) {
+    if (enrichedOrder) return;
+    setIsLoadingDetail(true);
+    try {
+      const response = await Api2.getTrusteeMatchVerificationDetail(order.id);
+      const detail = (response as ResponseBody<TrusteeMatchVerification>).data;
+      setEnrichedOrder({
+        ...detail,
+        matchCandidates: detail.matchCandidates.map((candidate) => ({
+          ...candidate,
+          appointments: candidate.appointments?.map((appt) => {
+            const court = courts.find(
+              (c) => c.courtDivisionCode === appt.divisionCode || c.courtId === appt.courtId,
+            );
+            return {
+              ...appt,
+              courtName: appt.courtName ?? court?.courtName,
+              courtDivisionName: appt.courtDivisionName ?? court?.courtDivisionName,
+            };
+          }),
+        })),
+      });
+    } catch {
+      setEnrichedOrder(null);
+    } finally {
+      setIsLoadingDetail(false);
+    }
+  }
 
   const { divisionCode } = getCaseIdParts(order.caseId);
   const courtDetails = courts.find((c) => c.courtDivisionCode === divisionCode);
@@ -268,12 +301,18 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
     legacy?.cityStateZipCountry,
   ].filter(Boolean) as string[];
 
+  const activeOrder = enrichedOrder ?? order;
+
   // For multiple match scenarios, show all candidates ranked by score
   // For other scenarios, show only the strongest match
   const candidatesToShow = isMultipleMatch
-    ? [...order.matchCandidates].sort((a, b) => b.totalScore - a.totalScore)
-    : order.matchCandidates.length > 0
-      ? [order.matchCandidates.reduce((best, c) => (c.totalScore > best.totalScore ? c : best))]
+    ? [...activeOrder.matchCandidates].sort((a, b) => b.totalScore - a.totalScore)
+    : activeOrder.matchCandidates.length > 0
+      ? [
+          activeOrder.matchCandidates.reduce((best, c) =>
+            c.totalScore > best.totalScore ? c : best,
+          ),
+        ]
       : [];
 
   const preselected = candidatesToShow.length > 0 ? candidatesToShow[0] : undefined;
@@ -392,7 +431,12 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
 
   return (
     <>
-      <Accordion key={order.id} id={`order-list-${order.id}`} hidden={hidden}>
+      <Accordion
+        key={order.id}
+        id={`order-list-${order.id}`}
+        hidden={hidden}
+        onExpand={handleExpand}
+      >
         <section
           className="accordion-heading grid-row grid-gap-lg"
           data-testid={`accordion-heading-${order.id}`}
@@ -439,12 +483,13 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
           className="accordion-content trustee-match-content"
           data-testid={`accordion-content-${order.id}`}
         >
-          {viewMode === 'resolved' ? (
+          {viewMode === 'resolved' && (
             <p className="resolved-statement" data-testid="resolved-statement">
               <span>Trustee {getResolvedTrusteeDisplayName()} was appointed to case: </span>
               {caseLink}
             </p>
-          ) : (
+          )}
+          {viewMode !== 'resolved' && (
             <>
               {isInactiveStatus ? (
                 <p className="problem-statement">
@@ -497,7 +542,8 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
                 </div>
               </div>
 
-              {viewMode === 'pending-with-candidate' && preselected && (
+              {isLoadingDetail && <LoadingSpinner caption="Loading candidate details..." />}
+              {!isLoadingDetail && viewMode === 'pending-with-candidate' && preselected && (
                 <div className="trustee-match-candidate-section" data-testid="candidate-info">
                   {isMultipleMatch ? (
                     <>
@@ -559,7 +605,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
                   )}
                 </div>
               )}
-              {viewMode === 'readonly-with-candidate' && preselected && (
+              {!isLoadingDetail && viewMode === 'readonly-with-candidate' && preselected && (
                 <>
                   {isMultipleMatch ? (
                     <>
@@ -611,7 +657,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
                   )}
                 </>
               )}
-              {viewMode === 'no-candidates' && (
+              {!isLoadingDetail && viewMode === 'no-candidates' && (
                 <TrusteeSearchLink
                   className="no-candidates-message"
                   linkMessage="There are no suggested matches in CAMS."

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -267,20 +267,21 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
   const [otherMatchesPage, setOtherMatchesPage] = useState(1);
   const [enrichedOrder, setEnrichedOrder] = useState<TrusteeMatchVerification | null>(null);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+  const [detailLoadError, setDetailLoadError] = useState(false);
   const OTHER_MATCHES_PAGE_SIZE = 5;
   const rejectionModalRef = useRef<TrusteeMatchRejectionModalImperative>(null);
   const confirmationModalRef = useRef<TrusteeMatchConfirmationModalImperative>(null);
   const searchModalRef = useRef<TrusteeSearchModalImperative>(null);
 
   async function handleExpand(_id: string) {
-    if (enrichedOrder) return;
+    if (enrichedOrder || detailLoadError) return;
     setIsLoadingDetail(true);
     try {
       const response = await Api2.getTrusteeMatchVerificationDetail(order.id);
       const detail = (response as ResponseBody<TrusteeMatchVerification>).data;
       setEnrichedOrder(enrichWithCourtNames(detail, courts));
     } catch {
-      setEnrichedOrder(null);
+      setDetailLoadError(true);
     } finally {
       setIsLoadingDetail(false);
     }
@@ -551,6 +552,10 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
 
               {isLoadingDetail ? (
                 <LoadingSpinner caption="Loading candidate details..." />
+              ) : detailLoadError ? (
+                <p className="text-error">
+                  Failed to load candidate details. Please try again later.
+                </p>
               ) : (
                 <>
                   {viewMode === 'pending-with-candidate' && preselected && (

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -461,6 +461,10 @@ async function getTrusteeMatchVerifications(params?: {
   return api().get<TrusteeMatchVerification[]>(`/trustee-match-verification`, query);
 }
 
+async function getTrusteeMatchVerificationDetail(id: string) {
+  return api().get<TrusteeMatchVerification>(`/trustee-match-verification/${id}`, {});
+}
+
 async function patchTrusteeVerificationOrderApproval(
   id: string,
   resolvedTrusteeId: string,
@@ -727,6 +731,7 @@ export const _Api2 = {
   getOrders,
   searchTrustees,
   getTrusteeMatchVerifications,
+  getTrusteeMatchVerificationDetail,
   patchTrusteeVerificationOrderApproval,
   patchTrusteeVerificationOrderRejection,
   getOrderSuggestions,

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -449,15 +449,9 @@ async function searchTrustees(name: string, courtId?: string) {
   return api().get<TrusteeSearchResult[]>(`/trustee-search`, params);
 }
 
-async function getTrusteeMatchVerifications(params?: {
-  status?: string;
-  limit?: number;
-  offset?: number;
-}) {
+async function getTrusteeMatchVerifications(params?: { status?: string }) {
   const query: Record<string, string> = {};
   if (params?.status) query.status = params.status;
-  if (params?.limit !== undefined) query.limit = String(params.limit);
-  if (params?.offset !== undefined) query.offset = String(params.offset);
   return api().get<TrusteeMatchVerification[]>(`/trustee-match-verification`, query);
 }
 

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -449,8 +449,16 @@ async function searchTrustees(name: string, courtId?: string) {
   return api().get<TrusteeSearchResult[]>(`/trustee-search`, params);
 }
 
-async function getTrusteeMatchVerifications() {
-  return api().get<TrusteeMatchVerification[]>(`/trustee-match-verification`, {});
+async function getTrusteeMatchVerifications(params?: {
+  status?: string;
+  limit?: number;
+  offset?: number;
+}) {
+  const query: Record<string, string> = {};
+  if (params?.status) query.status = params.status;
+  if (params?.limit !== undefined) query.limit = String(params.limit);
+  if (params?.offset !== undefined) query.offset = String(params.offset);
+  return api().get<TrusteeMatchVerification[]>(`/trustee-match-verification`, query);
 }
 
 async function patchTrusteeVerificationOrderApproval(

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -2472,6 +2472,12 @@ async function getTrusteeMatchVerifications(): Promise<ResponseBody<TrusteeMatch
   return get<TrusteeMatchVerification[]>(`/trustee-match-verification`);
 }
 
+async function getTrusteeMatchVerificationDetail(
+  id: string,
+): Promise<ResponseBody<TrusteeMatchVerification>> {
+  return get<TrusteeMatchVerification>(`/trustee-match-verification/${id}`);
+}
+
 async function patchTrusteeVerificationOrderApproval(
   _id: string,
   _resolvedTrusteeId: string,
@@ -3178,6 +3184,7 @@ const MockApi2 = {
   getOrders,
   searchTrustees,
   getTrusteeMatchVerifications,
+  getTrusteeMatchVerificationDetail,
   patchTrusteeVerificationOrderApproval,
   patchTrusteeVerificationOrderRejection,
   getOrderSuggestions,

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -2468,7 +2468,11 @@ async function searchTrustees(
   return { data: [] };
 }
 
-async function getTrusteeMatchVerifications(): Promise<ResponseBody<TrusteeMatchVerification[]>> {
+async function getTrusteeMatchVerifications(_params?: {
+  status?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<ResponseBody<TrusteeMatchVerification[]>> {
   return get<TrusteeMatchVerification[]>(`/trustee-match-verification`);
 }
 

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -374,7 +374,7 @@ describe('TrusteesList Component', () => {
       renderWithRouter(<TrusteesList />);
 
       await waitFor(() => {
-        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+        expect(screen.getAllByRole('link')).toHaveLength(3);
       });
 
       await user.click(screen.getByRole('columnheader', { name: /name/i }));

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -397,7 +397,7 @@ describe('TrusteesList Component', () => {
       renderWithRouter(<TrusteesList />);
 
       await waitFor(() => {
-        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+        expect(screen.getAllByRole('link')).toHaveLength(2);
       });
 
       const nameHeader = screen.getByRole('columnheader', { name: /name/i });


### PR DESCRIPTION
## Summary
- Add server-side pagination and status filter to the `trustee-match-verification` GET endpoint so the list response no longer returns all records at once
- Remove expensive per-record enrichment (trustee contact info, appointments, DXTR courts lookup) from the list endpoint — the response now returns only the lightweight stored documents with court names
- Add a GET-by-ID endpoint that returns a single fully-enriched record on demand, with enrichment logic moved to the use case layer
- Update the accordion UI to show the problem statement and DXTR trustee info immediately on expand, and lazy-load candidate/appointment details from the detail endpoint

## Test plan
- [ ] Verify the data verification screen loads without crashing in staging
- [ ] Confirm accordion headers display court name, date, task type, and status correctly from the list response
- [ ] Expand an accordion and verify the problem statement + DXTR trustee info appear immediately
- [ ] Confirm candidate details (address, phone, email, appointments) load after a brief spinner
- [ ] Verify appointment court names display correctly (mapped client-side from the courts prop)
- [ ] Test approve and reject actions still work after expanding
- [ ] Confirm status filter changes trigger a re-fetch of the list
- [ ] Verify pagination works when there are more than 25 records

## Summary by Sourcery

Introduce paginated, filterable trustee match verification listing with lightweight records and a separate enriched detail endpoint, and update the UI to lazy-load detailed trustee verification data on accordion expand.

New Features:
- Add a GET-by-ID trustee match verification endpoint and use case to return a single fully enriched verification record.
- Add pagination and status filtering support to the trustee match verification repository and API client, including a detail fetch method from the UI.

Bug Fixes:
- Prevent data verification screen crashes by avoiding loading and enriching all trustee match verification records at once.

Enhancements:
- Change the trustee match verification list endpoint to return lightweight records enriched only with court names and pagination metadata.
- Refine the data verification screen to manage orders and trustee verifications separately and merge them for display while respecting status filters.
- Update the trustee verification accordion to fetch detail on demand, show a loading spinner for candidate details, and map appointment court names client-side.

Tests:
- Adjust controller tests for trustee match verification to cover the new paginated list behavior, GET-by-ID flow, and manual trustee name resolution using the detail endpoint.