### PR TITLE
CAMS-752 Standardize breakpoint values with device-screens variables

### DIFF
--- a/user-interface/src/App.scss
+++ b/user-interface/src/App.scss
@@ -7,6 +7,7 @@
 @use 'styles/abstracts/colors';
 @use 'styles/abstracts/general' as general;
 @use 'styles/abstracts/tables';
+@use 'styles/abstracts/device-screens' as device-screens;
 
 /* Overriding USWDS Grid row large gap negative margins because they force
    the screen width overall to overflow and create scrollbars where there

--- a/user-interface/src/App.scss
+++ b/user-interface/src/App.scss
@@ -7,7 +7,6 @@
 @use 'styles/abstracts/colors';
 @use 'styles/abstracts/general' as general;
 @use 'styles/abstracts/tables';
-@use 'styles/abstracts/device-screens' as device-screens;
 
 /* Overriding USWDS Grid row large gap negative margins because they force
    the screen width overall to overflow and create scrollbars where there

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
@@ -1,4 +1,5 @@
 @use '@/lib/components/cams/CamsTable/cams-table-mixins' as cams-table;
+@use 'styles/abstracts/device-screens' as device-screens;
 
 .software-detail-layout {
   display: flex;
@@ -12,13 +13,13 @@
         top: 0;
       }
 
-      // Tablet (641px+): undo CamsTable flex — left nav leaves insufficient width
-      @media screen and (min-width: 641px) {
+      // Tablet: undo CamsTable flex — left nav leaves insufficient width
+      @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
         &.cams-table--responsive { @include cams-table.cams-table-stacked; }
       }
 
-      // Desktop (880px+): full flex-row table with column proportions
-      @media screen and (min-width: 880px) {
+      // Desktop: full flex-row table with column proportions
+      @media screen and (min-width: #{device-screens.$tablet-screen-small}) {
         &.cams-table--responsive {
           @include cams-table.cams-table-flex-row;
 
@@ -53,7 +54,7 @@
     }
   }
 
-  @media (min-width: 640px) {
+  @media (min-width: #{device-screens.$tablet-screen-extra-small}) {
     flex-direction: row;
     align-items: flex-start;
 
@@ -100,7 +101,7 @@
     width: 50%;
     min-width: 20rem;
 
-    @media (max-width: 640px) {
+    @media (max-width: #{device-screens.$tablet-screen-extra-small}) {
       width: 100%;
     }
   }
@@ -123,7 +124,7 @@
     width: 50%;
     min-width: 20rem;
 
-    @media (max-width: 640px) {
+    @media (max-width: #{device-screens.$tablet-screen-extra-small}) {
       width: 100%;
     }
   }

--- a/user-interface/src/admin/banks/BankDetail.scss
+++ b/user-interface/src/admin/banks/BankDetail.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/device-screens' as device-screens;
+
 .bank-detail {
   .bank-detail-content-container {
     display: flex;
@@ -28,7 +30,7 @@
     width: 50%;
     min-width: 20rem;
 
-    @media (max-width: 640px) {
+    @media (max-width: #{device-screens.$tablet-screen-extra-small}) {
       width: 100%;
     }
   }

--- a/user-interface/src/case-detail/CaseDetailScreen.scss
+++ b/user-interface/src/case-detail/CaseDetailScreen.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/device-screens' as device-screens;
+
 .case-detail, .record-detail {
   container-type: inline-size;
 
@@ -25,7 +27,7 @@
       width: auto;
     }
 
-    @container (max-width: 640px) {
+    @container (max-width: #{device-screens.$tablet-screen-extra-small}) {
       flex-direction: column;
 
       .grid-col-2,

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
@@ -1,4 +1,5 @@
 @use 'styles/abstracts/general' as general;
+@use 'styles/abstracts/device-screens' as device-screens;
 @import '../../trustees/panels/shared-card-styles.scss';
 
 .case-detail-trustee-panel {
@@ -67,8 +68,8 @@
       }
     }
 
-    // Smaller than tablet (640px): flex row, equal columns, show header
-    @media screen and (max-width: 640px) {
+    // Smaller than tablet: flex row, equal columns, show header
+    @media screen and (max-width: #{device-screens.$tablet-screen-extra-small}) {
       .cams-table__body .cams-table__row {
         &:first-child {
           padding: 0 1rem 0.625rem;

--- a/user-interface/src/data-verification/DataVerificationScreen.scss
+++ b/user-interface/src/data-verification/DataVerificationScreen.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/device-screens' as device-screens;
+
 .data-verification-screen {
   .order-list-container {
     .order-form {
@@ -73,7 +75,7 @@
   }
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: #{device-screens.$desktop-screen-small}) {
   .data-verification-screen {
     > .grid-row > .grid-col-10 {
       width: 90%;

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.scss
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.scss
@@ -1,4 +1,5 @@
 @use '@/styles/abstracts/colors';
+@use 'styles/abstracts/device-screens' as device-screens;
 
 .usa-accordion__content:has(.trustee-match-content) {
   padding-top: 0;
@@ -169,7 +170,7 @@
   }
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: #{device-screens.$desktop-screen-small}) {
   .trustee-match-content {
     .trustee-data-grid {
       .trustee-data-header {

--- a/user-interface/src/lib/components/cams/CamsTable/CamsTable.scss
+++ b/user-interface/src/lib/components/cams/CamsTable/CamsTable.scss
@@ -1,4 +1,5 @@
 @use 'styles/abstracts/general' as general;
+@use 'styles/abstracts/device-screens' as device-screens;
 
 // Base responsive styles applied automatically to every CamsTable.
 // To override breakpoint behavior in a screen, use the mixins in _cams-table-mixins.scss:
@@ -57,8 +58,8 @@
     margin-bottom: 0.25rem;
   }
 
-  // Tablet (641px+): flex row, equal columns, show header
-  @media screen and (min-width: 641px) {
+  // Tablet: flex row, equal columns, show header
+  @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
     .cams-table__header-group {
       @include general.visually-shown;
       display: block;

--- a/user-interface/src/my-cases/MyCasesScreen.scss
+++ b/user-interface/src/my-cases/MyCasesScreen.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/device-screens' as device-screens;
+
 .my-cases {
   .draft-notes-alert-message {
     display: inline-block;
@@ -15,7 +17,7 @@
     }
   }
 
-  @media screen and (min-width: 641px) {
+  @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
     .cams-table--responsive {
       .col-case-number { flex: 3 1 0; }
       .col-case-title  { flex: 3 1 0; }

--- a/user-interface/src/search/SearchScreen.scss
+++ b/user-interface/src/search/SearchScreen.scss
@@ -1,4 +1,5 @@
 @use '@/lib/components/cams/CamsTable/cams-table-mixins' as cams-table;
+@use 'styles/abstracts/device-screens' as device-screens;
 
 .search-screen {
   h1 {
@@ -38,8 +39,8 @@
     margin-top: 1.5rem;
   }
 
-  // Tablet (641px+): side-by-side filters and results, table stays stacked
-  @media screen and (min-width: 641px) {
+  // Tablet: side-by-side filters and results, table stays stacked
+  @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
     .search-pane {
       flex-direction: row;
       align-items: flex-start;
@@ -61,8 +62,8 @@
     .cams-table--responsive { @include cams-table.cams-table-stacked; }
   }
 
-  // Desktop (1025px+): wider filter panel, table switches to flex-row columns
-  @media screen and (min-width: 1025px) {
+  // Desktop: wider filter panel, table switches to flex-row columns
+  @media screen and (min-width: #{device-screens.$desktop-screen-small + 1}) {
     .search-filters {
       flex: 0 0 280px;
       width: 280px;

--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.scss
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.scss
@@ -1,4 +1,5 @@
 @use '@/lib/components/cams/CamsTable/cams-table-mixins' as cams-table;
+@use 'styles/abstracts/device-screens' as device-screens;
 
 .staff-assignment {
   .screen-heading {
@@ -34,13 +35,13 @@
     }
   }
 
-  // Tablet (641px+): undo CamsTable flex — not enough width without filter context
-  @media screen and (min-width: 641px) {
+  // Tablet: undo CamsTable flex — not enough width without filter context
+  @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
     .cams-table--responsive { @include cams-table.cams-table-stacked; }
   }
 
-  // Desktop (1025px+): full flex-row table with column proportions
-  @media screen and (min-width: 1025px) {
+  // Desktop: full flex-row table with column proportions
+  @media screen and (min-width: #{device-screens.$desktop-screen-small + 1}) {
     .cams-table--responsive {
       @include cams-table.cams-table-flex-row;
       .col-case-number      { flex: 3 1 0; }

--- a/user-interface/src/styles/abstracts/_device-screens.scss
+++ b/user-interface/src/styles/abstracts/_device-screens.scss
@@ -1,5 +1,3 @@
-$phone-screen-large: 412px;
 $tablet-screen-extra-small: 640px;
 $tablet-screen-small: 880px;
 $desktop-screen-small: 1024px;
-$desktop-screen-medium: 1280px;

--- a/user-interface/src/styles/abstracts/_device-screens.scss
+++ b/user-interface/src/styles/abstracts/_device-screens.scss
@@ -1,0 +1,5 @@
+$phone-screen-large: 412px;
+$tablet-screen-extra-small: 640px;
+$tablet-screen-small: 880px;
+$desktop-screen-small: 1024px;
+$desktop-screen-medium: 1280px;

--- a/user-interface/src/trustees/TrusteeDetailScreen.scss
+++ b/user-interface/src/trustees/TrusteeDetailScreen.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/device-screens' as device-screens;
+
 .record-detail .trustee-detail-screen {
   h2 {
     margin-bottom: 1rem;
@@ -28,7 +30,7 @@
         min-width: 0;
       }
 
-      @container (max-width: 640px) {
+      @container (max-width: #{device-screens.$tablet-screen-extra-small}) {
         .left-navigation-pane-container {
           width: 100%;
         }
@@ -71,7 +73,7 @@
   }
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: #{device-screens.$desktop-screen-small}) {
   .trustee-detail-screen {
     .screen-header {
       display: block;

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/device-screens' as device-screens;
+
 .trustees-list {
   margin-top: 20px;
   .trustees-list-count {
@@ -62,7 +64,7 @@
   }
 
   // Small phones — inline label, full line wraps naturally
-  @media screen and (max-width: 640px) {
+  @media screen and (max-width: #{device-screens.$tablet-screen-extra-small}) {
     .trustees-list-cell[data-cell] {
       padding: 0.25rem 0.375rem 0.25rem 0;
       min-height: unset;
@@ -76,7 +78,7 @@
   }
 
   // Tablet — equal columns
-  @media screen and (min-width: 641px) {
+  @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
     .trustees-list-count {
       padding-left: 0;
       margin-bottom: 1.25rem;
@@ -144,7 +146,7 @@
   }
 
   // Desktop — proportional columns
-  @media screen and (min-width: 1025px) {
+  @media screen and (min-width: #{device-screens.$desktop-screen-small + 1}) {
     .col-name {
       flex: 2 1 0;
       min-width: 160px;


### PR DESCRIPTION
## Summary
- Introduced `_device-screens.scss` with standard breakpoint variables (`$tablet-screen-extra-small`, `$tablet-screen-small`, `$desktop-screen-small`, etc.)
- Replaced all hardcoded `640px`, `641px`, `880px`, `1024px`, and `1025px` media query values across 12 SCSS files with the shared variables
- Improves consistency and makes future breakpoint adjustments a single-point change

## Test plan
- [x] Vite build compiles cleanly with no SCSS errors
- [x] Linting passes across all workspaces
- [ ] Visual spot-check at mobile (~375px), tablet (~768px), and desktop (~1280px) widths to confirm no layout regressions

Jira ticket: CAMS-752

## Summary by Sourcery

Standardize responsive layout breakpoints across the UI using shared device screen variables.

Enhancements:
- Introduce a shared `_device-screens.scss` partial defining named breakpoint variables for phone, tablet, and desktop widths.
- Replace hardcoded media query pixel values in multiple SCSS modules with references to the shared device screen variables to centralize breakpoint management and improve consistency.