### PR TITLE
CAMS-772 Mark archived appointments inactive

### DIFF
--- a/backend/lib/adapters/gateways/ats/ats.constants.ts
+++ b/backend/lib/adapters/gateways/ats/ats.constants.ts
@@ -121,6 +121,17 @@ export const SUBCHAPTER_V_STATUS_CODES = new Set(['V', 'VR']);
 export const CODE_1_STANDING_CHAPTERS = new Set(['12', '13']);
 
 /**
+ * Appointment types that TOD archived (rather than terminated) when inactive.
+ * If ARCHIVE_DATE is present on a CHAPTER_DETAILS row for one of these types,
+ * the appointment should be treated as inactive with effectiveDate = ARCHIVE_DATE.
+ */
+export const ARCHIVED_APPOINTMENT_TYPES = new Set<AppointmentType>([
+  'case-by-case',
+  'elected',
+  'converted-case',
+]);
+
+/**
  * Special chapter codes that include appointment type
  */
 export const SPECIAL_CHAPTER_CODES = {

--- a/backend/lib/adapters/gateways/ats/ats.gateway.test.ts
+++ b/backend/lib/adapters/gateways/ats/ats.gateway.test.ts
@@ -398,6 +398,100 @@ describe('ATS Gateway', () => {
       expect(loggerDebugSpy).toHaveBeenCalled();
     });
 
+    test('should include ARCHIVE_DATE in the CHAPTER_DETAILS SELECT query', async () => {
+      mockExecuteQuery.mockResolvedValue({ results: { recordset: [] } });
+
+      await gateway.getTrusteeAppointments(context, 123);
+
+      const query = mockExecuteQuery.mock.calls[0][1] as string;
+      expect(query).toContain('ARCHIVE_DATE');
+      expect(query).toContain('FROM CHAPTER_DETAILS');
+    });
+
+    test('should return inactive status when ARCHIVE_DATE is set for a case-by-case appointment (CAMS-772)', async () => {
+      const archiveDate = new Date('2019-06-15');
+      mockExecuteQuery.mockResolvedValue({
+        results: {
+          recordset: [
+            {
+              TRU_ID: 123,
+              DISTRICT: 'Middle',
+              STATE: 'Louisiana',
+              CHAPTER: '7',
+              STATUS: 'C', // case-by-case active code
+              DATE_APPOINTED: new Date('2010-01-01'),
+              EFFECTIVE_DATE: new Date('2010-01-01'),
+              ARCHIVE_DATE: archiveDate,
+            },
+          ],
+        },
+      });
+
+      const result = await gateway.getTrusteeAppointments(context, 123);
+
+      expect(result.cleanAppointments).toHaveLength(1);
+      expect(result.cleanAppointments[0]).toMatchObject({
+        appointmentType: 'case-by-case',
+        status: 'inactive',
+        effectiveDate: '2019-06-15',
+      });
+    });
+
+    test('should return inactive status when ARCHIVE_DATE is set for an elected appointment (CAMS-772)', async () => {
+      mockExecuteQuery.mockResolvedValue({
+        results: {
+          recordset: [
+            {
+              TRU_ID: 456,
+              DISTRICT: 'Middle',
+              STATE: 'Louisiana',
+              CHAPTER: '7',
+              STATUS: 'E', // elected active code
+              DATE_APPOINTED: new Date('2010-01-01'),
+              EFFECTIVE_DATE: new Date('2010-01-01'),
+              ARCHIVE_DATE: new Date('2020-03-01'),
+            },
+          ],
+        },
+      });
+
+      const result = await gateway.getTrusteeAppointments(context, 456);
+
+      expect(result.cleanAppointments).toHaveLength(1);
+      expect(result.cleanAppointments[0]).toMatchObject({
+        appointmentType: 'elected',
+        status: 'inactive',
+        effectiveDate: '2020-03-01',
+      });
+    });
+
+    test('should not override status when ARCHIVE_DATE is null for a case-by-case appointment (CAMS-772)', async () => {
+      mockExecuteQuery.mockResolvedValue({
+        results: {
+          recordset: [
+            {
+              TRU_ID: 789,
+              DISTRICT: 'Middle',
+              STATE: 'Louisiana',
+              CHAPTER: '7',
+              STATUS: 'C', // case-by-case — no archive date, stays active
+              DATE_APPOINTED: new Date('2022-01-01'),
+              EFFECTIVE_DATE: new Date('2022-01-01'),
+              ARCHIVE_DATE: null,
+            },
+          ],
+        },
+      });
+
+      const result = await gateway.getTrusteeAppointments(context, 789);
+
+      expect(result.cleanAppointments).toHaveLength(1);
+      expect(result.cleanAppointments[0]).toMatchObject({
+        appointmentType: 'case-by-case',
+        status: 'active',
+      });
+    });
+
     test('should handle overrides loading error gracefully', async () => {
       // Mock loadTrusteeOverrides to fail
       const loadOverridesMock = await import('./cleansing/ats-cleansing-overrides');

--- a/backend/lib/adapters/gateways/ats/ats.gateway.test.ts
+++ b/backend/lib/adapters/gateways/ats/ats.gateway.test.ts
@@ -89,6 +89,8 @@ describe('ATS Gateway', () => {
     let mockExecuteQuery: ReturnType<typeof vi.spyOn>;
 
     beforeEach(async () => {
+      vi.restoreAllMocks();
+
       // Create a mock context with ATS config
       context = await createMockApplicationContext();
 
@@ -122,10 +124,6 @@ describe('ATS Gateway', () => {
       // Mock the executeQuery method
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockExecuteQuery = vi.spyOn(gateway as any, 'executeQuery');
-    });
-
-    afterEach(() => {
-      vi.clearAllMocks();
     });
 
     test('should build correct query for first page of trustees', async () => {

--- a/backend/lib/adapters/gateways/ats/ats.gateway.ts
+++ b/backend/lib/adapters/gateways/ats/ats.gateway.ts
@@ -190,7 +190,8 @@ export class AtsGatewayImpl extends AbstractMssqlClient implements AtsGateway {
         CHAPTER,
         APPOINTED_DATE AS DATE_APPOINTED,
         STATUS,
-        STATUS_EFF_DATE AS EFFECTIVE_DATE
+        STATUS_EFF_DATE AS EFFECTIVE_DATE,
+        ARCHIVE_DATE
       FROM CHAPTER_DETAILS
       WHERE TRU_ID = @trusteeId
       ORDER BY APPOINTED_DATE DESC`;

--- a/backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-transform.test.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-transform.test.ts
@@ -5,6 +5,10 @@ import * as atsMappings from './ats-mappings';
 
 describe('ATS Cleansing Transform', () => {
   describe('transformAppointmentRecord', () => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+    });
+
     const baseRecord: AtsAppointmentRecord = {
       TRU_ID: 12345,
       DISTRICT: 'CA',

--- a/backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-transform.test.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-transform.test.ts
@@ -376,6 +376,108 @@ describe('ATS Cleansing Transform', () => {
       );
     });
 
+    test('should override status to inactive and use ARCHIVE_DATE as effectiveDate for archived case-by-case appointment', () => {
+      vi.spyOn(atsMappings, 'parseChapterAndType').mockReturnValue({ chapter: '7' });
+      vi.spyOn(atsMappings, 'parseTodStatus').mockReturnValue({
+        appointmentType: 'case-by-case',
+        status: 'active',
+      });
+      vi.spyOn(atsMappings, 'applyAppointmentOverrides').mockReturnValue({
+        chapter: '7',
+        appointmentType: 'case-by-case',
+        status: 'active',
+      });
+
+      const result = transformAppointmentRecord(
+        { ...baseRecord, ARCHIVE_DATE: new Date('2022-06-15') },
+        'court-123',
+      );
+
+      expect(result.status).toBe('inactive');
+      expect(result.effectiveDate).toBe('2022-06-15');
+    });
+
+    test('should override status to inactive and use ARCHIVE_DATE as effectiveDate for archived elected appointment', () => {
+      vi.spyOn(atsMappings, 'parseChapterAndType').mockReturnValue({ chapter: '7' });
+      vi.spyOn(atsMappings, 'parseTodStatus').mockReturnValue({
+        appointmentType: 'elected',
+        status: 'active',
+      });
+      vi.spyOn(atsMappings, 'applyAppointmentOverrides').mockReturnValue({
+        chapter: '7',
+        appointmentType: 'elected',
+        status: 'active',
+      });
+
+      const result = transformAppointmentRecord(
+        { ...baseRecord, ARCHIVE_DATE: new Date('2021-03-01') },
+        'court-123',
+      );
+
+      expect(result.status).toBe('inactive');
+      expect(result.effectiveDate).toBe('2021-03-01');
+    });
+
+    test('should override status to inactive and use ARCHIVE_DATE as effectiveDate for archived converted-case appointment', () => {
+      vi.spyOn(atsMappings, 'parseChapterAndType').mockReturnValue({ chapter: '7' });
+      vi.spyOn(atsMappings, 'parseTodStatus').mockReturnValue({
+        appointmentType: 'converted-case',
+        status: 'active',
+      });
+      vi.spyOn(atsMappings, 'applyAppointmentOverrides').mockReturnValue({
+        chapter: '7',
+        appointmentType: 'converted-case',
+        status: 'active',
+      });
+
+      const result = transformAppointmentRecord(
+        { ...baseRecord, ARCHIVE_DATE: new Date('2020-11-30') },
+        'court-123',
+      );
+
+      expect(result.status).toBe('inactive');
+      expect(result.effectiveDate).toBe('2020-11-30');
+    });
+
+    test('should NOT override status for panel appointment even when ARCHIVE_DATE is present', () => {
+      vi.spyOn(atsMappings, 'parseChapterAndType').mockReturnValue({ chapter: '7' });
+      vi.spyOn(atsMappings, 'parseTodStatus').mockReturnValue({
+        appointmentType: 'panel',
+        status: 'active',
+      });
+      vi.spyOn(atsMappings, 'applyAppointmentOverrides').mockReturnValue({
+        chapter: '7',
+        appointmentType: 'panel',
+        status: 'active',
+      });
+
+      const result = transformAppointmentRecord(
+        { ...baseRecord, ARCHIVE_DATE: new Date('2022-06-15') },
+        'court-123',
+      );
+
+      expect(result.status).toBe('active');
+      expect(result.effectiveDate).toBe('2024-01-20');
+    });
+
+    test('should NOT override status for case-by-case appointment without ARCHIVE_DATE', () => {
+      vi.spyOn(atsMappings, 'parseChapterAndType').mockReturnValue({ chapter: '7' });
+      vi.spyOn(atsMappings, 'parseTodStatus').mockReturnValue({
+        appointmentType: 'case-by-case',
+        status: 'active',
+      });
+      vi.spyOn(atsMappings, 'applyAppointmentOverrides').mockReturnValue({
+        chapter: '7',
+        appointmentType: 'case-by-case',
+        status: 'active',
+      });
+
+      const result = transformAppointmentRecord(baseRecord, 'court-123');
+
+      expect(result.status).toBe('active');
+      expect(result.effectiveDate).toBe('2024-01-20');
+    });
+
     test('should handle empty string STATUS field', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const recordWithEmptyStatus = { ...baseRecord, STATUS: '' as any };

--- a/backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-transform.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-transform.ts
@@ -1,6 +1,7 @@
 import { AtsAppointmentRecord } from '../../../../adapters/types/ats.types';
 import { TrusteeAppointmentInput } from '@common/cams/trustee-appointments';
 import { parseChapterAndType, parseTodStatus, applyAppointmentOverrides } from './ats-mappings';
+import { ARCHIVED_APPOINTMENT_TYPES } from '../ats.constants';
 
 /**
  * Transform cleansed ATS appointment record to CAMS format.
@@ -55,6 +56,19 @@ export function transformAppointmentRecord(
     // Both dates missing - use placeholder date (can be corrected later)
     appointedDate = '1970-01-01';
     effectiveDate = '1970-01-01';
+  }
+
+  // TOD archived case-by-case, elected, and converted-case appointments instead of terminating
+  // them. When ARCHIVE_DATE is present for these types, treat as inactive with the archive date.
+  if (cleanedRecord.ARCHIVE_DATE && ARCHIVED_APPOINTMENT_TYPES.has(appointmentType)) {
+    return {
+      chapter,
+      appointmentType,
+      courtId,
+      appointedDate,
+      status: 'inactive',
+      effectiveDate: cleanedRecord.ARCHIVE_DATE.toISOString().split('T')[0],
+    };
   }
 
   return {

--- a/backend/lib/adapters/types/ats.types.ts
+++ b/backend/lib/adapters/types/ats.types.ts
@@ -48,6 +48,7 @@ export interface AtsAppointmentRecord {
   DATE_APPOINTED?: Date;
   STATUS?: string;
   EFFECTIVE_DATE?: Date;
+  ARCHIVE_DATE?: Date;
 }
 
 /**

--- a/test/migration/trustee/TRUSTEE_MIGRATION_TESTING_SCRIPTS.md
+++ b/test/migration/trustee/TRUSTEE_MIGRATION_TESTING_SCRIPTS.md
@@ -1,4 +1,4 @@
-# Testing Trustee Migration Enhancements (CAMS-596 / CAMS-721)
+# Testing Trustee Migration Enhancements (CAMS-596 / CAMS-721 / CAMS-772)
 
 This guide covers local testing for trustee migration and matching enhancements.
 
@@ -10,6 +10,7 @@ This guide covers local testing for trustee migration and matching enhancements.
 | CAMS-596 | 2 | ACMS Professional ID Import | Each migrated trustee is linked to their ACMS `GROUP_DESIGNATOR-PROF_CODE` IDs |
 | CAMS-596 | 3 | Zoom CSV Import | Trustees are enriched with Zoom meeting info (including `accountEmail`) from a TSV file in Blob Storage |
 | CAMS-721 | — | Auto-Match Seeding | Seed CAMS trustees + appointments matching real DXTR data so `sync-trustee-appointments` produces auto-match telemetry for the workbook |
+| CAMS-772 | — | Archived Appointment Fix | Read `ARCHIVE_DATE` from ATS `CHAPTER_DETAILS`; override status to `inactive` for `case-by-case`, `elected`, and `converted-case` appointments with a non-null archive date |
 
 ## Prerequisites
 
@@ -87,7 +88,7 @@ npx tsx --tsconfig backend/tsconfig.json \
 Shows: all distinct STATUS values with counts, trustees with at least one active appointment,
 trustees with no appointments, and total trustee counts.
 
-### Test data seeder (Slices 2 + 3 + CAMS-721)
+### Test data seeder (Slices 2 + 3 + CAMS-721 + CAMS-772)
 
 Path: `test/migration/trustee/scripts/seed-test-trustees.ts`
 
@@ -96,6 +97,8 @@ Path: `test/migration/trustee/scripts/seed-test-trustees.ts`
 | `seed-proid` | Create 3 trustees WITH professional IDs + 3 WITHOUT (no VPN required) |
 | `seed-match-verification` | Create `TrusteeMatchVerification` docs for all non-auto-match outcomes (no VPN required) |
 | `seed-auto-match [N]` | Read real DXTR events and create matching CAMS trustees + appointments for auto-matching (**requires VPN + DXTR connection**) |
+| `seed-matching-scenarios` | Create 24 trustees covering all matching scenarios (auto-match, multiple, imperfect, etc.) |
+| `seed-archived-trustees` | Create 5 trustees covering the CAMS-772 ARCHIVE_DATE inactive condition (no VPN required) |
 | `list` | Show all seeded test data currently in MongoDB |
 | `clean` | Delete all seeded trustees (by `createdBy.id: 'SEED-SCRIPT'`), their appointments and proIds, **and all** `trustee-match-verification` records |
 | `clean-all` | Delete **all** trustee data regardless of origin — use to fully reset dev Cosmos DB |
@@ -120,6 +123,11 @@ npx tsx --tsconfig backend/tsconfig.json \
 npx tsx --tsconfig backend/tsconfig.json \
   test/migration/trustee/scripts/seed-test-trustees.ts \
   seed-auto-match 10
+
+# Seed CAMS-772 archived trustee appointment scenarios (no VPN required)
+npx tsx --tsconfig backend/tsconfig.json \
+  test/migration/trustee/scripts/seed-test-trustees.ts \
+  seed-archived-trustees
 
 # List seeded data currently in MongoDB
 npx tsx --tsconfig backend/tsconfig.json \
@@ -593,6 +601,84 @@ npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/seed-tes
 
 ---
 
+## CAMS-772: Archived Appointment Fix
+
+### What to verify
+
+TOD (the legacy ATS system) archived `case-by-case`, `elected`, and `converted-case` trustee
+appointments instead of terminating them. This left `ARCHIVE_DATE` populated on the
+`CHAPTER_DETAILS` row while `STATUS` still read as active. The migration imported these as
+`active`, causing false-active trustees to appear in the trustee list.
+
+**The fix:** when `ARCHIVE_DATE` is non-null for one of those three appointment types, the
+cleansing transform overrides `status` to `inactive` and uses the archive date as `effectiveDate`.
+
+### Seed data (no VPN required)
+
+```bash
+npx tsx --tsconfig backend/tsconfig.json \
+  test/migration/trustee/scripts/seed-test-trustees.ts \
+  seed-archived-trustees
+```
+
+**Seeded trustees:**
+
+| Name | Appointment type | Status | effectiveDate (= ARCHIVE_DATE) |
+|---|---|---|---|
+| SEED Test Archived CBC Trustee | `case-by-case` | `inactive` | 2019-06-15 |
+| SEED Test Archived Elected Trustee | `elected` | `inactive` | 2020-03-01 |
+| SEED Test Archived Converted Trustee | `converted-case` | `inactive` | 2018-11-30 |
+| SEED Test Active CBC Trustee | `case-by-case` | `active` | 2022-01-01 (no ARCHIVE_DATE — control) |
+| SEED Test Mixed Archive Active Trustee | `case-by-case` (inactive) + `panel` (active) | mixed | control: trustee should still appear active |
+
+### Verify in MongoDB
+
+```javascript
+// All 5 seeded trustees
+db.trustees.find({ 'createdBy.id': 'SEED-SCRIPT', name: /Archived|Active CBC|Mixed Archive/ })
+
+// Appointments for archived trustees — all should be inactive
+db['trustee-appointments'].find({
+  documentType: 'TRUSTEE_APPOINTMENT',
+  'createdBy.id': 'SEED-SCRIPT',
+  appointmentType: { $in: ['case-by-case', 'elected', 'converted-case'] }
+})
+
+// The "Mixed" trustee should have one inactive + one active appointment
+const mixed = db.trustees.findOne({ name: 'SEED Test Mixed Archive Active Trustee' });
+db['trustee-appointments'].find({ trusteeId: mixed.trusteeId })
+// Expected: case-by-case/inactive (2021-08-20) AND panel/active (2022-03-15)
+```
+
+### Testing the trustee list display (CAMS-767)
+
+1. Seed archived trustees (above)
+2. Open the trustee list in the CAMS UI
+3. Verify:
+   - "SEED Test Archived CBC Trustee", "SEED Test Archived Elected Trustee", and
+     "SEED Test Archived Converted Trustee" do **not** appear when filtered to active trustees
+   - "SEED Test Active CBC Trustee" does appear (genuinely active)
+   - "SEED Test Mixed Archive Active Trustee" does appear (panel appointment is still active)
+
+### Unit tests for the fix
+
+```bash
+# Cleansing transform (archive override logic)
+cd backend && npm test -- lib/adapters/gateways/ats/cleansing/ats-cleansing-transform.test.ts
+
+# All ATS gateway tests
+cd backend && npm test -- lib/adapters/gateways/ats/ats.gateway.test.ts
+```
+
+The transform tests cover all five conditions:
+- `case-by-case` + `ARCHIVE_DATE` → `inactive`
+- `elected` + `ARCHIVE_DATE` → `inactive`
+- `converted-case` + `ARCHIVE_DATE` → `inactive`
+- `panel` + `ARCHIVE_DATE` → NOT overridden (panel is not an archived type)
+- `case-by-case` without `ARCHIVE_DATE` → NOT overridden (stays active)
+
+---
+
 ## Running Unit Tests
 
 ```bash
@@ -617,4 +703,7 @@ cd common && npm test -- src/cams/trustees-validators.test.ts
 # CAMS-721 — Trustee matching / auto-match sync use case
 cd backend && npm test -- lib/use-cases/dataflows/sync-trustee-appointments.test.ts
 cd backend && npm test -- lib/use-cases/dataflows/trustee-match.helpers.test.ts
+
+# CAMS-772 — Archived appointment ARCHIVE_DATE override
+cd backend && npm test -- lib/adapters/gateways/ats/cleansing/ats-cleansing-transform.test.ts
 ```

--- a/test/migration/trustee/scripts/check-active-status.ts
+++ b/test/migration/trustee/scripts/check-active-status.ts
@@ -1,0 +1,191 @@
+/**
+ * Check active status distribution in the ATS CHAPTER_DETAILS table.
+ *
+ * Verifies the active-only trustee filter (Slice 1) and the CAMS-772 ARCHIVE_DATE
+ * condition are both working as expected before running a migration batch.
+ *
+ * Usage (from repo root):
+ *   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/check-active-status.ts
+ *
+ * Output:
+ *   - All distinct STATUS values with row counts
+ *   - How many trustees have at least one active appointment (will be migrated)
+ *   - How many trustees have no appointments or only inactive ones (will be skipped)
+ *   - CAMS-772: How many trustees have archived appointments that will import as inactive
+ */
+
+import * as dotenv from 'dotenv';
+import { InvocationContext } from '@azure/functions';
+import ApplicationContextCreator from '../../../../backend/function-apps/azure/application-context-creator';
+import factory from '../../../../backend/lib/factory';
+import { ACTIVE_STATUS_CODES } from '../../../../backend/lib/adapters/gateways/ats/ats.constants';
+
+dotenv.config({ path: 'backend/.env' });
+
+type Row = Record<string, string | number | null | Date>;
+
+async function checkActiveStatus() {
+  const invocationContext = new InvocationContext();
+  const context = await ApplicationContextCreator.getApplicationContext({
+    invocationContext,
+    logger: ApplicationContextCreator.getLogger(invocationContext),
+  });
+
+  const gateway = factory.getAtsGateway(context);
+
+  console.log('='.repeat(60));
+  console.log('ATS Active Status Check');
+  console.log('='.repeat(60));
+
+  const activeCodesInList = [...ACTIVE_STATUS_CODES].map((c) => `'${c}'`).join(', ');
+  console.log(`\nActive STATUS codes: ${activeCodesInList}\n`);
+
+  // -------------------------------------------------------------------------
+  // 1. All distinct STATUS values with row counts
+  // -------------------------------------------------------------------------
+  const statusDistQuery = `
+    SELECT
+      ISNULL(STATUS, '(null)') AS STATUS,
+      COUNT(*) AS row_count,
+      COUNT(DISTINCT TRU_ID) AS trustee_count
+    FROM CHAPTER_DETAILS
+    GROUP BY STATUS
+    ORDER BY row_count DESC
+  `;
+  const statusResult = await gateway.executeQuery(context, statusDistQuery, []);
+  const statusRows = statusResult.results.recordset as Row[];
+
+  console.log('STATUS distribution in CHAPTER_DETAILS:');
+  console.log('─'.repeat(55));
+  console.log('  STATUS'.padEnd(12) + 'rows'.padStart(10) + '  trustees');
+  console.log('─'.repeat(55));
+  for (const row of statusRows) {
+    const isActive = ACTIVE_STATUS_CODES.has(String(row.STATUS));
+    const marker = isActive ? ' ✓' : '  ';
+    console.log(
+      `${marker} ${String(row.STATUS).padEnd(10)} ${String(row.row_count).padStart(10)}  ${row.trustee_count}`,
+    );
+  }
+  console.log('  ✓ = active STATUS code (will be included in migration)');
+
+  // -------------------------------------------------------------------------
+  // 2. Trustee counts — who gets migrated vs. skipped
+  // -------------------------------------------------------------------------
+  const totalTrusteesQuery = `SELECT COUNT(*) AS total FROM TRUSTEES`;
+  const totalResult = await gateway.executeQuery(context, totalTrusteesQuery, []);
+  const totalRows = totalResult.results.recordset as Row[];
+  const totalTrustees = Number(totalRows[0]?.total ?? 0);
+
+  const activeFilterQuery = `
+    SELECT COUNT(*) AS active_count
+    FROM TRUSTEES T
+    WHERE EXISTS (
+      SELECT 1 FROM CHAPTER_DETAILS CD
+      WHERE CD.TRU_ID = T.ID
+        AND CD.STATUS IN (${activeCodesInList})
+    )
+  `;
+  const activeResult = await gateway.executeQuery(context, activeFilterQuery, []);
+  const activeRows = activeResult.results.recordset as Row[];
+  const activeTrustees = Number(activeRows[0]?.active_count ?? 0);
+  const skippedTrustees = totalTrustees - activeTrustees;
+
+  console.log('\nTrustee migration scope:');
+  console.log('─'.repeat(55));
+  console.log(`  Total trustees in TRUSTEES table  : ${totalTrustees}`);
+  console.log(`  Trustees with any active STATUS   : ${activeTrustees}  (will be migrated)`);
+  console.log(`  Trustees skipped (no active appt) : ${skippedTrustees}  (filtered out)`);
+
+  // -------------------------------------------------------------------------
+  // 3. Trustees with no appointments at all
+  // -------------------------------------------------------------------------
+  const noApptsQuery = `
+    SELECT COUNT(*) AS no_appt_count
+    FROM TRUSTEES T
+    WHERE NOT EXISTS (
+      SELECT 1 FROM CHAPTER_DETAILS CD WHERE CD.TRU_ID = T.ID
+    )
+  `;
+  const noApptsResult = await gateway.executeQuery(context, noApptsQuery, []);
+  const noApptsRows = noApptsResult.results.recordset as Row[];
+  const noAppts = Number(noApptsRows[0]?.no_appt_count ?? 0);
+  console.log(`  Trustees with no appointments     : ${noAppts}  (subset of skipped)`);
+
+  // -------------------------------------------------------------------------
+  // 4. CAMS-772: Archived appointments
+  //    STATUS codes C/E/O with a non-null ARCHIVE_DATE → imported as inactive
+  // -------------------------------------------------------------------------
+  const archiveQuery = `
+    SELECT
+      STATUS,
+      COUNT(*) AS archived_rows,
+      COUNT(DISTINCT TRU_ID) AS affected_trustees
+    FROM CHAPTER_DETAILS
+    WHERE ARCHIVE_DATE IS NOT NULL
+      AND STATUS IN ('C', 'E', 'O')
+    GROUP BY STATUS
+    ORDER BY STATUS
+  `;
+  const archiveResult = await gateway.executeQuery(context, archiveQuery, []);
+  const archiveRows = archiveResult.results.recordset as Row[];
+
+  const statusLabel: Record<string, string> = {
+    C: 'case-by-case',
+    E: 'elected',
+    O: 'converted-case',
+  };
+
+  console.log('\nCAMS-772: Archived appointments (ARCHIVE_DATE non-null for C/E/O):');
+  console.log('─'.repeat(55));
+  if (archiveRows.length === 0) {
+    console.log('  (none found — ARCHIVE_DATE column may be missing or empty)');
+  } else {
+    for (const row of archiveRows) {
+      const label = statusLabel[String(row.STATUS)] ?? String(row.STATUS);
+      console.log(
+        `  STATUS=${row.STATUS} (${label}): ${row.archived_rows} rows, ${row.affected_trustees} trustees → imported as inactive`,
+      );
+    }
+
+    const totalAffectedQuery = `
+      SELECT COUNT(DISTINCT TRU_ID) AS total
+      FROM CHAPTER_DETAILS
+      WHERE ARCHIVE_DATE IS NOT NULL
+        AND STATUS IN ('C', 'E', 'O')
+    `;
+    const totalAffectedResult = await gateway.executeQuery(context, totalAffectedQuery, []);
+    const totalAffectedRows = totalAffectedResult.results.recordset as Row[];
+    const totalAffected = Number(totalAffectedRows[0]?.total ?? 0);
+    console.log(
+      `\n  Total trustees affected by CAMS-772 fix : ${totalAffected}`,
+    );
+
+    // How many of those still have at least one active appointment (not fully inactive)
+    const mixedQuery = `
+      SELECT COUNT(DISTINCT T.ID) AS mixed_count
+      FROM TRUSTEES T
+      WHERE EXISTS (
+        SELECT 1 FROM CHAPTER_DETAILS CD
+        WHERE CD.TRU_ID = T.ID AND CD.ARCHIVE_DATE IS NOT NULL AND CD.STATUS IN ('C', 'E', 'O')
+      )
+      AND EXISTS (
+        SELECT 1 FROM CHAPTER_DETAILS CD2
+        WHERE CD2.TRU_ID = T.ID AND CD2.STATUS IN (${activeCodesInList})
+          AND (CD2.ARCHIVE_DATE IS NULL OR CD2.STATUS NOT IN ('C', 'E', 'O'))
+      )
+    `;
+    const mixedResult = await gateway.executeQuery(context, mixedQuery, []);
+    const mixedRows = mixedResult.results.recordset as Row[];
+    const mixedCount = Number(mixedRows[0]?.mixed_count ?? 0);
+    console.log(
+      `  Of those, trustees with ≥1 other active appointment (still in list): ${mixedCount}`,
+    );
+    console.log(
+      `  Trustees fully inactive after fix (all active appts were archived) : ${totalAffected - mixedCount}`,
+    );
+  }
+
+  console.log('\n' + '='.repeat(60));
+}
+
+checkActiveStatus().catch(console.error);

--- a/test/migration/trustee/scripts/check-active-status.ts
+++ b/test/migration/trustee/scripts/check-active-status.ts
@@ -19,6 +19,7 @@ import { InvocationContext } from '@azure/functions';
 import ApplicationContextCreator from '../../../../backend/function-apps/azure/application-context-creator';
 import factory from '../../../../backend/lib/factory';
 import { ACTIVE_STATUS_CODES } from '../../../../backend/lib/adapters/gateways/ats/ats.constants';
+import { ARCHIVE_STATUS_LABELS } from './shared';
 
 dotenv.config({ path: 'backend/.env' });
 
@@ -129,19 +130,13 @@ async function checkActiveStatus() {
   const archiveResult = await gateway.executeQuery(context, archiveQuery, []);
   const archiveRows = archiveResult.results.recordset as Row[];
 
-  const statusLabel: Record<string, string> = {
-    C: 'case-by-case',
-    E: 'elected',
-    O: 'converted-case',
-  };
-
   console.log('\nCAMS-772: Archived appointments (ARCHIVE_DATE non-null for C/E/O):');
   console.log('─'.repeat(55));
   if (archiveRows.length === 0) {
     console.log('  (none found — ARCHIVE_DATE column may be missing or empty)');
   } else {
     for (const row of archiveRows) {
-      const label = statusLabel[String(row.STATUS)] ?? String(row.STATUS);
+      const label = ARCHIVE_STATUS_LABELS[String(row.STATUS)] ?? String(row.STATUS);
       console.log(
         `  STATUS=${row.STATUS} (${label}): ${row.archived_rows} rows, ${row.affected_trustees} trustees → imported as inactive`,
       );

--- a/test/migration/trustee/scripts/check-appointments.ts
+++ b/test/migration/trustee/scripts/check-appointments.ts
@@ -44,7 +44,7 @@ async function checkAppointments() {
   `;
 
   const result = await gateway.executeQuery(context, query, []);
-  const rows = result.results as Row[];
+  const rows = result.results.recordset as Row[];
 
   console.log('Sample CHAPTER_DETAILS with TRUSTEES join:');
   console.log('===========================================');
@@ -59,7 +59,7 @@ async function checkAppointments() {
       WHERE EXISTS (SELECT 1 FROM TRUSTEES T WHERE T.ID = CD.TRU_ID)
     `;
     const altResult = await gateway.executeQuery(context, altQuery, []);
-    const altRows = altResult.results as Row[];
+    const altRows = altResult.results.recordset as Row[];
     console.log(`\nRecords that match when CD.TRU_ID = T.ID: ${altRows[0].count}`);
 
     // Check distinct TRU_ID values in CHAPTER_DETAILS
@@ -70,7 +70,7 @@ async function checkAppointments() {
       ORDER BY TRU_ID
     `;
     const distinctResult = await gateway.executeQuery(context, distinctQuery, []);
-    const distinctRows = distinctResult.results as Row[];
+    const distinctRows = distinctResult.results.recordset as Row[];
     console.log('\nSample TRU_ID values in CHAPTER_DETAILS:');
     for (const row of distinctRows) {
       console.log(`  ${row.TRU_ID}`);

--- a/test/migration/trustee/scripts/check-ats-schema.ts
+++ b/test/migration/trustee/scripts/check-ats-schema.ts
@@ -19,6 +19,7 @@ import * as dotenv from 'dotenv';
 import { InvocationContext } from '@azure/functions';
 import ApplicationContextCreator from '../../../../backend/function-apps/azure/application-context-creator';
 import factory from '../../../../backend/lib/factory';
+import { ARCHIVE_STATUS_LABELS } from './shared';
 
 // Load environment variables
 dotenv.config({ path: 'backend/.env' });
@@ -148,18 +149,12 @@ async function checkSchema() {
     const archiveCountResult = await gateway.executeQuery(context, archiveCountQuery, []);
     const archiveCounts = recordset(archiveCountResult);
 
-    const statusLabel: Record<string, string> = {
-      C: 'case-by-case',
-      E: 'elected',
-      O: 'converted-case',
-    };
-
     console.log('\n  Rows with non-null ARCHIVE_DATE (the three affected STATUS codes):');
     if (archiveCounts.length === 0) {
       console.log('  (none found — either no archived appointments or ARCHIVE_DATE column missing)');
     } else {
       for (const row of archiveCounts) {
-        const label = statusLabel[String(row.STATUS)] ?? String(row.STATUS);
+        const label = ARCHIVE_STATUS_LABELS[String(row.STATUS)] ?? String(row.STATUS);
         const earliest =
           row.earliest_archive instanceof Date
             ? row.earliest_archive.toISOString().split('T')[0]
@@ -215,7 +210,7 @@ async function checkSchema() {
           row.APPOINTED_DATE instanceof Date
             ? row.APPOINTED_DATE.toISOString().split('T')[0]
             : String(row.APPOINTED_DATE ?? 'N/A');
-        const label = statusLabel[String(row.STATUS)] ?? String(row.STATUS);
+        const label = ARCHIVE_STATUS_LABELS[String(row.STATUS)] ?? String(row.STATUS);
         console.log(
           `    TRU_ID=${row.TRU_ID}  DISTRICT=${row.DISTRICT}  CHAPTER=${row.CHAPTER}  STATUS=${row.STATUS} (${label})  appointed=${appointedDate}  archived=${archiveDate}`,
         );

--- a/test/migration/trustee/scripts/check-ats-schema.ts
+++ b/test/migration/trustee/scripts/check-ats-schema.ts
@@ -3,6 +3,16 @@
  *
  * Usage (from repo root):
  *   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/check-ats-schema.ts
+ *
+ * Checks:
+ *   1. TRUSTEES table columns
+ *   2. CHAPTER_DETAILS table columns
+ *   3. CAMS-772: ARCHIVE_DATE column presence and data conditions
+ *      - Verifies ARCHIVE_DATE exists with the expected type
+ *      - Counts rows where ARCHIVE_DATE is non-null for the three affected STATUS codes
+ *        (C=case-by-case, E=elected, O=converted-case)
+ *      - Shows how many distinct trustees are affected
+ *      - Samples a few archived rows so the data can be visually confirmed
  */
 
 import * as dotenv from 'dotenv';
@@ -13,7 +23,11 @@ import factory from '../../../../backend/lib/factory';
 // Load environment variables
 dotenv.config({ path: 'backend/.env' });
 
-type Row = Record<string, string | number | null>;
+type Row = Record<string, string | number | null | Date>;
+
+function recordset(result: { results: void | object }): Row[] {
+  return ((result.results as { recordset: Row[] })?.recordset) ?? [];
+}
 
 async function checkSchema() {
   console.log('Checking ATS database schema...\n');
@@ -27,8 +41,10 @@ async function checkSchema() {
   const gateway = factory.getAtsGateway(context);
 
   try {
-    // Get column information for TRUSTEES table
-    const query = `
+    // -------------------------------------------------------------------------
+    // 1. TRUSTEES table columns
+    // -------------------------------------------------------------------------
+    const trusteesSchemaQuery = `
       SELECT
         COLUMN_NAME,
         DATA_TYPE,
@@ -39,20 +55,21 @@ async function checkSchema() {
       ORDER BY ORDINAL_POSITION
     `;
 
-    const result = await gateway.executeQuery(context, query, []);
-    const rows = result.results as Row[];
+    const trusteesResult = await gateway.executeQuery(context, trusteesSchemaQuery, []);
+    const trusteesRows = recordset(trusteesResult);
 
     console.log('TRUSTEES table columns:');
     console.log('========================');
-
-    for (const col of rows) {
+    for (const col of trusteesRows) {
       const maxLen = col.CHARACTER_MAXIMUM_LENGTH ? `(${col.CHARACTER_MAXIMUM_LENGTH})` : '';
       const nullable = col.IS_NULLABLE === 'YES' ? 'NULL' : 'NOT NULL';
       console.log(`  ${String(col.COLUMN_NAME).padEnd(30)} ${col.DATA_TYPE}${maxLen} ${nullable}`);
     }
 
-    // Also check for CHAPTER_DETAILS table (appointments)
-    const appointmentsQuery = `
+    // -------------------------------------------------------------------------
+    // 2. CHAPTER_DETAILS table columns
+    // -------------------------------------------------------------------------
+    const chapterSchemaQuery = `
       SELECT
         COLUMN_NAME,
         DATA_TYPE,
@@ -63,14 +80,13 @@ async function checkSchema() {
       ORDER BY ORDINAL_POSITION
     `;
 
-    const appointmentsResult = await gateway.executeQuery(context, appointmentsQuery, []);
-    const appointmentRows = appointmentsResult.results as Row[];
+    const chapterResult = await gateway.executeQuery(context, chapterSchemaQuery, []);
+    const chapterRows = recordset(chapterResult);
 
-    if (appointmentRows.length > 0) {
+    if (chapterRows.length > 0) {
       console.log('\nCHAPTER_DETAILS table columns:');
       console.log('================================');
-
-      for (const col of appointmentRows) {
+      for (const col of chapterRows) {
         const maxLen = col.CHARACTER_MAXIMUM_LENGTH ? `(${col.CHARACTER_MAXIMUM_LENGTH})` : '';
         const nullable = col.IS_NULLABLE === 'YES' ? 'NULL' : 'NOT NULL';
         console.log(
@@ -79,12 +95,167 @@ async function checkSchema() {
       }
     }
 
-    // Get a sample row to see actual data
+    // -------------------------------------------------------------------------
+    // 3. CAMS-772: ARCHIVE_DATE verification
+    //
+    // TOD archived case-by-case (C), elected (E), and converted-case (O)
+    // appointments by setting ARCHIVE_DATE instead of changing STATUS. The
+    // migration fix reads ARCHIVE_DATE and overrides status to 'inactive' for
+    // those three types. This section confirms the column exists and shows the
+    // scope of affected data.
+    // -------------------------------------------------------------------------
+    console.log('\n\nCAMS-772: ARCHIVE_DATE verification');
+    console.log('=====================================');
+
+    // 3a. Confirm ARCHIVE_DATE column exists
+    const archiveDateColQuery = `
+      SELECT
+        COLUMN_NAME,
+        DATA_TYPE,
+        IS_NULLABLE
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_NAME = 'CHAPTER_DETAILS'
+        AND COLUMN_NAME = 'ARCHIVE_DATE'
+    `;
+    const archiveDateColResult = await gateway.executeQuery(context, archiveDateColQuery, []);
+    const archiveDateCols = recordset(archiveDateColResult);
+
+    if (archiveDateCols.length === 0) {
+      console.log('  ❌ ARCHIVE_DATE column NOT FOUND in CHAPTER_DETAILS');
+      console.log('     The CAMS-772 fix will not have data to act on until this column exists.');
+    } else {
+      const col = archiveDateCols[0];
+      console.log(
+        `  ✅ ARCHIVE_DATE column found: ${col.DATA_TYPE}, IS_NULLABLE=${col.IS_NULLABLE}`,
+      );
+    }
+
+    // 3b. Count rows with non-null ARCHIVE_DATE by STATUS code
+    //     STATUS codes affected: C (case-by-case), E (elected), O (converted-case)
+    const archiveCountQuery = `
+      SELECT
+        STATUS,
+        COUNT(*) AS row_count,
+        COUNT(DISTINCT TRU_ID) AS trustee_count,
+        MIN(ARCHIVE_DATE) AS earliest_archive,
+        MAX(ARCHIVE_DATE) AS latest_archive
+      FROM CHAPTER_DETAILS
+      WHERE ARCHIVE_DATE IS NOT NULL
+        AND STATUS IN ('C', 'E', 'O')
+      GROUP BY STATUS
+      ORDER BY STATUS
+    `;
+    const archiveCountResult = await gateway.executeQuery(context, archiveCountQuery, []);
+    const archiveCounts = recordset(archiveCountResult);
+
+    const statusLabel: Record<string, string> = {
+      C: 'case-by-case',
+      E: 'elected',
+      O: 'converted-case',
+    };
+
+    console.log('\n  Rows with non-null ARCHIVE_DATE (the three affected STATUS codes):');
+    if (archiveCounts.length === 0) {
+      console.log('  (none found — either no archived appointments or ARCHIVE_DATE column missing)');
+    } else {
+      for (const row of archiveCounts) {
+        const label = statusLabel[String(row.STATUS)] ?? String(row.STATUS);
+        const earliest =
+          row.earliest_archive instanceof Date
+            ? row.earliest_archive.toISOString().split('T')[0]
+            : String(row.earliest_archive ?? 'N/A');
+        const latest =
+          row.latest_archive instanceof Date
+            ? row.latest_archive.toISOString().split('T')[0]
+            : String(row.latest_archive ?? 'N/A');
+        console.log(
+          `    STATUS=${row.STATUS} (${label}): ${row.row_count} rows, ${row.trustee_count} trustees, range ${earliest} – ${latest}`,
+        );
+      }
+    }
+
+    // 3c. Total distinct trustees affected
+    const affectedTrusteesQuery = `
+      SELECT COUNT(DISTINCT TRU_ID) AS affected_trustees
+      FROM CHAPTER_DETAILS
+      WHERE ARCHIVE_DATE IS NOT NULL
+        AND STATUS IN ('C', 'E', 'O')
+    `;
+    const affectedResult = await gateway.executeQuery(context, affectedTrusteesQuery, []);
+    const affectedRows = recordset(affectedResult);
+    const affectedCount = affectedRows[0]?.affected_trustees ?? 0;
+    console.log(`\n  Total distinct trustees with at least one archived appointment: ${affectedCount}`);
+
+    // 3d. Sample archived rows (up to 5) so data can be visually confirmed
+    const sampleArchivedQuery = `
+      SELECT TOP 5
+        TRU_ID,
+        DISTRICT,
+        CHAPTER,
+        STATUS,
+        APPOINTED_DATE,
+        STATUS_EFF_DATE,
+        ARCHIVE_DATE
+      FROM CHAPTER_DETAILS
+      WHERE ARCHIVE_DATE IS NOT NULL
+        AND STATUS IN ('C', 'E', 'O')
+      ORDER BY ARCHIVE_DATE DESC
+    `;
+    const sampleArchivedResult = await gateway.executeQuery(context, sampleArchivedQuery, []);
+    const sampleArchivedRows = recordset(sampleArchivedResult);
+
+    if (sampleArchivedRows.length > 0) {
+      console.log('\n  Sample archived rows (newest ARCHIVE_DATE first):');
+      for (const row of sampleArchivedRows) {
+        const archiveDate =
+          row.ARCHIVE_DATE instanceof Date
+            ? row.ARCHIVE_DATE.toISOString().split('T')[0]
+            : String(row.ARCHIVE_DATE ?? 'N/A');
+        const appointedDate =
+          row.APPOINTED_DATE instanceof Date
+            ? row.APPOINTED_DATE.toISOString().split('T')[0]
+            : String(row.APPOINTED_DATE ?? 'N/A');
+        const label = statusLabel[String(row.STATUS)] ?? String(row.STATUS);
+        console.log(
+          `    TRU_ID=${row.TRU_ID}  DISTRICT=${row.DISTRICT}  CHAPTER=${row.CHAPTER}  STATUS=${row.STATUS} (${label})  appointed=${appointedDate}  archived=${archiveDate}`,
+        );
+      }
+    }
+
+    // 3e. Sanity check: rows where ARCHIVE_DATE is set but STATUS is NOT one of the three
+    //     (shouldn't be many — just verifying TOD's archiving convention held)
+    const unexpectedArchiveQuery = `
+      SELECT
+        STATUS,
+        COUNT(*) AS row_count
+      FROM CHAPTER_DETAILS
+      WHERE ARCHIVE_DATE IS NOT NULL
+        AND STATUS NOT IN ('C', 'E', 'O')
+      GROUP BY STATUS
+      ORDER BY row_count DESC
+    `;
+    const unexpectedResult = await gateway.executeQuery(context, unexpectedArchiveQuery, []);
+    const unexpectedRows = recordset(unexpectedResult);
+
+    if (unexpectedRows.length > 0) {
+      console.log(
+        '\n  ⚠️  Rows with ARCHIVE_DATE set but STATUS outside {C, E, O} — NOT overridden by the fix:',
+      );
+      for (const row of unexpectedRows) {
+        console.log(`    STATUS=${row.STATUS}: ${row.row_count} rows`);
+      }
+    } else {
+      console.log('\n  ✅ No unexpected STATUS codes with ARCHIVE_DATE — convention held.');
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. Sample TRUSTEES row
+    // -------------------------------------------------------------------------
     console.log('\n\nSample TRUSTEES row:');
     console.log('=====================');
     const sampleQuery = `SELECT TOP 1 * FROM TRUSTEES`;
     const sampleResult = await gateway.executeQuery(context, sampleQuery, []);
-    const sampleRows = sampleResult.results as Row[];
+    const sampleRows = recordset(sampleResult);
 
     if (sampleRows.length > 0) {
       const sample = sampleRows[0];

--- a/test/migration/trustee/scripts/check-trustee-data.ts
+++ b/test/migration/trustee/scripts/check-trustee-data.ts
@@ -28,19 +28,19 @@ async function checkData() {
   // Check total records
   const totalQuery = `SELECT COUNT(*) as total FROM TRUSTEES`;
   const totalResult = await gateway.executeQuery(context, totalQuery, []);
-  const totalRows = totalResult.results as Row[];
+  const totalRows = totalResult.results.recordset as Row[];
   console.log(`Total records in TRUSTEES: ${totalRows[0].total}`);
 
   // Check records with TRU_ID
   const withIdQuery = `SELECT COUNT(*) as total FROM TRUSTEES WHERE TRU_ID IS NOT NULL`;
   const withIdResult = await gateway.executeQuery(context, withIdQuery, []);
-  const withIdRows = withIdResult.results as Row[];
+  const withIdRows = withIdResult.results.recordset as Row[];
   console.log(`Records with TRU_ID: ${withIdRows[0].total}`);
 
   // Check records without TRU_ID
   const withoutIdQuery = `SELECT COUNT(*) as total FROM TRUSTEES WHERE TRU_ID IS NULL`;
   const withoutIdResult = await gateway.executeQuery(context, withoutIdQuery, []);
-  const withoutIdRows = withoutIdResult.results as Row[];
+  const withoutIdRows = withoutIdResult.results.recordset as Row[];
   console.log(`Records with NULL TRU_ID: ${withoutIdRows[0].total}`);
 
   // Get sample records (using ID instead of TRU_ID)
@@ -58,7 +58,7 @@ async function checkData() {
     ORDER BY ID
   `;
   const sampleResult = await gateway.executeQuery(context, sampleQuery, []);
-  const sampleRows = sampleResult.results as Row[];
+  const sampleRows = sampleResult.results.recordset as Row[];
 
   for (const row of sampleRows) {
     console.log(`\n  ID: ${row.ID} | TRU_ID: ${row.TRU_ID}`);

--- a/test/migration/trustee/scripts/seed-test-trustees.ts
+++ b/test/migration/trustee/scripts/seed-test-trustees.ts
@@ -13,6 +13,11 @@
  *   so that running sync-trustee-appointments produces auto-match telemetry
  *   visible in the trustee-matching-analytics workbook.
  *
+ * CAMS-772: Seeds 5 trustees covering the ARCHIVE_DATE inactive condition so
+ *   the trustee list display can be verified locally. TOD archived case-by-case,
+ *   elected, and converted-case appointments instead of terminating them; the
+ *   migration fix reads ARCHIVE_DATE and overrides status to 'inactive'.
+ *
  * Usage (from repo root):
  *   npx tsx --tsconfig backend/tsconfig.json \
  *     test/migration/trustee/scripts/seed-test-trustees.ts \
@@ -23,6 +28,7 @@
  *   seed-match-verification  Create TrusteeMatchVerification docs for all slice 3 outcomes
  *   seed-auto-match          Create CAMS trustees + appointments matching real DXTR data
  *   seed-matching-scenarios  Create 24 trustees with appointments covering all matching scenarios
+ *   seed-archived-trustees   Create 5 trustees covering the CAMS-772 ARCHIVE_DATE condition
  *   list                     Show seeded test data currently in MongoDB
  *   clean                    Delete all seeded test data from MongoDB
  *   help                     Show this message
@@ -83,7 +89,12 @@ const TRUSTEES_WITHOUT_PROID: TrusteeSeedNoProId[] = [
 ];
 
 function makeTrusteeInput(name: string, state: string): TrusteeInput {
+  const parts = name.trim().split(/\s+/);
+  const firstName = parts[0] ?? '';
+  const lastName = parts[parts.length - 1] ?? '';
   return {
+    firstName,
+    lastName,
     name,
     public: {
       address: {
@@ -393,6 +404,132 @@ const MATCHING_SCENARIO_TRUSTEES: MatchingScenarioTrustee[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// CAMS-772: Archived appointment seed data
+//
+// TOD archived case-by-case, elected, and converted-case appointments instead
+// of terminating them. After the fix, the migration sets these to inactive
+// with effectiveDate = ARCHIVE_DATE. These seeds simulate that post-migration
+// state so the trustee list filtering (CAMS-767) can be verified locally.
+// ---------------------------------------------------------------------------
+
+type ArchivedTrusteeSeed = {
+  name: string;
+  state: string;
+  note: string;
+  appointments: Array<{
+    courtId: string;
+    divisionCode: string;
+    chapter: AppointmentChapterType;
+    appointedDate: string;
+    appointmentType: AppointmentType;
+    status: AppointmentStatus;
+    effectiveDate: string;
+  }>;
+};
+
+const ARCHIVED_TRUSTEE_SEEDS: ArchivedTrusteeSeed[] = [
+  // Scenario 1: case-by-case appointment archived → inactive
+  {
+    name: 'SEED Test Archived CBC Trustee',
+    state: 'NY',
+    note: 'case-by-case appointment archived in TOD — should appear inactive, not in active list',
+    appointments: [
+      {
+        courtId: '0208',
+        divisionCode: '1',
+        chapter: '7',
+        appointedDate: '2010-01-01',
+        appointmentType: 'case-by-case',
+        status: 'inactive',
+        effectiveDate: '2019-06-15', // simulates ARCHIVE_DATE
+      },
+    ],
+  },
+
+  // Scenario 2: elected appointment archived → inactive
+  {
+    name: 'SEED Test Archived Elected Trustee',
+    state: 'IL',
+    note: 'elected appointment archived in TOD — should appear inactive, not in active list',
+    appointments: [
+      {
+        courtId: '0752',
+        divisionCode: '1',
+        chapter: '7',
+        appointedDate: '2010-01-01',
+        appointmentType: 'elected',
+        status: 'inactive',
+        effectiveDate: '2020-03-01', // simulates ARCHIVE_DATE
+      },
+    ],
+  },
+
+  // Scenario 3: converted-case appointment archived → inactive
+  {
+    name: 'SEED Test Archived Converted Trustee',
+    state: 'TX',
+    note: 'converted-case appointment archived in TOD — should appear inactive, not in active list',
+    appointments: [
+      {
+        courtId: '0539',
+        divisionCode: '1',
+        chapter: '7',
+        appointedDate: '2010-01-01',
+        appointmentType: 'converted-case',
+        status: 'inactive',
+        effectiveDate: '2018-11-30', // simulates ARCHIVE_DATE
+      },
+    ],
+  },
+
+  // Scenario 4: genuinely active case-by-case (no archive date) → stays active
+  {
+    name: 'SEED Test Active CBC Trustee',
+    state: 'CA',
+    note: 'case-by-case appointment with no ARCHIVE_DATE — should stay active and appear in active list',
+    appointments: [
+      {
+        courtId: '0973',
+        divisionCode: '1',
+        chapter: '7',
+        appointedDate: '2022-01-01',
+        appointmentType: 'case-by-case',
+        status: 'active',
+        effectiveDate: '2022-01-01',
+      },
+    ],
+  },
+
+  // Scenario 5: mixed — archived case-by-case + active panel on the same trustee
+  // The panel should keep the trustee in the active list; only the CBC appointment is inactive.
+  {
+    name: 'SEED Test Mixed Archive Active Trustee',
+    state: 'OH',
+    note: 'one archived case-by-case + one active panel — trustee still appears active (panel drives it)',
+    appointments: [
+      {
+        courtId: '0647',
+        divisionCode: '1',
+        chapter: '7',
+        appointedDate: '2010-01-01',
+        appointmentType: 'case-by-case',
+        status: 'inactive',
+        effectiveDate: '2021-08-20', // simulates ARCHIVE_DATE
+      },
+      {
+        courtId: '0647',
+        divisionCode: '1',
+        chapter: '7',
+        appointedDate: '2022-03-15',
+        appointmentType: 'panel',
+        status: 'active',
+        effectiveDate: '2022-03-15',
+      },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
 // Match verification definitions
 // ---------------------------------------------------------------------------
 
@@ -450,7 +587,7 @@ type VerificationSeed = {
   mismatchReason: TrusteeAppointmentSyncErrorCode;
   status: 'pending' | 'approved' | 'rejected';
   candidates: RichCandidate[];
-  inactiveAppointmentStatus?: string;
+  inactiveAppointmentStatus?: AppointmentStatus;
   note: string;
 };
 
@@ -757,6 +894,7 @@ function buildVerificationDoc(seed: VerificationSeed): TrusteeMatchVerification 
     ...(seed.inactiveAppointmentStatus ? { inactiveAppointmentStatus: seed.inactiveAppointmentStatus } : {}),
     matchCandidates: seed.candidates,
     taskType: 'trustee-match',
+    taskDate: now,
     status: seed.status,
     createdOn: now,
     createdBy: SEED_SYSTEM_USER,
@@ -888,6 +1026,8 @@ async function seedMatchingScenarios() {
   for (const seed of MATCHING_SCENARIO_TRUSTEES) {
     // Create trustee
     const trusteeInput: TrusteeInput = {
+      firstName: seed.firstName,
+      lastName: seed.lastName,
       name: seed.name,
       public: {
         address: {
@@ -1024,8 +1164,12 @@ async function seedAutoMatches(maxCount = 5) {
       continue;
     }
 
+    const fullName = event.dxtrTrustee.fullName;
+    const nameParts = fullName.trim().split(/\s+/);
     const trusteeInput: TrusteeInput = {
-      name: event.dxtrTrustee.fullName,
+      firstName: nameParts[0] ?? '',
+      lastName: nameParts[nameParts.length - 1] ?? '',
+      name: fullName,
       public: {
         address: {
           address1: event.dxtrTrustee.legacy?.address1 || '123 DXTR Street',
@@ -1071,6 +1215,70 @@ async function seedAutoMatches(maxCount = 5) {
   if (skippedBadChapter > 0) console.log(`  Skipped ${skippedBadChapter} events (unsupported chapter).`);
   console.log('\nNext step: trigger the sync-trustee-appointments dataflow to generate auto-match telemetry.');
   console.log('Run "list" to verify seeded data.');
+}
+
+/**
+ * Seed trustees representing the CAMS-772 archive condition.
+ *
+ * TOD archived case-by-case, elected, and converted-case appointments instead
+ * of terminating them. The migration fix reads ARCHIVE_DATE from CHAPTER_DETAILS
+ * and overrides status to 'inactive' for those appointment types. These seeds
+ * simulate the post-migration state so the trustee list display (CAMS-767) can
+ * be exercised locally.
+ *
+ * Scenarios:
+ *  1. case-by-case appointment archived → inactive
+ *  2. elected appointment archived → inactive
+ *  3. converted-case appointment archived → inactive
+ *  4. genuinely active case-by-case (no archive date) → stays active  [control]
+ *  5. mixed: one archived case-by-case + one active panel             [control]
+ */
+async function seedArchivedTrustees() {
+  console.log('\nSeeding CAMS-772 archived trustee appointment scenarios...');
+  const context = await getContext();
+  const trusteesRepo = factory.getTrusteesRepository(context);
+  const appointmentsRepo = factory.getTrusteeAppointmentsRepository(context);
+
+  let successCount = 0;
+  let appointmentCount = 0;
+
+  for (const seed of ARCHIVED_TRUSTEE_SEEDS) {
+    const trustee = await trusteesRepo.createTrustee(makeTrusteeInput(seed.name, seed.state), SEED_SYSTEM_USER);
+
+    for (const appt of seed.appointments) {
+      const appointmentInput: TrusteeAppointmentInput = {
+        chapter: appt.chapter,
+        appointmentType: appt.appointmentType,
+        courtId: appt.courtId,
+        divisionCode: appt.divisionCode,
+        appointedDate: appt.appointedDate,
+        status: appt.status,
+        effectiveDate: appt.effectiveDate,
+      };
+      await appointmentsRepo.createAppointment(trustee.trusteeId, appointmentInput, SEED_SYSTEM_USER);
+      appointmentCount++;
+    }
+
+    const apptSummary = seed.appointments
+      .map((a) => `${a.appointmentType}/${a.status} (${a.effectiveDate})`)
+      .join(', ');
+    console.log(`  Created: ${seed.name}`);
+    console.log(`    trusteeId   : ${trustee.trusteeId}`);
+    console.log(`    appointments: ${apptSummary}`);
+    console.log(`    note        : ${seed.note}`);
+
+    successCount++;
+    await sleep(150); // avoid Cosmos RU throttle
+  }
+
+  console.log(`\nCreated ${successCount} trustees with ${appointmentCount} appointments.`);
+  console.log('\nScenario coverage (CAMS-772):');
+  console.log('  ✓ Archived case-by-case → inactive');
+  console.log('  ✓ Archived elected → inactive');
+  console.log('  ✓ Archived converted-case → inactive');
+  console.log('  ✓ Active case-by-case (no ARCHIVE_DATE) → stays active');
+  console.log('  ✓ Mixed: archived case-by-case + active panel → trustee still active');
+  console.log('\nDone. Run "list" to verify.');
 }
 
 async function listSeededData() {
@@ -1329,6 +1537,10 @@ async function main() {
       await seedMatchingScenarios();
       break;
 
+    case 'seed-archived-trustees':
+      await seedArchivedTrustees();
+      break;
+
     case 'list':
       await listSeededData();
       break;
@@ -1383,6 +1595,18 @@ Commands:
                            All trustees use "SEED Test" prefix for easy cleanup.
                            Courts: 0208, 0311, 0867, 0209 with multiple divisions/chapters.
 
+  seed-archived-trustees   Seed 5 trustees covering the CAMS-772 ARCHIVE_DATE condition.
+                           TOD archived case-by-case, elected, and converted-case appointments
+                           instead of terminating them. The migration fix reads ARCHIVE_DATE
+                           and overrides status to 'inactive' for those types. Scenarios:
+                             • case-by-case archived → inactive         (0208, Ch7)
+                             • elected archived → inactive              (0752, Ch7)
+                             • converted-case archived → inactive       (0539, Ch7)
+                             • active case-by-case (no archive date)    (0973, Ch7) [control]
+                             • mixed: archived CBC + active panel       (0647, Ch7) [control]
+                           Use to verify the trustee list correctly excludes fully-archived
+                           trustees while keeping those with at least one active appointment.
+
   list                     Show all seeded test data currently in MongoDB
 
   clean                    Delete seeded test data (all trustees created by SEED-SCRIPT, their
@@ -1402,6 +1626,7 @@ Examples:
   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/seed-test-trustees.ts seed-auto-match
   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/seed-test-trustees.ts seed-auto-match 10
   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/seed-test-trustees.ts seed-matching-scenarios
+  npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/seed-test-trustees.ts seed-archived-trustees
   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/seed-test-trustees.ts list
   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/seed-test-trustees.ts clean
   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/seed-test-trustees.ts clean-all

--- a/test/migration/trustee/scripts/seed-test-trustees.ts
+++ b/test/migration/trustee/scripts/seed-test-trustees.ts
@@ -88,10 +88,16 @@ const TRUSTEES_WITHOUT_PROID: TrusteeSeedNoProId[] = [
   { name: 'SEED Test Ambiguous Duplicate', state: 'WA' },
 ];
 
+function parseFullName(fullName: string): { firstName: string; lastName: string } {
+  const parts = fullName.trim().split(/\s+/);
+  return {
+    firstName: parts[0] ?? '',
+    lastName: parts[parts.length - 1] ?? '',
+  };
+}
+
 function makeTrusteeInput(name: string, state: string): TrusteeInput {
-  const parts = name.trim().split(/\s+/);
-  const firstName = parts[0] ?? '';
-  const lastName = parts[parts.length - 1] ?? '';
+  const { firstName, lastName } = parseFullName(name);
   return {
     firstName,
     lastName,
@@ -1165,10 +1171,10 @@ async function seedAutoMatches(maxCount = 5) {
     }
 
     const fullName = event.dxtrTrustee.fullName;
-    const nameParts = fullName.trim().split(/\s+/);
+    const { firstName, lastName } = parseFullName(fullName);
     const trusteeInput: TrusteeInput = {
-      firstName: nameParts[0] ?? '',
-      lastName: nameParts[nameParts.length - 1] ?? '',
+      firstName,
+      lastName,
       name: fullName,
       public: {
         address: {

--- a/test/migration/trustee/scripts/shared.ts
+++ b/test/migration/trustee/scripts/shared.ts
@@ -1,0 +1,7 @@
+/** Shared constants and utilities for ATS migration diagnostic scripts. */
+
+export const ARCHIVE_STATUS_LABELS: Record<string, string> = {
+  C: 'case-by-case',
+  E: 'elected',
+  O: 'converted-case',
+};

--- a/test/migration/trustee/scripts/show-mapping.ts
+++ b/test/migration/trustee/scripts/show-mapping.ts
@@ -1,6 +1,10 @@
 /**
  * Show data mapping from ATS to CAMS trustee collection
  *
+ * Fetches one trustee from ATS, runs it through the current cleansing pipeline,
+ * and prints the source data alongside the transformed CAMS output so the
+ * mapping can be visually confirmed.
+ *
  * Usage (from repo root):
  *   npx tsx --tsconfig backend/tsconfig.json test/migration/trustee/scripts/show-mapping.ts
  */
@@ -9,12 +13,7 @@ import * as dotenv from 'dotenv';
 import { InvocationContext } from '@azure/functions';
 import ApplicationContextCreator from '../../../../backend/function-apps/azure/application-context-creator';
 import factory from '../../../../backend/lib/factory';
-import {
-  transformTrusteeRecord,
-  transformAppointmentRecord,
-  parseTodStatus,
-  deriveTrusteeStatus,
-} from '../../../../backend/lib/adapters/gateways/ats/ats-mappings';
+import { transformTrusteeRecord } from '../../../../backend/lib/adapters/gateways/ats/cleansing/ats-mappings';
 
 dotenv.config({ path: 'backend/.env' });
 
@@ -31,7 +30,7 @@ async function showMapping() {
   console.log(' DATA MAPPING: ATS → CAMS Trustee Collection');
   console.log('='.repeat(80));
 
-  // Get a sample trustee from ATS
+  // Fetch one trustee from ATS
   const trustees = await gateway.getTrusteesPage(context, null, 1);
 
   if (trustees.length === 0) {
@@ -45,107 +44,55 @@ async function showMapping() {
   console.log('─'.repeat(60));
   console.log(JSON.stringify(atsTrustee, null, 2));
 
-  // Get appointments for this trustee
-  const atsAppointments = await gateway.getTrusteeAppointments(context, atsTrustee.ID);
+  // Run through the current cleansing pipeline
+  const { cleanAppointments, failedAppointments, stats } =
+    await gateway.getTrusteeAppointments(context, atsTrustee.ID);
 
-  console.log('\n2️⃣  SOURCE DATA FROM ATS CHAPTER_DETAILS TABLE:');
+  console.log('\n2️⃣  CHAPTER_DETAILS → CLEANSED APPOINTMENTS:');
   console.log('─'.repeat(60));
-  if (atsAppointments.length > 0) {
-    console.log(`Found ${atsAppointments.length} appointment(s) for trustee ${atsTrustee.ID}`);
-    console.log('\nFirst appointment:');
-    console.log(JSON.stringify(atsAppointments[0], null, 2));
-  } else {
-    console.log('No appointments found for this trustee');
+  console.log(`  Total raw rows : ${stats.total}`);
+  console.log(`  Clean          : ${stats.clean}`);
+  console.log(`  Auto-recovered : ${stats.autoRecoverable}`);
+  console.log(`  Problematic    : ${stats.problematic}`);
+  console.log(`  Uncleansable   : ${stats.uncleansable}`);
+  console.log(`  Skipped        : ${stats.skipped}`);
+
+  if (cleanAppointments.length > 0) {
+    console.log(`\n  First clean appointment:`);
+    console.log(JSON.stringify(cleanAppointments[0], null, 2));
+
+    // Flag any archived appointments the CAMS-772 fix would override
+    const archived = cleanAppointments.filter((a) => a.status === 'inactive' && (
+      a.appointmentType === 'case-by-case' ||
+      a.appointmentType === 'elected' ||
+      a.appointmentType === 'converted-case'
+    ));
+    if (archived.length > 0) {
+      console.log(`\n  ℹ️  CAMS-772: ${archived.length} appointment(s) set to inactive via ARCHIVE_DATE:`);
+      for (const a of archived) {
+        console.log(`    ${a.appointmentType} / ${a.courtId} — effectiveDate=${a.effectiveDate}`);
+      }
+    }
   }
 
-  // Transform the trustee record
+  if (failedAppointments.length > 0) {
+    console.log(`\n  First failed appointment (${failedAppointments[0].classification}):`);
+    console.log(JSON.stringify(failedAppointments[0].atsAppointment, null, 2));
+  }
+
+  // Transform trustee record
   const trusteeInput = transformTrusteeRecord(atsTrustee);
 
   console.log('\n3️⃣  TRANSFORMED TRUSTEE (before saving to MongoDB):');
   console.log('─'.repeat(60));
   console.log(JSON.stringify(trusteeInput, null, 2));
 
-  // Transform appointments
-  const transformedAppointments = [];
-  for (const atsAppt of atsAppointments) {
-    try {
-      const transformed = transformAppointmentRecord(atsAppt);
-      transformedAppointments.push(transformed);
-    } catch (error) {
-      console.log(
-        `Warning: Could not transform appointment: ${error instanceof Error ? error.message : error}`,
-      );
-    }
-  }
-
-  if (transformedAppointments.length > 0) {
-    console.log('\n4️⃣  TRANSFORMED APPOINTMENTS:');
-    console.log('─'.repeat(60));
-    console.log(JSON.stringify(transformedAppointments[0], null, 2));
-  }
-
-  // Derive trustee status from appointment statuses
-  const appointmentStatuses = atsAppointments.map((a) => parseTodStatus(a.STATUS).status);
-  const derivedStatus = deriveTrusteeStatus(appointmentStatuses);
-
-  console.log('\n4️⃣b DERIVED TRUSTEE STATUS:');
+  console.log('\n4️⃣  TRANSFORMED APPOINTMENTS (clean output → MongoDB):');
   console.log('─'.repeat(60));
-  console.log(`  Appointment statuses: [${appointmentStatuses.join(', ')}]`);
-  console.log(`  Derived trustee status: '${derivedStatus}'`);
-
-  // Show what the final MongoDB document would look like
-  console.log('\n5️⃣  FINAL MONGODB TRUSTEE DOCUMENT:');
-  console.log('─'.repeat(60));
-
-  // This is a simulation of what would be saved
-  const mongoDocument: Record<string, unknown> = {
-    _id: 'trustee-' + Math.random().toString(36).substring(7), // MongoDB would generate this
-    trusteeId: 'trustee-' + Math.random().toString(36).substring(7), // CAMS would generate this
-    name: trusteeInput.name,
-    status: derivedStatus,
-    public: trusteeInput.public,
-    legacy: trusteeInput.legacy,
-    createdBy: {
-      id: 'SYSTEM',
-      name: 'ATS Migration',
-    },
-    createdOn: new Date().toISOString(),
-    updatedBy: {
-      id: 'SYSTEM',
-      name: 'ATS Migration',
-    },
-    updatedOn: new Date().toISOString(),
-  };
-
-  // Add internal contact if present
-  if (trusteeInput.internal) {
-    mongoDocument.internal = trusteeInput.internal;
-  }
-
-  console.log(JSON.stringify(mongoDocument, null, 2));
-
-  if (transformedAppointments.length > 0) {
-    console.log('\n6️⃣  MONGODB TRUSTEE_APPOINTMENT DOCUMENT:');
-    console.log('─'.repeat(60));
-
-    const appointmentDoc = {
-      _id: 'appointment-' + Math.random().toString(36).substring(7),
-      appointmentId: 'appointment-' + Math.random().toString(36).substring(7),
-      trusteeId: mongoDocument.trusteeId,
-      ...transformedAppointments[0],
-      createdBy: {
-        id: 'SYSTEM',
-        name: 'ATS Migration',
-      },
-      createdOn: new Date().toISOString(),
-      updatedBy: {
-        id: 'SYSTEM',
-        name: 'ATS Migration',
-      },
-      updatedOn: new Date().toISOString(),
-    };
-
-    console.log(JSON.stringify(appointmentDoc, null, 2));
+  if (cleanAppointments.length > 0) {
+    console.log(JSON.stringify(cleanAppointments[0], null, 2));
+  } else {
+    console.log('  (no clean appointments)');
   }
 
   console.log('\n' + '='.repeat(80));
@@ -154,47 +101,39 @@ async function showMapping() {
   console.log(`
 ATS TRUSTEES Table → MongoDB trustees Collection:
   ID               → legacy.truId (stored as string)
-  (derived)        → status (derived from CHAPTER_DETAILS.STATUS via deriveTrusteeStatus:
-                       any 'active' appointment → 'active',
-                       any suspended appointment → 'suspended',
-                       otherwise → 'not active')
-  FIRST_NAME       → Concatenated into 'name' field
-  MIDDLE           → Concatenated into 'name' field
-  LAST_NAME        → Concatenated into 'name' field
+  FIRST_NAME       → firstName, concatenated into name
+  MIDDLE           → middleName, concatenated into name
+  LAST_NAME        → lastName, concatenated into name
   COMPANY          → public.companyName
+  DISP_ON_WEB      → controls which address set (primary vs A2) becomes public
 
-  Public Address:
-  STREET           → public.address.address1
-  STREET1          → public.address.address2
-  CITY             → public.address.city
-  STATE            → public.address.state
-  ZIP + ZIP_PLUS   → public.address.zipCode (formatted as ZIP-PLUS4)
-
-  Internal Address (if present):
-  STREET_A2        → internal.address.address1
-  STREET1_A2       → internal.address.address2
-  CITY_A2          → internal.address.city
-  STATE_A2         → internal.address.state
-  ZIP_A2 + ZIP_PLUS_A2 → internal.address.zipCode (formatted as ZIP-PLUS4)
+  Public Address (DISP_ON_WEB_A2='y' uses A2 fields; otherwise uses primary):
+  STREET / STREET_A2   → public.address.address1
+  STREET1 / STREET1_A2 → public.address.address2
+  CITY / CITY_A2       → public.address.city
+  STATE / STATE_A2     → public.address.state
+  ZIP + ZIP_PLUS       → public.address.zipCode (formatted as ZIP-PLUS4)
 
   Contact Info:
   TELEPHONE        → public.phone.number & internal.phone.number (formatted)
   EMAIL_ADDRESS    → public.email & internal.email
 
-ATS CHAPTER_DETAILS Table → MongoDB trustee_appointments Collection:
-  TRU_ID           → Links to trustee via trusteeId
-  DISTRICT         → Maps to courtId via lookup
-  DIVISION         → divisionCode
-  CHAPTER          → chapter (normalized, e.g., '7', '11', '12', '13')
-  STATUS           → Maps to appointmentType (e.g., 'PA' → 'panel', '1' → 'trustee')
+ATS CHAPTER_DETAILS Table → MongoDB trustee-appointments Collection:
+  TRU_ID           → links to trustee via trusteeId
+  DISTRICT         → courtId (via DISTRICT_TO_COURT_MAP)
+  SERVING_STATE    → used for multi-district state expansion
+  CHAPTER          → chapter (normalized: '7', '11', '12', '13')
+  STATUS           → appointmentType + status (via TOD_STATUS_MAP)
   APPOINTED_DATE   → appointedDate
   STATUS_EFF_DATE  → effectiveDate
+  ARCHIVE_DATE     → CAMS-772: when non-null for case-by-case/elected/converted-case,
+                     overrides status → 'inactive', effectiveDate → ARCHIVE_DATE
 
-Special Chapter Mappings:
-  '7CBC'  → chapter: '7',  appointmentType: 'caseByCase'
-  '12CBC' → chapter: '12', appointmentType: 'caseByCase'
-  '13CBC' → chapter: '13', appointmentType: 'caseByCase'
-  `);
+Special Chapter Codes:
+  12CBC → chapter: '12', appointmentType: 'case-by-case'
+  13CBC → chapter: '13', appointmentType: 'case-by-case'
+  11 + STATUS=V/VR → chapter: '11-subchapter-v'
+`);
 }
 
 showMapping().catch(console.error);

--- a/test/migration/trustee/scripts/test-trustee-migration-local.ts
+++ b/test/migration/trustee/scripts/test-trustee-migration-local.ts
@@ -24,6 +24,7 @@ import factory from '../../../../backend/lib/factory';
 import { cleanseAndMapAppointment } from '../../../../backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-pipeline';
 import { AtsAppointmentRecord } from '../../../../backend/lib/adapters/types/ats.types';
 import { TrusteeOverride } from '../../../../backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-types';
+import { AppointmentType } from '@common/cams/trustees';
 
 // Load environment variables
 dotenv.config({ path: 'backend/.env' });
@@ -342,7 +343,7 @@ async function verifyArchiveDateScenarios() {
     record: AtsAppointmentRecord;
     expectStatus: 'active' | 'inactive';
     expectEffectiveDate?: string;
-    expectType: string;
+    expectType: AppointmentType;
   };
 
   const SCENARIOS: Scenario[] = [

--- a/test/migration/trustee/scripts/test-trustee-migration-local.ts
+++ b/test/migration/trustee/scripts/test-trustee-migration-local.ts
@@ -21,6 +21,9 @@ import {
 } from '../../../../backend/lib/use-cases/dataflows/trustee-migration-state.service';
 import { ApplicationConfiguration } from '../../../../backend/lib/configs/application-configuration';
 import factory from '../../../../backend/lib/factory';
+import { cleanseAndMapAppointment } from '../../../../backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-pipeline';
+import { AtsAppointmentRecord } from '../../../../backend/lib/adapters/types/ats.types';
+import { TrusteeOverride } from '../../../../backend/lib/adapters/gateways/ats/cleansing/ats-cleansing-types';
 
 // Load environment variables
 dotenv.config({ path: 'backend/.env' });
@@ -99,13 +102,13 @@ async function previewMigration(limit = 5) {
       );
 
       // Get appointments for this trustee
-      const appointments = await gateway.getTrusteeAppointments(context, trustee.ID);
-      console.log(`    Appointments: ${appointments.length}`);
+      const { cleanAppointments, failedAppointments } = await gateway.getTrusteeAppointments(context, trustee.ID);
+      console.log(`    Appointments: ${cleanAppointments.length} clean, ${failedAppointments.length} failed`);
 
-      if (appointments.length > 0) {
-        const firstAppt = appointments[0];
+      if (cleanAppointments.length > 0) {
+        const firstAppt = cleanAppointments[0];
         console.log(
-          `      First appointment: District ${firstAppt.DISTRICT}, Chapter ${firstAppt.CHAPTER}`,
+          `      First appointment: Court ${firstAppt.courtId}, Chapter ${firstAppt.chapter}, Type ${firstAppt.appointmentType}, Status ${firstAppt.status}`,
         );
       }
     }
@@ -199,7 +202,7 @@ async function runMigrationBatch(pageSize = 10) {
   console.log(`Processing ${trustees.length} trustees...`);
 
   // Process the batch
-  const processResult = await MigrateTrusteesUseCase.processPageOfTrustees(context, trustees);
+  const processResult = await MigrateTrusteesUseCase.processPageOfTrustees(context, trustees, 'migrate-trustees-out');
 
   if (processResult.error) {
     console.error('❌ Error processing batch:', processResult.error.message);
@@ -249,6 +252,7 @@ async function resetMigration() {
     lastTrusteeId: null,
     processedCount: 0,
     appointmentsProcessedCount: 0,
+    ambiguousCount: 0,
     errors: 0,
     startedAt: new Date().toISOString(),
     lastUpdatedAt: new Date().toISOString(),
@@ -297,6 +301,7 @@ async function cleanAppointments() {
       lastTrusteeId: null,
       processedCount: 0,
       appointmentsProcessedCount: 0,
+      ambiguousCount: 0,
       errors: 0,
       startedAt: new Date().toISOString(),
       lastUpdatedAt: new Date().toISOString(),
@@ -311,6 +316,143 @@ async function cleanAppointments() {
   } finally {
     await client.close();
   }
+}
+
+/**
+ * CAMS-772: Verify ARCHIVE_DATE override scenarios through the cleansing pipeline.
+ *
+ * Runs synthetic ATS records through cleanseAndMapAppointment() — no DB connection
+ * required. Asserts that appointments with ARCHIVE_DATE set for case-by-case (C),
+ * elected (E), or converted-case (O) come out inactive, and that appointments
+ * without ARCHIVE_DATE stay active.
+ */
+async function verifyArchiveDateScenarios() {
+  console.log('\nCAMS-772: Verifying ARCHIVE_DATE override scenarios...');
+
+  const invocationContext = new InvocationContext();
+  const context = await ApplicationContextCreator.getApplicationContext({
+    invocationContext,
+    logger: ApplicationContextCreator.getLogger(invocationContext),
+  });
+
+  const emptyOverrides = new Map<string, TrusteeOverride[]>();
+
+  type Scenario = {
+    label: string;
+    record: AtsAppointmentRecord;
+    expectStatus: 'active' | 'inactive';
+    expectEffectiveDate?: string;
+    expectType: string;
+  };
+
+  const SCENARIOS: Scenario[] = [
+    {
+      label: 'case-by-case (STATUS=C) with ARCHIVE_DATE → inactive',
+      record: {
+        TRU_ID: 1,
+        DISTRICT: 'Middle',
+        STATE: 'Louisiana',
+        CHAPTER: '7',
+        STATUS: 'C',
+        DATE_APPOINTED: new Date('2010-01-01'),
+        EFFECTIVE_DATE: new Date('2010-01-01'),
+        ARCHIVE_DATE: new Date('2019-06-15'),
+      },
+      expectStatus: 'inactive',
+      expectEffectiveDate: '2019-06-15',
+      expectType: 'case-by-case',
+    },
+    {
+      label: 'elected (STATUS=E) with ARCHIVE_DATE → inactive',
+      record: {
+        TRU_ID: 2,
+        DISTRICT: 'Middle',
+        STATE: 'Louisiana',
+        CHAPTER: '7',
+        STATUS: 'E',
+        DATE_APPOINTED: new Date('2010-01-01'),
+        EFFECTIVE_DATE: new Date('2010-01-01'),
+        ARCHIVE_DATE: new Date('2020-03-01'),
+      },
+      expectStatus: 'inactive',
+      expectEffectiveDate: '2020-03-01',
+      expectType: 'elected',
+    },
+    {
+      label: 'converted-case (STATUS=O) with ARCHIVE_DATE → inactive',
+      record: {
+        TRU_ID: 3,
+        DISTRICT: 'Middle',
+        STATE: 'Louisiana',
+        CHAPTER: '7',
+        STATUS: 'O',
+        DATE_APPOINTED: new Date('2010-01-01'),
+        EFFECTIVE_DATE: new Date('2010-01-01'),
+        ARCHIVE_DATE: new Date('2018-11-30'),
+      },
+      expectStatus: 'inactive',
+      expectEffectiveDate: '2018-11-30',
+      expectType: 'converted-case',
+    },
+    {
+      label: 'case-by-case (STATUS=C) without ARCHIVE_DATE → active',
+      record: {
+        TRU_ID: 4,
+        DISTRICT: 'Middle',
+        STATE: 'Louisiana',
+        CHAPTER: '7',
+        STATUS: 'C',
+        DATE_APPOINTED: new Date('2022-01-01'),
+        EFFECTIVE_DATE: new Date('2022-01-01'),
+        ARCHIVE_DATE: undefined,
+      },
+      expectStatus: 'active',
+      expectType: 'case-by-case',
+    },
+    {
+      label: 'panel (STATUS=PA) with ARCHIVE_DATE present → active (PA not in archived set)',
+      record: {
+        TRU_ID: 5,
+        DISTRICT: 'Middle',
+        STATE: 'Louisiana',
+        CHAPTER: '7',
+        STATUS: 'PA',
+        DATE_APPOINTED: new Date('2020-01-01'),
+        EFFECTIVE_DATE: new Date('2020-01-01'),
+        ARCHIVE_DATE: new Date('2021-01-01'),
+      },
+      expectStatus: 'active',
+      expectType: 'panel',
+    },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const scenario of SCENARIOS) {
+    const result = cleanseAndMapAppointment(context, String(scenario.record.TRU_ID), scenario.record, emptyOverrides);
+    const appt = result.appointment;
+
+    const statusOk = appt?.status === scenario.expectStatus;
+    const typeOk = appt?.appointmentType === scenario.expectType;
+    const dateOk = !scenario.expectEffectiveDate || appt?.effectiveDate === scenario.expectEffectiveDate;
+    const ok = statusOk && typeOk && dateOk;
+
+    if (ok) {
+      console.log(`  ✅ ${scenario.label}`);
+      passed++;
+    } else {
+      console.log(`  ❌ ${scenario.label}`);
+      if (!statusOk) console.log(`       status:        expected=${scenario.expectStatus}  got=${appt?.status}`);
+      if (!typeOk)   console.log(`       appointmentType: expected=${scenario.expectType}  got=${appt?.appointmentType}`);
+      if (!dateOk)   console.log(`       effectiveDate:  expected=${scenario.expectEffectiveDate}  got=${appt?.effectiveDate}`);
+      if (!appt)     console.log(`       (no appointment produced — classification=${result.classification})`);
+      failed++;
+    }
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exitCode = 1;
 }
 
 async function main() {
@@ -351,6 +493,10 @@ async function main() {
       await cleanAppointments();
       break;
 
+    case 'verify-archive-date':
+      await verifyArchiveDateScenarios();
+      break;
+
     case 'help':
     default:
       console.log('\nUsage: npx tsx scripts/test-trustee-migration-local.ts [command] [options]');
@@ -361,12 +507,14 @@ async function main() {
       console.log('  run [size]          Run migration batch (default size: 10)');
       console.log('  reset               Reset migration state only');
       console.log('  clean               Delete all appointments and reset state');
+      console.log('  verify-archive-date Verify CAMS-772 ARCHIVE_DATE override scenarios (no DB needed)');
       console.log('  help                Show this help message');
       console.log('\nExamples:');
       console.log('  npx tsx scripts/test-trustee-migration-local.ts test');
       console.log('  npx tsx scripts/test-trustee-migration-local.ts preview 10');
       console.log('  npx tsx scripts/test-trustee-migration-local.ts run 50');
       console.log('  npx tsx scripts/test-trustee-migration-local.ts clean');
+      console.log('  npx tsx scripts/test-trustee-migration-local.ts verify-archive-date');
       break;
   }
 


### PR DESCRIPTION
# Bug

TOD (the legacy ATS system) archived `case-by-case`, `elected`, and `converted-case` trustee appointments by setting `ARCHIVE_DATE` in `CHAPTER_DETAILS` instead of changing `STATUS`. Because the migration only looked at `STATUS`, these archived appointments were imported as `active`, causing terminated trustees to appear in the active trustee list.

# Purpose

Ensure that trustees whose appointments were archived by TOD are correctly imported as inactive, so they do not appear in the active trustee list after migration.

# Major Changes

- Added `ARCHIVE_DATE` field to `AtsAppointmentRecord` and to the `CHAPTER_DETAILS` SQL SELECT
- Added `ARCHIVED_APPOINTMENT_TYPES` constant (`case-by-case`, `elected`, `converted-case`) — the only three types TOD archived rather than terminated
- Added override logic in `ats-cleansing-transform.ts`: when `ARCHIVE_DATE` is non-null for one of these types, status is overridden to `inactive` and `effectiveDate` is set to the archive date
- Extended migration tooling: `check-ats-schema.ts` (ARCHIVE_DATE column/data verification), `check-active-status.ts` (new script), `seed-test-trustees.ts` (5 CAMS-772 seed scenarios), `test-trustee-migration-local.ts` (`verify-archive-date` command exercising all 5 scenarios), `show-mapping.ts` (updated to current pipeline API)

# Testing/Validation

Implemented using TDD. Unit tests cover the transform layer (5 cases: case-by-case/elected/converted-case with archive date → inactive, null archive date → active, panel with archive date → active). Gateway-level integration tests confirm the `ARCHIVE_DATE` column is present in the SQL query and that the full pipeline produces the correct status. Migration script `verify-archive-date` runs all scenarios against the real pipeline code without a DB connection (5/5 passing).

# Notes

The fix is scoped to exactly the three appointment types TOD archived (`case-by-case`, `elected`, `converted-case`). Other appointment types with an `ARCHIVE_DATE` (sanity-checked as rare/none in the dev dataset) are not overridden. The `check-ats-schema` script now includes a section that verifies the column exists and reports scope of affected data before a migration run.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Handle TOD-archived trustee appointments as inactive during ATS → CAMS migration and extend local tooling to validate and exercise this behavior.

Bug Fixes:
- Treat case-by-case, elected, and converted-case appointments with ARCHIVE_DATE set in ATS as inactive with effective dates based on the archive date so terminated trustees do not appear active after migration.

Enhancements:
- Extend ATS appointment transformation and gateway to carry the ARCHIVE_DATE field through the pipeline and add a constant for archived appointment types.
- Update migration and inspection scripts to surface ARCHIVE_DATE usage, active-status distributions, and mapping behavior, including a new check-active-status script and richer show-mapping output.
- Add a local, DB-free verification command for ARCHIVE_DATE scenarios in the migration test harness and include ambiguous-count tracking in migration state.
- Improve trustee seeding utilities by adding archived-appointment test datasets, ensuring first/last names are populated, and enriching verification documents with task dates.

Documentation:
- Expand trustee migration testing documentation with CAMS-772 archived-appointment guidance, new seeding commands, and relevant test instructions.

Tests:
- Add unit and integration tests around ARCHIVE_DATE handling in the ATS cleansing transform and gateway, and around the new verification and seeding flows.