### PR TITLE
CAMS-773 Fix trustee list profile link underline

### DIFF
--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.scss
@@ -17,10 +17,7 @@
     flex-wrap: wrap;
   }
 
-  // Ensure underline shows through IconLabel component in all trustee links
-  .usa-link .cams-icon-label span {
-    text-decoration: underline;
-  }
+
 }
 
 .past-trustees-section {

--- a/user-interface/src/lib/components/cams/IconLabel/IconLabel.scss
+++ b/user-interface/src/lib/components/cams/IconLabel/IconLabel.scss
@@ -1,3 +1,7 @@
+.usa-link .cams-icon-label span {
+  text-decoration: underline;
+}
+
 .cams-icon-label {
   display: inline-flex;
   align-items: center;

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -43,6 +43,10 @@
   .trustees-list-cell {
     padding: 0;
     word-wrap: break-word;
+
+    .usa-link .cams-icon-label span {
+      text-decoration: underline;
+    }
   }
 
   .trustees-list-cell[data-cell] {

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -43,10 +43,6 @@
   .trustees-list-cell {
     padding: 0;
     word-wrap: break-word;
-
-    .usa-link .cams-icon-label span {
-      text-decoration: underline;
-    }
   }
 
   .trustees-list-cell[data-cell] {


### PR DESCRIPTION
# Bug

The trustee profile link on the trustee list page was not underlined, making it visually inconsistent with the same link in other locations (e.g., case detail). The link uses the `TrusteeName` component with `openNewTab`, which renders an `IconLabel` with `display: inline-flex`. This prevents `text-decoration` from reaching the inner `<span>` without an explicit rule.

# Purpose

Restore visual consistency for the trustee profile link so users can recognize it as a clickable link, matching behavior already present elsewhere in the application.

# Major Changes

* Added `.usa-link .cams-icon-label span { text-decoration: underline }` to `TrusteesList.scss`, matching the identical rule already in `CaseDetailTrusteePanel.scss`

# Testing/Validation

Manually verified in dev that the trustee name link is now underlined on the trustee list page. Confirmed the rule matches the existing pattern used in the case detail panel.

# Notes

The root cause is that `display: inline-flex` on `.cams-icon-label` breaks `text-decoration` inheritance — the underline applies to the flex container but not to the inner `<span>` that holds the text. The fix mirrors the same targeted rule already present in `CaseDetailTrusteePanel.scss`.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Bug Fixes:
- Fix missing underline on trustee profile links in the trustees list by explicitly underlining the link text within icon labels.