### PR TITLE
CAMS-752 Fix mobile table spacing and breakpoints

### DIFF
--- a/user-interface/src/admin/bankruptcy-software/AssociatedBanksTable.tsx
+++ b/user-interface/src/admin/bankruptcy-software/AssociatedBanksTable.tsx
@@ -111,7 +111,7 @@ export function AssociatedBanksTable({
           <CamsTableHeaderCell>Associated Bank Name</CamsTableHeaderCell>
           <CamsTableHeaderCell>Trustees</CamsTableHeaderCell>
           <CamsTableHeaderCell>Status</CamsTableHeaderCell>
-          <CamsTableHeaderCell className="text-right"></CamsTableHeaderCell>
+          <CamsTableHeaderCell></CamsTableHeaderCell>
         </CamsTableHeader>
         <CamsTableBody>
           {associations.length === 0 && (
@@ -157,7 +157,7 @@ export function AssociatedBanksTable({
                 <CamsTableCell data-cell="Status">
                   {association.status === 'active' ? 'Active' : 'Inactive'}
                 </CamsTableCell>
-                <CamsTableCell data-cell="" className="text-right">
+                <CamsTableCell data-cell="">
                   {bankProfileMap.get(association.bankId)?.status === 'active' && (
                     <Button
                       id={`edit-status-${association.bankId}`}

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
@@ -1,3 +1,5 @@
+@use '@/lib/components/cams/CamsTable/cams-table-mixins' as cams-table;
+
 .software-detail-layout {
   display: flex;
   flex-direction: column;
@@ -6,34 +8,47 @@
 
   .associated-banks-section {
     #associated-banks-table {
-      .cams-table__cell:nth-child(1) {
-        flex: 3 1 0;
-      }
-      .cams-table__cell:nth-child(2) {
-        flex: 1 1 0;
-      }
-      .cams-table__cell:nth-child(3) {
-        flex: 1 1 0;
-      }
-      .cams-table__cell:nth-child(4) {
-        flex: 0 0 8.25rem;
-      }
-
-      .cams-table__header-row .cams-table__cell {
-        padding-top: 0;
-      }
-
-      .cams-table__body .cams-table__row {
-        align-items: center;
-      }
-
-      .cams-table__body .cams-table__cell {
-        padding-top: 0.5rem;
-        padding-bottom: 0.5rem;
-      }
-
       .cams-table__body .cams-icon-label {
         top: 0;
+      }
+
+      // Tablet (641px+): undo CamsTable flex — left nav leaves insufficient width
+      @media screen and (min-width: 641px) {
+        &.cams-table--responsive { @include cams-table.cams-table-stacked; }
+      }
+
+      // Desktop (880px+): full flex-row table with column proportions
+      @media screen and (min-width: 880px) {
+        &.cams-table--responsive {
+          @include cams-table.cams-table-flex-row;
+
+          .cams-table__cell:nth-child(1) {
+            flex: 3 1 0;
+          }
+          .cams-table__cell:nth-child(2) {
+            flex: 1 1 0;
+          }
+          .cams-table__cell:nth-child(3) {
+            flex: 1 1 0;
+          }
+          .cams-table__cell:nth-child(4) {
+            flex: 0 0 8.25rem;
+            text-align: right;
+          }
+
+          .cams-table__header-row .cams-table__cell {
+            padding-top: 0;
+          }
+
+          .cams-table__body .cams-table__row {
+            align-items: center;
+          }
+
+          .cams-table__body .cams-table__cell {
+            padding-top: 0.5rem;
+            padding-bottom: 0.5rem;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
# Bug

The associated banks table had three mobile view issues:
1. Vertical spacing between lines was 16px instead of the expected 8px
2. The table stayed in columnar layout too long, becoming illegible as columns compressed
3. The Edit Status button was right-aligned in mobile view using a utility class instead of SCSS media queries

# Purpose

Improve the associated banks table mobile experience by snapping to stacked layout earlier and fixing spacing/alignment per design feedback.

# Major Changes

* Raised the responsive breakpoint for the associated banks table from 641px to 880px, using the same stacked-override pattern as StaffAssignmentScreen
* Moved cell padding overrides (0.5rem) into the desktop-only media query so mobile stacked view uses the default 8px (0.25rem) spacing
* Replaced `text-right` utility class with SCSS `text-align: right` scoped to the desktop media query, left-aligned in mobile per Fritz's guidance

# Testing/Validation

All 166 existing tests in the bankruptcy-software directory pass. Verified SCSS compiles successfully through Vite build. No test file changes needed since this is purely CSS/layout behavior.

# Notes

The breakpoint of 880px was chosen because the left navigation pane takes 12rem (192px) at 640px+, leaving only ~450px for the table at the global 641px breakpoint — far too narrow for 4 columns. At 880px, the table gets ~688px which comfortably fits the proportional column widths (3:1:1:fixed).

This follows the established pattern from StaffAssignmentScreen.scss which also overrides the CamsTable global breakpoint using the `cams-table-stacked` and `cams-table-flex-row` mixins.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Adjust associated banks table responsive behavior and alignment to improve mobile readability and match design expectations.

Bug Fixes:
- Correct mobile vertical spacing in the associated banks table by using default cell padding in stacked view.
- Ensure the associated banks table switches to stacked layout at a wider breakpoint to avoid overly compressed columns on smaller screens.
- Align the Edit Status column right only on desktop while keeping it left-aligned in mobile for better layout consistency.

Enhancements:
- Adopt shared CamsTable mixins for stacked and flex-row layouts to align the associated banks table with existing responsive patterns.