### PR TITLE
CAMS-763 Optimize trustee name search

### DIFF
--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
@@ -1404,7 +1404,7 @@ describe('TrusteesMongoRepository', () => {
       expect(pipelineArg.stages.some((s) => s.stage === 'SCORE')).toBe(true);
     });
 
-    test('should include notExists fallback in pre-filter so trustees without phoneticTokens are searchable', async () => {
+    test('should filter pre-filter by phoneticTokens contains (no notExists fallback)', async () => {
       const paginateSpy = vi
         .spyOn(MongoCollectionAdapter.prototype, 'paginate')
         .mockResolvedValue({ metadata: { total: 0 }, data: [] });
@@ -1414,13 +1414,11 @@ describe('TrusteesMongoRepository', () => {
       const pipelineArg = paginateSpy.mock.calls[0][0] as {
         stages: { condition?: string; values?: unknown[]; conditions?: unknown[] }[];
       };
-      // The first MATCH stage should contain an OR with a notExists condition.
-      // Serialize the pipeline to JSON and verify the EXISTS:false condition is present,
-      // which is what doc('phoneticTokens').notExists() produces.
       const pipelineJson = JSON.stringify(pipelineArg);
+      // phoneticTokens must be present in the filter
       expect(pipelineJson).toContain('phoneticTokens');
-      expect(pipelineJson).toContain('"condition":"EXISTS"');
-      expect(pipelineJson).toContain('"rightOperand":false');
+      // notExists fallback must NOT be present — all trustees have tokens
+      expect(pipelineJson).not.toContain('"rightOperand":false');
     });
 
     test('should include matchScore > 0 filter stage after scoring', async () => {

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
@@ -1412,13 +1412,22 @@ describe('TrusteesMongoRepository', () => {
       await repository.searchTrusteesByNameScored('smith');
 
       const pipelineArg = paginateSpy.mock.calls[0][0] as {
-        stages: { condition?: string; values?: unknown[]; conditions?: unknown[] }[];
+        stages: { stage: string; conjunction?: string; values?: unknown[] }[];
       };
-      const pipelineJson = JSON.stringify(pipelineArg);
-      // phoneticTokens must be present in the filter
-      expect(pipelineJson).toContain('phoneticTokens');
+      const preFilterMatch = pipelineArg.stages[0] as {
+        stage: string;
+        conjunction: string;
+        values: { condition: string; leftOperand: { name: string }; rightOperand: unknown }[];
+      };
+      expect(preFilterMatch.stage).toBe('MATCH');
+      expect(preFilterMatch.conjunction).toBe('AND');
+      expect(
+        preFilterMatch.values.some(
+          (v) => v.condition === 'CONTAINS' && v.leftOperand.name === 'phoneticTokens',
+        ),
+      ).toBe(true);
       // notExists fallback must NOT be present — all trustees have tokens
-      expect(pipelineJson).not.toContain('"rightOperand":false');
+      expect(preFilterMatch.values.every((v) => v.condition !== 'NOT_EXISTS')).toBe(true);
     });
 
     test('should include matchScore > 0 filter stage after scoring', async () => {
@@ -1432,9 +1441,16 @@ describe('TrusteesMongoRepository', () => {
       // There must be a MATCH stage after the SCORE stage that filters matchScore > 0
       const stages = pipelineArg.stages;
       const scoreIndex = stages.findIndex((s) => s.stage === 'SCORE');
-      const matchAfterScore = stages.slice(scoreIndex + 1).find((s) => s.stage === 'MATCH');
+      const matchAfterScore = stages.slice(scoreIndex + 1).find((s) => s.stage === 'MATCH') as {
+        stage: string;
+        condition: string;
+        leftOperand: { name: string };
+        rightOperand: number;
+      };
       expect(matchAfterScore).toBeDefined();
-      expect(JSON.stringify(matchAfterScore)).toContain('matchScore');
+      expect(matchAfterScore.condition).toBe('GREATER_THAN');
+      expect(matchAfterScore.leftOperand.name).toBe('matchScore');
+      expect(matchAfterScore.rightOperand).toBe(0);
     });
 
     test('should include nickname tokens in the scored pipeline', async () => {

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.ts
@@ -28,7 +28,7 @@ const MODULE_NAME = 'TRUSTEES-MONGO-REPOSITORY';
 const COLLECTION_NAME = 'trustees';
 const MAX_RESULTS = 25;
 
-const { using, and, or } = QueryBuilder;
+const { using, and } = QueryBuilder;
 
 export type TrusteeDocument = Trustee & {
   documentType: 'TRUSTEE';
@@ -316,11 +316,7 @@ export class TrusteesMongoRepository extends BaseMongoRepository implements Trus
         doc('documentType').equals('TRUSTEE'),
       ];
       if (allTokens.length > 0) {
-        // Include trustees that match tokens OR have no phoneticTokens field (not yet indexed).
-        // Trustees without tokens are scored on name field alone (exact/prefix still work).
-        conditions.push(
-          or(doc('phoneticTokens').contains(allTokens), doc('phoneticTokens').notExists()),
-        );
+        conditions.push(doc('phoneticTokens').contains(allTokens));
       }
 
       const spec = pipeline(

--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
@@ -374,13 +374,9 @@ resource trusteesCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDataba
         {
           key: {
             keys: [
-              '$**'
+              'documentType'
+              'phoneticTokens'
             ]
-          }
-        }
-        {
-          key: {
-            keys: ['phoneticTokens']
           }
         }
       ]


### PR DESCRIPTION
## Summary

- Remove `phoneticTokens.notExists()` fallback branch from `searchTrusteesByNameScored` — this OR branch caused a full collection scan on every trustee search query. All trustees now have `phoneticTokens` so the fallback is no longer needed.
- Replace the `$**` wildcard index with a targeted compound `{documentType, phoneticTokens}` index on the trustees collection, which aligns with the query's actual filter shape.

## Why now

A/B testing on the `CAMS-763-perf-ab` branch confirmed the optimized query (without `notExists()`) is consistently faster and returns identical results. This PR applies those optimizations directly to the existing endpoint rather than maintaining a parallel one.

## Test plan

- [ ] Search for trustees by name in the Trustee List page — results should appear correctly
- [ ] Search for trustees in the Data Verification page — results should appear correctly
- [ ] Verify no regressions in trustee search behavior (partial names, phonetic matches)
- [ ] Bicep index change requires a redeploy to take effect in non-local environments

Jira ticket: CAMS-763

## Summary by Sourcery

Optimize trustee name search by requiring phoneticTokens in the query filter and aligning the Mongo index with the query pattern.

Bug Fixes:
- Prevent unnecessary full-collection scans in trustee name searches by removing the phoneticTokens notExists fallback from the query filter.

Enhancements:
- Tighten trustee search pre-filter to only match documents with phoneticTokens, assuming all trustees are now indexed.
- Consolidate and narrow MongoDB indexes on the trustees collection to a compound {documentType, phoneticTokens} index matching the search workload.

Tests:
- Update trustee search repository tests to assert the absence of the notExists fallback and the presence of phoneticTokens-based filtering.