### PR TITLE
Restore trustee name links to open in new tab

### DIFF
--- a/test/e2e/playwright/trustees.spec.ts
+++ b/test/e2e/playwright/trustees.spec.ts
@@ -31,8 +31,9 @@ test.describe('Trustees', () => {
     await expect(page.locator('[role="columnheader"]:has-text("Name")')).toBeVisible();
   });
 
-  test('should navigate to trustee detail page when clicking on a trustee name', async ({
+  test('should open trustee detail page in new tab when clicking on a trustee name', async ({
     page,
+    context,
   }) => {
     // Wait for the trustees table to load
     const trusteesTable = page.getByTestId('trustees-table');
@@ -43,13 +44,14 @@ test.describe('Trustees', () => {
 
     // Only proceed if there are trustees in the table
     if ((await firstTrusteeLink.count()) > 0) {
-      await firstTrusteeLink.click();
+      const [newPage] = await Promise.all([context.waitForEvent('page'), firstTrusteeLink.click()]);
+      await newPage.waitForLoadState();
 
-      // Verify we navigated to the trustee detail page
-      await expect(page).toHaveURL(new RegExp('/trustees/[^/]+$'));
+      // Verify the new tab navigated to the trustee detail page
+      await expect(newPage).toHaveURL(new RegExp('/trustees/[^/]+$'));
 
       // Verify the trustee detail page loaded
-      await expect(page.getByTestId('trustee-detail-screen')).toBeVisible(timeoutOption);
+      await expect(newPage.getByTestId('trustee-detail-screen')).toBeVisible(timeoutOption);
     } else {
       // If no trustees exist, just verify the table structure is correct
       console.log('No trustees found in table - skipping navigation test');

--- a/test/e2e/playwright/trustees.spec.ts
+++ b/test/e2e/playwright/trustees.spec.ts
@@ -44,8 +44,16 @@ test.describe('Trustees', () => {
 
     // Only proceed if there are trustees in the table
     if ((await firstTrusteeLink.count()) > 0) {
+      const pageCountBefore = context.pages().length;
       const [newPage] = await Promise.all([context.waitForEvent('page'), firstTrusteeLink.click()]);
       await newPage.waitForLoadState();
+
+      // Verify a new tab was actually opened
+      expect(newPage).not.toBe(page);
+      expect(context.pages().length).toBe(pageCountBefore + 1);
+
+      // Verify the original page remains on the trustees list
+      await expect(page).toHaveURL(/\/trustees$/);
 
       // Verify the new tab navigated to the trustee detail page
       await expect(newPage).toHaveURL(new RegExp('/trustees/[^/]+$'));

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -125,8 +125,8 @@ describe('TrusteesList Component', () => {
       '/trustees/trustee-2',
     );
 
-    expect(screen.getByTestId('trustee-link-trustee-1')).not.toHaveAttribute('target', '_blank');
-    expect(screen.getByTestId('trustee-link-trustee-2')).not.toHaveAttribute('target', '_blank');
+    expect(screen.getByTestId('trustee-link-trustee-1')).toHaveAttribute('target', '_blank');
+    expect(screen.getByTestId('trustee-link-trustee-2')).toHaveAttribute('target', '_blank');
   });
 
   test('should fire analytics event when trustee link is clicked', async () => {

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -617,7 +617,6 @@ export default function TrusteesList() {
                             trusteeId={trustee.trusteeId}
                             dataTestId={`trustee-link-${trustee.trusteeId}`}
                             source="trustee-list"
-                            openNewTab={false}
                           />
                         ) : (
                           <span aria-hidden="true"></span>

--- a/user-interface/src/trustees/modals/UseTrusteeAssignments.test.ts
+++ b/user-interface/src/trustees/modals/UseTrusteeAssignments.test.ts
@@ -170,10 +170,9 @@ describe('useTrusteeAssignments', () => {
 
     await waitFor(() => {
       expect(result.current.assignments).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
     });
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBeNull();
   });
 
   test('should handle non-Error throw in fetch assignments', async () => {

--- a/user-interface/test/accessibility/trustee-appointment-form.test.ts
+++ b/user-interface/test/accessibility/trustee-appointment-form.test.ts
@@ -6,16 +6,16 @@ test.describe('Trustee Appointment Form', () => {
 
   let trusteeProfilePage;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
     await page.goto(getUrl('/trustees'));
     await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
 
     const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
     await expect(trusteeProfileLink).toBeVisible();
 
-    await trusteeProfileLink.click();
-    await page.waitForLoadState();
-    trusteeProfilePage = page;
+    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
+    await newPage.waitForLoadState();
+    trusteeProfilePage = newPage;
 
     await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
 

--- a/user-interface/test/accessibility/trustee-appointment-form.test.ts
+++ b/user-interface/test/accessibility/trustee-appointment-form.test.ts
@@ -1,5 +1,6 @@
 import test, { expect } from '@playwright/test';
-import { ANALYZE_DELAY, COMPLEX_TEST_TIMEOUT, createAxeBuilder, getUrl } from './test-constants';
+import { ANALYZE_DELAY, COMPLEX_TEST_TIMEOUT, createAxeBuilder } from './test-constants';
+import { openFirstTrusteeProfileInNewTab } from './trustee-common';
 
 test.describe('Trustee Appointment Form', () => {
   test.describe.configure({ retries: 0, mode: 'serial' });
@@ -7,17 +8,7 @@ test.describe('Trustee Appointment Form', () => {
   let trusteeProfilePage;
 
   test.beforeEach(async ({ page, context }) => {
-    await page.goto(getUrl('/trustees'));
-    await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
-
-    const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
-    await expect(trusteeProfileLink).toBeVisible();
-
-    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
-    await newPage.waitForLoadState();
-    trusteeProfilePage = newPage;
-
-    await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
+    trusteeProfilePage = await openFirstTrusteeProfileInNewTab(page, context);
 
     await trusteeProfilePage.locator('[data-testid="trustee-appointments-nav-link"]').click();
     await trusteeProfilePage.waitForSelector('#add-appointment-button', { state: 'visible' });

--- a/user-interface/test/accessibility/trustee-assistants.test.ts
+++ b/user-interface/test/accessibility/trustee-assistants.test.ts
@@ -6,16 +6,16 @@ test.describe('Trustee Assistants', () => {
 
   let trusteeProfilePage;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
     await page.goto(getUrl('/trustees'));
     await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
 
     const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
     await expect(trusteeProfileLink).toBeVisible();
 
-    await trusteeProfileLink.click();
-    await page.waitForLoadState();
-    trusteeProfilePage = page;
+    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
+    await newPage.waitForLoadState();
+    trusteeProfilePage = newPage;
 
     await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
   });

--- a/user-interface/test/accessibility/trustee-assistants.test.ts
+++ b/user-interface/test/accessibility/trustee-assistants.test.ts
@@ -1,5 +1,6 @@
 import test, { expect } from '@playwright/test';
-import { ANALYZE_DELAY, COMPLEX_TEST_TIMEOUT, createAxeBuilder, getUrl } from './test-constants';
+import { ANALYZE_DELAY, COMPLEX_TEST_TIMEOUT, createAxeBuilder } from './test-constants';
+import { openFirstTrusteeProfileInNewTab } from './trustee-common';
 
 test.describe('Trustee Assistants', () => {
   test.describe.configure({ retries: 0, mode: 'serial' });
@@ -7,17 +8,7 @@ test.describe('Trustee Assistants', () => {
   let trusteeProfilePage;
 
   test.beforeEach(async ({ page, context }) => {
-    await page.goto(getUrl('/trustees'));
-    await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
-
-    const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
-    await expect(trusteeProfileLink).toBeVisible();
-
-    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
-    await newPage.waitForLoadState();
-    trusteeProfilePage = newPage;
-
-    await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
+    trusteeProfilePage = await openFirstTrusteeProfileInNewTab(page, context);
   });
 
   test('trustee profile with no assistants should not have accessibility issues', async () => {

--- a/user-interface/test/accessibility/trustee-common.ts
+++ b/user-interface/test/accessibility/trustee-common.ts
@@ -1,0 +1,23 @@
+import { BrowserContext, expect, Page } from '@playwright/test';
+import { getUrl } from './test-constants';
+
+/**
+ * Opens the first trustee profile from the trustees list in a new tab.
+ * Returns the newly opened trustee profile page.
+ */
+export async function openFirstTrusteeProfileInNewTab(
+  page: Page,
+  context: BrowserContext,
+): Promise<Page> {
+  await page.goto(getUrl('/trustees'));
+  await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
+
+  const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
+  await expect(trusteeProfileLink).toBeVisible();
+
+  const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
+  await newPage.waitForLoadState();
+  await expect(newPage.locator('.case-detail-header')).toBeVisible();
+
+  return newPage;
+}

--- a/user-interface/test/accessibility/trustee-key-dates.test.ts
+++ b/user-interface/test/accessibility/trustee-key-dates.test.ts
@@ -1,5 +1,6 @@
 import test, { expect } from '@playwright/test';
-import { ANALYZE_DELAY, COMPLEX_TEST_TIMEOUT, createAxeBuilder, getUrl } from './test-constants';
+import { ANALYZE_DELAY, COMPLEX_TEST_TIMEOUT, createAxeBuilder } from './test-constants';
+import { openFirstTrusteeProfileInNewTab } from './trustee-common';
 
 test.describe('Trustee Key Dates', () => {
   test.describe.configure({ retries: 0, mode: 'serial' });
@@ -7,17 +8,7 @@ test.describe('Trustee Key Dates', () => {
   let trusteeProfilePage;
 
   test.beforeEach(async ({ page, context }) => {
-    await page.goto(getUrl('/trustees'));
-    await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
-
-    const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
-    await expect(trusteeProfileLink).toBeVisible();
-
-    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
-    await newPage.waitForLoadState();
-    trusteeProfilePage = newPage;
-
-    await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
+    trusteeProfilePage = await openFirstTrusteeProfileInNewTab(page, context);
 
     await trusteeProfilePage.locator('[data-testid="trustee-appointments-nav-link"]').click();
     await trusteeProfilePage.waitForSelector('.appointment-card-container', { state: 'visible' });

--- a/user-interface/test/accessibility/trustee-key-dates.test.ts
+++ b/user-interface/test/accessibility/trustee-key-dates.test.ts
@@ -6,16 +6,16 @@ test.describe('Trustee Key Dates', () => {
 
   let trusteeProfilePage;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
     await page.goto(getUrl('/trustees'));
     await page.waitForSelector('[data-testid="trustees-table"]', { state: 'visible' });
 
     const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
     await expect(trusteeProfileLink).toBeVisible();
 
-    await trusteeProfileLink.click();
-    await page.waitForLoadState();
-    trusteeProfilePage = page;
+    const [newPage] = await Promise.all([context.waitForEvent('page'), trusteeProfileLink.click()]);
+    await newPage.waitForLoadState();
+    trusteeProfilePage = newPage;
 
     await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
 

--- a/user-interface/test/accessibility/trustee.test.ts
+++ b/user-interface/test/accessibility/trustee.test.ts
@@ -1,5 +1,6 @@
 import test, { expect } from '@playwright/test';
 import { ANALYZE_DELAY, createAxeBuilder, getUrl } from './test-constants';
+import { openFirstTrusteeProfileInNewTab } from './trustee-common';
 
 test.describe('Trustees', () => {
   test.describe.configure({ retries: 0, mode: 'serial' });
@@ -25,16 +26,7 @@ test.describe('Trustees', () => {
   });
 
   test('trustee profile should not have accessibility issues', async ({ page, context }) => {
-    const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
-    await expect(trusteeProfileLink).toBeVisible();
-
-    const [trusteeProfilePage] = await Promise.all([
-      context.waitForEvent('page'),
-      trusteeProfileLink.click(),
-    ]);
-    await trusteeProfilePage.waitForLoadState();
-
-    await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
+    const trusteeProfilePage = await openFirstTrusteeProfileInNewTab(page, context);
 
     await trusteeProfilePage.waitForTimeout(ANALYZE_DELAY);
     const accessibilityScanResults = await createAxeBuilder(trusteeProfilePage).analyze();

--- a/user-interface/test/accessibility/trustee.test.ts
+++ b/user-interface/test/accessibility/trustee.test.ts
@@ -24,17 +24,20 @@ test.describe('Trustees', () => {
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 
-  test('trustee profile should not have accessibility issues', async ({ page }) => {
+  test('trustee profile should not have accessibility issues', async ({ page, context }) => {
     const trusteeProfileLink = page.locator('[data-testid^="trustee-link-"]').first();
     await expect(trusteeProfileLink).toBeVisible();
 
-    await trusteeProfileLink.click();
-    await page.waitForLoadState();
+    const [trusteeProfilePage] = await Promise.all([
+      context.waitForEvent('page'),
+      trusteeProfileLink.click(),
+    ]);
+    await trusteeProfilePage.waitForLoadState();
 
-    await expect(page.locator('.case-detail-header')).toBeVisible();
+    await expect(trusteeProfilePage.locator('.case-detail-header')).toBeVisible();
 
-    await page.waitForTimeout(ANALYZE_DELAY);
-    const accessibilityScanResults = await createAxeBuilder(page).analyze();
+    await trusteeProfilePage.waitForTimeout(ANALYZE_DELAY);
+    const accessibilityScanResults = await createAxeBuilder(trusteeProfilePage).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 });


### PR DESCRIPTION
# Purpose

Restore trustee name links to open in new tab

# Major Changes

Trustee profile links in the list should open in a new tab. Removes the openNewTab=false override from TrusteesList, corrects unit test assertions, restores context/waitForEvent('page') in four a11y tests, and updates the E2E navigation test to assert on the new tab page.

## Summary by Sourcery

Ensure trustee profile links in the list open trustee detail pages in a new browser tab and align automated tests with the updated navigation behavior.

New Features:
- Open trustee profile links from the trustees list in a new browser tab instead of the current tab.

Enhancements:
- Update trustee list component behavior to rely on default link-target behavior by removing an explicit override that prevented opening in a new tab.

Tests:
- Adjust unit tests to assert that trustee profile links now have a `_blank` target.
- Update Playwright E2E navigation test to wait for and verify the trustee detail page in a newly opened tab.
- Modify accessibility tests to open trustee profiles in a new tab via the browser context and run Axe scans against the new page.