### PR TITLE
Pin applicationinsights to 3.14.0 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,10 +25,10 @@
       "groupName": "vite"
     },
     {
-      "description": "Group Application Insights packages — applicationinsights pinned to 3.14.0 because 3.15.0 introduced protobufjs@8 via @opentelemetry/otlp-transformer@0.217.0, triggering 9 Snyk CVEs (4 High, 5 Medium). 3.14.0 keeps the OpenTelemetry tree on 0.208.x which uses only protobufjs@7.x (no CVEs).",
+      "description": "Group Application Insights packages — applicationinsights blocked below 3.15.0 because 3.15.0 introduced protobufjs@8 via @opentelemetry/otlp-transformer@0.217.0, triggering 9 Snyk CVEs (4 High, 5 Medium). <3.15.0 keeps the OpenTelemetry tree on 0.208.x which uses only protobufjs@7.x (no CVEs).",
       "matchPackageNames": ["applicationinsights", "@microsoft/applicationinsights-react-js", "@microsoft/applicationinsights-web"],
       "groupName": "applicationinsights",
-      "allowedVersions": "3.14.0"
+      "allowedVersions": "<3.15.0"
     },
     {
       "description": "Automatically pin dependency ranges to exact versions",

--- a/renovate.json
+++ b/renovate.json
@@ -25,9 +25,10 @@
       "groupName": "vite"
     },
     {
-      "description": "Group Application Insights packages",
+      "description": "Group Application Insights packages — applicationinsights pinned to 3.14.0 because 3.15.0 introduced protobufjs@8 via @opentelemetry/otlp-transformer@0.217.0, triggering 9 Snyk CVEs (4 High, 5 Medium). 3.14.0 keeps the OpenTelemetry tree on 0.208.x which uses only protobufjs@7.x (no CVEs).",
       "matchPackageNames": ["applicationinsights", "@microsoft/applicationinsights-react-js", "@microsoft/applicationinsights-web"],
-      "groupName": "applicationinsights"
+      "groupName": "applicationinsights",
+      "allowedVersions": "3.14.0"
     },
     {
       "description": "Automatically pin dependency ranges to exact versions",


### PR DESCRIPTION
# Purpose

Prevent Renovate from upgrading `applicationinsights` beyond 3.14.0 to avoid reintroducing known Snyk CVEs.

# Major Changes

* Added `allowedVersions: "3.14.0"` to the existing `applicationinsights` package rule in `renovate.json`
* Added an inline description explaining the CVE rationale so future reviewers understand why the pin exists

# Testing/Validation

No code changes — Renovate config only. Verified the `allowedVersions` field is correctly scoped to the `applicationinsights` group rule.

# Notes

`applicationinsights@3.15.0` introduced `protobufjs@8.0.1` via `@opentelemetry/otlp-transformer@0.217.0`, triggering 9 Snyk CVEs (4 High, 5 Medium). Reverting to `3.14.0` keeps the OpenTelemetry dependency tree on `0.208.x`, which uses only `protobufjs@7.x` (no known CVEs). The pin should be revisited once a clean upgrade path exists.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Pin applicationinsights dependency version in Renovate configuration to avoid reintroducing known security vulnerabilities.

Build:
- Restrict Renovate updates for applicationinsights by pinning allowedVersions to 3.14.0 in renovate.json.

Documentation:
- Document the security rationale inline in the Renovate rule so future reviewers understand why the version pin exists.