### PR TITLE
Block real fetch calls in Vitest global setup

### DIFF
--- a/user-interface/src/setupTests.ts
+++ b/user-interface/src/setupTests.ts
@@ -37,6 +37,12 @@ if (!window.location) {
   });
 }
 
+// Block real HTTP requests — all fetch calls must be mocked at the Api2 or http.adapter layer.
+// If you see this error, add a vi.spyOn(Api2, '...').mockResolvedValue(...) to your test.
+vi.stubGlobal('fetch', () => {
+  throw new Error('Unmocked fetch call — stub Api2 or http.adapter in your test');
+});
+
 // Clean up timers after each test to prevent them from running after jsdom teardown
 afterEach(() => {
   vi.clearAllTimers();


### PR DESCRIPTION
# Bug

Vitest tests that forgot to mock `Api2` would silently fall through to the real `fetch` implementation, making real HTTP requests in CI and causing intermittent failures depending on network availability.

# Purpose

Prevent flaky CI failures caused by unmocked `fetch` calls by making the failure loud and immediate instead of silent and intermittent.

# Major Changes

* Added a global `vi.stubGlobal('fetch', ...)` in `setupTests.ts` that throws a clear error if any test reaches real `fetch`

# Testing/Validation

All 222 test files (3105 tests) pass with the guard in place, confirming no existing tests rely on real `fetch`.

# Notes

The project mocks at the `Api2` layer (`vi.spyOn(Api2, '...')`), so real `fetch` should never be reached in tests. This guard enforces that convention and gives a clear error message pointing developers to the right fix.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enforce a global guard in Vitest setup to prevent unmocked fetch calls from making real HTTP requests during tests.

Bug Fixes:
- Prevent Vitest tests from silently performing real HTTP requests when fetch is not mocked.

Tests:
- Add a global fetch stub in test setup that throws a clear error when tests reach the real fetch implementation.