### PR TITLE
CAMS-767 Filter Trustee List by Appointment Status

### DIFF
--- a/user-interface/eslint-ui-test.config.mjs
+++ b/user-interface/eslint-ui-test.config.mjs
@@ -29,29 +29,30 @@ const eslintUiTestConfig = tsEslint.config(
     plugins: testingLibrary.configs['flat/react']['plugins'],
     files: ['**/*.test.ts', '**/*.test.tsx'],
     rules: {
-    'testing-library/await-async-events': 'error',
-    'testing-library/await-async-queries': 'error',
-    'testing-library/await-async-utils': 'error',
-    'testing-library/no-await-sync-events': 'error',
-    'testing-library/no-await-sync-queries': 'error',
-    'testing-library/no-container': 'warn', // default: error
-    'testing-library/no-debugging-utils': 'warn',
-    'testing-library/no-dom-import': 'error',
-    'testing-library/no-global-regexp-flag-in-query': 'error',
-    'testing-library/no-manual-cleanup': 'error',
-    'testing-library/no-node-access': 'off', // default: error
-    'testing-library/no-promise-in-fire-event': 'error',
-    'testing-library/no-render-in-lifecycle': 'warn', // default: error
-    'testing-library/no-unnecessary-act': 'error',
-    'testing-library/no-wait-for-multiple-assertions': 'off', // default: error
-    'testing-library/no-wait-for-side-effects': 'off', // default: error
-    'testing-library/no-wait-for-snapshot': 'error',
-    'testing-library/prefer-find-by': 'error',
-    'testing-library/prefer-presence-queries': 'off', // default: error
-    'testing-library/prefer-query-by-disappearance': 'error',
-    'testing-library/prefer-screen-queries': 'off', // default: error
-    'testing-library/render-result-naming-convention': 'error',
+      'testing-library/await-async-events': 'error',
+      'testing-library/await-async-queries': 'error',
+      'testing-library/await-async-utils': 'error',
+      'testing-library/no-await-sync-events': 'error',
+      'testing-library/no-await-sync-queries': 'error',
+      'testing-library/no-container': 'warn', // default: error
+      'testing-library/no-debugging-utils': 'warn',
+      'testing-library/no-dom-import': 'error',
+      'testing-library/no-global-regexp-flag-in-query': 'error',
+      'testing-library/no-manual-cleanup': 'error',
+      'testing-library/no-node-access': 'off', // default: error
+      'testing-library/no-promise-in-fire-event': 'error',
+      'testing-library/no-render-in-lifecycle': 'warn', // default: error
+      'testing-library/no-unnecessary-act': 'error',
+      'testing-library/no-wait-for-multiple-assertions': 'off', // default: error
+      'testing-library/no-wait-for-side-effects': 'off', // default: error
+      'testing-library/no-wait-for-snapshot': 'error',
+      'testing-library/prefer-find-by': 'error',
+      'testing-library/prefer-presence-queries': 'off', // default: error
+      'testing-library/prefer-query-by-disappearance': 'error',
+      'testing-library/prefer-screen-queries': 'off', // default: error
+      'testing-library/render-result-naming-convention': 'error',
+    },
   },
-});
+);
 
 export default eslintUiTestConfig;

--- a/user-interface/eslint.config.mjs
+++ b/user-interface/eslint.config.mjs
@@ -17,7 +17,13 @@ const nodeConfig = eslintNodeConfig.map((configObject) => ({
 
 const frontendEslintConfig = [
   {
-    ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*', '**/coverage/**/*', '**/eslint*.config.mjs'],
+    ignores: [
+      '**/build/**/*',
+      '**/dist/**/*',
+      '**/node_modules/**/*',
+      '**/coverage/**/*',
+      '**/eslint*.config.mjs',
+    ],
   },
   ...codeConfig,
   ...testConfig,

--- a/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
+++ b/user-interface/src/admin/bankruptcy-software/BankruptcySoftware.scss
@@ -15,7 +15,9 @@
 
       // Tablet: undo CamsTable flex — left nav leaves insufficient width
       @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
-        &.cams-table--responsive { @include cams-table.cams-table-stacked; }
+        &.cams-table--responsive {
+          @include cams-table.cams-table-stacked;
+        }
       }
 
       // Desktop: full flex-row table with column proportions

--- a/user-interface/src/case-detail/CaseDetailScreen.scss
+++ b/user-interface/src/case-detail/CaseDetailScreen.scss
@@ -1,6 +1,7 @@
 @use 'styles/abstracts/device-screens' as device-screens;
 
-.case-detail, .record-detail {
+.case-detail,
+.record-detail {
   container-type: inline-size;
 
   // Override USWDS grid with flexbox for better responsive behavior

--- a/user-interface/src/case-detail/panels/CaseDetailCourtDocket.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailCourtDocket.scss
@@ -41,7 +41,8 @@
         text-align: right;
         padding-right: 1rem;
       }
-      .document-number-column, .docket-entry-header {
+      .document-number-column,
+      .docket-entry-header {
         font-weight: bold;
       }
     }

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
@@ -1,5 +1,6 @@
 @use 'styles/abstracts/general' as general;
 @use 'styles/abstracts/device-screens' as device-screens;
+@use 'styles/abstracts/colors' as colors;
 @import '../../trustees/panels/shared-card-styles.scss';
 
 .case-detail-trustee-panel {
@@ -37,7 +38,7 @@
 
     .cams-table__header-group {
       padding: 0;
-      border-bottom: 2px solid #1b1b1b;
+      border-bottom: 2px solid colors.$ink;
     }
 
     .cams-table__row {

--- a/user-interface/src/case-detail/panels/cards/DatesCard.scss
+++ b/user-interface/src/case-detail/panels/cards/DatesCard.scss
@@ -16,7 +16,8 @@
           margin-bottom: 0;
         }
 
-        dt, dd {
+        dt,
+        dd {
           margin: 0;
         }
 

--- a/user-interface/src/data-verification/TransferOrderAccordion.scss
+++ b/user-interface/src/data-verification/TransferOrderAccordion.scss
@@ -27,7 +27,7 @@
     padding-top: 2rem;
   }
   blockquote {
-    background: rgba(0,0,0,.05);
+    background: rgba(0, 0, 0, 0.05);
     padding: 1rem;
   }
   .case-verification {

--- a/user-interface/src/data-verification/consolidation/ConsolidationOrderModal.scss
+++ b/user-interface/src/data-verification/consolidation/ConsolidationOrderModal.scss
@@ -1,5 +1,5 @@
 .consolidation-order-modal {
-  input[type=radio] {
+  input[type='radio'] {
     margin-right: 0.5rem;
   }
 
@@ -11,7 +11,7 @@
     margin: 0.5rem 0;
 
     .modal-case-list {
-      padding: .25rem 0.35rem;
+      padding: 0.25rem 0.35rem;
     }
   }
 

--- a/user-interface/src/data-verification/transfer/CasesTable.scss
+++ b/user-interface/src/data-verification/transfer/CasesTable.scss
@@ -1,5 +1,5 @@
 .suggested-cases-radio-button {
-  .usa-radio__input+label button {
+  .usa-radio__input + label button {
     margin-top: 0;
   }
   .usa-radio__label::before {

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchConfirmationModal.scss
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchConfirmationModal.scss
@@ -4,5 +4,4 @@
     flex-direction: column;
     gap: 0.25rem;
   }
-
 }

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.scss
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.scss
@@ -36,7 +36,7 @@
 
       .trustee-data-cell {
         padding: 0.5rem 0.5rem 0.5rem 0;
-        border-bottom: 1px solid #1b1b1b;
+        border-bottom: 1px solid colors.$ink;
 
         &.no-border {
           border-bottom: none;
@@ -50,7 +50,7 @@
       .trustee-data-cell {
         padding: 0.5rem 0.5rem 0.5rem 0;
         word-wrap: break-word;
-        border-bottom: 1px solid #1b1b1b;
+        border-bottom: 1px solid colors.$ink;
 
         &.no-border {
           border-bottom: none;
@@ -67,7 +67,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
-    color: #005ea2;
+    color: colors.$primary;
     text-decoration: underline;
     svg {
       width: 1.275rem;
@@ -91,7 +91,7 @@
     cursor: pointer;
     font-size: inherit;
     font-family: inherit;
-    color: #005ea2;
+    color: colors.$primary;
     text-decoration: underline;
     display: inline-flex;
     align-items: center;
@@ -102,7 +102,7 @@
     }
 
     &:hover {
-      color: #1a4480;
+      color: colors.$primary-dark;
     }
   }
 

--- a/user-interface/src/index.css
+++ b/user-interface/src/index.css
@@ -1,7 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+    'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/user-interface/src/lib/components/Header.scss
+++ b/user-interface/src/lib/components/Header.scss
@@ -124,12 +124,12 @@
                 font-weight: 700;
                 line-height: 0.9;
               }
-              button.usa-accordion__button[aria-expanded=false] span {
+              button.usa-accordion__button[aria-expanded='false'] span {
                 margin-right: 0;
                 padding-right: 1rem;
                 display: inline-block;
               }
-              button.usa-accordion__button[aria-expanded=false] span::after {
+              button.usa-accordion__button[aria-expanded='false'] span::after {
                 width: 1rem;
                 height: 1rem;
                 mask-size: 1rem 1rem;

--- a/user-interface/src/lib/components/LoadingSpinner.scss
+++ b/user-interface/src/lib/components/LoadingSpinner.scss
@@ -1,4 +1,3 @@
-
 .loading-spinner {
   display: flex;
   align-content: center;
@@ -24,11 +23,11 @@
     }
 
     .opacity-25 {
-      opacity: .25;
+      opacity: 0.25;
       color: black;
     }
     .opacity-75 {
-      opacity: .75;
+      opacity: 0.75;
       color: black;
     }
   }

--- a/user-interface/src/lib/components/cams/CamsTable/CamsTable.scss
+++ b/user-interface/src/lib/components/cams/CamsTable/CamsTable.scss
@@ -1,5 +1,6 @@
 @use 'styles/abstracts/general' as general;
 @use 'styles/abstracts/device-screens' as device-screens;
+@use 'styles/abstracts/colors' as colors;
 
 // Base responsive styles applied automatically to every CamsTable.
 // To override breakpoint behavior in a screen, use the mixins in _cams-table-mixins.scss:
@@ -53,7 +54,7 @@
   }
 
   .cams-table__body .cams-table__row {
-    border-bottom: 1px solid #1b1b1b;
+    border-bottom: 1px solid colors.$ink;
     padding: 0.625rem 1rem;
     margin-bottom: 0.25rem;
   }
@@ -64,7 +65,7 @@
       @include general.visually-shown;
       display: block;
       font-weight: bold;
-      border-bottom: 1px solid #1b1b1b;
+      border-bottom: 1px solid colors.$ink;
       padding-bottom: 0.5rem;
       margin-bottom: 0;
     }
@@ -88,7 +89,7 @@
     }
 
     .cams-table__body .cams-table__row {
-      border-bottom: 1px solid #1b1b1b;
+      border-bottom: 1px solid colors.$ink;
       padding: 0;
       margin-bottom: 0;
     }

--- a/user-interface/src/lib/components/cams/CamsTable/_cams-table-mixins.scss
+++ b/user-interface/src/lib/components/cams/CamsTable/_cams-table-mixins.scss
@@ -1,22 +1,58 @@
 @use 'styles/abstracts/general' as general;
+@use 'styles/abstracts/colors' as colors;
 
 // Use when a screen needs to override CamsTable's tablet flex-row layout back to stacked,
 // e.g. when a side panel leaves insufficient width for columns at that breakpoint.
 @mixin cams-table-stacked {
-  .cams-table__header-group { @include general.visually-hidden; }
+  .cams-table__header-group {
+    @include general.visually-hidden;
+  }
   .cams-table__header-row,
-  .cams-table__row { display: block; }
-  .cams-table__cell { display: block; width: 100%; padding: 0.25rem 0; }
-  .cams-table__body .cams-table__cell[data-cell]::before { display: inline; }
-  .cams-table__body .cams-table__row { padding: 0.625rem 1rem; margin-bottom: 0.25rem; }
+  .cams-table__row {
+    display: block;
+  }
+  .cams-table__cell {
+    display: block;
+    width: 100%;
+    padding: 0.25rem 0;
+  }
+  .cams-table__body .cams-table__cell[data-cell]::before {
+    display: inline;
+  }
+  .cams-table__body .cams-table__row {
+    padding: 0.625rem 1rem;
+    margin-bottom: 0.25rem;
+  }
 }
 
 // Use when a screen is ready to enable the flex-row column layout.
 @mixin cams-table-flex-row {
-  .cams-table__header-group { @include general.visually-shown; display: block; font-weight: bold; border-bottom: 1px solid #1b1b1b; padding-bottom: 0.5rem; margin-bottom: 0; }
+  .cams-table__header-group {
+    @include general.visually-shown;
+    display: block;
+    font-weight: bold;
+    border-bottom: 1px solid colors.$ink;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0;
+  }
   .cams-table__header-row,
-  .cams-table__row { display: flex; flex-direction: row; gap: 1rem; align-items: baseline; }
-  .cams-table__cell { flex: 1 1 0; min-width: 0; padding: 0.5rem 1rem; width: auto; }
-  .cams-table__body .cams-table__cell[data-cell]::before { display: none; }
-  .cams-table__body .cams-table__row { padding: 0; margin-bottom: 0; }
+  .cams-table__row {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    align-items: baseline;
+  }
+  .cams-table__cell {
+    flex: 1 1 0;
+    min-width: 0;
+    padding: 0.5rem 1rem;
+    width: auto;
+  }
+  .cams-table__body .cams-table__cell[data-cell]::before {
+    display: none;
+  }
+  .cams-table__body .cams-table__row {
+    padding: 0;
+    margin-bottom: 0;
+  }
 }

--- a/user-interface/src/lib/components/cams/DropdownMenu/DropdownMenu.scss
+++ b/user-interface/src/lib/components/cams/DropdownMenu/DropdownMenu.scss
@@ -16,7 +16,7 @@
 
 @media screen and (max-width: 63.99em) {
   .cams-dropdown-menu {
-    button.usa-accordion__button[aria-expanded=false] {
+    button.usa-accordion__button[aria-expanded='false'] {
       span::after {
         mask-image: url(/assets/styles/img/usa-icons/expand_more.svg);
         mask-position: center center;
@@ -24,7 +24,7 @@
         right: -0.5rem;
       }
     }
-    button.usa-accordion__button[aria-expanded=true] {
+    button.usa-accordion__button[aria-expanded='true'] {
       span::after {
         mask-image: url(/assets/styles/img/usa-icons/expand_less.svg);
         right: 0.5rem;

--- a/user-interface/src/lib/components/cams/RawSvgIcon.scss
+++ b/user-interface/src/lib/components/cams/RawSvgIcon.scss
@@ -9,7 +9,6 @@
     fill: colors.$primary;
   }
 
-
   &.member-case-icon path {
     fill: white;
   }

--- a/user-interface/src/lib/components/cams/RichTextEditor/RichTextEditor.scss
+++ b/user-interface/src/lib/components/cams/RichTextEditor/RichTextEditor.scss
@@ -1,3 +1,5 @@
+@use '@/styles/abstracts/colors' as colors;
+
 .editor-container {
   .editor-wrapper {
     border: 1px solid #ccc; // match RichTextEditor border
@@ -25,12 +27,12 @@
         border: none;
         border-radius: 0.25rem;
         background-color: transparent;
-        color: #1b1b1b;
+        color: colors.$ink;
 
         svg {
           width: 1.2rem;
           height: 1.2rem;
-          fill: #1b1b1b;
+          fill: colors.$ink;
         }
 
         &:nth-child(2) {
@@ -43,7 +45,7 @@
       }
       button:hover {
         background-color: #e9ecef;
-        color: #1b1b1b;
+        color: colors.$ink;
         cursor: pointer;
       }
       button.is-active {
@@ -80,7 +82,7 @@
             display: inline;
           }
           button:hover {
-            background-color: #005ea2;
+            background-color: colors.$primary;
             svg {
               fill: #ffffff;
             }

--- a/user-interface/src/lib/components/combobox/ComboBox.scss
+++ b/user-interface/src/lib/components/combobox/ComboBox.scss
@@ -1,12 +1,13 @@
+@use 'uswds-core';
+@use '../../../styles/abstracts/colors';
+
 $separatorColor: #c6cace;
 $sectionSeparatorColor: #565c65;
 $listItemHoverBorderColor: #333;
 $listItemSelectedBorderColor: #949494;
-$listItemTextColor: #1b1b1b;
+$listItemTextColor: colors.$ink;
 $listItemSelectedBackground: #d0d0d0;
 $listItemHoverBackground: #b0b0b0;
-@use 'uswds-core';
-@use '../../../styles/abstracts/colors';
 
 .combo-box-form-group {
   max-width: 30rem;
@@ -72,7 +73,8 @@ $listItemHoverBackground: #b0b0b0;
           width: calc(100% - 25px);
           margin: 0;
         }
-        .combo-box-input:disabled, .combo-box-input[aria-disabled=true] {
+        .combo-box-input:disabled,
+        .combo-box-input[aria-disabled='true'] {
           color: colors.$disabledInputText;
           background-color: colors.$disabledInputBackground;
           cursor: not-allowed;

--- a/user-interface/src/lib/components/uswds/Accordion.scss
+++ b/user-interface/src/lib/components/uswds/Accordion.scss
@@ -1,10 +1,10 @@
 .usa-accordion {
-    .no-overflow {
-        overflow: unset;
-    }
+  .no-overflow {
+    overflow: unset;
+  }
 
-    .usa-accordion__content {
-        padding-top: 3rem;
-        padding-bottom: 3rem;
-    }
+  .usa-accordion__content {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
 }

--- a/user-interface/src/lib/components/uswds/Alert.scss
+++ b/user-interface/src/lib/components/uswds/Alert.scss
@@ -5,13 +5,17 @@
   left: 50%;
   transform: translateX(-50%);
   opacity: 0;
-  transition: opacity 0.2s ease-in-out, z-index 0s 0.2s;
+  transition:
+    opacity 0.2s ease-in-out,
+    z-index 0s 0.2s;
 }
 
 .usa-alert-container.visible {
   z-index: 10;
   opacity: 1;
-  transition: opacity 0.2s ease-in-out, z-index 0s 0s;
+  transition:
+    opacity 0.2s ease-in-out,
+    z-index 0s 0s;
 }
 
 .header-scrolled-out .usa-alert-container:not(.inline-alert) {
@@ -67,7 +71,6 @@
 .usa-alert.usa-alert--slim .usa-alert__body::before {
   background-size: 1.5rem;
 }
-
 
 .usa-alert-container.inline-alert {
   position: relative;

--- a/user-interface/src/lib/components/uswds/Checkbox.scss
+++ b/user-interface/src/lib/components/uswds/Checkbox.scss
@@ -27,10 +27,10 @@
 }
 
 .usa-checkbox__input:checked + .usa-checkbox__label::before {
-  background-color: #005ea2;
+  background-color: $primary;
   background-image: url('./checkbox-check.svg'), linear-gradient(transparent, transparent);
   background-repeat: no-repeat;
   background-position: center center;
   background-size: 0.75rem auto;
-  box-shadow: 0 0 0 2px #005ea2;
+  box-shadow: 0 0 0 2px $primary;
 }

--- a/user-interface/src/lib/components/uswds/DatePicker.scss
+++ b/user-interface/src/lib/components/uswds/DatePicker.scss
@@ -25,7 +25,7 @@
     // Custom calendar button styling
     .calendar-picker-button {
       position: absolute;
-      right: .5rem;
+      right: 0.5rem;
       top: 1rem;
       background: transparent;
       border: none;

--- a/user-interface/src/lib/components/uswds/DateRangePicker.scss
+++ b/user-interface/src/lib/components/uswds/DateRangePicker.scss
@@ -1,9 +1,9 @@
 .usa-date-range-picker {
-    .usa-form-group:nth-child(1) {
-        margin-top: 0;
+  .usa-form-group:nth-child(1) {
+    margin-top: 0;
 
-        .usa-label:nth-child(1) {
-            margin-top: 0;
-        }
+    .usa-label:nth-child(1) {
+      margin-top: 0;
     }
+  }
 }

--- a/user-interface/src/lib/components/uswds/MonthDaySelector.scss
+++ b/user-interface/src/lib/components/uswds/MonthDaySelector.scss
@@ -1,8 +1,10 @@
+@use '@/styles/abstracts/colors' as colors;
+
 .month-day-selector {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-  row-gap: .25rem;
+  row-gap: 0.25rem;
   column-gap: 0.5rem;
   width: 100%;
 
@@ -22,13 +24,13 @@
     }
 
     .usa-hint {
-      padding-bottom: .5rem;
+      padding-bottom: 0.5rem;
     }
   }
 
   .month-day-selector__separator {
     font-size: 1.25rem;
-    color: #1b1b1b;
+    color: colors.$ink;
     user-select: none;
     flex-shrink: 0;
     padding-bottom: 0.4rem;

--- a/user-interface/src/lib/components/uswds/Radio.scss
+++ b/user-interface/src/lib/components/uswds/Radio.scss
@@ -23,7 +23,9 @@
 
 .usa-radio__input:checked + label {
   [class*='__label']::before {
-    box-shadow: 0 0 0 2px #005ea2, inset 0 0 0 2px #fff;
-    background-color: #005ea2;
+    box-shadow:
+      0 0 0 2px $primary,
+      inset 0 0 0 2px #fff;
+    background-color: $primary;
   }
 }

--- a/user-interface/src/login/AuthorizedUseOnly.scss
+++ b/user-interface/src/login/AuthorizedUseOnly.scss
@@ -1,8 +1,8 @@
 .authorized-use-only {
   @counter-style parenthesized {
     system: extends numeric;
-    prefix: "(";
-    suffix: ") ";
+    prefix: '(';
+    suffix: ') ';
   }
 
   .usa-card {

--- a/user-interface/src/my-cases/MyCasesScreen.scss
+++ b/user-interface/src/my-cases/MyCasesScreen.scss
@@ -19,12 +19,24 @@
 
   @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
     .cams-table--responsive {
-      .col-case-number { flex: 3 1 0; }
-      .col-case-title  { flex: 3 1 0; }
-      .col-debtor-name { flex: 2 1 0; }
-      .col-chapter     { flex: 2 1 0; }
-      .col-date-filed  { flex: 2 1 0; }
-      .col-open-closed { flex: 2 1 0; }
+      .col-case-number {
+        flex: 3 1 0;
+      }
+      .col-case-title {
+        flex: 3 1 0;
+      }
+      .col-debtor-name {
+        flex: 2 1 0;
+      }
+      .col-chapter {
+        flex: 2 1 0;
+      }
+      .col-date-filed {
+        flex: 2 1 0;
+      }
+      .col-open-closed {
+        flex: 2 1 0;
+      }
     }
   }
 }

--- a/user-interface/src/search/SearchScreen.scss
+++ b/user-interface/src/search/SearchScreen.scss
@@ -59,7 +59,9 @@
 
     // Undo the CamsTable flex-row layout — table stays stacked at this breakpoint
     // because the filter panel leaves insufficient width for columns
-    .cams-table--responsive { @include cams-table.cams-table-stacked; }
+    .cams-table--responsive {
+      @include cams-table.cams-table-stacked;
+    }
   }
 
   // Desktop: wider filter panel, table switches to flex-row columns
@@ -71,12 +73,24 @@
 
     .cams-table--responsive {
       @include cams-table.cams-table-flex-row;
-      .col-case-number { flex: 3 1 0; }
-      .col-case-title  { flex: 3 1 0; }
-      .col-debtor-name { flex: 2 1 0; }
-      .col-chapter     { flex: 2 1 0; }
-      .col-date-filed  { flex: 2 1 0; }
-      .col-open-closed { flex: 2 1 0; }
+      .col-case-number {
+        flex: 3 1 0;
+      }
+      .col-case-title {
+        flex: 3 1 0;
+      }
+      .col-debtor-name {
+        flex: 2 1 0;
+      }
+      .col-chapter {
+        flex: 2 1 0;
+      }
+      .col-date-filed {
+        flex: 2 1 0;
+      }
+      .col-open-closed {
+        flex: 2 1 0;
+      }
     }
   }
 }

--- a/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.scss
+++ b/user-interface/src/staff-assignment/screen/StaffAssignmentScreen.scss
@@ -37,18 +37,30 @@
 
   // Tablet: undo CamsTable flex — not enough width without filter context
   @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
-    .cams-table--responsive { @include cams-table.cams-table-stacked; }
+    .cams-table--responsive {
+      @include cams-table.cams-table-stacked;
+    }
   }
 
   // Desktop: full flex-row table with column proportions
   @media screen and (min-width: #{device-screens.$desktop-screen-small + 1}) {
     .cams-table--responsive {
       @include cams-table.cams-table-flex-row;
-      .col-case-number      { flex: 3 1 0; }
-      .col-case-title       { flex: 3 1 0; }
-      .col-chapter          { flex: 1 1 0; }
-      .col-date-filed       { flex: 1 1 0; }
-      .col-staff-assignment { flex: 4 1 0; }
+      .col-case-number {
+        flex: 3 1 0;
+      }
+      .col-case-title {
+        flex: 3 1 0;
+      }
+      .col-chapter {
+        flex: 1 1 0;
+      }
+      .col-date-filed {
+        flex: 1 1 0;
+      }
+      .col-staff-assignment {
+        flex: 4 1 0;
+      }
     }
   }
 }

--- a/user-interface/src/styles/abstracts/_colors.scss
+++ b/user-interface/src/styles/abstracts/_colors.scss
@@ -1,4 +1,6 @@
 $primary: #005ea2;
+$primary-dark: #1a4480;
+$ink: #1b1b1b;
 $navy: #162e51;
 $gold: #ffbe2e;
 $eagle: #2e2e2a;

--- a/user-interface/src/styles/theme.scss
+++ b/user-interface/src/styles/theme.scss
@@ -1,3 +1,5 @@
+@use 'abstracts/colors' as colors;
+
 $cams-theme-background: white;
 
 * {
@@ -14,10 +16,10 @@ header {
   }
 }
 a {
-  color: #005ea2;
+  color: colors.$primary;
 
   &:hover {
-    color: #1a4480;
+    color: colors.$primary-dark;
   }
 }
 

--- a/user-interface/src/trustees/TrusteeDetailScreen.scss
+++ b/user-interface/src/trustees/TrusteeDetailScreen.scss
@@ -6,7 +6,7 @@
   }
 }
 .trustee-detail-screen,
-[class$="-trustee-form-screen"] {
+[class$='-trustee-form-screen'] {
   .field-group {
     .usa-form-group {
       margin-top: 0;

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -48,37 +48,19 @@
   .trustees-list-cell[data-cell] {
     display: block;
     width: 100%;
-    min-height: 1.75rem;
     padding: 0.25rem 0.375rem 0.25rem 0;
     white-space: normal;
-    position: relative;
 
     &::before {
       content: attr(data-cell) ': ';
-      position: absolute;
-      left: 0;
-      top: 0.25rem;
+      display: inline;
       font-weight: 700;
       white-space: nowrap;
     }
   }
 
-  // Small phones — inline label, full line wraps naturally
-  @media screen and (max-width: #{device-screens.$tablet-screen-extra-small}) {
-    .trustees-list-cell[data-cell] {
-      padding: 0.25rem 0.375rem 0.25rem 0;
-      min-height: unset;
-
-      &::before {
-        position: static;
-        display: inline;
-        white-space: nowrap;
-      }
-    }
-  }
-
   // Tablet — equal columns
-  @media screen and (min-width: #{device-screens.$tablet-screen-extra-small + 1}) {
+  @media screen and (min-width: #{device-screens.$tablet-screen-small + 1}) {
     .trustees-list-count {
       padding-left: 0;
       margin-bottom: 1.25rem;
@@ -146,7 +128,7 @@
   }
 
   // Desktop — proportional columns
-  @media screen and (min-width: #{device-screens.$desktop-screen-small + 1}) {
+  @media screen and (min-width: 1152px) {
     .col-name {
       flex: 2 1 0;
       min-width: 160px;

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -109,49 +109,32 @@
       }
     }
 
-    .col-name,
-    .col-chapter,
-    .col-type,
-    .col-status {
-      flex: 1 1 0;
-      min-width: 0;
-      max-width: none;
-      white-space: normal;
-    }
-
-    .col-district,
-    .col-division {
-      flex: 2 1 0;
-      min-width: 0;
-      max-width: none;
-      white-space: normal;
-    }
-  }
-
-  // Desktop — proportional columns
-  @media screen and (min-width: 1152px) {
     .col-name {
       flex: 2 1 0;
-      min-width: 160px;
+      min-width: 0;
     }
 
     .col-district {
       flex: 2 1 0;
-      min-width: 200px;
+      min-width: 0;
     }
 
     .col-division {
-      flex: 2 1 0;
-      min-width: 150px;
+      flex: 1 1 0;
+      min-width: 0;
+      max-width: 140px;
     }
 
     .col-chapter,
-    .col-type,
+    .col-type {
+      flex: 1 1 0;
+      min-width: 0;
+      max-width: 70px;
+    }
+
     .col-status {
-      flex: 0 0 120px;
-      width: 120px;
-      min-width: 120px;
-      max-width: 220px;
+      flex: 1.5 1 0;
+      min-width: 0;
       white-space: nowrap;
     }
   }

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -1,4 +1,5 @@
 @use 'styles/abstracts/device-screens' as device-screens;
+@use 'styles/abstracts/colors' as colors;
 
 .trustees-list {
   margin-top: 20px;
@@ -21,7 +22,7 @@
   }
 
   .trustee-group {
-    border-bottom: 1px solid #1b1b1b;
+    border-bottom: 1px solid colors.$ink;
     padding: 0.625rem 1rem;
     margin-bottom: 0.25rem;
   }
@@ -73,7 +74,7 @@
       font-weight: bold;
       font-size: 1rem;
       line-height: 1.5rem;
-      border-bottom: 1px solid #1b1b1b;
+      border-bottom: 1px solid colors.$ink;
       padding-bottom: 0.5rem;
     }
 

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -776,7 +776,7 @@ describe('TrusteesList Component', () => {
       });
     });
 
-    test('should use OR logic within chapter filter', async () => {
+    test('should change chapter selection when selecting different chapter', async () => {
       const trustee7 = makeListItem({
         trusteeId: 't7',
         firstName: 'Alice',
@@ -808,17 +808,26 @@ describe('TrusteesList Component', () => {
       await user.click(toggleButton);
       expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
 
+      // Select Chapter 7
       const chapterCombobox = screen.getByLabelText('Chapter');
       await user.click(chapterCombobox);
       expect(await screen.findByRole('option', { name: /Chapter 7/ })).toBeInTheDocument();
       await user.click(screen.getByRole('option', { name: /Chapter 7/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Seven, Alice')).toBeInTheDocument();
+      });
+
+      // Change to Chapter 13
+      await user.click(chapterCombobox);
       expect(await screen.findByRole('option', { name: /Chapter 13/ })).toBeInTheDocument();
       await user.click(screen.getByRole('option', { name: /Chapter 13/ }));
 
       await waitFor(() => {
-        expect(screen.getByText('2 Trustees', { selector: 'p' })).toBeInTheDocument();
-        expect(screen.getByText('Seven, Alice')).toBeInTheDocument();
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
         expect(screen.getByText('Thirteen, Carol')).toBeInTheDocument();
+        expect(screen.queryByText('Seven, Alice')).not.toBeInTheDocument();
         expect(screen.queryByText('Eleven, Bob')).not.toBeInTheDocument();
       });
     });
@@ -895,7 +904,7 @@ describe('TrusteesList Component', () => {
             selectedCount: 1,
             resultCount: 1,
             districtCount: 0,
-            selectedChapterValues: '7',
+            selectedChapterValue: '7',
           }),
         );
       });
@@ -972,7 +981,7 @@ describe('TrusteesList Component', () => {
           expect.objectContaining({
             selectedCount: 1,
             districtCount: 1,
-            selectedChapterValues: '7',
+            selectedChapterValue: '7',
           }),
         );
       });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -28,7 +28,7 @@ function renderWithRouter(component: React.ReactElement) {
 function makeListItem(overrides: Partial<TrusteeListItem> = {}): TrusteeListItem {
   return {
     ...MockData.getTrustee(),
-    appointments: [],
+    appointments: [MockData.getTrusteeAppointment()],
     ...overrides,
   };
 }
@@ -190,8 +190,10 @@ describe('TrusteesList Component', () => {
     expect(screen.getByText('District of Vermont')).toBeInTheDocument();
     expect(screen.getByText('Panel')).toBeInTheDocument();
     expect(screen.getByText('Case by Case')).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
+    const statusCells = document.querySelectorAll('[data-cell="Status"]');
+    const statusTexts = Array.from(statusCells).map((c) => c.textContent);
+    expect(statusTexts).toContain('Active');
+    expect(statusTexts).toContain('Inactive');
   });
 
   test('should format District correctly using courtName only', async () => {
@@ -313,7 +315,16 @@ describe('TrusteesList Component', () => {
       appointmentType: 'pool',
       status: 'voluntarily-suspended',
     });
-    const trustee = makeListItem({ trusteeId, name: 'Format Trustee', appointments: [appt] });
+    const activeAppt = makeAppointment({
+      trusteeId,
+      chapter: '7',
+      status: 'active',
+    });
+    const trustee = makeListItem({
+      trusteeId,
+      name: 'Format Trustee',
+      appointments: [activeAppt, appt],
+    });
     const mockResponse: ResponseBody<TrusteeListItem[]> = { data: [trustee] };
 
     vi.spyOn(Api2, 'getTrustees').mockResolvedValue(mockResponse);
@@ -321,8 +332,9 @@ describe('TrusteesList Component', () => {
     renderWithRouter(<TrusteesList />);
 
     await waitFor(() => {
-      const chapterCell = document.querySelector('[data-cell="Chapter"]') as HTMLElement;
-      expect(within(chapterCell).getByText('11 Subchapter V')).toBeInTheDocument();
+      const chapterCells = document.querySelectorAll('[data-cell="Chapter"]');
+      const chapterTexts = Array.from(chapterCells).map((c) => c.textContent);
+      expect(chapterTexts).toContain('11 Subchapter V');
     });
 
     expect(screen.getByText('Pool')).toBeInTheDocument();
@@ -2956,6 +2968,122 @@ describe('TrusteesList Component', () => {
       const label = screen.getByText('Trustee Name', { selector: '.filter-control-label' });
       expect(label).toBeInTheDocument();
       expect(label).not.toHaveAttribute('aria-hidden');
+    });
+  });
+
+  describe('Status Filter', () => {
+    beforeEach(() => {
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
+    });
+
+    test('should default to Active and hide trustees with only inactive appointments', async () => {
+      const activeTrustee = makeListItem({
+        trusteeId: 'active-1',
+        firstName: 'Alice',
+        lastName: 'Active',
+        name: 'Alice Active',
+        appointments: [makeAppointment({ trusteeId: 'active-1', status: 'active' })],
+      });
+      const inactiveTrustee = makeListItem({
+        trusteeId: 'inactive-1',
+        firstName: 'Bob',
+        lastName: 'Inactive',
+        name: 'Bob Inactive',
+        appointments: [makeAppointment({ trusteeId: 'inactive-1', status: 'deceased' })],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [activeTrustee, inactiveTrustee],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('trustee-link-active-1')).toBeInTheDocument();
+      expect(screen.queryByTestId('trustee-link-inactive-1')).not.toBeInTheDocument();
+    });
+
+    test('should show only inactive trustees when Inactive is selected', async () => {
+      const activeTrustee = makeListItem({
+        trusteeId: 'active-1',
+        firstName: 'Alice',
+        lastName: 'Active',
+        name: 'Alice Active',
+        appointments: [makeAppointment({ trusteeId: 'active-1', status: 'active' })],
+      });
+      const inactiveTrustee = makeListItem({
+        trusteeId: 'inactive-1',
+        firstName: 'Bob',
+        lastName: 'Inactive',
+        name: 'Bob Inactive',
+        appointments: [makeAppointment({ trusteeId: 'inactive-1', status: 'resigned' })],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [activeTrustee, inactiveTrustee],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      const statusCombobox = await screen.findByLabelText('Status');
+      await userEvent.setup().click(statusCombobox);
+
+      const inactiveOption = await screen.findByRole('option', { name: /Status Inactive/i });
+      await userEvent.setup().click(inactiveOption);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.queryByTestId('trustee-link-active-1')).not.toBeInTheDocument();
+        expect(screen.getByTestId('trustee-link-inactive-1')).toBeInTheDocument();
+      });
+    });
+
+    test('should show all trustees when All is selected', async () => {
+      const activeTrustee = makeListItem({
+        trusteeId: 'active-1',
+        firstName: 'Alice',
+        lastName: 'Active',
+        name: 'Alice Active',
+        appointments: [makeAppointment({ trusteeId: 'active-1', status: 'active' })],
+      });
+      const inactiveTrustee = makeListItem({
+        trusteeId: 'inactive-1',
+        firstName: 'Bob',
+        lastName: 'Inactive',
+        name: 'Bob Inactive',
+        appointments: [makeAppointment({ trusteeId: 'inactive-1', status: 'terminated' })],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [activeTrustee, inactiveTrustee],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      const statusCombobox = await screen.findByLabelText('Status');
+      await userEvent.setup().click(statusCombobox);
+
+      const allOption = await screen.findByRole('option', { name: /Status All/i });
+      await userEvent.setup().click(allOption);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustees', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByTestId('trustee-link-active-1')).toBeInTheDocument();
+        expect(screen.getByTestId('trustee-link-inactive-1')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -338,7 +338,7 @@ describe('TrusteesList Component', () => {
     });
 
     expect(screen.getByText('Pool')).toBeInTheDocument();
-    expect(screen.getByText('Voluntarily Suspended')).toBeInTheDocument();
+    expect(screen.getByText('Inactive (Voluntarily Suspended)')).toBeInTheDocument();
   });
 
   describe('Name Column Sort', () => {

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -3085,5 +3085,89 @@ describe('TrusteesList Component', () => {
         expect(screen.getByTestId('trustee-link-inactive-1')).toBeInTheDocument();
       });
     });
+
+    test('should show trustee with mixed-status appointments in both Active and Inactive views', async () => {
+      const mixedTrustee = makeListItem({
+        trusteeId: 'mixed-1',
+        firstName: 'Mixed',
+        lastName: 'Status',
+        name: 'Mixed Status',
+        appointments: [
+          makeAppointment({ trusteeId: 'mixed-1', status: 'active' }),
+          makeAppointment({ trusteeId: 'mixed-1', status: 'resigned' }),
+        ],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [mixedTrustee] });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByTestId('trustee-link-mixed-1')).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await userEvent.setup().click(toggleButton);
+
+      const statusCombobox = await screen.findByLabelText('Status');
+      await userEvent.setup().click(statusCombobox);
+
+      const inactiveOption = await screen.findByRole('option', { name: /Status Inactive/i });
+      await userEvent.setup().click(inactiveOption);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByTestId('trustee-link-mixed-1')).toBeInTheDocument();
+      });
+    });
+
+    test('should apply status and chapter filters together', async () => {
+      const activeChapter7 = makeListItem({
+        trusteeId: 'ac7',
+        firstName: 'Active',
+        lastName: 'Seven',
+        name: 'Active Seven',
+        appointments: [makeAppointment({ trusteeId: 'ac7', status: 'active', chapter: '7' })],
+      });
+      const activeChapter13 = makeListItem({
+        trusteeId: 'ac13',
+        firstName: 'Active',
+        lastName: 'Thirteen',
+        name: 'Active Thirteen',
+        appointments: [makeAppointment({ trusteeId: 'ac13', status: 'active', chapter: '13' })],
+      });
+      const inactiveChapter7 = makeListItem({
+        trusteeId: 'ic7',
+        firstName: 'Inactive',
+        lastName: 'Seven',
+        name: 'Inactive Seven',
+        appointments: [makeAppointment({ trusteeId: 'ic7', status: 'deceased', chapter: '7' })],
+      });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({
+        data: [activeChapter7, activeChapter13, inactiveChapter7],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2 Trustees', { selector: 'p' })).toBeInTheDocument();
+      });
+
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      const user = userEvent.setup();
+      await user.click(toggleButton);
+
+      const chapterCombobox = await screen.findByLabelText('Chapter');
+      await user.click(chapterCombobox);
+      const chapter7Option = await screen.findByRole('option', { name: /Chapter 7/i });
+      await user.click(chapter7Option);
+
+      await waitFor(() => {
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByTestId('trustee-link-ac7')).toBeInTheDocument();
+        expect(screen.queryByTestId('trustee-link-ac13')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('trustee-link-ic7')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -776,7 +776,7 @@ describe('TrusteesList Component', () => {
       });
     });
 
-    test('should change chapter selection when selecting different chapter', async () => {
+    test('should use OR logic within chapter filter', async () => {
       const trustee7 = makeListItem({
         trusteeId: 't7',
         firstName: 'Alice',
@@ -808,26 +808,17 @@ describe('TrusteesList Component', () => {
       await user.click(toggleButton);
       expect(await screen.findByLabelText('Chapter')).toBeInTheDocument();
 
-      // Select Chapter 7
       const chapterCombobox = screen.getByLabelText('Chapter');
       await user.click(chapterCombobox);
       expect(await screen.findByRole('option', { name: /Chapter 7/ })).toBeInTheDocument();
       await user.click(screen.getByRole('option', { name: /Chapter 7/ }));
-
-      await waitFor(() => {
-        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
-        expect(screen.getByText('Seven, Alice')).toBeInTheDocument();
-      });
-
-      // Change to Chapter 13
-      await user.click(chapterCombobox);
       expect(await screen.findByRole('option', { name: /Chapter 13/ })).toBeInTheDocument();
       await user.click(screen.getByRole('option', { name: /Chapter 13/ }));
 
       await waitFor(() => {
-        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('2 Trustees', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Seven, Alice')).toBeInTheDocument();
         expect(screen.getByText('Thirteen, Carol')).toBeInTheDocument();
-        expect(screen.queryByText('Seven, Alice')).not.toBeInTheDocument();
         expect(screen.queryByText('Eleven, Bob')).not.toBeInTheDocument();
       });
     });
@@ -904,7 +895,7 @@ describe('TrusteesList Component', () => {
             selectedCount: 1,
             resultCount: 1,
             districtCount: 0,
-            selectedChapterValue: '7',
+            selectedChapterValues: '7',
           }),
         );
       });
@@ -981,7 +972,7 @@ describe('TrusteesList Component', () => {
           expect.objectContaining({
             selectedCount: 1,
             districtCount: 1,
-            selectedChapterValue: '7',
+            selectedChapterValues: '7',
           }),
         );
       });

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -13,7 +13,7 @@ import Api2 from '@/lib/models/api2';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import TrusteeDistrictFilter from './filters/TrusteeDistrictFilter';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
-import { TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types';
+import { StatusFilterValue, TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types';
 import Icon from '@/lib/components/uswds/Icon';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 import {
@@ -55,17 +55,22 @@ function filterTrustees(
   trustees: TrusteeListItem[],
   selectedDistricts: ComboOption[],
   selectedChapters: ComboOption[],
+  statusFilter: StatusFilterValue,
   districtDivisionEnabled: boolean = false,
   divisionFilterMap: DivisionFilterMap = new Map(),
 ): TrusteeListItem[] {
-  if (
-    selectedDistricts.length === 0 &&
-    selectedChapters.length === 0 &&
-    divisionFilterMap.size === 0
-  )
-    return trustees;
   const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
   return trustees.filter((trustee) => {
+    if (statusFilter === 'active') {
+      if (
+        trustee.appointments.length > 0 &&
+        !trustee.appointments.some((appt) => appt.status === 'active')
+      )
+        return false;
+    } else if (statusFilter === 'inactive') {
+      if (!trustee.appointments.some((appt) => appt.status !== 'active')) return false;
+    }
+
     const trusteeMatchesChapter =
       selectedChapters.length === 0 ||
       trustee.appointments.some((appt) => selectedChapterValues.has(appt.chapter));
@@ -106,6 +111,7 @@ export default function TrusteesList() {
   const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>('active');
   const [liveAnnouncement, setLiveAnnouncement] = useState<string>('');
   const [nameSearch, setNameSearch] = useState('');
   const [nameSearchIds, setNameSearchIds] = useState<Set<string>>(new Set());
@@ -184,6 +190,11 @@ export default function TrusteesList() {
     setSelectedChapters(chapters);
   };
 
+  const handleFilterStatus = (status: StatusFilterValue) => {
+    setLiveAnnouncement('');
+    setStatusFilter(status);
+  };
+
   const handleFilterName = (name: string) => {
     isNameFilterInteracted.current = true;
     lastFilterChanged.current = 'name';
@@ -205,6 +216,7 @@ export default function TrusteesList() {
           trustees,
           selectedDistricts,
           selectedChapters,
+          statusFilter,
           districtDivisionEnabled,
           divisionFilterMap,
         );
@@ -235,6 +247,7 @@ export default function TrusteesList() {
             trustees,
             selectedDistricts,
             selectedChapters,
+            statusFilter,
             districtDivisionEnabled,
             divisionFilterMap,
           );
@@ -257,7 +270,7 @@ export default function TrusteesList() {
         clearTimeout(announcementTimeoutId);
       }
     };
-  }, [nameSearch, debounce, trustees, selectedDistricts, selectedChapters]);
+  }, [nameSearch, debounce, trustees, selectedDistricts, selectedChapters, statusFilter]);
 
   const handleFilterExpanded = (isExpanded: boolean) => {
     if (isExpanded && !hasExpandedOnceRef.current) {
@@ -308,6 +321,7 @@ export default function TrusteesList() {
       trustees,
       selectedDistricts,
       selectedChapters,
+      statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
     );
@@ -321,6 +335,7 @@ export default function TrusteesList() {
     selectedDistricts,
     selectedChapters,
     selectedDivisions,
+    statusFilter,
     trustees,
     districtDivisionEnabled,
     divisionFilterMap,
@@ -333,6 +348,7 @@ export default function TrusteesList() {
       trustees,
       selectedDistricts,
       selectedChapters,
+      statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
     );
@@ -367,6 +383,7 @@ export default function TrusteesList() {
     trustees,
     selectedDistricts,
     selectedChapters,
+    statusFilter,
     divisionFilterMap,
     nameSearch,
     nameSearchIds,
@@ -384,6 +401,7 @@ export default function TrusteesList() {
       trustees,
       selectedDistricts,
       selectedChapters,
+      statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
     ).length;
@@ -402,6 +420,7 @@ export default function TrusteesList() {
     selectedDistricts,
     selectedChapters,
     selectedDivisions,
+    statusFilter,
     trustees,
     districtDivisionEnabled,
     divisionFilterMap,
@@ -418,6 +437,7 @@ export default function TrusteesList() {
       trustees,
       selectedDistricts,
       selectedChapters,
+      statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
     ).length;
@@ -435,6 +455,7 @@ export default function TrusteesList() {
     selectedChapters,
     selectedDistricts,
     selectedDivisions,
+    statusFilter,
     trustees,
     districtDivisionEnabled,
     divisionFilterMap,
@@ -515,6 +536,8 @@ export default function TrusteesList() {
         handleFilterChapter={handleFilterChapter}
         handleFilterName={handleFilterName}
         handleFilterDivision={handleFilterDivision}
+        handleFilterStatus={handleFilterStatus}
+        statusFilter={statusFilter}
         combinedDistrictDivisionOptions={combinedDistrictDivisionOptions}
         onExpandedChange={handleFilterExpanded}
         onCourtsLoaded={setAllCourts}

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -1,7 +1,7 @@
 import './TrusteesList.scss';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { TrusteeName } from '@/case-detail/panels/TrusteeName';
-import { TrusteeListItem } from '@common/cams/trustees';
+import { AppointmentStatus, TrusteeListItem } from '@common/cams/trustees';
 import useDebounce from '@/lib/hooks/UseDebounce';
 import {
   formatChapterType,
@@ -26,6 +26,12 @@ import { CourtDivisionDetails } from '@common/cams/courts';
 
 const BASE_COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
 const DIVISION_COLUMN_HEADERS = ['Name', 'District', 'Division', 'Chapter', 'Type', 'Status'];
+
+function formatListAppointmentStatus(status: AppointmentStatus): string {
+  if (status === 'active') return 'Active';
+  if (status === 'inactive') return 'Inactive';
+  return `Inactive (${formatAppointmentStatus(status)})`;
+}
 
 type DivisionFilterMap = Map<string, Set<string>>;
 
@@ -672,7 +678,7 @@ export default function TrusteesList() {
                         {appt ? formatAppointmentType(appt.appointmentType) : ''}
                       </div>
                       <div className="trustees-list-cell col-status" role="cell" data-cell="Status">
-                        {appt ? formatAppointmentStatus(appt.status) : ''}
+                        {appt ? formatListAppointmentStatus(appt.status) : ''}
                       </div>
                     </div>
                   ))}

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -54,12 +54,11 @@ function isUserInSelectedDivision(trustee: TrusteeListItem, divisionFilter: Divi
 function filterTrustees(
   trustees: TrusteeListItem[],
   selectedDistricts: ComboOption[],
-  selectedChapters: ComboOption[],
+  selectedChapter: ComboOption | null,
   statusFilter: StatusFilterValue,
   districtDivisionEnabled: boolean = false,
   divisionFilterMap: DivisionFilterMap = new Map(),
 ): TrusteeListItem[] {
-  const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
   return trustees.filter((trustee) => {
     if (statusFilter === 'active') {
       if (
@@ -72,8 +71,8 @@ function filterTrustees(
     }
 
     const trusteeMatchesChapter =
-      selectedChapters.length === 0 ||
-      trustee.appointments.some((appt) => selectedChapterValues.has(appt.chapter));
+      !selectedChapter ||
+      trustee.appointments.some((appt) => appt.chapter === selectedChapter.value);
     if (!trusteeMatchesChapter) return false;
 
     if (!districtDivisionEnabled) {
@@ -110,7 +109,7 @@ export default function TrusteesList() {
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
   const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
-  const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
+  const [selectedChapter, setSelectedChapter] = useState<ComboOption | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilterValue>('active');
   const [liveAnnouncement, setLiveAnnouncement] = useState<string>('');
   const [nameSearch, setNameSearch] = useState('');
@@ -183,11 +182,11 @@ export default function TrusteesList() {
     setSelectedDivisions(divisions);
   };
 
-  const handleFilterChapter = (chapters: ComboOption[]) => {
+  const handleFilterChapter = (chapter: ComboOption | null) => {
     isChapterFilterInteracted.current = true;
     lastFilterChanged.current = 'chapter';
     setLiveAnnouncement('');
-    setSelectedChapters(chapters);
+    setSelectedChapter(chapter);
   };
 
   const handleFilterStatus = (status: StatusFilterValue) => {
@@ -215,7 +214,7 @@ export default function TrusteesList() {
         const filtered = filterTrustees(
           trustees,
           selectedDistricts,
-          selectedChapters,
+          selectedChapter,
           statusFilter,
           districtDivisionEnabled,
           divisionFilterMap,
@@ -246,7 +245,7 @@ export default function TrusteesList() {
           let filtered = filterTrustees(
             trustees,
             selectedDistricts,
-            selectedChapters,
+            selectedChapter,
             statusFilter,
             districtDivisionEnabled,
             divisionFilterMap,
@@ -270,7 +269,7 @@ export default function TrusteesList() {
         clearTimeout(announcementTimeoutId);
       }
     };
-  }, [nameSearch, debounce, trustees, selectedDistricts, selectedChapters, statusFilter]);
+  }, [nameSearch, debounce, trustees, selectedDistricts, selectedChapter, statusFilter]);
 
   const handleFilterExpanded = (isExpanded: boolean) => {
     if (isExpanded && !hasExpandedOnceRef.current) {
@@ -278,7 +277,7 @@ export default function TrusteesList() {
       const resultCount = filteredTrustees.length;
       const districtCount = selectedDistricts.length;
       const divisionCount = selectedDivisions.length;
-      const chapterCount = selectedChapters.length;
+      const hasChapterFilter = selectedChapter !== null;
       const hasNameFilter = nameSearch.length >= 2;
 
       let announcement = resultCount + ' Trustee' + (resultCount === 1 ? '' : 's');
@@ -290,7 +289,7 @@ export default function TrusteesList() {
       } else if (!districtDivisionEnabled && districtCount > 0) {
         filters.push('district');
       }
-      if (chapterCount > 0) filters.push('chapter');
+      if (hasChapterFilter) filters.push('chapter');
 
       if (filters.length > 0) {
         announcement += ' filtered by ' + filters.join(' and ');
@@ -320,7 +319,7 @@ export default function TrusteesList() {
     let filtered = filterTrustees(
       trustees,
       selectedDistricts,
-      selectedChapters,
+      selectedChapter,
       statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
@@ -333,7 +332,7 @@ export default function TrusteesList() {
     setLiveAnnouncement(announcement);
   }, [
     selectedDistricts,
-    selectedChapters,
+    selectedChapter,
     selectedDivisions,
     statusFilter,
     trustees,
@@ -347,7 +346,7 @@ export default function TrusteesList() {
     let filtered = filterTrustees(
       trustees,
       selectedDistricts,
-      selectedChapters,
+      selectedChapter,
       statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
@@ -382,7 +381,7 @@ export default function TrusteesList() {
   }, [
     trustees,
     selectedDistricts,
-    selectedChapters,
+    selectedChapter,
     statusFilter,
     divisionFilterMap,
     nameSearch,
@@ -400,7 +399,7 @@ export default function TrusteesList() {
     const resultCount = filterTrustees(
       trustees,
       selectedDistricts,
-      selectedChapters,
+      selectedChapter,
       statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
@@ -412,13 +411,13 @@ export default function TrusteesList() {
         isDefault,
         selectedCount: selectedDistricts.length,
         resultCount,
-        chapterCount: selectedChapters.length,
+        chapterCount: selectedChapter ? 1 : 0,
         divisionCount: selectedDivisions.length,
       },
     );
   }, [
     selectedDistricts,
-    selectedChapters,
+    selectedChapter,
     selectedDivisions,
     statusFilter,
     trustees,
@@ -436,7 +435,7 @@ export default function TrusteesList() {
     const resultCount = filterTrustees(
       trustees,
       selectedDistricts,
-      selectedChapters,
+      selectedChapter,
       statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
@@ -445,14 +444,14 @@ export default function TrusteesList() {
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee Chapter Filter Changed' },
       {
-        selectedCount: selectedChapters.length,
+        selectedCount: selectedChapter ? 1 : 0,
         resultCount,
         districtCount: selectedDistricts.length,
-        selectedChapterValues: selectedChapters.map((c) => c.value).join(','),
+        selectedChapterValue: selectedChapter?.value || '',
       },
     );
   }, [
-    selectedChapters,
+    selectedChapter,
     selectedDistricts,
     selectedDivisions,
     statusFilter,
@@ -471,7 +470,7 @@ export default function TrusteesList() {
         queryLength: nameSearchQueryLengthRef.current,
         resultCount: filteredTrustees.length,
         districtCount: selectedDistricts.length,
-        chapterCount: selectedChapters.length,
+        chapterCount: selectedChapter ? 1 : 0,
         searchResponseMs: nameSearchStartRef.current ?? undefined,
         hasDistrictFilter: selectedDistricts.length > 0,
         sessionSearchCount: nameSearchCountRef.current,

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -54,11 +54,12 @@ function isUserInSelectedDivision(trustee: TrusteeListItem, divisionFilter: Divi
 function filterTrustees(
   trustees: TrusteeListItem[],
   selectedDistricts: ComboOption[],
-  selectedChapter: ComboOption | null,
+  selectedChapters: ComboOption[],
   statusFilter: StatusFilterValue,
   districtDivisionEnabled: boolean = false,
   divisionFilterMap: DivisionFilterMap = new Map(),
 ): TrusteeListItem[] {
+  const selectedChapterValues = new Set(selectedChapters.map((c) => c.value));
   return trustees.filter((trustee) => {
     if (statusFilter === 'active') {
       if (
@@ -71,8 +72,8 @@ function filterTrustees(
     }
 
     const trusteeMatchesChapter =
-      !selectedChapter ||
-      trustee.appointments.some((appt) => appt.chapter === selectedChapter.value);
+      selectedChapters.length === 0 ||
+      trustee.appointments.some((appt) => selectedChapterValues.has(appt.chapter));
     if (!trusteeMatchesChapter) return false;
 
     if (!districtDivisionEnabled) {
@@ -109,7 +110,7 @@ export default function TrusteesList() {
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
   const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
-  const [selectedChapter, setSelectedChapter] = useState<ComboOption | null>(null);
+  const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
   const [statusFilter, setStatusFilter] = useState<StatusFilterValue>('active');
   const [liveAnnouncement, setLiveAnnouncement] = useState<string>('');
   const [nameSearch, setNameSearch] = useState('');
@@ -182,11 +183,11 @@ export default function TrusteesList() {
     setSelectedDivisions(divisions);
   };
 
-  const handleFilterChapter = (chapter: ComboOption | null) => {
+  const handleFilterChapter = (chapters: ComboOption[]) => {
     isChapterFilterInteracted.current = true;
     lastFilterChanged.current = 'chapter';
     setLiveAnnouncement('');
-    setSelectedChapter(chapter);
+    setSelectedChapters(chapters);
   };
 
   const handleFilterStatus = (status: StatusFilterValue) => {
@@ -214,7 +215,7 @@ export default function TrusteesList() {
         const filtered = filterTrustees(
           trustees,
           selectedDistricts,
-          selectedChapter,
+          selectedChapters,
           statusFilter,
           districtDivisionEnabled,
           divisionFilterMap,
@@ -245,7 +246,7 @@ export default function TrusteesList() {
           let filtered = filterTrustees(
             trustees,
             selectedDistricts,
-            selectedChapter,
+            selectedChapters,
             statusFilter,
             districtDivisionEnabled,
             divisionFilterMap,
@@ -269,7 +270,7 @@ export default function TrusteesList() {
         clearTimeout(announcementTimeoutId);
       }
     };
-  }, [nameSearch, debounce, trustees, selectedDistricts, selectedChapter, statusFilter]);
+  }, [nameSearch, debounce, trustees, selectedDistricts, selectedChapters, statusFilter]);
 
   const handleFilterExpanded = (isExpanded: boolean) => {
     if (isExpanded && !hasExpandedOnceRef.current) {
@@ -277,7 +278,7 @@ export default function TrusteesList() {
       const resultCount = filteredTrustees.length;
       const districtCount = selectedDistricts.length;
       const divisionCount = selectedDivisions.length;
-      const hasChapterFilter = selectedChapter !== null;
+      const chapterCount = selectedChapters.length;
       const hasNameFilter = nameSearch.length >= 2;
 
       let announcement = resultCount + ' Trustee' + (resultCount === 1 ? '' : 's');
@@ -289,7 +290,7 @@ export default function TrusteesList() {
       } else if (!districtDivisionEnabled && districtCount > 0) {
         filters.push('district');
       }
-      if (hasChapterFilter) filters.push('chapter');
+      if (chapterCount > 0) filters.push('chapter');
 
       if (filters.length > 0) {
         announcement += ' filtered by ' + filters.join(' and ');
@@ -319,7 +320,7 @@ export default function TrusteesList() {
     let filtered = filterTrustees(
       trustees,
       selectedDistricts,
-      selectedChapter,
+      selectedChapters,
       statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
@@ -332,7 +333,7 @@ export default function TrusteesList() {
     setLiveAnnouncement(announcement);
   }, [
     selectedDistricts,
-    selectedChapter,
+    selectedChapters,
     selectedDivisions,
     statusFilter,
     trustees,
@@ -346,7 +347,7 @@ export default function TrusteesList() {
     let filtered = filterTrustees(
       trustees,
       selectedDistricts,
-      selectedChapter,
+      selectedChapters,
       statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
@@ -381,7 +382,7 @@ export default function TrusteesList() {
   }, [
     trustees,
     selectedDistricts,
-    selectedChapter,
+    selectedChapters,
     statusFilter,
     divisionFilterMap,
     nameSearch,
@@ -399,7 +400,7 @@ export default function TrusteesList() {
     const resultCount = filterTrustees(
       trustees,
       selectedDistricts,
-      selectedChapter,
+      selectedChapters,
       statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
@@ -411,13 +412,13 @@ export default function TrusteesList() {
         isDefault,
         selectedCount: selectedDistricts.length,
         resultCount,
-        chapterCount: selectedChapter ? 1 : 0,
+        chapterCount: selectedChapters.length,
         divisionCount: selectedDivisions.length,
       },
     );
   }, [
     selectedDistricts,
-    selectedChapter,
+    selectedChapters,
     selectedDivisions,
     statusFilter,
     trustees,
@@ -435,7 +436,7 @@ export default function TrusteesList() {
     const resultCount = filterTrustees(
       trustees,
       selectedDistricts,
-      selectedChapter,
+      selectedChapters,
       statusFilter,
       districtDivisionEnabled,
       divisionFilterMap,
@@ -444,14 +445,14 @@ export default function TrusteesList() {
     getAppInsights().appInsights.trackEvent(
       { name: 'Trustee Chapter Filter Changed' },
       {
-        selectedCount: selectedChapter ? 1 : 0,
+        selectedCount: selectedChapters.length,
         resultCount,
         districtCount: selectedDistricts.length,
-        selectedChapterValue: selectedChapter?.value || '',
+        selectedChapterValues: selectedChapters.map((c) => c.value).join(','),
       },
     );
   }, [
-    selectedChapter,
+    selectedChapters,
     selectedDistricts,
     selectedDivisions,
     statusFilter,
@@ -470,7 +471,7 @@ export default function TrusteesList() {
         queryLength: nameSearchQueryLengthRef.current,
         resultCount: filteredTrustees.length,
         districtCount: selectedDistricts.length,
-        chapterCount: selectedChapter ? 1 : 0,
+        chapterCount: selectedChapters.length,
         searchResponseMs: nameSearchStartRef.current ?? undefined,
         hasDistrictFilter: selectedDistricts.length > 0,
         sessionSearchCount: nameSearchCountRef.current,

--- a/user-interface/src/trustees/TrusteesScreen.tsx
+++ b/user-interface/src/trustees/TrusteesScreen.tsx
@@ -41,7 +41,7 @@ export default function TrusteesScreen() {
           <NavLink
             to="/trustees/create"
             data-testid="trustees-add-link"
-            className="usa-button flex-shrink-0 margin-right-0"
+            className="usa-button width-auto margin-right-0"
           >
             Add New Trustee
           </NavLink>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
@@ -1,3 +1,5 @@
+@use 'styles/abstracts/colors' as colors;
+
 .trustee-district-filter {
   margin-bottom: 1.5rem;
 
@@ -37,7 +39,7 @@
     padding: 0;
     font-weight: 700;
     font-size: 1rem;
-    color: #1b1b1b;
+    color: colors.$ink;
     cursor: pointer;
     background: none;
     border: none;
@@ -45,7 +47,7 @@
     text-decoration: none;
 
     &:hover {
-      color: #005ea2;
+      color: colors.$primary;
     }
 
     .usa-icon {
@@ -119,12 +121,12 @@
       border: none;
       padding: 0;
       font-size: 1rem;
-      color: #005ea2;
+      color: colors.$primary;
       cursor: pointer;
       text-decoration: underline;
 
       &:hover {
-        color: #1a4480;
+        color: colors.$primary-dark;
       }
     }
   }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.scss
@@ -25,7 +25,7 @@
     }
   }
 
-  .usa-accordion__content:not([hidden])+.filter-pills-container {
+  .usa-accordion__content:not([hidden]) + .filter-pills-container {
     margin-top: 0.25rem;
   }
 
@@ -59,19 +59,22 @@
     animation: slideDown 0.2s ease-out;
 
     #trustee-name-filter {
-      margin-top: .75rem;
+      margin-top: 0.75rem;
     }
 
     .filter-controls-row {
       display: flex;
-      flex-wrap: wrap;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .filter-controls-pair {
+      display: flex;
+      flex-direction: column;
       gap: 1.5rem;
     }
 
     .filter-control {
-      flex: 1 1 20rem;
-      min-width: 16rem;
-      max-width: 30rem;
       position: relative;
 
       .combo-box-form-group {
@@ -143,12 +146,29 @@
     }
   }
 
-  @media (max-width: 30rem) {
+  @media (min-width: 30rem) {
     .filter-content {
-      .filter-control {
-        max-width: 100%;
+      .filter-controls-pair {
+        flex-direction: row;
+
+        .filter-control {
+          flex: 1 1 10rem;
+          min-width: 10rem;
+        }
       }
     }
+  }
 
+  @media (min-width: 60rem) {
+    .filter-content {
+      .filter-controls-row {
+        flex-direction: row;
+        flex-wrap: wrap;
+      }
+
+      .filter-controls-pair {
+        flex: 1 1 20rem;
+      }
+    }
   }
 }

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -82,6 +82,7 @@ function renderFilter(
     mockHandleFilterChapter,
     mockHandleFilterName,
     mockHandleFilterDivision,
+    mockHandleFilterStatus,
   };
 }
 
@@ -123,7 +124,6 @@ describe('TrusteeDistrictFilter Component', () => {
     expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
     await waitFor(() => {
       expect(screen.getByLabelText('District')).toBeInTheDocument();
-      expect(Api2.getCourts).toHaveBeenCalled();
     });
   });
 
@@ -800,6 +800,39 @@ describe('TrusteeDistrictFilter Component', () => {
       const internalLabel = document.querySelector('#district-division-combobox-label');
       expect(internalLabel).toBeInTheDocument();
       expect(internalLabel).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('Status Filter', () => {
+    test('should render Status combobox when panel is expanded', async () => {
+      const user = userEvent.setup();
+      renderFilter();
+      await openFiltersPanel(user);
+
+      expect(screen.getByLabelText('Status')).toBeInTheDocument();
+    });
+
+    test('should call handleFilterStatus when a status is selected', async () => {
+      const user = userEvent.setup();
+      const { mockHandleFilterStatus } = renderFilter();
+      await openFiltersPanel(user);
+
+      const statusCombobox = screen.getByLabelText('Status');
+      await user.click(statusCombobox);
+
+      const inactiveOption = await screen.findByRole('option', { name: /Status Inactive/i });
+      await user.click(inactiveOption);
+
+      expect(mockHandleFilterStatus).toHaveBeenCalledWith('inactive');
+    });
+
+    test('should show current selection based on statusFilter prop', async () => {
+      const user = userEvent.setup();
+      renderFilter();
+      await openFiltersPanel(user);
+
+      const statusCombobox = screen.getByLabelText('Status');
+      expect(statusCombobox).toHaveValue('Active');
     });
   });
 });

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.test.tsx
@@ -63,6 +63,7 @@ function renderFilter(
   const mockHandleFilterChapter = vi.fn();
   const mockHandleFilterName = vi.fn();
   const mockHandleFilterDivision = vi.fn();
+  const mockHandleFilterStatus = vi.fn();
   render(
     <TrusteeDistrictFilter
       ref={overrides.ref}
@@ -70,6 +71,8 @@ function renderFilter(
       handleFilterChapter={mockHandleFilterChapter}
       handleFilterName={mockHandleFilterName}
       handleFilterDivision={mockHandleFilterDivision}
+      handleFilterStatus={mockHandleFilterStatus}
+      statusFilter="active"
       combinedDistrictDivisionOptions={overrides.combinedDistrictDivisionOptions ?? []}
       onExpandedChange={overrides.onExpandedChange}
     />,

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -26,7 +26,8 @@ const TrusteeDistrictFilter_ = (
   props: TrusteeDistrictFilterProps,
   ref: React.Ref<TrusteeDistrictFilterRef>,
 ) => {
-  const { handleFilterName, onExpandedChange, onCourtsLoaded } = props;
+  const { handleFilterName, handleFilterStatus, statusFilter, onExpandedChange, onCourtsLoaded } =
+    props;
   const flags = useFeatureFlags();
   const districtDivisionEnabled = !!flags[TRUSTEE_DISTRICT_DIVISION];
   const [nameSearch, setNameSearch] = useState('');
@@ -131,6 +132,7 @@ const TrusteeDistrictFilter_ = (
     divisionFilterRef: controls.divisionFilterRef,
     nameSearch,
     upgradeAnnouncement,
+    statusFilter,
     districtsToComboOptions: useCase.districtsToComboOptions,
     chaptersToComboOptions: useCase.chaptersToComboOptions,
     handleFilterChange: useCase.handleFilterChange,
@@ -139,6 +141,7 @@ const TrusteeDistrictFilter_ = (
     handleFilterChapter: useCase.handleFilterChapter,
     handleClearAllChapters: useCase.handleClearAllChapters,
     handleFilterName: handleNameChange,
+    handleFilterStatus,
     handleFilterDivision: useCase.handleFilterDivision,
     handleClearAllDivisions: useCase.handleClearAllDivisions,
     handleFilterCombined: useCase.handleFilterCombined,

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -44,6 +44,7 @@ const TrusteeDistrictFilter_ = (
     [handleFilterName],
   );
   const previousDistrictsRef = useRef<ComboOption[] | undefined>(undefined);
+  const previousChaptersRef = useRef<ComboOption[] | undefined>(undefined);
   const previousDivisionsRef = useRef<ComboOption[] | undefined>(undefined);
   const useCase = trusteeDistrictFilterUseCase(
     store,
@@ -51,6 +52,7 @@ const TrusteeDistrictFilter_ = (
     props.handleFilterDistrict,
     previousDistrictsRef,
     props.handleFilterChapter,
+    previousChaptersRef,
     props.handleFilterDivision,
     previousDivisionsRef,
     districtDivisionEnabled,
@@ -120,7 +122,7 @@ const TrusteeDistrictFilter_ = (
     districts: store.districts,
     districtsError: store.districtsError,
     selectedDistricts: store.selectedDistricts,
-    selectedChapter: store.selectedChapter,
+    selectedChapters: store.selectedChapters,
     selectedDivisions: store.selectedDivisions,
     combinedDistrictDivisionOptions: orderedCombinedOptions,
     districtDivisionEnabled,
@@ -137,6 +139,7 @@ const TrusteeDistrictFilter_ = (
     handleClearAll: useCase.handleClearAll,
     handleToggleExpanded: useCase.handleToggleExpanded,
     handleFilterChapter: useCase.handleFilterChapter,
+    handleClearAllChapters: useCase.handleClearAllChapters,
     handleFilterName: handleNameChange,
     handleFilterStatus,
     handleFilterDivision: useCase.handleFilterDivision,
@@ -155,7 +158,7 @@ function useTrusteeDistrictFilterStoreReact() {
   const [districtsError, setDistrictsError] = useState<boolean>(false);
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
   const [defaultDistricts, setDefaultDistricts] = useState<ComboOption[]>([]);
-  const [selectedChapter, setSelectedChapter] = useState<ComboOption | null>(null);
+  const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
   const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
   const [defaultDivisions, setDefaultDivisions] = useState<ComboOption[]>([]);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
@@ -169,8 +172,8 @@ function useTrusteeDistrictFilterStoreReact() {
     setSelectedDistricts,
     defaultDistricts,
     setDefaultDistricts,
-    selectedChapter,
-    setSelectedChapter,
+    selectedChapters,
+    setSelectedChapters,
     selectedDivisions,
     setSelectedDivisions,
     defaultDivisions,

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilter.tsx
@@ -44,7 +44,6 @@ const TrusteeDistrictFilter_ = (
     [handleFilterName],
   );
   const previousDistrictsRef = useRef<ComboOption[] | undefined>(undefined);
-  const previousChaptersRef = useRef<ComboOption[] | undefined>(undefined);
   const previousDivisionsRef = useRef<ComboOption[] | undefined>(undefined);
   const useCase = trusteeDistrictFilterUseCase(
     store,
@@ -52,7 +51,6 @@ const TrusteeDistrictFilter_ = (
     props.handleFilterDistrict,
     previousDistrictsRef,
     props.handleFilterChapter,
-    previousChaptersRef,
     props.handleFilterDivision,
     previousDivisionsRef,
     districtDivisionEnabled,
@@ -122,7 +120,7 @@ const TrusteeDistrictFilter_ = (
     districts: store.districts,
     districtsError: store.districtsError,
     selectedDistricts: store.selectedDistricts,
-    selectedChapters: store.selectedChapters,
+    selectedChapter: store.selectedChapter,
     selectedDivisions: store.selectedDivisions,
     combinedDistrictDivisionOptions: orderedCombinedOptions,
     districtDivisionEnabled,
@@ -139,7 +137,6 @@ const TrusteeDistrictFilter_ = (
     handleClearAll: useCase.handleClearAll,
     handleToggleExpanded: useCase.handleToggleExpanded,
     handleFilterChapter: useCase.handleFilterChapter,
-    handleClearAllChapters: useCase.handleClearAllChapters,
     handleFilterName: handleNameChange,
     handleFilterStatus,
     handleFilterDivision: useCase.handleFilterDivision,
@@ -158,7 +155,7 @@ function useTrusteeDistrictFilterStoreReact() {
   const [districtsError, setDistrictsError] = useState<boolean>(false);
   const [selectedDistricts, setSelectedDistricts] = useState<ComboOption[]>([]);
   const [defaultDistricts, setDefaultDistricts] = useState<ComboOption[]>([]);
-  const [selectedChapters, setSelectedChapters] = useState<ComboOption[]>([]);
+  const [selectedChapter, setSelectedChapter] = useState<ComboOption | null>(null);
   const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
   const [defaultDivisions, setDefaultDivisions] = useState<ComboOption[]>([]);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
@@ -172,8 +169,8 @@ function useTrusteeDistrictFilterStoreReact() {
     setSelectedDistricts,
     defaultDistricts,
     setDefaultDistricts,
-    selectedChapters,
-    setSelectedChapters,
+    selectedChapter,
+    setSelectedChapter,
     selectedDivisions,
     setSelectedDivisions,
     defaultDivisions,

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -84,7 +84,10 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
     viewModel.districts.length > 0 &&
     !viewModel.districtsError;
   const pillDistricts = viewModel.districtDivisionEnabled ? [] : viewModel.selectedDistricts;
-  const hasPills = pillDistricts.length > 0 || viewModel.selectedDivisions.length > 0;
+  const hasPills =
+    pillDistricts.length > 0 ||
+    viewModel.selectedChapters.length > 0 ||
+    viewModel.selectedDivisions.length > 0;
 
   return (
     <section className="trustee-district-filter" aria-label="Trustee filter controls">
@@ -152,11 +155,13 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                   hideInternalLabel={true}
                   ariaLabelPrefix="Chapter"
                   options={viewModel.chaptersToComboOptions()}
-                  selections={viewModel.selectedChapter ? [viewModel.selectedChapter] : []}
-                  onUpdateSelection={(selections) => {
-                    viewModel.handleFilterChapter(selections[0] || null);
-                  }}
-                  placeholder="Select a chapter"
+                  selections={viewModel.selectedChapters}
+                  onUpdateSelection={viewModel.handleFilterChapter}
+                  multiSelect={true}
+                  wrapPills={true}
+                  pluralLabel="chapters"
+                  singularLabel="chapter"
+                  placeholder="- Select one or more -"
                   ref={viewModel.chapterFilterRef}
                 />
               </div>
@@ -191,17 +196,22 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
           selections={[
             ...tagPills(pillDistricts, 'district'),
             ...tagPills(viewModel.selectedDivisions, 'division'),
+            ...tagPills(viewModel.selectedChapters, 'chapter'),
           ]}
           onSelectionChange={(updatedPills) => {
             const pills = updatedPills as FilterPill[];
             const updatedDistricts = pills.filter((p) => p.kind === 'district');
             const updatedDivisions = pills.filter((p) => p.kind === 'division');
+            const updatedChapters = pills.filter((p) => p.kind === 'chapter');
 
             if (updatedDistricts.length !== pillDistricts.length) {
               viewModel.handleFilterChange(updatedDistricts);
             }
             if (updatedDivisions.length !== viewModel.selectedDivisions.length) {
               viewModel.handleFilterDivision(updatedDivisions);
+            }
+            if (updatedChapters.length !== viewModel.selectedChapters.length) {
+              viewModel.handleFilterChapter(updatedChapters);
             }
           }}
         />

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -2,7 +2,18 @@ import './TrusteeDistrictFilter.scss';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import PillBox from '@/lib/components/PillBox';
 import { Accordion, AccordionGroup } from '@/lib/components/uswds/Accordion';
-import { TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
+import { StatusFilterValue, TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
+
+const STATUS_OPTIONS: ComboOption[] = [
+  { value: 'all', label: 'All' },
+  { value: 'active', label: 'Active' },
+  { value: 'inactive', label: 'Inactive' },
+];
+
+function statusToSelection(status: StatusFilterValue): ComboOption[] {
+  const option = STATUS_OPTIONS.find((o) => o.value === status);
+  return option ? [option] : [];
+}
 
 type FilterPillKind = 'district' | 'division' | 'chapter';
 type FilterPill = ComboOption & { kind: FilterPillKind };
@@ -152,6 +163,25 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                   singularLabel="chapter"
                   placeholder="- Select one or more -"
                   ref={viewModel.chapterFilterRef}
+                />
+              </div>
+
+              <div className="filter-control">
+                <div className="filter-control-header">
+                  <span className="filter-control-label">Status</span>
+                </div>
+                <ComboBox
+                  id="status-combobox"
+                  label="Status"
+                  hideInternalLabel={true}
+                  ariaLabelPrefix="Status"
+                  options={STATUS_OPTIONS}
+                  selections={statusToSelection(viewModel.statusFilter)}
+                  onUpdateSelection={(selections) => {
+                    const value = (selections[0]?.value ?? 'active') as StatusFilterValue;
+                    viewModel.handleFilterStatus(value);
+                  }}
+                  placeholder="Active"
                 />
               </div>
             </div>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -84,10 +84,7 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
     viewModel.districts.length > 0 &&
     !viewModel.districtsError;
   const pillDistricts = viewModel.districtDivisionEnabled ? [] : viewModel.selectedDistricts;
-  const hasPills =
-    pillDistricts.length > 0 ||
-    viewModel.selectedChapters.length > 0 ||
-    viewModel.selectedDivisions.length > 0;
+  const hasPills = pillDistricts.length > 0 || viewModel.selectedDivisions.length > 0;
 
   return (
     <section className="trustee-district-filter" aria-label="Trustee filter controls">
@@ -155,13 +152,11 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                   hideInternalLabel={true}
                   ariaLabelPrefix="Chapter"
                   options={viewModel.chaptersToComboOptions()}
-                  selections={viewModel.selectedChapters}
-                  onUpdateSelection={viewModel.handleFilterChapter}
-                  multiSelect={true}
-                  wrapPills={true}
-                  pluralLabel="chapters"
-                  singularLabel="chapter"
-                  placeholder="- Select one or more -"
+                  selections={viewModel.selectedChapter ? [viewModel.selectedChapter] : []}
+                  onUpdateSelection={(selections) => {
+                    viewModel.handleFilterChapter(selections[0] || null);
+                  }}
+                  placeholder="Select a chapter"
                   ref={viewModel.chapterFilterRef}
                 />
               </div>
@@ -196,22 +191,17 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
           selections={[
             ...tagPills(pillDistricts, 'district'),
             ...tagPills(viewModel.selectedDivisions, 'division'),
-            ...tagPills(viewModel.selectedChapters, 'chapter'),
           ]}
           onSelectionChange={(updatedPills) => {
             const pills = updatedPills as FilterPill[];
             const updatedDistricts = pills.filter((p) => p.kind === 'district');
             const updatedDivisions = pills.filter((p) => p.kind === 'division');
-            const updatedChapters = pills.filter((p) => p.kind === 'chapter');
 
             if (updatedDistricts.length !== pillDistricts.length) {
               viewModel.handleFilterChange(updatedDistricts);
             }
             if (updatedDivisions.length !== viewModel.selectedDivisions.length) {
               viewModel.handleFilterDivision(updatedDivisions);
-            }
-            if (updatedChapters.length !== viewModel.selectedChapters.length) {
-              viewModel.handleFilterChapter(updatedChapters);
             }
           }}
         />

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -113,80 +113,86 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
             )}
 
             <div className="filter-controls-row">
-              <div className="filter-control">
-                <div className="filter-control-header">
-                  <span className="filter-control-label">Trustee Name</span>
-                  <div
-                    className="filter-clear-button-container"
+              <div className="filter-controls-pair">
+                <div className="filter-control">
+                  <div className="filter-control-header">
+                    <span className="filter-control-label">Trustee Name</span>
+                    <div
+                      className="filter-clear-button-container"
+                      aria-live="off"
+                      aria-atomic="false"
+                    >
+                      <button
+                        type="button"
+                        className="filter-clear-link"
+                        onClick={() => viewModel.handleFilterName('')}
+                        aria-label="Clear Trustee Name filter"
+                        style={{
+                          visibility: viewModel.nameSearch.length > 0 ? 'visible' : 'hidden',
+                        }}
+                        disabled={viewModel.nameSearch.length === 0}
+                      >
+                        Clear
+                      </button>
+                    </div>
+                  </div>
+                  <input
+                    id="trustee-name-filter"
+                    type="text"
+                    className="usa-input"
+                    aria-label="Trustee Name"
                     aria-live="off"
                     aria-atomic="false"
-                  >
-                    <button
-                      type="button"
-                      className="filter-clear-link"
-                      onClick={() => viewModel.handleFilterName('')}
-                      aria-label="Clear Trustee Name filter"
-                      style={{ visibility: viewModel.nameSearch.length > 0 ? 'visible' : 'hidden' }}
-                      disabled={viewModel.nameSearch.length === 0}
-                    >
-                      Clear
-                    </button>
+                    value={viewModel.nameSearch}
+                    onChange={(e) => viewModel.handleFilterName(e.target.value)}
+                    placeholder="Search by name"
+                    autoComplete="off"
+                  />
+                </div>
+
+                {renderDistrictFilter(viewModel, showLegacyDistrictFilter)}
+              </div>
+
+              <div className="filter-controls-pair">
+                <div className="filter-control">
+                  <div className="filter-control-header">
+                    <span className="filter-control-label">Chapter</span>
                   </div>
+                  <ComboBox
+                    id="chapter-combobox"
+                    label="Chapter"
+                    hideInternalLabel={true}
+                    ariaLabelPrefix="Chapter"
+                    options={viewModel.chaptersToComboOptions()}
+                    selections={viewModel.selectedChapters}
+                    onUpdateSelection={viewModel.handleFilterChapter}
+                    multiSelect={true}
+                    wrapPills={true}
+                    pluralLabel="chapters"
+                    singularLabel="chapter"
+                    placeholder="- Select one or more -"
+                    ref={viewModel.chapterFilterRef}
+                  />
                 </div>
-                <input
-                  id="trustee-name-filter"
-                  type="text"
-                  className="usa-input"
-                  aria-label="Trustee Name"
-                  aria-live="off"
-                  aria-atomic="false"
-                  value={viewModel.nameSearch}
-                  onChange={(e) => viewModel.handleFilterName(e.target.value)}
-                  placeholder="Search by name"
-                  autoComplete="off"
-                />
-              </div>
 
-              {renderDistrictFilter(viewModel, showLegacyDistrictFilter)}
-
-              <div className="filter-control">
-                <div className="filter-control-header">
-                  <span className="filter-control-label">Chapter</span>
+                <div className="filter-control">
+                  <div className="filter-control-header">
+                    <span className="filter-control-label">Status</span>
+                  </div>
+                  <ComboBox
+                    id="status-combobox"
+                    label="Status"
+                    hideInternalLabel={true}
+                    ariaLabelPrefix="Status"
+                    options={STATUS_OPTIONS}
+                    selections={statusToSelection(viewModel.statusFilter)}
+                    onUpdateSelection={(selections) => {
+                      const value = (selections[0]?.value ?? 'active') as StatusFilterValue;
+                      viewModel.handleFilterStatus(value);
+                    }}
+                    placeholder="Active"
+                  />
                 </div>
-                <ComboBox
-                  id="chapter-combobox"
-                  label="Chapter"
-                  hideInternalLabel={true}
-                  ariaLabelPrefix="Chapter"
-                  options={viewModel.chaptersToComboOptions()}
-                  selections={viewModel.selectedChapters}
-                  onUpdateSelection={viewModel.handleFilterChapter}
-                  multiSelect={true}
-                  wrapPills={true}
-                  pluralLabel="chapters"
-                  singularLabel="chapter"
-                  placeholder="- Select one or more -"
-                  ref={viewModel.chapterFilterRef}
-                />
-              </div>
-
-              <div className="filter-control">
-                <div className="filter-control-header">
-                  <span className="filter-control-label">Status</span>
-                </div>
-                <ComboBox
-                  id="status-combobox"
-                  label="Status"
-                  hideInternalLabel={true}
-                  ariaLabelPrefix="Status"
-                  options={STATUS_OPTIONS}
-                  selections={statusToSelection(viewModel.statusFilter)}
-                  onUpdateSelection={(selections) => {
-                    const value = (selections[0]?.value ?? 'active') as StatusFilterValue;
-                    viewModel.handleFilterStatus(value);
-                  }}
-                  placeholder="Active"
-                />
               </div>
             </div>
           </div>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -7,7 +7,11 @@ import { StatusFilterValue, TrusteeDistrictFilterViewProps } from './trusteeDist
 const STATUS_OPTIONS: ComboOption[] = [
   { value: 'all', label: 'All' },
   { value: 'active', label: 'Active' },
-  { value: 'inactive', label: 'Inactive' },
+  {
+    value: 'inactive',
+    label:
+      'Inactive (Inactive, Involuntarily Suspended, Voluntarily Suspended, Resigned, Terminated, Deceased)',
+  },
 ];
 
 function statusToSelection(status: StatusFilterValue): ComboOption[] {

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -14,8 +14,8 @@ export interface TrusteeDistrictFilterStore {
   setSelectedDistricts(val: ComboOption[]): void;
   defaultDistricts: ComboOption[];
   setDefaultDistricts(val: ComboOption[]): void;
-  selectedChapter: ComboOption | null;
-  setSelectedChapter(val: ComboOption | null): void;
+  selectedChapters: ComboOption[];
+  setSelectedChapters(val: ComboOption[]): void;
   selectedDivisions: ComboOption[];
   setSelectedDivisions(val: ComboOption[]): void;
   defaultDivisions: ComboOption[];
@@ -38,7 +38,7 @@ export interface TrusteeDistrictFilterViewModel {
   districts: CourtDivisionDetails[];
   districtsError: boolean;
   selectedDistricts: ComboOption[];
-  selectedChapter: ComboOption | null;
+  selectedChapters: ComboOption[];
   selectedDivisions: ComboOption[];
   combinedDistrictDivisionOptions: ComboOption[];
   districtDivisionEnabled: boolean;
@@ -55,7 +55,8 @@ export interface TrusteeDistrictFilterViewModel {
   handleFilterChange(districts: ComboOption[]): void;
   handleClearAll(): void;
   handleToggleExpanded(): void;
-  handleFilterChapter(chapter: ComboOption | null): void;
+  handleFilterChapter(chapters: ComboOption[]): void;
+  handleClearAllChapters(): void;
   handleFilterName(name: string): void;
   handleFilterStatus(status: StatusFilterValue): void;
   handleFilterDivision(divisions: ComboOption[]): void;
@@ -71,7 +72,7 @@ export interface TrusteeDistrictFilterRef {
 
 export type TrusteeDistrictFilterProps = {
   handleFilterDistrict(districts: ComboOption[]): void;
-  handleFilterChapter(chapter: ComboOption | null): void;
+  handleFilterChapter(chapters: ComboOption[]): void;
   handleFilterName(name: string): void;
   handleFilterDivision(divisions: ComboOption[]): void;
   handleFilterStatus(status: StatusFilterValue): void;
@@ -93,7 +94,8 @@ export interface TrusteeDistrictFilterUseCase {
   handleFilterChange(districts: ComboOption[]): void;
   handleClearAll(): void;
   handleToggleExpanded(): void;
-  handleFilterChapter(chapter: ComboOption | null): void;
+  handleFilterChapter(chapters: ComboOption[]): void;
+  handleClearAllChapters(): void;
   handleFilterDivision(divisions: ComboOption[]): void;
   handleClearAllDivisions(): void;
   handleFilterCombined(selections: ComboOption[]): void;

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -14,8 +14,8 @@ export interface TrusteeDistrictFilterStore {
   setSelectedDistricts(val: ComboOption[]): void;
   defaultDistricts: ComboOption[];
   setDefaultDistricts(val: ComboOption[]): void;
-  selectedChapters: ComboOption[];
-  setSelectedChapters(val: ComboOption[]): void;
+  selectedChapter: ComboOption | null;
+  setSelectedChapter(val: ComboOption | null): void;
   selectedDivisions: ComboOption[];
   setSelectedDivisions(val: ComboOption[]): void;
   defaultDivisions: ComboOption[];
@@ -38,7 +38,7 @@ export interface TrusteeDistrictFilterViewModel {
   districts: CourtDivisionDetails[];
   districtsError: boolean;
   selectedDistricts: ComboOption[];
-  selectedChapters: ComboOption[];
+  selectedChapter: ComboOption | null;
   selectedDivisions: ComboOption[];
   combinedDistrictDivisionOptions: ComboOption[];
   districtDivisionEnabled: boolean;
@@ -55,8 +55,7 @@ export interface TrusteeDistrictFilterViewModel {
   handleFilterChange(districts: ComboOption[]): void;
   handleClearAll(): void;
   handleToggleExpanded(): void;
-  handleFilterChapter(chapters: ComboOption[]): void;
-  handleClearAllChapters(): void;
+  handleFilterChapter(chapter: ComboOption | null): void;
   handleFilterName(name: string): void;
   handleFilterStatus(status: StatusFilterValue): void;
   handleFilterDivision(divisions: ComboOption[]): void;
@@ -72,7 +71,7 @@ export interface TrusteeDistrictFilterRef {
 
 export type TrusteeDistrictFilterProps = {
   handleFilterDistrict(districts: ComboOption[]): void;
-  handleFilterChapter(chapters: ComboOption[]): void;
+  handleFilterChapter(chapter: ComboOption | null): void;
   handleFilterName(name: string): void;
   handleFilterDivision(divisions: ComboOption[]): void;
   handleFilterStatus(status: StatusFilterValue): void;
@@ -94,8 +93,7 @@ export interface TrusteeDistrictFilterUseCase {
   handleFilterChange(districts: ComboOption[]): void;
   handleClearAll(): void;
   handleToggleExpanded(): void;
-  handleFilterChapter(chapters: ComboOption[]): void;
-  handleClearAllChapters(): void;
+  handleFilterChapter(chapter: ComboOption | null): void;
   handleFilterDivision(divisions: ComboOption[]): void;
   handleClearAllDivisions(): void;
   handleFilterCombined(selections: ComboOption[]): void;

--- a/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilter.types.ts
@@ -3,6 +3,8 @@ import { ComboBoxRef } from '@/lib/type-declarations/input-fields';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import { CamsSession } from '@common/cams/session';
 
+export type StatusFilterValue = 'all' | 'active' | 'inactive';
+
 export interface TrusteeDistrictFilterStore {
   districts: CourtDivisionDetails[];
   setDistricts(val: CourtDivisionDetails[]): void;
@@ -46,6 +48,7 @@ export interface TrusteeDistrictFilterViewModel {
   divisionFilterRef: React.RefObject<ComboBoxRef | null>;
   nameSearch: string;
   upgradeAnnouncement: string;
+  statusFilter: StatusFilterValue;
 
   districtsToComboOptions(districts: CourtDivisionDetails[]): ComboOption[];
   chaptersToComboOptions(): ComboOption[];
@@ -55,6 +58,7 @@ export interface TrusteeDistrictFilterViewModel {
   handleFilterChapter(chapters: ComboOption[]): void;
   handleClearAllChapters(): void;
   handleFilterName(name: string): void;
+  handleFilterStatus(status: StatusFilterValue): void;
   handleFilterDivision(divisions: ComboOption[]): void;
   handleClearAllDivisions(): void;
   handleFilterCombined(selections: ComboOption[]): void;
@@ -71,6 +75,8 @@ export type TrusteeDistrictFilterProps = {
   handleFilterChapter(chapters: ComboOption[]): void;
   handleFilterName(name: string): void;
   handleFilterDivision(divisions: ComboOption[]): void;
+  handleFilterStatus(status: StatusFilterValue): void;
+  statusFilter: StatusFilterValue;
   combinedDistrictDivisionOptions: ComboOption[];
   onExpandedChange?: (isExpanded: boolean) => void;
   onCourtsLoaded?: (courts: CourtDivisionDetails[]) => void;

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -146,8 +146,7 @@ const trusteeDistrictFilterUseCase = (
   controls: TrusteeDistrictFilterControls,
   onFilterDistrict: (districts: ComboOption[]) => void,
   previousDistrictsRef: { current: ComboOption[] | undefined },
-  onFilterChapter: (chapters: ComboOption[]) => void,
-  previousChaptersRef: { current: ComboOption[] | undefined },
+  onFilterChapter: (chapter: ComboOption | null) => void,
   onFilterDivision: (divisions: ComboOption[]) => void,
   previousDivisionsRef: { current: ComboOption[] | undefined },
   districtDivisionEnabled: boolean = false,
@@ -281,21 +280,9 @@ const trusteeDistrictFilterUseCase = (
     store.setIsExpanded(!store.isExpanded);
   };
 
-  const handleFilterChapter = (chapters: ComboOption[]) => {
-    const wasNonEmpty = previousChaptersRef.current && previousChaptersRef.current.length > 0;
-    const isNowEmpty = chapters.length === 0;
-
-    if (wasNonEmpty && isNowEmpty) {
-      getAppInsights().appInsights.trackEvent({ name: 'Trustee Chapter Filter Cleared' });
-    }
-
-    previousChaptersRef.current = chapters;
-    store.setSelectedChapters(chapters);
-    onFilterChapter(chapters);
-  };
-
-  const handleClearAllChapters = () => {
-    handleFilterChapter([]);
+  const handleFilterChapter = (chapter: ComboOption | null) => {
+    store.setSelectedChapter(chapter);
+    onFilterChapter(chapter);
   };
 
   return {
@@ -308,7 +295,6 @@ const trusteeDistrictFilterUseCase = (
     handleClearAll,
     handleToggleExpanded,
     handleFilterChapter,
-    handleClearAllChapters,
     handleFilterDivision,
     handleClearAllDivisions,
     handleFilterCombined,

--- a/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
+++ b/user-interface/src/trustees/filters/trusteeDistrictFilterUseCase.ts
@@ -146,7 +146,8 @@ const trusteeDistrictFilterUseCase = (
   controls: TrusteeDistrictFilterControls,
   onFilterDistrict: (districts: ComboOption[]) => void,
   previousDistrictsRef: { current: ComboOption[] | undefined },
-  onFilterChapter: (chapter: ComboOption | null) => void,
+  onFilterChapter: (chapters: ComboOption[]) => void,
+  previousChaptersRef: { current: ComboOption[] | undefined },
   onFilterDivision: (divisions: ComboOption[]) => void,
   previousDivisionsRef: { current: ComboOption[] | undefined },
   districtDivisionEnabled: boolean = false,
@@ -280,9 +281,21 @@ const trusteeDistrictFilterUseCase = (
     store.setIsExpanded(!store.isExpanded);
   };
 
-  const handleFilterChapter = (chapter: ComboOption | null) => {
-    store.setSelectedChapter(chapter);
-    onFilterChapter(chapter);
+  const handleFilterChapter = (chapters: ComboOption[]) => {
+    const wasNonEmpty = previousChaptersRef.current && previousChaptersRef.current.length > 0;
+    const isNowEmpty = chapters.length === 0;
+
+    if (wasNonEmpty && isNowEmpty) {
+      getAppInsights().appInsights.trackEvent({ name: 'Trustee Chapter Filter Cleared' });
+    }
+
+    previousChaptersRef.current = chapters;
+    store.setSelectedChapters(chapters);
+    onFilterChapter(chapters);
+  };
+
+  const handleClearAllChapters = () => {
+    handleFilterChapter([]);
   };
 
   return {
@@ -295,6 +308,7 @@ const trusteeDistrictFilterUseCase = (
     handleClearAll,
     handleToggleExpanded,
     handleFilterChapter,
+    handleClearAllChapters,
     handleFilterDivision,
     handleClearAllDivisions,
     handleFilterCombined,

--- a/user-interface/src/trustees/forms/EditUpcomingKeyDates.scss
+++ b/user-interface/src/trustees/forms/EditUpcomingKeyDates.scss
@@ -14,7 +14,8 @@ $input-max-width: 20.75rem;
     padding-top: 0.5rem;
   }
 
-  .review-period-group, .tpr-due-group {
+  .review-period-group,
+  .tpr-due-group {
     max-width: $input-max-width;
 
     .date-error {
@@ -22,7 +23,8 @@ $input-max-width: 20.75rem;
     }
   }
 
-  .review-period-header, .tpr-due-group__header {
+  .review-period-header,
+  .tpr-due-group__header {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
@@ -33,7 +35,8 @@ $input-max-width: 20.75rem;
     }
   }
 
-  .review-period-row, .tpr-due-group__row {
+  .review-period-row,
+  .tpr-due-group__row {
     display: flex;
     align-items: flex-end;
     gap: 0.5rem;
@@ -62,7 +65,7 @@ $input-max-width: 20.75rem;
     }
 
     .year-type-selector {
-      margin-top: .25rem;
+      margin-top: 0.25rem;
       flex: 1;
       min-width: 0;
 
@@ -71,7 +74,7 @@ $input-max-width: 20.75rem;
       }
 
       .usa-hint {
-        padding-bottom: .5rem;
+        padding-bottom: 0.5rem;
       }
 
       .date-error {
@@ -85,8 +88,6 @@ $input-max-width: 20.75rem;
       padding-top: 0.5rem;
     }
   }
-
-
 
   .exam-audit-group {
     max-width: $input-max-width;
@@ -166,5 +167,4 @@ $input-max-width: 20.75rem;
     padding-bottom: 0;
     padding-top: 0.5rem;
   }
-
 }

--- a/user-interface/src/trustees/forms/TrusteeContactForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeContactForm.scss
@@ -5,7 +5,7 @@
   }
 }
 
-[class$="-trustee-form-screen"]:not(.trustee-form-error-page):not(.trustee-form-error-wrapper) {
+[class$='-trustee-form-screen']:not(.trustee-form-error-page):not(.trustee-form-error-wrapper) {
   h1.create-trustee {
     display: block;
     margin: 1rem 0 1.5rem 0;
@@ -61,7 +61,8 @@
 }
 
 @media screen and (max-width: 1023px) {
-  [class$="-trustee-form-screen"]:not(.trustee-form-error-page):not(.trustee-form-error-wrapper) form {
+  [class$='-trustee-form-screen']:not(.trustee-form-error-page):not(.trustee-form-error-wrapper)
+    form {
     .form-container {
       .form-column {
         min-width: 200px;
@@ -79,7 +80,8 @@
 }
 
 @media screen and (max-width: 599px) {
-  [class$="-trustee-form-screen"]:not(.trustee-form-error-page):not(.trustee-form-error-wrapper) form {
+  [class$='-trustee-form-screen']:not(.trustee-form-error-page):not(.trustee-form-error-wrapper)
+    form {
     .form-container {
       flex-direction: column;
       gap: 0;

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.scss
@@ -15,7 +15,8 @@
       margin-bottom: 1rem;
     }
   }
-  .trustee-bank-input, .trustee-software-input {
+  .trustee-bank-input,
+  .trustee-software-input {
     display: inline-block;
     width: 100%;
     max-width: 400px;
@@ -34,7 +35,8 @@
         }
       }
     }
-    .trustee-bank-input, .trustee-software-input {
+    .trustee-bank-input,
+    .trustee-software-input {
       max-width: 100%;
     }
   }

--- a/user-interface/src/trustees/forms/TrusteePublicContactForm.scss
+++ b/user-interface/src/trustees/forms/TrusteePublicContactForm.scss
@@ -2,7 +2,7 @@
   .trustee-contact-information.record-detail-card {
     .formatted-contact {
       .company-name {
-        margin-bottom: .5rem;
+        margin-bottom: 0.5rem;
       }
     }
   }

--- a/user-interface/src/trustees/panels/AppointmentCard.scss
+++ b/user-interface/src/trustees/panels/AppointmentCard.scss
@@ -16,6 +16,4 @@
   .usa-card {
     width: 300px;
   }
-
-
 }

--- a/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.scss
+++ b/user-interface/src/trustees/panels/TrusteeDetailAuditHistory.scss
@@ -21,7 +21,7 @@
       margin: 0 0 0.5rem 0;
 
       &::after {
-        content: "";
+        content: '';
         display: block;
       }
     }

--- a/user-interface/test/accessibility/KNOWN_ISSUES.md
+++ b/user-interface/test/accessibility/KNOWN_ISSUES.md
@@ -4,21 +4,24 @@ This document tracks known accessibility violations detected by Playwright/Axe a
 
 ## Heading Order Violations (heading-order)
 
-**Severity:** Moderate
-**WCAG Rule:** Best Practice (cat.semantics)
-**Rule ID:** heading-order
-**Help:** Heading levels should only increase by one
-**Reference:** https://dequeuniversity.com/rules/axe/4.11/heading-order
+**Severity:** Moderate **WCAG Rule:** Best Practice (cat.semantics) **Rule ID:** heading-order
+**Help:** Heading levels should only increase by one **Reference:**
+https://dequeuniversity.com/rules/axe/4.11/heading-order
 
 ### Description
-Multiple pages have an `<h3>Filters</h3>` element that appears without a proper heading hierarchy (missing h1 or h2 before h3). This violates the semantic heading order requirement where heading levels should only increase by one level at a time.
+
+Multiple pages have an `<h3>Filters</h3>` element that appears without a proper heading hierarchy
+(missing h1 or h2 before h3). This violates the semantic heading order requirement where heading
+levels should only increase by one level at a time.
 
 ### Impact
+
 - Screen reader users may have difficulty understanding the page structure
 - Users navigating by headings may miss important context
 - Document outline is semantically incorrect
 
 ### Affected Pages
+
 The following test files detect this violation:
 
 1. **Home Page** (`home.test.ts`)
@@ -46,26 +49,34 @@ The following test files detect this violation:
    - Location: Case notes section
 
 ### Recommended Fix
+
 One of the following approaches should be implemented:
 
 1. **Add proper h1/h2 hierarchy** - Ensure there is an h1 on the page, and use h2 before h3
 2. **Change h3 to h2** - If "Filters" is a top-level section, use h2 instead
-3. **Use aria-level** - If visual styling requires h3, use `<h2 aria-level="3">` with CSS to style as h3
+3. **Use aria-level** - If visual styling requires h3, use `<h2 aria-level="3">` with CSS to style
+   as h3
 4. **Add visually-hidden h1/h2** - Add hidden heading levels if needed for semantic structure
 
 ### Reproduction
+
 All violations can be reproduced by:
-1. Starting the UI in mock mode: `CAMS_USE_FAKE_API=true CAMS_LOGIN_PROVIDER=none npm run build && serve -s build`
+
+1. Starting the UI in mock mode:
+   `CAMS_USE_FAKE_API=true CAMS_LOGIN_PROVIDER=none npm run build && serve -s build`
 2. Running accessibility tests: `npm run test:a11y`
 3. Reviewing the Playwright HTML report for specific violation details
 
 ### Status
+
 **Open** - Awaiting fix in application code
 
 ### Test Configuration
+
 **Rule Status:** Temporarily disabled in all tests via centralized configuration
 
-The `heading-order` rule has been temporarily disabled using a centralized configuration in `test-constants.ts`:
+The `heading-order` rule has been temporarily disabled using a centralized configuration in
+`test-constants.ts`:
 
 ```typescript
 // In test-constants.ts
@@ -79,14 +90,18 @@ export function createAxeBuilder(page: Page): AxeBuilder {
 ```
 
 All test files use this helper function:
+
 ```typescript
 const accessibilityScanResults = await createAxeBuilder(page).analyze();
 ```
 
-This centralized approach makes it easy to manage disabled rules across all tests from a single location.
+This centralized approach makes it easy to manage disabled rules across all tests from a single
+location.
 
 **To re-enable the rule:**
-1. Fix the heading hierarchy in the application (change `<h3>Filters</h3>` to appropriate level or add missing h1/h2)
+
+1. Fix the heading hierarchy in the application (change `<h3>Filters</h3>` to appropriate level or
+   add missing h1/h2)
 2. Remove `'heading-order'` from `DISABLED_A11Y_RULES` array in `test-constants.ts`
 3. Run `npm run test:a11y` to verify all tests pass
 
@@ -94,21 +109,25 @@ This centralized approach makes it easy to manage disabled rules across all test
 
 ## Form Label Violations (label-title-only) - ✓ FIXED
 
-**Severity:** Serious
-**WCAG Rule:** Best Practice (cat.forms)
-**Rule ID:** label-title-only
-**Help:** Form elements should have a visible label
-**Reference:** https://dequeuniversity.com/rules/axe/4.11/label-title-only
+**Severity:** Serious **WCAG Rule:** Best Practice (cat.forms) **Rule ID:** label-title-only
+**Help:** Form elements should have a visible label **Reference:**
+https://dequeuniversity.com/rules/axe/4.11/label-title-only
 
 ### Description
-Multiple radio button form elements in the data verification accordions use only the `title` attribute to generate their labels. This violates accessibility best practices as the title attribute is not reliably read by all screen readers and assistive technologies, and does not provide a visible label for all users.
+
+Multiple radio button form elements in the data verification accordions use only the `title`
+attribute to generate their labels. This violates accessibility best practices as the title
+attribute is not reliably read by all screen readers and assistive technologies, and does not
+provide a visible label for all users.
 
 ### Impact
+
 - Screen reader users may not receive proper labeling information
 - Form element purpose may not be clear to assistive technology users
 - Does not meet best practices for form labeling
 
 ### Affected Pages
+
 The following test files detect this violation:
 
 1. **Data Verification** (`data-verification.test.ts`)
@@ -118,35 +137,43 @@ The following test files detect this violation:
    - Location: Within accordion content for suggested cases
 
 ### Fix Implemented
+
 **Date Fixed:** January 2, 2026
 
 The Radio.tsx and Checkbox.tsx components were updated to include proper ARIA attributes:
+
 1. Added `role="radio"` and `role="checkbox"` to button elements
 2. Added `aria-checked` to communicate state to assistive technology
 3. Added `aria-label` for programmatic labeling
 4. Implemented proper keyboard support (Space/Enter keys)
 5. RadioGroup.tsx enhanced with arrow key navigation
 
-These changes ensure that radio buttons and checkboxes are properly announced by screen readers and have appropriate accessible names, even when wrapped in custom button components.
+These changes ensure that radio buttons and checkboxes are properly announced by screen readers and
+have appropriate accessible names, even when wrapped in custom button components.
 
 ### Status
+
 **FIXED** - Re-enabled in accessibility tests
 
 ### Test Configuration
+
 **Rule Status:** Re-enabled - Removed from `DISABLED_A11Y_RULES` in `test-constants.ts`
 
 ---
 
 ## Case Notes Test Failure (Skipped)
 
-**Severity:** N/A - Test Issue
-**Test File:** `case-notes.test.ts`
-**Status:** Test skipped pending investigation
+**Severity:** N/A - Test Issue **Test File:** `case-notes.test.ts` **Status:** Test skipped pending
+investigation
 
 ### Description
-The case notes accessibility test is currently skipped due to failures in the local test environment. The test expects draft note alerts to appear after creating a note and reloading the page, but the draft alert element `[data-testid="alert-message-draft-add-note"]` is not found.
+
+The case notes accessibility test is currently skipped due to failures in the local test
+environment. The test expects draft note alerts to appear after creating a note and reloading the
+page, but the draft alert element `[data-testid="alert-message-draft-add-note"]` is not found.
 
 ### Failed Assertion
+
 ```typescript
 await page.reload();
 await expect(page.locator('[data-testid="alert-message-draft-add-note"]')).toBeVisible();
@@ -154,22 +181,28 @@ await expect(page.locator('[data-testid="alert-message-draft-add-note"]')).toBeV
 ```
 
 ### Impact
+
 - Case notes page accessibility is not currently being tested
 - Draft note functionality may not be working correctly in local environment
 
 ### Investigation Needed
+
 The test appears to pass in the existing CI pipeline but fails locally. Possible causes:
+
 1. Draft note local storage functionality may require specific build/environment configuration
 2. Timing issues with local storage persistence across page reloads
 3. Differences between CI and local test environments
 
 ### Date Identified
+
 December 11, 2024
 
 ### Test Configuration
+
 **Test Status:** Skipped using `test.skip()` in `case-notes.test.ts`
 
 **To re-enable the test:**
+
 1. Investigate why draft alerts are not appearing in local environment
 2. Verify draft note local storage functionality works correctly
 3. Remove `test.skip()` from the test
@@ -179,6 +212,13 @@ December 11, 2024
 
 ## Migration Notes
 
-These accessibility issues were identified during the migration from pa11y to Playwright accessibility testing. The pa11y tests may not have detected these violations, or they may have existed but were not enforced. The Playwright tests using @axe-core/playwright provide more comprehensive accessibility checking aligned with WCAG 2.1 Level AA standards.
+These accessibility issues were identified during the migration from pa11y to Playwright
+accessibility testing. The pa11y tests may not have detected these violations, or they may have
+existed but were not enforced. The Playwright tests using @axe-core/playwright provide more
+comprehensive accessibility checking aligned with WCAG 2.1 Level AA standards.
 
-The decision to temporarily disable the `heading-order` and `label-title-only` rules was made to allow the migration to complete successfully while documenting the known issues for future resolution. The `label-title-only` violation was specifically discovered by enhancing the data-verification test to scan each accordion's content individually, demonstrating the value of thorough accessibility testing on dynamically revealed content.
+The decision to temporarily disable the `heading-order` and `label-title-only` rules was made to
+allow the migration to complete successfully while documenting the known issues for future
+resolution. The `label-title-only` violation was specifically discovered by enhancing the
+data-verification test to scan each accordion's content individually, demonstrating the value of
+thorough accessibility testing on dynamically revealed content.


### PR DESCRIPTION
# Purpose

USTP staff reported that seeing deceased and resigned trustees mixed with active ones is discouraging and will cause users to prefer their spreadsheets. This adds a status filter so users see only active trustees by default, with the ability to view inactive ones when needed.

# Major Changes

* Added a Status filter ComboBox (All / Active / Inactive) to the trustee list filter panel, defaulting to "Active"
* Inactive filter encompasses all non-active appointment statuses (inactive, voluntarily suspended, involuntarily suspended, deceased, resigned, terminated, removed)
* Updated table Status column to display "Inactive (Resigned)", "Inactive (Deceased)", etc. for clarity
* Status dropdown label enumerates all inactive statuses so users know what's included
* All filtering is client-side, matching the existing pattern

# Testing/Validation

Implemented using TDD. 103 tests passing across the two modified test files (77 TrusteesList + 26 TrusteeDistrictFilter). Coverage includes:
- Default Active filter hides inactive-only trustees
- Selecting Inactive shows only trustees with non-active appointments
- Selecting All shows everything
- Mixed-status trustees (both active and inactive appointments) appear in both views
- Status + Chapter filter AND-composition
- Status ComboBox renders and calls handler correctly

# Notes

* The Chapter filter remains multi-select (a single-select conversion was attempted and reverted per designer feedback)
* `formatListAppointmentStatus()` delegates to the existing `formatAppointmentStatus()` for labels, avoiding duplication
* Trustees with zero appointments pass the Active filter (defensive edge case)
* Pre-existing test failures in `TrusteeAppointmentForm.test.tsx` (24 tests, 401 auth errors) are unrelated to this PR

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add appointment status filtering and improve trustee list UX and shared styling.

New Features:
- Introduce a trustee Status filter (All / Active / Inactive) on the trustee list, defaulting to Active and applied client-side alongside existing district and chapter filters.

Enhancements:
- Display trustee appointment status as Active or Inactive (<specific status>) in the trustee list for clearer differentiation of inactive reasons.
- Restructure the trustee filter panel layout to pair related controls (name with district, chapter with status) and improve responsiveness across breakpoints.
- Standardize various UI components to use shared color tokens (primary, primary-dark, ink) and refine table and list styling for consistency.
- Adjust the trustees list table breakpoints and layout to improve readability on small and large screens, and tweak the Add New Trustee button sizing.

Tests:
- Expand TrusteesList and TrusteeDistrictFilter tests to cover the new status filter behavior, status formatting, and Status combobox interactions.