### PR TITLE
Increase trustees table chapter column max-width

### DIFF
--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -144,7 +144,7 @@
     .col-type {
       flex: 1 1 0;
       min-width: 0;
-      max-width: 70px;
+      max-width: 110px;
     }
 
     .col-status {


### PR DESCRIPTION
# Bug

The chapter column in the trustees list table was being truncated because `.col-chapter` and `.col-type` had a `max-width` of `70px`, which was too narrow to display some chapter and type values without wrapping.

# Purpose

Ensure chapter and type values in the trustees table are fully visible without wrapping.

# Major Changes

* Increased `.col-type`, `.col-chapter` max-width from `70px` to `110px` in `TrusteesList.scss`

BEFORE

Chapter column
<img width="1456" height="329" alt="Screenshot 2026-06-19 at 9 53 40 AM" src="https://github.com/user-attachments/assets/74f4e438-fa8c-40bf-867c-862e73693e91" />

Type column (Case by Case)
<img width="1316" height="237" alt="Screenshot 2026-06-19 at 11 01 32 AM" src="https://github.com/user-attachments/assets/a436217d-63bd-4d79-8d12-c3ae0000bc1e" />


AFTER

Chapter column
<img width="1391" height="190" alt="Screenshot 2026-06-19 at 9 53 57 AM" src="https://github.com/user-attachments/assets/68c5aed6-392c-4cf4-8054-9f37682705a7" />

Type column (case by Case)
<img width="1429" height="185" alt="Screenshot 2026-06-19 at 11 01 42 AM" src="https://github.com/user-attachments/assets/01366c69-7ee0-4ea3-b698-c026b7dae34f" />


# Testing/Validation

Visually verified in the trustees list that chapter column values are no longer truncated.

# Notes

No logic changes — CSS-only fix.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Bug Fixes:
- Adjust table column styling so chapter values in the trustees list are no longer clipped due to an overly small max-width constraint.