### PR TITLE
CAMS-752 Fix table column width and edit status alignment

### DIFF
--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
@@ -6,16 +6,14 @@
 
   .associated-banks-section {
     #associated-banks-table {
-      max-width: 56rem;
-
       .cams-table__cell:nth-child(1) {
-        flex: 1 1 0;
+        flex: 3 1 0;
       }
       .cams-table__cell:nth-child(2) {
-        flex: 0 0 8rem;
+        flex: 1 1 0;
       }
       .cams-table__cell:nth-child(3) {
-        flex: 0 0 7rem;
+        flex: 1 1 0;
       }
       .cams-table__cell:nth-child(4) {
         flex: 0 0 8.25rem;

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
@@ -6,6 +6,8 @@
 
   .associated-banks-section {
     #associated-banks-table {
+      max-width: 56rem;
+
       .cams-table__cell:nth-child(1) {
         flex: 1 1 0;
       }
@@ -30,6 +32,10 @@
       .cams-table__body .cams-table__cell {
         padding-top: 0.5rem;
         padding-bottom: 0.5rem;
+      }
+
+      .cams-table__body .cams-icon-label {
+        top: 0;
       }
     }
   }


### PR DESCRIPTION
# Bug

In the associated banks table on the bankruptcy software detail page, the Trustees and Status columns were spaced too far from the bank name, and the Edit Status button text was vertically misaligned with other row content.

# Purpose

Address UI feedback that the associated banks table columns were too spread out and the Edit Status text did not align with the rest of the row.

# Major Changes

* Added `max-width: 56rem` to the associated banks table to prevent columns from spreading too far apart on wide screens
* Reset `top: 0` on `.cams-icon-label` within the table to neutralize a global `-0.3rem` offset from Button.scss that was misaligning the Edit Status text

# Testing/Validation

* Verified SCSS compiles without errors via `vite build`
* All 16 existing AssociatedBanksTable unit tests pass
* Visual inspection confirms columns are closer together and Edit Status aligns with row text

# Notes

The root cause of the Edit Status misalignment was `top: -0.3rem` applied globally to `.cams-icon-label` inside `button.usa-button` in Button.scss. Rather than modifying the global rule (which may be intentional for other button contexts), we override it to `top: 0` within the scoped table context.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Tighten the associated banks table layout on the bankruptcy software detail page to address column spacing and button alignment issues.

Bug Fixes:
- Constrain the associated banks table width to prevent excessive spacing between columns on wide screens.
- Correct the vertical alignment of the Edit Status icon label within the table rows.