### PR TITLE
Fix flaky unit tests in TrusteesList and ComboBox utilities

### DIFF
--- a/common/src/cams/test-utilities/mock-data.ts
+++ b/common/src/cams/test-utilities/mock-data.ts
@@ -22,6 +22,7 @@ import {
 import { Debtor, DebtorAttorney, Party, LegacyAddress, LegacyTrustee } from '../parties';
 import { PhoneNumber, Address, ContactInformation } from '../contact';
 import { Trustee, TrusteeHistory, TrusteeInput } from '../trustees';
+import { FIRST_NAME_MAX, LAST_NAME_MAX } from '../trustees-validators';
 import { TrusteeNote, TrusteeNoteDeleteRequest, TrusteeNoteEditRequest } from '../trustee-notes';
 import { TrusteeAppointment } from '../trustee-appointments';
 import { TrusteeAssistant } from '../trustee-assistants';
@@ -607,8 +608,8 @@ function getTrustee(override: Partial<Trustee> = {}): Trustee {
 }
 
 function getTrusteeInput(override: Partial<TrusteeInput> = {}): TrusteeInput {
-  const firstName = override.firstName ?? faker.person.firstName();
-  const lastName = override.lastName ?? faker.person.lastName();
+  const firstName = (override.firstName ?? faker.person.firstName()).slice(0, FIRST_NAME_MAX);
+  const lastName = (override.lastName ?? faker.person.lastName()).slice(0, LAST_NAME_MAX);
   const middleName = override.middleName;
   const nameParts = [firstName, middleName, lastName].filter(Boolean);
   return {
@@ -623,8 +624,8 @@ function getTrusteeInput(override: Partial<TrusteeInput> = {}): TrusteeInput {
 
 function getChapter13Trustee(override: Partial<Trustee> = {}): Trustee {
   const trusteeLastName = faker.person.lastName().toLowerCase().replace(/\s/g, '-');
-  const firstName = override.firstName ?? faker.person.firstName();
-  const lastName = override.lastName ?? faker.person.lastName();
+  const firstName = (override.firstName ?? faker.person.firstName()).slice(0, FIRST_NAME_MAX);
+  const lastName = (override.lastName ?? faker.person.lastName()).slice(0, LAST_NAME_MAX);
   const publicContact = getContactInformation({
     website: `https://www.${trusteeLastName}-ch13.com`,
   });

--- a/user-interface/src/lib/testing/testing-utilities.ts
+++ b/user-interface/src/lib/testing/testing-utilities.ts
@@ -148,16 +148,6 @@ async function toggleComboBoxItemSelection(id: string, itemIndex: number = 0, se
   const listItem = screen.getByTestId(testId);
 
   await userEvent.click(listItem);
-  // Use waitFor (Testing Library) rather than vi.waitFor so each retry is
-  // wrapped in act(), ensuring React flushes all batched state updates
-  // (setSelectedMap, setExpanded, setFormData, setFieldErrors) before we
-  // inspect the DOM. vi.waitFor does not wrap in act and can observe
-  // intermediate render states mid-click, causing the 'selected' class
-  // to appear absent when the dropdown has already closed.
-  //
-  // Use querySelector instead of getByTestId because single-select ComboBoxes
-  // close the dropdown after selection, hiding items with display:none.
-  // screen.getByTestId can be unreliable for hidden elements.
   await waitFor(() => {
     const currentItem = document.querySelector(`[data-testid="${testId}"]`);
     expect(currentItem).not.toBeNull();

--- a/user-interface/src/lib/testing/testing-utilities.ts
+++ b/user-interface/src/lib/testing/testing-utilities.ts
@@ -148,10 +148,17 @@ async function toggleComboBoxItemSelection(id: string, itemIndex: number = 0, se
   const listItem = screen.getByTestId(testId);
 
   await userEvent.click(listItem);
-  await vi.waitFor(() => {
-    // Use querySelector instead of getByTestId because single-select ComboBoxes
-    // close the dropdown after selection, hiding items with display:none.
-    // screen.getByTestId can be unreliable for hidden elements.
+  // Use waitFor (Testing Library) rather than vi.waitFor so each retry is
+  // wrapped in act(), ensuring React flushes all batched state updates
+  // (setSelectedMap, setExpanded, setFormData, setFieldErrors) before we
+  // inspect the DOM. vi.waitFor does not wrap in act and can observe
+  // intermediate render states mid-click, causing the 'selected' class
+  // to appear absent when the dropdown has already closed.
+  //
+  // Use querySelector instead of getByTestId because single-select ComboBoxes
+  // close the dropdown after selection, hiding items with display:none.
+  // screen.getByTestId can be unreliable for hidden elements.
+  await waitFor(() => {
     const currentItem = document.querySelector(`[data-testid="${testId}"]`);
     expect(currentItem).not.toBeNull();
     if (selected) {

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -335,6 +335,7 @@ describe('TrusteesList Component', () => {
     });
 
     afterEach(() => {
+      vi.clearAllTimers();
       vi.useRealTimers();
     });
 

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -330,6 +330,14 @@ describe('TrusteesList Component', () => {
   });
 
   describe('Name Column Sort', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     function makeTrusteeWithName(
       trusteeId: string,
       firstName: string,
@@ -355,7 +363,7 @@ describe('TrusteesList Component', () => {
     });
 
     test('should sort descending by last name when Name header is clicked', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
       const adams = makeTrusteeWithName('t1', 'Alice', 'Adams');
       const smith = makeTrusteeWithName('t2', 'Bob', 'Smith');
       const jones = makeTrusteeWithName('t3', 'Carol', 'Jones');
@@ -379,7 +387,7 @@ describe('TrusteesList Component', () => {
     });
 
     test('should toggle back to ascending when Name header is clicked again', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
       const adams = makeTrusteeWithName('t1', 'Alice', 'Adams');
       const smith = makeTrusteeWithName('t2', 'Bob', 'Smith');
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [adams, smith] });
@@ -402,7 +410,7 @@ describe('TrusteesList Component', () => {
     });
 
     test('should update aria-sort attribute when sort direction changes', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
         data: [makeTrusteeWithName('t1', 'Alice', 'Smith')],
       });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -332,6 +332,7 @@ describe('TrusteesList Component', () => {
   describe('Name Column Sort', () => {
     beforeEach(() => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
     });
 
     afterEach(() => {


### PR DESCRIPTION
# Bug

Several unit tests were intermittently failing in CI with timing-related errors:

- `TrusteesList` — `should sort descending by last name when Name header is clicked` and `should toggle back to ascending when Name header is clicked again` failing with `TestingLibraryElementError: Unable to find role="link"`
- `TrusteePublicContactForm` and `TrusteeInternalContactForm` — `should call globalAlert.error when patchTrustee rejects during edit` failing with class or call assertion errors
- `TrusteesUseCase` — `should ignore immutable fields in update data` failing with `Trustee validation failed: $.lastName: Max length 20 characters` when faker generated a name exceeding the validator limit

# Purpose

Eliminate async timer, React render-flush, and test-data validation races in unit tests so they pass reliably under CI load without changing any production behavior.

# Major Changes

* Added `beforeEach`/`afterEach` fake timer hooks (`vi.useFakeTimers` / `vi.clearAllTimers` / `vi.useRealTimers`) to the `Name Column Sort` describe block in `TrusteesList.test.tsx`, matching the existing pattern in the `Name Filter` block
* Added `userEvent.setup({ delay: null })` to sort tests so click simulation is synchronous under fake timers
* Mocked `Api2.getCourts` in the `Name Column Sort` `beforeEach` — without this, `TrusteeDistrictFilter` made a real async call on mount that cascaded into `setSelectedDistricts` → debounce → `setNameSearchLoading(true)`, replacing the link list with a spinner mid-assertion
* Switched `vi.waitFor` to Testing Library's `waitFor` in `toggleComboBoxItemSelection` (`testing-utilities.ts`) so each retry is wrapped in `act()`, flushing all batched React state (including `setSelectedMap` and `setFormData`) before inspecting the `selected` class
* Capped faker-generated `firstName` and `lastName` in `getTrusteeInput` and `getChapter13Trustee` to their validator max lengths (15 and 20 chars respectively), preventing intermittent failures when faker produced names that exceed validation limits

# Testing/Validation

All 72 tests in `TrusteesList.test.tsx` and all tests in `TrusteePublicContactForm`, `TrusteeInternalContactForm`, `ComboBox`, `TrusteeOversightAssignmentModal`, `TrusteeAssignedStaff`, and `TrusteesUseCase` pass locally.

# Notes

There were three distinct root causes:

**TrusteesList sort tests:** `TrusteeDistrictFilter` calls `Api2.getCourts` on mount. When unmocked, this async call fails, triggers `handleFilterDistrict` → `setSelectedDistricts`, which re-runs the `nameSearch` effect. With real timers, the debounce fires and transiently sets `nameSearchLoading=true`, hiding the trustee link list behind a spinner exactly when the sort assertion runs.

**ComboBox form tests:** `vi.waitFor` (Vitest's) does not wrap retries in `act()`, so it can observe intermediate React renders where `setExpanded(false)` has committed but `setFormData` (called via `onUpdateSelection`) has not. The `selected` class check would pass while `formData.state` was still unset — causing the subsequent form submit to fail validation. Switching to Testing Library's `waitFor` ensures all batched state updates are flushed before each assertion retry.

**TrusteesUseCase update tests:** `faker.person.lastName()` / `faker.person.firstName()` occasionally generate names longer than the 20/15 character validator limits. The `updateTrustee` code falls back to full-spec validation when the update payload contains no spec-validated fields, which then validates the faker-generated name on the existing trustee record. Capping the generated names at their max lengths in the mock factory eliminates this race.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application