### PR TITLE
CAMS-767 Single-select status filter with non-removable pill

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
-        args: ["-x"]
+        args: ['-x']
   - repo: local
     hooks:
       - id: update-workflow-diagrams

--- a/user-interface/src/lib/components/Pill.scss
+++ b/user-interface/src/lib/components/Pill.scss
@@ -64,8 +64,13 @@
   justify-content: center;
   min-width: 2.6rem;
 
-  &:hover {
+  &:hover,
+  &:active,
+  &:focus {
     filter: none;
+    background-color: color('primary');
+    color: color('white');
+    text-decoration: none;
   }
 
   .pill-text {

--- a/user-interface/src/lib/components/Pill.scss
+++ b/user-interface/src/lib/components/Pill.scss
@@ -61,6 +61,8 @@
 
 .pill.usa-button--unstyled.not-removable {
   cursor: default;
+  justify-content: center;
+  min-width: 2.6rem;
 
   &:hover {
     filter: none;

--- a/user-interface/src/lib/components/Pill.scss
+++ b/user-interface/src/lib/components/Pill.scss
@@ -58,3 +58,15 @@
 .pill:hover {
   filter: brightness(0.9);
 }
+
+.pill.usa-button--unstyled.not-removable {
+  cursor: default;
+
+  &:hover {
+    filter: none;
+  }
+
+  .pill-text {
+    max-width: 100%;
+  }
+}

--- a/user-interface/src/lib/components/Pill.test.tsx
+++ b/user-interface/src/lib/components/Pill.test.tsx
@@ -49,7 +49,7 @@ describe('Test pill', () => {
     expect(clickFn).not.toHaveBeenCalled();
   });
 
-  test('should not call onClick when removable is false and pill is clicked', async () => {
+  test('should not call onClick and should omit "Click to deselect" when removable is false', async () => {
     const clickFn = vi.fn((_value: string) => {});
 
     render(
@@ -68,20 +68,6 @@ describe('Test pill', () => {
     fireEvent.keyDown(pill, { key: ' ' });
 
     expect(clickFn).not.toHaveBeenCalled();
-  });
-
-  test('should omit "Click to deselect" from aria-label when removable is false', () => {
-    render(
-      <Pill
-        id="test"
-        label="Test pill"
-        value="test-value"
-        onClick={() => {}}
-        removable={false}
-      ></Pill>,
-    );
-
-    const pill = screen.getByTestId('pill-test');
     expect(pill).toHaveAttribute('aria-label', 'Test pill selected');
   });
 });

--- a/user-interface/src/lib/components/Pill.test.tsx
+++ b/user-interface/src/lib/components/Pill.test.tsx
@@ -48,4 +48,40 @@ describe('Test pill', () => {
     expect(keyDownFn).toHaveBeenCalled();
     expect(clickFn).not.toHaveBeenCalled();
   });
+
+  test('should not call onClick when removable is false and pill is clicked', async () => {
+    const clickFn = vi.fn((_value: string) => {});
+
+    render(
+      <Pill
+        id="test"
+        label="Test pill"
+        value="test-value"
+        onClick={clickFn}
+        removable={false}
+      ></Pill>,
+    );
+
+    const pill = screen.getByTestId('pill-test');
+    fireEvent.click(pill);
+    fireEvent.keyDown(pill, { key: 'Enter' });
+    fireEvent.keyDown(pill, { key: ' ' });
+
+    expect(clickFn).not.toHaveBeenCalled();
+  });
+
+  test('should omit "Click to deselect" from aria-label when removable is false', () => {
+    render(
+      <Pill
+        id="test"
+        label="Test pill"
+        value="test-value"
+        onClick={() => {}}
+        removable={false}
+      ></Pill>,
+    );
+
+    const pill = screen.getByTestId('pill-test');
+    expect(pill).toHaveAttribute('aria-label', 'Test pill selected');
+  });
 });

--- a/user-interface/src/lib/components/Pill.tsx
+++ b/user-interface/src/lib/components/Pill.tsx
@@ -57,10 +57,13 @@ function Pill_(props: PillProps, ref: React.Ref<Partial<HTMLButtonElement>>) {
     <button
       id={props.id}
       data-testid={`pill-${props.id}`}
-      className={`pill usa-button--unstyled ${wrapTextClass} ${removableClass}`.trim()}
+      className={['pill', 'usa-button--unstyled', wrapTextClass, removableClass]
+        .filter(Boolean)
+        .join(' ')}
       onClick={handleClick}
       onKeyDown={(ev) => handleKeyDown(ev)}
-      tabIndex={0}
+      tabIndex={removable ? 0 : -1}
+      aria-disabled={removable ? undefined : true}
       aria-label={ariaLabel}
       disabled={props.disabled}
       data-value={props.value}

--- a/user-interface/src/lib/components/Pill.tsx
+++ b/user-interface/src/lib/components/Pill.tsx
@@ -11,12 +11,20 @@ type PillProps = {
   onClick: (value: string) => void;
   onKeyDown?: (ev: React.KeyboardEvent<HTMLButtonElement>, num: number) => void;
   disabled?: boolean;
+  removable?: boolean;
 };
 
 function Pill_(props: PillProps, ref: React.Ref<Partial<HTMLButtonElement>>) {
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const removable = props.removable !== false;
 
   function handleKeyDown(ev: React.KeyboardEvent<HTMLButtonElement>) {
+    if (!removable) {
+      if (props.onKeyDown) {
+        props.onKeyDown(ev, 0);
+      }
+      return;
+    }
     if (ev.key === 'Enter' || ev.key === ' ') {
       props.onClick(props.value);
       ev.preventDefault();
@@ -25,7 +33,14 @@ function Pill_(props: PillProps, ref: React.Ref<Partial<HTMLButtonElement>>) {
     }
   }
 
+  function handleClick() {
+    if (!removable) return;
+    props.onClick(props.value);
+  }
+
   const wrapTextClass = props.wrapText === true ? 'wrap-text' : '';
+  const removableClass = removable ? '' : 'not-removable';
+  const ariaLabel = `${props.ariaLabelPrefix ? props.ariaLabelPrefix + ' - ' : ''}${props.label} selected${removable ? '. Click to deselect.' : ''}`;
 
   const focusButton = () => {
     buttonRef.current?.focus();
@@ -41,18 +56,18 @@ function Pill_(props: PillProps, ref: React.Ref<Partial<HTMLButtonElement>>) {
     <button
       id={props.id}
       data-testid={`pill-${props.id}`}
-      className={`pill usa-button--unstyled ${wrapTextClass}`}
-      onClick={() => props.onClick(props.value)}
+      className={`pill usa-button--unstyled ${wrapTextClass} ${removableClass}`.trim()}
+      onClick={handleClick}
       onKeyDown={(ev) => handleKeyDown(ev)}
       tabIndex={0}
-      aria-label={`${props.ariaLabelPrefix ? props.ariaLabelPrefix + ' - ' : ''}${props.label} selected. Click to deselect.`}
+      aria-label={ariaLabel}
       disabled={props.disabled}
       data-value={props.value}
       title={`${props.label}`}
       ref={buttonRef}
     >
       <div className="pill-text">{props.label}</div>
-      <Icon name="close"></Icon>
+      {removable && <Icon name="close"></Icon>}
     </button>
   );
 }

--- a/user-interface/src/lib/components/Pill.tsx
+++ b/user-interface/src/lib/components/Pill.tsx
@@ -30,7 +30,7 @@ function Pill_(props: PillProps, ref: React.Ref<Partial<HTMLButtonElement>>) {
       props.onClick(props.value);
       ev.preventDefault();
     } else if (props.onKeyDown) {
-      props.onKeyDown(ev, 0);
+      props.onKeyDown(ev, props.index ?? 0);
     }
   }
 

--- a/user-interface/src/lib/components/Pill.tsx
+++ b/user-interface/src/lib/components/Pill.tsx
@@ -7,6 +7,7 @@ type PillProps = {
   label: string;
   ariaLabelPrefix?: string;
   value: string;
+  index?: number;
   wrapText?: boolean;
   onClick: (value: string) => void;
   onKeyDown?: (ev: React.KeyboardEvent<HTMLButtonElement>, num: number) => void;
@@ -21,7 +22,7 @@ function Pill_(props: PillProps, ref: React.Ref<Partial<HTMLButtonElement>>) {
   function handleKeyDown(ev: React.KeyboardEvent<HTMLButtonElement>) {
     if (!removable) {
       if (props.onKeyDown) {
-        props.onKeyDown(ev, 0);
+        props.onKeyDown(ev, props.index ?? 0);
       }
       return;
     }

--- a/user-interface/src/lib/components/PillBox.test.tsx
+++ b/user-interface/src/lib/components/PillBox.test.tsx
@@ -92,6 +92,32 @@ describe('Tests for Pill Box', () => {
     expect(selectionChange).toHaveBeenCalledWith(resultSelections);
   });
 
+  test('Should not invoke onSelectionChange when a non-removable pill is clicked, and should keep removable siblings working', async () => {
+    const selectionChange = vi.fn((_foo: ComboOption[]) => {});
+    const mixedSelections = [
+      { label: 'Status: Active', value: 'status-active', removable: false },
+      { label: 'pill 1', value: 'p1' },
+    ];
+
+    render(
+      <PillBox
+        id="test-pillbox"
+        selections={mixedSelections}
+        onSelectionChange={selectionChange}
+      ></PillBox>,
+    );
+
+    const statusPill = document.querySelector('#pill-test-pillbox-0') as HTMLElement;
+    const removablePill = document.querySelector('#pill-test-pillbox-1') as HTMLElement;
+
+    fireEvent.click(statusPill);
+    expect(selectionChange).not.toHaveBeenCalled();
+
+    fireEvent.click(removablePill);
+    const survivingValues = selectionChange.mock.calls[0][0].map((s) => s.value);
+    expect(survivingValues).toEqual(['status-active']);
+  });
+
   test('Should focus on next pill if previous pill is deleted', async () => {
     let selections = [...testSelections];
     const selectionChange = vi.fn((newSelections: ComboOption[]) => {

--- a/user-interface/src/lib/components/PillBox.test.tsx
+++ b/user-interface/src/lib/components/PillBox.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import PillBox from './PillBox';
 import { ComboOption } from './combobox/ComboBox';
 import TestingUtilities, { CamsUserEvent } from '@/lib/testing/testing-utilities';
@@ -107,8 +107,8 @@ describe('Tests for Pill Box', () => {
       ></PillBox>,
     );
 
-    const statusPill = document.querySelector('#pill-test-pillbox-0') as HTMLElement;
-    const removablePill = document.querySelector('#pill-test-pillbox-1') as HTMLElement;
+    const statusPill = screen.getByTestId('pill-pill-test-pillbox-0');
+    const removablePill = screen.getByTestId('pill-pill-test-pillbox-1');
 
     fireEvent.click(statusPill);
     expect(selectionChange).not.toHaveBeenCalled();

--- a/user-interface/src/lib/components/PillBox.tsx
+++ b/user-interface/src/lib/components/PillBox.tsx
@@ -2,14 +2,16 @@ import { useEffect, useRef, useState } from 'react';
 import { ComboOption } from './combobox/ComboBox';
 import Pill from './Pill';
 
+export type PillBoxSelection = ComboOption & { removable?: boolean };
+
 type PillBoxProps = {
   id: string;
   disabled?: boolean;
   ariaLabelPrefix?: string;
   className?: string;
-  selections: ComboOption[];
+  selections: PillBoxSelection[];
   wrapPills?: boolean;
-  onSelectionChange: (selections: ComboOption[]) => void;
+  onSelectionChange: (selections: PillBoxSelection[]) => void;
 };
 
 type PillFocus = {
@@ -21,7 +23,7 @@ function PillBox(props: PillBoxProps) {
   const { onSelectionChange, ariaLabelPrefix, disabled, wrapPills } = props;
   const pillRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
-  const [selections, setSelections] = useState<Map<string, ComboOption>>(
+  const [selections, setSelections] = useState<Map<string, PillBoxSelection>>(
     new Map(props.selections.map((value) => [value.value, value])),
   );
   const [pillFocus, setPillFocus] = useState<PillFocus>({ shouldFocus: false, index: 0 });
@@ -72,6 +74,7 @@ function PillBox(props: PillBoxProps) {
               onClick={onPillClick}
               disabled={disabled}
               wrapText={wrapPills}
+              removable={selection.removable !== false}
               ref={(el: HTMLButtonElement | null) => {
                 pillRefs.current[idx] = el;
               }}

--- a/user-interface/src/lib/components/PillBox.tsx
+++ b/user-interface/src/lib/components/PillBox.tsx
@@ -11,7 +11,7 @@ type PillBoxProps = {
   className?: string;
   selections: PillBoxSelection[];
   wrapPills?: boolean;
-  onSelectionChange: (selections: PillBoxSelection[]) => void;
+  onSelectionChange?: (selections: PillBoxSelection[]) => void;
 };
 
 type PillFocus = {
@@ -29,6 +29,8 @@ function PillBox(props: PillBoxProps) {
   const [pillFocus, setPillFocus] = useState<PillFocus>({ shouldFocus: false, index: 0 });
 
   function onPillClick(value: string) {
+    if (!onSelectionChange) return;
+
     const removedIndex = Array.from(selections.entries()).findIndex(([key, _]) => key === value);
 
     const newSelections = new Map(selections);

--- a/user-interface/src/lib/components/PillBox.tsx
+++ b/user-interface/src/lib/components/PillBox.tsx
@@ -74,7 +74,8 @@ function PillBox(props: PillBoxProps) {
               onClick={onPillClick}
               disabled={disabled}
               wrapText={wrapPills}
-              removable={selection.removable !== false}
+              index={idx}
+              removable={selection.removable}
               ref={(el: HTMLButtonElement | null) => {
                 pillRefs.current[idx] = el;
               }}

--- a/user-interface/src/trustees/TrusteesListStatusFilter.test.tsx
+++ b/user-interface/src/trustees/TrusteesListStatusFilter.test.tsx
@@ -246,6 +246,41 @@ describe('TrusteesList Status Filter', () => {
     });
   });
 
+  test('should render a non-removable status pill that reflects the current status filter', async () => {
+    const activeTrustee = makeListItem({
+      trusteeId: 'active-1',
+      firstName: 'Alice',
+      lastName: 'Active',
+      name: 'Alice Active',
+      appointments: [makeAppointment({ trusteeId: 'active-1', status: 'active' })],
+    });
+    vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [activeTrustee] });
+
+    renderWithRouter(<TrusteesList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+    });
+
+    const activePill = screen.getByRole('button', { name: /^Active selected$/ });
+
+    const user = userEvent.setup();
+    await user.click(activePill);
+    expect(screen.getByRole('button', { name: /^Active selected$/ })).toBeInTheDocument();
+
+    const toggleButton = screen.getByRole('button', { name: /filters/i });
+    await user.click(toggleButton);
+    const statusCombobox = await screen.findByLabelText('Status');
+    await user.click(statusCombobox);
+    const allOption = await screen.findByRole('option', { name: /Status All/i });
+    await user.click(allOption);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^All selected$/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /^Active selected$/ })).not.toBeInTheDocument();
+  });
+
   test('should keep filters accordion open and chapter selection when status changes', async () => {
     const activeChapter7 = makeListItem({
       trusteeId: 'ac7',

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -191,6 +191,8 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
                       viewModel.handleFilterStatus(value);
                     }}
                     placeholder="Active"
+                    multiSelect={false}
+                    hideClearAllButton={true}
                   />
                 </div>
               </div>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -86,6 +86,92 @@ function renderDistrictFilter(
   );
 }
 
+function renderNameFilter(viewModel: TrusteeDistrictFilterViewProps['viewModel']) {
+  return (
+    <div className="filter-control">
+      <div className="filter-control-header">
+        <span className="filter-control-label">Trustee Name</span>
+        <div className="filter-clear-button-container" aria-live="off" aria-atomic="false">
+          <button
+            type="button"
+            className="filter-clear-link"
+            onClick={() => viewModel.handleFilterName('')}
+            aria-label="Clear Trustee Name filter"
+            style={{
+              visibility: viewModel.nameSearch.length > 0 ? 'visible' : 'hidden',
+            }}
+            disabled={viewModel.nameSearch.length === 0}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+      <input
+        id="trustee-name-filter"
+        type="text"
+        className="usa-input"
+        aria-label="Trustee Name"
+        aria-live="off"
+        aria-atomic="false"
+        value={viewModel.nameSearch}
+        onChange={(e) => viewModel.handleFilterName(e.target.value)}
+        placeholder="Search by name"
+        autoComplete="off"
+      />
+    </div>
+  );
+}
+
+function renderChapterFilter(viewModel: TrusteeDistrictFilterViewProps['viewModel']) {
+  return (
+    <div className="filter-control">
+      <div className="filter-control-header">
+        <span className="filter-control-label">Chapter</span>
+      </div>
+      <ComboBox
+        id="chapter-combobox"
+        label="Chapter"
+        hideInternalLabel={true}
+        ariaLabelPrefix="Chapter"
+        options={viewModel.chaptersToComboOptions()}
+        selections={viewModel.selectedChapters}
+        onUpdateSelection={viewModel.handleFilterChapter}
+        multiSelect={true}
+        wrapPills={true}
+        pluralLabel="chapters"
+        singularLabel="chapter"
+        placeholder="- Select one or more -"
+        ref={viewModel.chapterFilterRef}
+      />
+    </div>
+  );
+}
+
+function renderStatusFilter(viewModel: TrusteeDistrictFilterViewProps['viewModel']) {
+  return (
+    <div className="filter-control">
+      <div className="filter-control-header">
+        <span className="filter-control-label">Status</span>
+      </div>
+      <ComboBox
+        id="status-combobox"
+        label="Status"
+        hideInternalLabel={true}
+        ariaLabelPrefix="Status"
+        options={STATUS_OPTIONS}
+        selections={statusToSelection(viewModel.statusFilter)}
+        onUpdateSelection={(selections) => {
+          const value = (selections[0]?.value ?? 'active') as StatusFilterValue;
+          viewModel.handleFilterStatus(value);
+        }}
+        placeholder="Active"
+        multiSelect={false}
+        hideClearAllButton={true}
+      />
+    </div>
+  );
+}
+
 function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
   const { viewModel } = props;
 
@@ -122,87 +208,13 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
 
             <div className="filter-controls-row">
               <div className="filter-controls-pair">
-                <div className="filter-control">
-                  <div className="filter-control-header">
-                    <span className="filter-control-label">Trustee Name</span>
-                    <div
-                      className="filter-clear-button-container"
-                      aria-live="off"
-                      aria-atomic="false"
-                    >
-                      <button
-                        type="button"
-                        className="filter-clear-link"
-                        onClick={() => viewModel.handleFilterName('')}
-                        aria-label="Clear Trustee Name filter"
-                        style={{
-                          visibility: viewModel.nameSearch.length > 0 ? 'visible' : 'hidden',
-                        }}
-                        disabled={viewModel.nameSearch.length === 0}
-                      >
-                        Clear
-                      </button>
-                    </div>
-                  </div>
-                  <input
-                    id="trustee-name-filter"
-                    type="text"
-                    className="usa-input"
-                    aria-label="Trustee Name"
-                    aria-live="off"
-                    aria-atomic="false"
-                    value={viewModel.nameSearch}
-                    onChange={(e) => viewModel.handleFilterName(e.target.value)}
-                    placeholder="Search by name"
-                    autoComplete="off"
-                  />
-                </div>
-
+                {renderNameFilter(viewModel)}
                 {renderDistrictFilter(viewModel, showLegacyDistrictFilter)}
               </div>
 
               <div className="filter-controls-pair">
-                <div className="filter-control">
-                  <div className="filter-control-header">
-                    <span className="filter-control-label">Chapter</span>
-                  </div>
-                  <ComboBox
-                    id="chapter-combobox"
-                    label="Chapter"
-                    hideInternalLabel={true}
-                    ariaLabelPrefix="Chapter"
-                    options={viewModel.chaptersToComboOptions()}
-                    selections={viewModel.selectedChapters}
-                    onUpdateSelection={viewModel.handleFilterChapter}
-                    multiSelect={true}
-                    wrapPills={true}
-                    pluralLabel="chapters"
-                    singularLabel="chapter"
-                    placeholder="- Select one or more -"
-                    ref={viewModel.chapterFilterRef}
-                  />
-                </div>
-
-                <div className="filter-control">
-                  <div className="filter-control-header">
-                    <span className="filter-control-label">Status</span>
-                  </div>
-                  <ComboBox
-                    id="status-combobox"
-                    label="Status"
-                    hideInternalLabel={true}
-                    ariaLabelPrefix="Status"
-                    options={STATUS_OPTIONS}
-                    selections={statusToSelection(viewModel.statusFilter)}
-                    onUpdateSelection={(selections) => {
-                      const value = (selections[0]?.value ?? 'active') as StatusFilterValue;
-                      viewModel.handleFilterStatus(value);
-                    }}
-                    placeholder="Active"
-                    multiSelect={false}
-                    hideClearAllButton={true}
-                  />
-                </div>
+                {renderChapterFilter(viewModel)}
+                {renderStatusFilter(viewModel)}
               </div>
             </div>
           </div>

--- a/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
+++ b/user-interface/src/trustees/filters/TrusteeDistrictFilterView.tsx
@@ -1,6 +1,6 @@
 import './TrusteeDistrictFilter.scss';
 import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
-import PillBox from '@/lib/components/PillBox';
+import PillBox, { PillBoxSelection } from '@/lib/components/PillBox';
 import { Accordion, AccordionGroup } from '@/lib/components/uswds/Accordion';
 import { StatusFilterValue, TrusteeDistrictFilterViewProps } from './trusteeDistrictFilter.types';
 
@@ -14,13 +14,19 @@ const STATUS_OPTIONS: ComboOption[] = [
   },
 ];
 
+const STATUS_PILL_LABELS: Record<StatusFilterValue, string> = {
+  all: 'All',
+  active: 'Active',
+  inactive: 'Inactive',
+};
+
 function statusToSelection(status: StatusFilterValue): ComboOption[] {
   const option = STATUS_OPTIONS.find((o) => o.value === status);
   return option ? [option] : [];
 }
 
-type FilterPillKind = 'district' | 'division' | 'chapter';
-type FilterPill = ComboOption & { kind: FilterPillKind };
+type FilterPillKind = 'district' | 'division' | 'chapter' | 'status';
+type FilterPill = PillBoxSelection & { kind: FilterPillKind };
 
 function tagPills(options: ComboOption[], kind: FilterPillKind): FilterPill[] {
   return options.map((o) => ({ ...o, kind }));
@@ -88,10 +94,12 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
     viewModel.districts.length > 0 &&
     !viewModel.districtsError;
   const pillDistricts = viewModel.districtDivisionEnabled ? [] : viewModel.selectedDistricts;
-  const hasPills =
-    pillDistricts.length > 0 ||
-    viewModel.selectedChapters.length > 0 ||
-    viewModel.selectedDivisions.length > 0;
+  const statusPill: FilterPill = {
+    value: `status-${viewModel.statusFilter}`,
+    label: STATUS_PILL_LABELS[viewModel.statusFilter],
+    kind: 'status',
+    removable: false,
+  };
 
   return (
     <section className="trustee-district-filter" aria-label="Trustee filter controls">
@@ -201,33 +209,32 @@ function TrusteeDistrictFilterView(props: TrusteeDistrictFilterViewProps) {
         </Accordion>
       </AccordionGroup>
 
-      {hasPills && (
-        <PillBox
-          id="filter-pills"
-          className="filter-pills-container"
-          selections={[
-            ...tagPills(pillDistricts, 'district'),
-            ...tagPills(viewModel.selectedDivisions, 'division'),
-            ...tagPills(viewModel.selectedChapters, 'chapter'),
-          ]}
-          onSelectionChange={(updatedPills) => {
-            const pills = updatedPills as FilterPill[];
-            const updatedDistricts = pills.filter((p) => p.kind === 'district');
-            const updatedDivisions = pills.filter((p) => p.kind === 'division');
-            const updatedChapters = pills.filter((p) => p.kind === 'chapter');
+      <PillBox
+        id="filter-pills"
+        className="filter-pills-container"
+        selections={[
+          statusPill,
+          ...tagPills(pillDistricts, 'district'),
+          ...tagPills(viewModel.selectedDivisions, 'division'),
+          ...tagPills(viewModel.selectedChapters, 'chapter'),
+        ]}
+        onSelectionChange={(updatedPills) => {
+          const pills = updatedPills as FilterPill[];
+          const updatedDistricts = pills.filter((p) => p.kind === 'district');
+          const updatedDivisions = pills.filter((p) => p.kind === 'division');
+          const updatedChapters = pills.filter((p) => p.kind === 'chapter');
 
-            if (updatedDistricts.length !== pillDistricts.length) {
-              viewModel.handleFilterChange(updatedDistricts);
-            }
-            if (updatedDivisions.length !== viewModel.selectedDivisions.length) {
-              viewModel.handleFilterDivision(updatedDivisions);
-            }
-            if (updatedChapters.length !== viewModel.selectedChapters.length) {
-              viewModel.handleFilterChapter(updatedChapters);
-            }
-          }}
-        />
-      )}
+          if (updatedDistricts.length !== pillDistricts.length) {
+            viewModel.handleFilterChange(updatedDistricts);
+          }
+          if (updatedDivisions.length !== viewModel.selectedDivisions.length) {
+            viewModel.handleFilterDivision(updatedDivisions);
+          }
+          if (updatedChapters.length !== viewModel.selectedChapters.length) {
+            viewModel.handleFilterChapter(updatedChapters);
+          }
+        }}
+      />
     </section>
   );
 }

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.scss
@@ -35,14 +35,6 @@
       max-width: var(--form-field-max-width); // Match form field width
     }
 
-    .division-pill-static {
-      cursor: default;
-
-      .pill-text {
-        max-width: 100%;
-      }
-    }
-
     .division-pill {
       display: inline-flex;
       align-items: center;

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -655,7 +655,6 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
                         ]}
                         wrapPills={true}
                         ariaLabelPrefix="Division"
-                        onSelectionChange={() => {}}
                       />
                     ) : (
                       <PillBox

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -655,7 +655,7 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
                         ]}
                         wrapPills={true}
                         ariaLabelPrefix="Division"
-                        onSelectionChange={handlePillRemoval}
+                        onSelectionChange={() => {}}
                       />
                     ) : (
                       <PillBox

--- a/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeAppointmentForm.tsx
@@ -647,14 +647,17 @@ function TrusteeAppointmentForm(props: Readonly<TrusteeAppointmentFormProps>) {
                     divisionSelections &&
                     (formData.divisionCodes.length === 1 &&
                     formData.divisionCodes[0] === ALL_DIVISIONS_VALUE ? (
-                      // Show non-interactive badge when only "All Divisions" is selected
-                      <div className="division-pills-container">
-                        <span className="pill usa-button--unstyled division-pill-static">
-                          <div className="pill-text">All Divisions</div>
-                        </span>
-                      </div>
+                      <PillBox
+                        id="division-pills"
+                        className="division-pills-container"
+                        selections={[
+                          { value: ALL_DIVISIONS_VALUE, label: 'All Divisions', removable: false },
+                        ]}
+                        wrapPills={true}
+                        ariaLabelPrefix="Division"
+                        onSelectionChange={handlePillRemoval}
+                      />
                     ) : (
-                      // Use PillBox for removable specific divisions
                       <PillBox
                         id="division-pills"
                         className="division-pills-container"


### PR DESCRIPTION
# Purpose

Display the current Trustees list Status selection as a pill alongside the other filter pills (district, division, chapter), so users see all active filters in one consistent place. Status must remain set at all times, so its pill cannot be removed.

# Major Changes

* Added an optional `removable` prop to the `Pill` component (defaults to `true`). When `false`, the close icon is hidden, click and Enter/Space do not invoke `onClick`, and the aria-label drops "Click to deselect".
* Extended `PillBox` with a `PillBoxSelection` type so callers can mark individual pills as non-removable. Mixed removable/non-removable pills coexist in one PillBox.
* Wired a non-removable status pill into the trustees filter view (`TrusteeDistrictFilterView`) as the first pill in the existing filter pills container.
* Replaced the hand-rolled static "All Divisions" badge in `TrusteeAppointmentForm` with a `PillBox` rendering a single `removable: false` pill, removing the now-unused `.division-pill-static` SCSS rule. Non-removable pill styling now lives in one place (`Pill.scss`).
* Made the `multiSelect={false}` status combobox the source of truth (separate prior commit on this branch).

# Testing/Validation

Implemented using TDD. Added unit tests covering:
* `Pill`: clicking and pressing Enter/Space on a non-removable pill does not invoke `onClick`; the aria-label omits "Click to deselect".
* `PillBox`: a non-removable pill in a mixed selection list does not invoke `onSelectionChange` when clicked, while removable siblings still work.
* `TrusteesList`: the status pill renders with the current status filter and updates when the filter changes, never showing a "Click to deselect" affordance.

All affected test suites pass (Pill, PillBox, trustees list, trustees filters).

# Notes

* `Pill` is the single owner of the non-removable rule. `PillBox.onPillClick` is never reached for a non-removable pill because `Pill.handleClick` short-circuits first, so no duplicate guard is needed in `PillBox`.
* The `filter-pills-container` always renders now (since the status pill is always present), simplifying the conditional that previously toggled the container based on whether any removable filter was active.
* Component catalog entries for `Pill` and `PillBox` were updated to describe the new `removable` behavior.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce non-removable pills for status and "All Divisions" filters and wire them into trustees filters while keeping status as a required, single-select filter.

Enhancements:
- Extend Pill and PillBox components to support non-removable pills with dedicated styling and accessibility labels.
- Always render the trustees filter pills container and include a non-removable status pill alongside existing district, division, and chapter pills.
- Replace the custom static "All Divisions" badge in the trustee appointment form with a PillBox-driven, non-removable pill for consistent UI behavior.

Tests:
- Add unit coverage for non-removable Pill behavior, including click/keyboard handling and aria-label text.
- Add tests to ensure PillBox ignores clicks on non-removable pills but still updates selections for removable siblings.
- Add trustees list status filter tests to verify the status pill reflects the current filter and updates as the status changes.