### PR TITLE
Pin protobufjs to 7.x in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,12 @@
       "groupName": "vite"
     },
     {
+      "description": "Stay on protobufjs version 7, until applicationinsights version is updated with no cves on protobufjs version 8.",
+      "matchPackageNames": ["protobufjs"],
+      "groupName": "protobufjs",
+      "allowedVersions": "7.x"
+    },
+    {
       "description": "Group Application Insights packages — applicationinsights blocked below 3.15.0 because 3.15.0 introduced protobufjs@8 via @opentelemetry/otlp-transformer@0.217.0, triggering 9 Snyk CVEs (4 High, 5 Medium). <3.15.0 keeps the OpenTelemetry tree on 0.208.x which uses only protobufjs@7.x (no CVEs).",
       "matchPackageNames": ["applicationinsights", "@microsoft/applicationinsights-react-js", "@microsoft/applicationinsights-web"],
       "groupName": "applicationinsights",


### PR DESCRIPTION
# Purpose

Prevent Renovate from upgrading protobufjs to v8, which introduces Snyk CVEs, until applicationinsights ships a version that bundles a clean protobufjs@8.

# Major Changes

* Added a `packageRule` in `renovate.json` restricting `protobufjs` to `7.x`

# Testing/Validation

No code changes — config only. Validated by reviewing the existing Application Insights package rule comment, which documents that protobufjs@8 (introduced via applicationinsights@3.15.0) triggers 9 Snyk CVEs (4 High, 5 Medium).

# Notes

The existing `applicationinsights` package rule already blocks upgrades past 3.14.x for the same underlying reason. This rule adds an explicit constraint on protobufjs itself so Renovate does not attempt to upgrade it independently.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Restrict Renovate from upgrading protobufjs beyond the 7.x series to avoid known security issues introduced in protobufjs 8 until upstream dependencies are updated.

Build:
- Add a Renovate package rule to pin protobufjs dependencies to version 7.x in automated updates.

Chores:
- Align Renovate dependency rules with existing applicationinsights constraints to consistently block insecure protobufjs 8 upgrades.