### PR TITLE
CAMS-767: ui issues

### DIFF
--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -4,6 +4,16 @@
 .trustees-list {
   margin-top: 20px;
 
+  .usa-alert-container.inline-alert {
+    margin-left: 0;
+    margin-right: 0;
+
+    .usa-alert {
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
   .trustees-list-count {
     font-size: 1rem;
     font-weight: bold;

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2802,12 +2802,8 @@ describe('TrusteesList Component', () => {
 
       renderWithRouter(<TrusteesList />);
 
-      await waitFor(() => {
-        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
-      });
-
       const user = userEvent.setup();
-      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      const toggleButton = await screen.findByRole('button', { name: /filters/i });
       await user.click(toggleButton);
 
       await waitFor(() => {

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -438,6 +438,23 @@ export default function TrusteesList() {
     displayCount = stableCountRef.current;
   }
 
+  const renderPageStatus = () => {
+    if (loading) return <LoadingSpinner caption="Loading trustees..." />;
+    if (error) {
+      return (
+        <div className="usa-alert usa-alert--error" role="alert">
+          <div className="usa-alert__body">
+            <h3 className="usa-alert__heading">Error loading trustees</h3>
+            <p className="usa-alert__text">{error}</p>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const pageStatus = renderPageStatus();
+
   return (
     <div className="trustees-list">
       <TrusteeDistrictFilter
@@ -455,16 +472,7 @@ export default function TrusteesList() {
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">
         {liveAnnouncement}
       </div>
-      {loading ? (
-        <LoadingSpinner caption="Loading trustees..." />
-      ) : error ? (
-        <div className="usa-alert usa-alert--error" role="alert">
-          <div className="usa-alert__body">
-            <h3 className="usa-alert__heading">Error loading trustees</h3>
-            <p className="usa-alert__text">{error}</p>
-          </div>
-        </div>
-      ) : (
+      {pageStatus ?? (
         <>
           {filteredTrustees.length === 0 && !nameSearchLoading ? (
             <div className="usa-alert usa-alert--info" role="alert">

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -433,21 +433,6 @@ export default function TrusteesList() {
     previousNameSearchRef.current = nameSearch;
   }, [nameSearch]);
 
-  if (loading) {
-    return <LoadingSpinner caption="Loading trustees..." />;
-  }
-
-  if (error) {
-    return (
-      <div className="usa-alert usa-alert--error" role="alert">
-        <div className="usa-alert__body">
-          <h3 className="usa-alert__heading">Error loading trustees</h3>
-          <p className="usa-alert__text">{error}</p>
-        </div>
-      </div>
-    );
-  }
-
   let displayCount = filteredTrustees.length;
   if (nameSearchLoading && stableCountRef.current !== null) {
     displayCount = stableCountRef.current;
@@ -470,150 +455,173 @@ export default function TrusteesList() {
       <div role="status" aria-live="polite" aria-atomic="true" className="usa-sr-only">
         {liveAnnouncement}
       </div>
-      {filteredTrustees.length === 0 && !nameSearchLoading ? (
-        <div className="usa-alert usa-alert--info" role="alert">
+      {loading ? (
+        <LoadingSpinner caption="Loading trustees..." />
+      ) : error ? (
+        <div className="usa-alert usa-alert--error" role="alert">
           <div className="usa-alert__body">
-            <h3 className="usa-alert__heading">No trustees found</h3>
-            <p className="usa-alert__text">Consider adjusting your filters.</p>
+            <h3 className="usa-alert__heading">Error loading trustees</h3>
+            <p className="usa-alert__text">{error}</p>
           </div>
         </div>
       ) : (
-        <p className="trustees-list-count" aria-live="off" aria-atomic="false">
-          {displayCount} {displayCount === 1 ? 'Trustee' : 'Trustees'}
-        </p>
-      )}
-      {(filteredTrustees.length > 0 || nameSearchLoading) && (
-        <div
-          className="trustees-list-grid"
-          role="table"
-          aria-label="Trustees"
-          aria-live="off"
-          aria-atomic="false"
-          data-testid="trustees-table"
-        >
-          <div role="rowgroup">
-            <div className="trustees-list-header" role="row">
-              {COLUMN_HEADERS.map((header) => {
-                const isNameCol = header === 'Name';
-                return (
-                  <div
-                    key={header}
-                    className={`trustees-list-cell ${toColClass(header)}${isNameCol ? ' sortable' : ''}`}
-                    role="columnheader"
-                    tabIndex={isNameCol ? 0 : undefined}
-                    aria-sort={
-                      isNameCol ? (sortDirection === 'asc' ? 'ascending' : 'descending') : undefined
-                    }
-                    onClick={
-                      isNameCol
-                        ? () => {
-                            const newDirection = sortDirection === 'asc' ? 'desc' : 'asc';
-                            setSortDirection(newDirection);
-                            getAppInsights().appInsights.trackEvent(
-                              { name: 'Trustee List Sort Changed' },
-                              { sortDirection: newDirection },
-                            );
-                          }
-                        : undefined
-                    }
-                    onKeyDown={
-                      isNameCol
-                        ? (e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault();
-                              setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
-                            }
-                          }
-                        : undefined
-                    }
-                    style={isNameCol ? { cursor: 'pointer' } : undefined}
-                  >
-                    {header}
-                    {isNameCol && (
-                      <Icon name={sortDirection === 'asc' ? 'arrow_upward' : 'arrow_downward'} />
-                    )}
-                  </div>
-                );
-              })}
+        <>
+          {filteredTrustees.length === 0 && !nameSearchLoading ? (
+            <div className="usa-alert usa-alert--info" role="alert">
+              <div className="usa-alert__body">
+                <h3 className="usa-alert__heading">No trustees found</h3>
+                <p className="usa-alert__text">Consider adjusting your filters.</p>
+              </div>
             </div>
-          </div>
-          <div role="rowgroup">
-            {nameSearchLoading ? (
-              <LoadingSpinner caption="Searching trustees..." />
-            ) : (
-              filteredTrustees.map((trustee) => {
-                const rows = trustee.appointments.length === 0 ? [null] : trustee.appointments;
-
-                return (
-                  <div key={trustee.trusteeId} className="trustee-group">
-                    {rows.map((appt, idx) => (
+          ) : (
+            <p className="trustees-list-count" aria-live="off" aria-atomic="false">
+              {displayCount} {displayCount === 1 ? 'Trustee' : 'Trustees'}
+            </p>
+          )}
+          {(filteredTrustees.length > 0 || nameSearchLoading) && (
+            <div
+              className="trustees-list-grid"
+              role="table"
+              aria-label="Trustees"
+              aria-live="off"
+              aria-atomic="false"
+              data-testid="trustees-table"
+            >
+              <div role="rowgroup">
+                <div className="trustees-list-header" role="row">
+                  {COLUMN_HEADERS.map((header) => {
+                    const isNameCol = header === 'Name';
+                    return (
                       <div
-                        key={`${trustee.trusteeId}-${idx}`}
-                        className={`trustees-list-row${idx > 0 ? ' trustees-list-row--continuation' : ''}`}
-                        role="row"
+                        key={header}
+                        className={`trustees-list-cell ${toColClass(header)}${isNameCol ? ' sortable' : ''}`}
+                        role="columnheader"
+                        tabIndex={isNameCol ? 0 : undefined}
+                        aria-sort={
+                          isNameCol
+                            ? sortDirection === 'asc'
+                              ? 'ascending'
+                              : 'descending'
+                            : undefined
+                        }
+                        onClick={
+                          isNameCol
+                            ? () => {
+                                const newDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+                                setSortDirection(newDirection);
+                                getAppInsights().appInsights.trackEvent(
+                                  { name: 'Trustee List Sort Changed' },
+                                  { sortDirection: newDirection },
+                                );
+                              }
+                            : undefined
+                        }
+                        onKeyDown={
+                          isNameCol
+                            ? (e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+                                }
+                              }
+                            : undefined
+                        }
+                        style={isNameCol ? { cursor: 'pointer' } : undefined}
                       >
-                        <div
-                          className="trustees-list-cell col-name"
-                          role="cell"
-                          {...(idx === 0 ? { 'data-cell': 'Name' } : {})}
-                        >
-                          {idx === 0 ? (
-                            <TrusteeName
-                              trusteeName={formatTrusteeListName(
-                                trustee.firstName,
-                                trustee.middleName,
-                                trustee.lastName,
-                                trustee.name,
-                              )}
-                              trusteeId={trustee.trusteeId}
-                              dataTestId={`trustee-link-${trustee.trusteeId}`}
-                              source="trustee-list"
-                            />
-                          ) : (
-                            <span aria-hidden="true"></span>
-                          )}
-                        </div>
-                        <div
-                          className="trustees-list-cell col-district"
-                          role="cell"
-                          data-cell="District"
-                        >
-                          {appt ? formatDistrict(appt) : ''}
-                        </div>
-                        {districtDivisionEnabled && (
-                          <div
-                            className="trustees-list-cell col-division"
-                            role="cell"
-                            data-cell="Division"
-                          >
-                            {appt ? buildDivisionsDisplay(appt, allCourts) : ''}
-                          </div>
+                        {header}
+                        {isNameCol && (
+                          <Icon
+                            name={sortDirection === 'asc' ? 'arrow_upward' : 'arrow_downward'}
+                          />
                         )}
-                        <div
-                          className="trustees-list-cell col-chapter"
-                          role="cell"
-                          data-cell="Chapter"
-                        >
-                          {appt ? formatChapterType(appt.chapter) : ''}
-                        </div>
-                        <div className="trustees-list-cell col-type" role="cell" data-cell="Type">
-                          {appt ? formatAppointmentType(appt.appointmentType) : ''}
-                        </div>
-                        <div
-                          className="trustees-list-cell col-status"
-                          role="cell"
-                          data-cell="Status"
-                        >
-                          {appt ? formatListAppointmentStatus(appt.status) : ''}
-                        </div>
                       </div>
-                    ))}
-                  </div>
-                );
-              })
-            )}
-          </div>
-        </div>
+                    );
+                  })}
+                </div>
+              </div>
+              <div role="rowgroup">
+                {nameSearchLoading ? (
+                  <LoadingSpinner caption="Searching trustees..." />
+                ) : (
+                  filteredTrustees.map((trustee) => {
+                    const rows = trustee.appointments.length === 0 ? [null] : trustee.appointments;
+
+                    return (
+                      <div key={trustee.trusteeId} className="trustee-group">
+                        {rows.map((appt, idx) => (
+                          <div
+                            key={`${trustee.trusteeId}-${idx}`}
+                            className={`trustees-list-row${idx > 0 ? ' trustees-list-row--continuation' : ''}`}
+                            role="row"
+                          >
+                            <div
+                              className="trustees-list-cell col-name"
+                              role="cell"
+                              {...(idx === 0 ? { 'data-cell': 'Name' } : {})}
+                            >
+                              {idx === 0 ? (
+                                <TrusteeName
+                                  trusteeName={formatTrusteeListName(
+                                    trustee.firstName,
+                                    trustee.middleName,
+                                    trustee.lastName,
+                                    trustee.name,
+                                  )}
+                                  trusteeId={trustee.trusteeId}
+                                  dataTestId={`trustee-link-${trustee.trusteeId}`}
+                                  source="trustee-list"
+                                />
+                              ) : (
+                                <span aria-hidden="true"></span>
+                              )}
+                            </div>
+                            <div
+                              className="trustees-list-cell col-district"
+                              role="cell"
+                              data-cell="District"
+                            >
+                              {appt ? formatDistrict(appt) : ''}
+                            </div>
+                            {districtDivisionEnabled && (
+                              <div
+                                className="trustees-list-cell col-division"
+                                role="cell"
+                                data-cell="Division"
+                              >
+                                {appt ? buildDivisionsDisplay(appt, allCourts) : ''}
+                              </div>
+                            )}
+                            <div
+                              className="trustees-list-cell col-chapter"
+                              role="cell"
+                              data-cell="Chapter"
+                            >
+                              {appt ? formatChapterType(appt.chapter) : ''}
+                            </div>
+                            <div
+                              className="trustees-list-cell col-type"
+                              role="cell"
+                              data-cell="Type"
+                            >
+                              {appt ? formatAppointmentType(appt.appointmentType) : ''}
+                            </div>
+                            <div
+                              className="trustees-list-cell col-status"
+                              role="cell"
+                              data-cell="Status"
+                            >
+                              {appt ? formatListAppointmentStatus(appt.status) : ''}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -15,6 +15,7 @@ import TrusteeDistrictFilter from './filters/TrusteeDistrictFilter';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { StatusFilterValue, TrusteeDistrictFilterRef } from './filters/trusteeDistrictFilter.types';
 import Icon from '@/lib/components/uswds/Icon';
+import Alert, { UswdsAlertStyle } from '@/lib/components/uswds/Alert';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 import {
   sortTrusteeAppointments,
@@ -442,12 +443,13 @@ export default function TrusteesList() {
     if (loading) return <LoadingSpinner caption="Loading trustees..." />;
     if (error) {
       return (
-        <div className="usa-alert usa-alert--error" role="alert">
-          <div className="usa-alert__body">
-            <h3 className="usa-alert__heading">Error loading trustees</h3>
-            <p className="usa-alert__text">{error}</p>
-          </div>
-        </div>
+        <Alert
+          type={UswdsAlertStyle.Error}
+          title="Error loading trustees"
+          message={error}
+          show={true}
+          inline={true}
+        />
       );
     }
     return null;
@@ -475,12 +477,14 @@ export default function TrusteesList() {
       {pageStatus ?? (
         <>
           {filteredTrustees.length === 0 && !nameSearchLoading ? (
-            <div className="usa-alert usa-alert--info" role="alert">
-              <div className="usa-alert__body">
-                <h3 className="usa-alert__heading">No trustees found</h3>
-                <p className="usa-alert__text">Consider adjusting your filters.</p>
-              </div>
-            </div>
+            <Alert
+              type={UswdsAlertStyle.Info}
+              title="No trustees found"
+              message="Consider adjusting your filters."
+              show={true}
+              inline={true}
+              role="status"
+            />
           ) : (
             <p className="trustees-list-count" aria-live="off" aria-atomic="false">
               {displayCount} {displayCount === 1 ? 'Trustee' : 'Trustees'}

--- a/user-interface/src/trustees/TrusteesListStatusFilter.test.tsx
+++ b/user-interface/src/trustees/TrusteesListStatusFilter.test.tsx
@@ -245,4 +245,66 @@ describe('TrusteesList Status Filter', () => {
       expect(screen.queryByTestId('trustee-link-ac13')).not.toBeInTheDocument();
     });
   });
+
+  test('should keep filters accordion open and chapter selection when status changes', async () => {
+    const activeChapter7 = makeListItem({
+      trusteeId: 'ac7',
+      firstName: 'Active',
+      lastName: 'Seven',
+      name: 'Active Seven',
+      appointments: [makeAppointment({ trusteeId: 'ac7', status: 'active', chapter: '7' })],
+    });
+    const inactiveChapter7 = makeListItem({
+      trusteeId: 'ic7',
+      firstName: 'Inactive',
+      lastName: 'Seven',
+      name: 'Inactive Seven',
+      appointments: [makeAppointment({ trusteeId: 'ic7', status: 'resigned', chapter: '7' })],
+    });
+    const spy = vi.spyOn(Api2, 'getTrustees');
+    spy.mockResolvedValue({ data: [activeChapter7] });
+
+    renderWithRouter(<TrusteesList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    const toggleButton = screen.getByRole('button', { name: /filters/i });
+    await user.click(toggleButton);
+
+    // Select a chapter filter
+    const chapterCombobox = await screen.findByLabelText('Chapter');
+    await user.click(chapterCombobox);
+    const chapter7Option = await screen.findByRole('option', { name: /Chapter 7/i });
+    await user.click(chapter7Option);
+
+    // The chapter pill should now be present
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /^7 selected\. click to deselect\./i }),
+      ).toBeInTheDocument();
+    });
+
+    // Now change the status filter
+    spy.mockResolvedValue({ data: [inactiveChapter7] });
+    const statusCombobox = await screen.findByLabelText('Status');
+    await user.click(statusCombobox);
+    const inactiveOption = await screen.findByRole('option', { name: /Status Inactive/i });
+    await user.click(inactiveOption);
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenLastCalledWith('inactive');
+      expect(screen.getByTestId('trustee-link-ic7')).toBeInTheDocument();
+    });
+
+    // The accordion content should remain expanded (not collapsed by the reload)
+    expect(screen.getByLabelText('Chapter')).toBeVisible();
+
+    // The chapter selection should still be applied (pill still present)
+    expect(
+      screen.getByRole('button', { name: /^7 selected\. click to deselect\./i }),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
# Bug

On the Trustees screen, changing the **Status** filter caused three regressions:

1. The whole screen flashed the loading spinner instead of just the table — the filter accordion disappeared during reload.
2. Any selected **Chapter** filters were silently cleared.
3. The Filters accordion collapsed even though the user had it open.

# Purpose

Make the Status filter behave like the other filters: only the table reloads, the filter UI stays mounted, and the user's other selections are preserved.

# Major Changes

- `TrusteesList.tsx`: Removed the early-return of `<LoadingSpinner>` / error alert that was unmounting `<TrusteeDistrictFilter>` on every status change. The filter now stays mounted; the loading spinner, error alert, empty state, and table are all rendered inside the same layout, so only the table region swaps while data reloads.
- Because the filter no longer remounts, its accordion expanded state, selected chapters, selected districts/divisions, and status selection all persist across reloads triggered by `setStatusFilter`.

# Testing/Validation

- Added `should keep filters accordion open and chapter selection when status changes` to `TrusteesListStatusFilter.test.tsx` — selects a chapter, switches status from Active to Inactive, and asserts both the chapter combobox is still visible (accordion still open) and the chapter pill is still present after the reload.
- Adjusted one existing test in `TrusteesList.test.tsx` (`default session divisions appear at top of combined dropdown with divider`) that was using "1 Trustee" as a wait gate. With the filter now mounted during loading, default session divisions correctly apply sooner and filter out the test's mock trustee, so the gate now waits on the Filters toggle button instead.
- All 102 tests in `TrusteesList.test.tsx`, `TrusteesListStatusFilter.test.tsx`, and `filters/TrusteeDistrictFilter.test.tsx` pass.
- Manually verified by clicking through the Filters accordion: open Filters → select chapter pill → change Status to Inactive — the accordion stays open, the chapter pill stays applied, and only the table area shows the spinner.

# Notes

The 24 unrelated failures observed in `forms/TrusteeAppointmentForm.test.tsx` reproduce on `main` (verified via `git stash`); they are pre-existing and out of scope for this PR.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Preserve the trustees list layout while loading and on error, and ensure filters remain visible and applied when status changes.

Bug Fixes:
- Keep the trustees table and filter UI visible while data is loading or when an error occurs instead of short-circuiting the render.
- Maintain the filters accordion open state and chapter selection when the status filter is changed and data is reloaded.

Tests:
- Add a regression test to verify filters accordion stays open and chapter selection persists when switching trustee status filters.
- Adjust an existing trustees list test to wait for the filters toggle button via findByRole for more robust async behavior.