### PR TITLE
CAMS-763 Fix ComboBox client-side filtering with fuzzy search

### DIFF
--- a/user-interface/src/data-verification/trustee-verification/TrusteeSearchModal.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeSearchModal.tsx
@@ -186,6 +186,7 @@ function TrusteeSearchModal_(
             onUpdateSelection={handleSelection}
             autoComplete="off"
             placeholder="- Search Trustee name -"
+            disableFiltering={true}
           />
           {selectedTrustee && (
             <div className="trustee-details">

--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -974,6 +974,57 @@ describe('ComboBox', () => {
       await userEvent.type(inputField, 'test');
       expect(updateFilterMock).toHaveBeenCalledWith('test');
     });
+
+    test('should show all options when disableFiltering is true, even when filter text does not match', async () => {
+      const options = [
+        { label: 'Jonathan Smith', value: 'j1' },
+        { label: 'Jane Doe', value: 'j2' },
+        { label: 'Robert Jones', value: 'r1' },
+      ];
+      renderWithProps({ options, disableFiltering: true });
+      await toggleDropdown();
+
+      const inputField = await getFocusedComboInputField(comboboxId);
+      await userEvent.type(inputField, 'jonathon');
+
+      const listItems = document.querySelectorAll('li[role="option"]');
+      expect(listItems).toHaveLength(3);
+    });
+
+    test('should still filter options when disableFiltering is false', async () => {
+      const options = [
+        { label: 'Jonathan Smith', value: 'j1' },
+        { label: 'Jane Doe', value: 'j2' },
+        { label: 'Robert Jones', value: 'r1' },
+      ];
+      renderWithProps({ options, disableFiltering: false });
+      await toggleDropdown();
+
+      const inputField = await getFocusedComboInputField(comboboxId);
+      await userEvent.type(inputField, 'Jonathan');
+
+      const listItems = document.querySelectorAll('li[role="option"]');
+      expect(listItems).toHaveLength(1);
+      expect(listItems[0]).toHaveTextContent('Jonathan Smith');
+    });
+
+    test('Tab should move focus to first item when disableFiltering is true and filter text is entered', async () => {
+      const options = [
+        { label: 'Jonathan Smith', value: 'j1' },
+        { label: 'Jane Doe', value: 'j2' },
+      ];
+      renderWithProps({ options, disableFiltering: true });
+      await toggleDropdown();
+
+      const inputField = await getFocusedComboInputField(comboboxId);
+      await userEvent.type(inputField, 'jonathon');
+      await userEvent.keyboard('{Tab}');
+
+      const firstListItem = document.querySelector('li[role="option"]');
+      await waitFor(() => {
+        expect(firstListItem).toHaveFocus();
+      });
+    });
   });
 
   describe('Clear Button', () => {

--- a/user-interface/src/lib/components/combobox/ComboBox.test.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.test.tsx
@@ -117,6 +117,7 @@ describe('ComboBox', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    updateFilterMock.mockClear();
   });
 
   describe('Toggle & Dropdown Behavior', () => {
@@ -504,60 +505,35 @@ describe('ComboBox', () => {
       });
     });
 
-    test('should handle ArrowUp key on toggle button', async () => {
-      const preventDefault = vi.fn();
-      const stopPropagation = vi.fn();
-
+    test('pressing ArrowUp on the input while the dropdown is closed should close the dropdown', async () => {
       renderWithProps({});
 
-      const toggleButton = screen.getByRole('combobox');
-      expect(toggleButton).toBeInTheDocument();
+      const input = document.querySelector(`#${comboboxId}-combo-box-input`) as HTMLInputElement;
+      input.focus();
 
-      toggleButton.focus();
-      expect(toggleButton).toHaveFocus();
-
-      const arrowUpEvent = new KeyboardEvent('keydown', {
-        key: 'ArrowUp',
-        bubbles: true,
-        cancelable: true,
+      await userEvent.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(isDropdownOpen()).toBeTruthy();
       });
 
-      arrowUpEvent.preventDefault = preventDefault;
-      arrowUpEvent.stopPropagation = stopPropagation;
-
-      toggleButton.dispatchEvent(arrowUpEvent);
-
-      expect(preventDefault).toHaveBeenCalled();
-      expect(stopPropagation).toHaveBeenCalled();
-
-      expect(isDropdownClosed()).toBeTruthy();
+      await userEvent.keyboard('{ArrowUp}');
+      await waitFor(() => {
+        expect(isDropdownClosed()).toBeTruthy();
+      });
     });
 
-    test('should handle key events on disabled toggle button (early return path)', async () => {
-      const preventDefault = vi.fn();
-      const stopPropagation = vi.fn();
+    test('pressing a key on the toggle button while disabled should not open the dropdown', async () => {
+      const updateFilterMock = vi.fn();
+      renderWithProps({ disabled: true, onUpdateFilter: updateFilterMock });
 
-      renderWithProps({ disabled: true });
-
-      const toggleButton = screen.getByRole('combobox');
+      const toggleButton = document.querySelector(`#${comboboxId}-expand`) as HTMLButtonElement;
       expect(toggleButton).toBeInTheDocument();
-
       toggleButton.focus();
-      expect(toggleButton).toHaveFocus();
 
-      const arrowUpEvent = new KeyboardEvent('keydown', {
-        key: 'ArrowUp',
-        bubbles: true,
-        cancelable: true,
-      });
+      await userEvent.keyboard('a');
 
-      arrowUpEvent.preventDefault = preventDefault;
-      arrowUpEvent.stopPropagation = stopPropagation;
-
-      toggleButton.dispatchEvent(arrowUpEvent);
-
-      expect(preventDefault).not.toHaveBeenCalled();
-      expect(stopPropagation).not.toHaveBeenCalled();
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(updateFilterMock).not.toHaveBeenCalled();
     });
   });
 
@@ -653,8 +629,6 @@ describe('ComboBox', () => {
       const updateSelection = vi.fn();
       const results = [options[0]];
       renderWithProps({ options, onUpdateSelection: updateSelection });
-      await toggleDropdown();
-
       await toggleDropdown(comboboxId);
       const listButtons = document.querySelectorAll('li');
       await userEvent.click(listButtons![0]);
@@ -1103,7 +1077,7 @@ describe('ComboBox', () => {
       });
     });
 
-    test('should call onFocus callback when input is focused', async () => {
+    test('should call onFocus callback with focus event when input is focused', async () => {
       const onFocusMock = vi.fn();
       renderWithProps({ onFocus: onFocusMock });
 
@@ -1114,7 +1088,38 @@ describe('ComboBox', () => {
 
       inputField.focus();
 
-      expect(onFocusMock).toHaveBeenCalled();
+      expect(onFocusMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'focus' }));
+    });
+
+    test('should hide clear button when hideClearAllButton is true', async () => {
+      renderWithProps({ hideClearAllButton: true });
+
+      await toggleDropdown(comboboxId);
+      const listItems = document.querySelectorAll('li');
+      await userEvent.click(listItems[0]);
+
+      await toggleDropdown(comboboxId);
+
+      expect(document.querySelector('.clear-all-button')).not.toBeInTheDocument();
+    });
+
+    test('should focus input after clicking clear button', async () => {
+      renderWithProps({ multiSelect: true });
+
+      await toggleDropdown(comboboxId);
+      const listItems = document.querySelectorAll('li');
+      await userEvent.click(listItems[0]);
+      await toggleDropdown(comboboxId);
+
+      const clearButton = document.querySelector('.clear-all-button') as HTMLButtonElement;
+      expect(clearButton).toBeInTheDocument();
+
+      await userEvent.click(clearButton);
+
+      await waitFor(() => {
+        const input = document.querySelector(`#${comboboxId}-combo-box-input`);
+        expect(input).toHaveFocus();
+      });
     });
   });
 
@@ -1394,12 +1399,6 @@ describe('ComboBox', () => {
       expect(comboboxContainer).toHaveClass(customClass);
     });
 
-    test('should handle wrapPills prop', async () => {
-      renderWithProps({ wrapPills: true });
-
-      expect(screen.getByRole('combobox')).toBeInTheDocument();
-    });
-
     test('should add divider style when divider prop is set to true', async () => {
       const options: ComboOption[] = [
         { label: 'option 0', value: 'o0', divider: true },
@@ -1668,83 +1667,37 @@ describe('ComboBox', () => {
   });
 
   describe('Edge Cases', () => {
-    test('should open dropdown and set letter in input field when letter key is pressed on closed dropdown', async () => {
-      const updateFilterMock = vi.fn();
-      renderWithProps({ onUpdateFilter: updateFilterMock });
+    test.each([
+      ['lowercase letter', 'a'],
+      ['uppercase letter', 'A'],
+      ['number', '5'],
+    ])(
+      'should open dropdown and seed input when %s key is pressed on closed toggle button',
+      async (_desc, key) => {
+        const updateFilterMock = vi.fn();
+        renderWithProps({ onUpdateFilter: updateFilterMock });
 
-      const toggleButton = document.querySelector(`#${comboboxId}-expand`) as HTMLButtonElement;
-      expect(toggleButton).toBeInTheDocument();
-      toggleButton.focus();
+        const toggleButton = document.querySelector(`#${comboboxId}-expand`) as HTMLButtonElement;
+        expect(toggleButton).toBeInTheDocument();
+        toggleButton.focus();
 
-      await userEvent.keyboard('a');
+        await userEvent.keyboard(key);
 
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).toBeInTheDocument();
-      });
+        await waitFor(() => {
+          expect(screen.getByRole('listbox')).toBeInTheDocument();
+        });
 
-      const inputField = document.querySelector(
-        `#${comboboxId}-combo-box-input`,
-      ) as HTMLInputElement;
-      await waitFor(() => {
-        expect(inputField).toBeInTheDocument();
-        expect(inputField.value).toBe('a');
-        expect(inputField).toHaveFocus();
-      });
+        const inputField = document.querySelector(
+          `#${comboboxId}-combo-box-input`,
+        ) as HTMLInputElement;
+        await waitFor(() => {
+          expect(inputField.value).toBe(key);
+          expect(inputField).toHaveFocus();
+        });
 
-      expect(updateFilterMock).toHaveBeenCalledWith('a');
-    });
-
-    test('should open dropdown and set number in input field when number key is pressed on closed dropdown', async () => {
-      const updateFilterMock = vi.fn();
-      renderWithProps({ onUpdateFilter: updateFilterMock });
-
-      const toggleButton = document.querySelector(`#${comboboxId}-expand`) as HTMLButtonElement;
-      expect(toggleButton).toBeInTheDocument();
-      toggleButton.focus();
-
-      await userEvent.keyboard('5');
-
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).toBeInTheDocument();
-      });
-
-      const inputField = document.querySelector(
-        `#${comboboxId}-combo-box-input`,
-      ) as HTMLInputElement;
-      await waitFor(() => {
-        expect(inputField).toBeInTheDocument();
-        expect(inputField.value).toBe('5');
-        expect(inputField).toHaveFocus();
-      });
-
-      expect(updateFilterMock).toHaveBeenCalledWith('5');
-    });
-
-    test('should open dropdown and set uppercase letter in input field when uppercase letter key is pressed', async () => {
-      const updateFilterMock = vi.fn();
-      renderWithProps({ onUpdateFilter: updateFilterMock });
-
-      const toggleButton = document.querySelector(`#${comboboxId}-expand`) as HTMLButtonElement;
-      expect(toggleButton).toBeInTheDocument();
-      toggleButton.focus();
-
-      await userEvent.keyboard('A');
-
-      await waitFor(() => {
-        expect(screen.getByRole('listbox')).toBeInTheDocument();
-      });
-
-      const inputField = document.querySelector(
-        `#${comboboxId}-combo-box-input`,
-      ) as HTMLInputElement;
-      await waitFor(() => {
-        expect(inputField).toBeInTheDocument();
-        expect(inputField.value).toBe('A');
-        expect(inputField).toHaveFocus();
-      });
-
-      expect(updateFilterMock).toHaveBeenCalledWith('A');
-    });
+        expect(updateFilterMock).toHaveBeenCalledWith(key);
+      },
+    );
 
     test('should not trigger alphanumeric behavior when dropdown is already open', async () => {
       const updateFilterMock = vi.fn();
@@ -1835,29 +1788,6 @@ describe('ComboBox', () => {
 
       const listItems = document.querySelectorAll('li');
       expect(listItems).toHaveLength(0);
-    });
-
-    test('should call focusInput ref method correctly', async () => {
-      const ref = React.createRef<ComboBoxRef>();
-      renderWithProps({}, ref);
-
-      await toggleDropdown(comboboxId);
-      act(() => ref.current?.focusInput());
-      await waitFor(() => {
-        const inputField = document.querySelector(`#${comboboxId}-combo-box-input`);
-        expect(inputField).toHaveFocus();
-      });
-    });
-
-    test('should handle focus ref method correctly', async () => {
-      const ref = React.createRef<ComboBoxRef>();
-      renderWithProps({}, ref);
-
-      act(() => ref.current?.focus());
-      await waitFor(() => {
-        const input = document.querySelector(`#${comboboxId}-combo-box-input`) as HTMLInputElement;
-        expect(input).toHaveFocus();
-      });
     });
 
     test('should handle setSelections with empty array', async () => {
@@ -1956,21 +1886,6 @@ describe('ComboBox', () => {
       expect(document.querySelector('.item-list-container')).toBeInTheDocument();
     });
 
-    test('should handle multiple filter changes rapidly', async () => {
-      const options = getDefaultOptions(10);
-      const onUpdateFilterMock = vi.fn();
-      renderWithProps({ options, onUpdateFilter: onUpdateFilterMock });
-
-      await toggleDropdown(comboboxId);
-      const inputField = await getFocusedComboInputField(comboboxId);
-
-      await userEvent.type(inputField, 'abc');
-
-      expect(onUpdateFilterMock).toHaveBeenCalledWith('a');
-      expect(onUpdateFilterMock).toHaveBeenCalledWith('ab');
-      expect(onUpdateFilterMock).toHaveBeenCalledWith('abc');
-    });
-
     test('should handle Enter key behavior correctly', async () => {
       const options = [{ label: 'Option 1', value: 'opt1' }];
       renderWithProps({ options });
@@ -1990,15 +1905,6 @@ describe('ComboBox', () => {
         expect(listItems).toHaveLength(1);
         expect(listItem).toHaveAttribute('aria-label', expect.stringContaining(', selected'));
       });
-    });
-
-    test('should render with icon prop', () => {
-      renderWithProps({ icon: 'custom-icon' });
-
-      const input = screen.getByRole('combobox');
-      expect(input).toBeInTheDocument();
-      // icon prop is accepted by TypeScript interface but not used in rendering
-      // This test verifies the prop doesn't cause crashes
     });
 
     test('should apply autoComplete attribute to input', () => {

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -101,7 +101,6 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
   const comboBoxRef = useRef(null);
   const comboBoxListRef = useRef<HTMLUListElement>(null);
   const filterRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
   const selectedMapRef = useRef<Map<string, ComboOption>>(selectedMap);
 
   // Keep ref in sync with state
@@ -253,16 +252,10 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
     }
   };
 
-  function focusCombobox() {
-    requestAnimationFrame(() => {
-      containerRef.current?.focus();
-    });
-  }
-
   function handleClearAllClick() {
     clearSelections();
     clearFilter();
-    focusCombobox();
+    focusInput();
 
     if (onUpdateSelection) {
       onUpdateSelection([]);

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -53,6 +53,7 @@ export interface ComboBoxProps extends Omit<InputProps, 'onChange' | 'onFocus' |
   hideClearAllButton?: boolean;
   placeholder?: string;
   scrollToSelected?: boolean;
+  disableFiltering?: boolean;
 }
 
 function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
@@ -77,6 +78,7 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
     hideClearAllButton,
     placeholder,
     scrollToSelected,
+    disableFiltering,
     ...otherProps
   } = props;
 
@@ -306,9 +308,11 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
       case 'Tab':
         // If has filter text and currently focused on input, check if there are filtered results
         if (filter && filter.trim().length > 0 && index === 0) {
-          const filteredOptions = _options.filter((option) =>
-            option.label.toLowerCase().includes(filter.toLowerCase()),
-          );
+          const filteredOptions = disableFiltering
+            ? _options
+            : _options.filter((option) =>
+                option.label.toLowerCase().includes(filter.toLowerCase()),
+              );
 
           // Only move focus to first item if there are actually filtered results
           if (filteredOptions.length > 0) {
@@ -657,7 +661,10 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
               {/* eslint-disable jsx-a11y/role-has-required-aria-props */}
               {_options
                 .filter(
-                  (option) => !filter || option.label.toLowerCase().includes(filter.toLowerCase()),
+                  (option) =>
+                    disableFiltering ||
+                    !filter ||
+                    option.label.toLowerCase().includes(filter.toLowerCase()),
                 )
                 .map((option, idx) => (
                   <li

--- a/user-interface/src/lib/components/combobox/ComboBox.tsx
+++ b/user-interface/src/lib/components/combobox/ComboBox.tsx
@@ -16,6 +16,18 @@ import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
 
 const DROPDOWN_POSITION_THRESHOLD_RATIO = 0.5; // Show dropdown above input when element is in bottom half of viewport
 
+function getVisibleOptions(
+  options: ComboOption[],
+  filter: string | null,
+  disableFiltering: boolean | undefined,
+): ComboOption[] {
+  if (disableFiltering || !filter || !filter.trim()) {
+    return options;
+  }
+  const normalizedFilter = filter.trim().toLowerCase();
+  return options.filter((option) => option.label.toLowerCase().includes(normalizedFilter));
+}
+
 export type ComboOption<T = string> = {
   value: T;
   label: string;
@@ -301,11 +313,7 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
       case 'Tab':
         // If has filter text and currently focused on input, check if there are filtered results
         if (filter && filter.trim().length > 0 && index === 0) {
-          const filteredOptions = disableFiltering
-            ? _options
-            : _options.filter((option) =>
-                option.label.toLowerCase().includes(filter.toLowerCase()),
-              );
+          const filteredOptions = getVisibleOptions(_options, filter, disableFiltering);
 
           // Only move focus to first item if there are actually filtered results
           if (filteredOptions.length > 0) {
@@ -652,37 +660,30 @@ function ComboBox_(props: ComboBoxProps, ref: React.Ref<ComboBoxRef>) {
               ref={comboBoxListRef}
             >
               {/* eslint-disable jsx-a11y/role-has-required-aria-props */}
-              {_options
-                .filter(
-                  (option) =>
-                    disableFiltering ||
-                    !filter ||
-                    option.label.toLowerCase().includes(filter.toLowerCase()),
-                )
-                .map((option, idx) => (
-                  <li
-                    id={`option-${option.value}`}
-                    className={setListItemClass(idx, option)}
-                    role="option"
-                    data-value={option.value}
-                    data-testid={`${comboBoxId}-option-item-${idx}`}
-                    key={`${comboBoxId}-${idx}`}
-                    onClick={() => handleDropdownItemSelection(option)}
-                    onKeyDown={(ev) => handleKeyDown(ev, idx + 1, option)}
-                    tabIndex={expanded ? 0 : -1}
-                    aria-label={
-                      (option.isAriaDefault ? 'Default ' : '') +
-                      (ariaLabelPrefix ? ariaLabelPrefix + ' ' : '') +
-                      option.label +
-                      (selectedMap.has(option.value) ? ', selected' : ', not selected')
-                    }
-                  >
-                    <span aria-hidden="true">
-                      {option.label}
-                      {selectedMap.has(option.value) && <Icon name="check"></Icon>}
-                    </span>
-                  </li>
-                ))}
+              {getVisibleOptions(_options, filter, disableFiltering).map((option, idx) => (
+                <li
+                  id={`option-${option.value}`}
+                  className={setListItemClass(idx, option)}
+                  role="option"
+                  data-value={option.value}
+                  data-testid={`${comboBoxId}-option-item-${idx}`}
+                  key={`${comboBoxId}-${idx}`}
+                  onClick={() => handleDropdownItemSelection(option)}
+                  onKeyDown={(ev) => handleKeyDown(ev, idx + 1, option)}
+                  tabIndex={expanded ? 0 : -1}
+                  aria-label={
+                    (option.isAriaDefault ? 'Default ' : '') +
+                    (ariaLabelPrefix ? ariaLabelPrefix + ' ' : '') +
+                    option.label +
+                    (selectedMap.has(option.value) ? ', selected' : ', not selected')
+                  }
+                >
+                  <span aria-hidden="true">
+                    {option.label}
+                    {selectedMap.has(option.value) && <Icon name="check"></Icon>}
+                  </span>
+                </li>
+              ))}
               {/* eslint-enable jsx-a11y/role-has-required-aria-props */}
             </ul>
           </div>


### PR DESCRIPTION
# Bug

The ComboBox component filtered its option list client-side using a
`.includes()` string match on every keystroke. When used with a
server-side fuzzy/phonetic search (like trustee name search), results
that didn't contain the exact search string were silently dropped —
defeating the entire purpose of fuzzy matching.

Additionally, `focusCombobox()` in `handleClearAllClick` was calling
`containerRef.current?.focus()`, but `containerRef` was never attached
to any JSX element, so clicking Clear never returned focus anywhere.

# Purpose

Ensure that server-driven searches (fuzzy, phonetic, or otherwise) can
display all results returned from the API without the UI second-guessing
them. Restore correct focus behavior after clearing selections.

# Major Changes

* Added `disableFiltering` prop to `ComboBox` (default `false`) — when
  `true`, skips client-side `.includes()` filtering so all server-returned
  options are displayed as-is
* Set `disableFiltering={true}` on the trustee name ComboBox in
  `TrusteeSearchModal`
* Removed dead `containerRef` (never attached to JSX) and replaced
  `focusCombobox()` with `focusInput()` in `handleClearAllClick` so
  focus correctly returns to the input after clearing selections

# Testing/Validation

All changes developed with TDD. ComboBox test suite updated and
expanded:

* Added tests covering `disableFiltering` behavior (all options shown
  when `true`, filtering still works when `false`)
* Added `hideClearAllButton` test (previously untested prop)
* Added test verifying focus returns to input after clicking Clear
* Fixed two misnamed keyboard tests that were exercising the input
  handler instead of the toggle button handler
* Fixed shared `vi.fn()` mock not being cleared between tests
  (accumulated call history was polluting assertions)
* Collapsed 3 identical alphanumeric keystroke tests into one
  `test.each`
* Removed hollow `wrapPills` and `icon` smoke tests that only asserted
  the component rendered
* Deleted a duplicate rapid-filter test

# Notes

The `disableFiltering` prop defaults to `false` so all existing
ComboBox usages (court district picker, case assignment dropdowns, etc.)
are unaffected. Only the trustee search ComboBox opts in.

The `selectedMap.size === 0` condition in `isOutsideClick` was
identified as a behavioral quirk (closes dropdown on any outside click
when no selection exists, regardless of coordinate check), but fixing
it is a separate concern — `useOutsideClick` handles true outside-click
detection via DOM `contains()` before `isOutsideClick` is ever called
in a real browser.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce optional server-side-first behavior to the ComboBox and improve its accessibility and focus handling while tightening and expanding its test coverage.

New Features:
- Add a disableFiltering prop to ComboBox to allow bypassing client-side label filtering when desired.
- Enable disableFiltering on the trustee name ComboBox to show all server-returned trustee search results.

Bug Fixes:
- Ensure pressing Tab with filter text and disableFiltering enabled still moves focus correctly to the first option.
- Prevent the disabled ComboBox toggle button from opening the dropdown or updating the filter on keypress.
- Restore focus to the ComboBox input after clearing all selections via the clear button.
- Ensure the ComboBox onFocus callback receives the focus event object.

Enhancements:
- Refine keyboard interaction tests for the ComboBox, including ArrowUp, alphanumeric seeding, and Tab behavior.
- Remove unused containerRef and rely on the existing focusInput helper for programmatic focus management.
- Simplify and consolidate edge-case keyboard tests using table-driven test.each cases.
- Remove low-value smoke tests for wrapPills and icon props and delete a redundant rapid filter-change test.

Tests:
- Add tests for disableFiltering behavior to verify options are not client-side filtered when the flag is enabled and still are when disabled.
- Add tests for hideClearAllButton behavior and for focus returning to the input after clearing selections.
- Fix mis-targeted keyboard interaction tests and ensure shared mocks such as updateFilterMock are cleared between tests.