### PR TITLE
CAMS-761 Assign ZZ-NNNNN professional code to new trustees

### DIFF
--- a/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.test.ts
@@ -24,7 +24,6 @@ describe('Runtime State Repo', () => {
   });
 
   afterEach(async () => {
-    vi.restoreAllMocks();
     await closeDeferred(context);
   });
 

--- a/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.test.ts
@@ -1,12 +1,13 @@
 import { vi } from 'vitest';
 import { createMockApplicationContext } from '../../../testing/testing-utilities';
-import { OrderSyncState } from '../../../use-cases/gateways.types';
+import { OrderSyncState, ProfessionalIdCounterState } from '../../../use-cases/gateways.types';
 import { ApplicationContext } from '../../types/basic';
 import { RuntimeStateMongoRepository } from './runtime-state.mongo.repository';
 import * as crypto from 'crypto';
 import { MongoCollectionAdapter } from './utils/mongo-adapter';
 import { closeDeferred } from '../../../deferrable/defer-close';
 import { UnknownError } from '../../../common-errors/unknown-error';
+import { CamsError } from '../../../common-errors/cams-error';
 
 describe('Runtime State Repo', () => {
   const expected: OrderSyncState = {
@@ -79,5 +80,80 @@ describe('Runtime State Repo', () => {
     expect(findOneSpy).toHaveBeenCalled();
     await expect(repo.upsert(expected)).rejects.toThrow(expectedError);
     expect(replaceSpy).toHaveBeenCalled();
+  });
+
+  describe('atomicDecrement', () => {
+    let counterRepo: RuntimeStateMongoRepository<ProfessionalIdCounterState>;
+
+    beforeEach(() => {
+      counterRepo = new RuntimeStateMongoRepository<ProfessionalIdCounterState>(context);
+    });
+
+    test('should seed the counter then atomically decrement it via two findOneAndUpdate calls', async () => {
+      const findOneAndUpdateSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'findOneAndUpdate')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          documentType: 'PROFESSIONAL_ID_COUNTER',
+          lastAssigned: 99999,
+        });
+
+      await counterRepo.atomicDecrement('PROFESSIONAL_ID_COUNTER', 'lastAssigned', 100000);
+
+      expect(findOneAndUpdateSpy).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.objectContaining({
+          $set: { documentType: 'PROFESSIONAL_ID_COUNTER' },
+          $setOnInsert: expect.objectContaining({ lastAssigned: 100000 }),
+        }),
+        { upsert: true },
+      );
+      expect(findOneAndUpdateSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        { $inc: { lastAssigned: -1 } },
+        { returnDocument: 'after' },
+      );
+    });
+
+    test('should return the post-decrement field value from the returned document', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOneAndUpdate')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          documentType: 'PROFESSIONAL_ID_COUNTER',
+          lastAssigned: 99999,
+        });
+
+      const result = await counterRepo.atomicDecrement(
+        'PROFESSIONAL_ID_COUNTER',
+        'lastAssigned',
+        100000,
+      );
+      expect(result).toEqual(99999);
+    });
+
+    test('should throw when the decrement step returns null', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOneAndUpdate')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        counterRepo.atomicDecrement('PROFESSIONAL_ID_COUNTER', 'lastAssigned', 100000),
+      ).rejects.toThrow(CamsError);
+    });
+
+    test('should rewrap driver errors via getCamsError', async () => {
+      const driverError = new Error('driver-failure');
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOneAndUpdate').mockRejectedValue(driverError);
+
+      await expect(
+        counterRepo.atomicDecrement('PROFESSIONAL_ID_COUNTER', 'lastAssigned', 100000),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          isCamsError: true,
+        }),
+      );
+    });
   });
 });

--- a/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.ts
@@ -8,7 +8,7 @@ import QueryBuilder from '../../../query/query-builder';
 import { getCamsError } from '../../../common-errors/error-utilities';
 import { UnknownError } from '../../../common-errors/unknown-error';
 import { BaseMongoRepository } from './utils/base-mongo-repository';
-import * as crypto from 'crypto';
+import { randomUUID } from 'crypto';
 
 const MODULE_NAME = 'RUNTIME-STATE-MONGO-REPOSITORY';
 const COLLECTION_NAME = 'runtime-state';
@@ -64,7 +64,7 @@ export class RuntimeStateMongoRepository<T extends RuntimeState>
         query,
         {
           $set: { documentType },
-          $setOnInsert: { [field]: initialValue, id: crypto.randomUUID() },
+          $setOnInsert: { [field]: initialValue, id: randomUUID() },
         },
         { upsert: true },
       );
@@ -79,7 +79,13 @@ export class RuntimeStateMongoRepository<T extends RuntimeState>
           message: `atomicDecrement returned no document for ${documentType}.`,
         });
       }
-      return result[field] as number;
+      const value = result[field];
+      if (typeof value !== 'number') {
+        throw new UnknownError(MODULE_NAME, {
+          message: `atomicDecrement: field '${field}' is not a number in ${documentType}.`,
+        });
+      }
+      return value;
     } catch (e) {
       throw getCamsError(e, MODULE_NAME);
     }

--- a/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/runtime-state.mongo.repository.ts
@@ -6,7 +6,9 @@ import {
 } from '../../../use-cases/gateways.types';
 import QueryBuilder from '../../../query/query-builder';
 import { getCamsError } from '../../../common-errors/error-utilities';
+import { UnknownError } from '../../../common-errors/unknown-error';
 import { BaseMongoRepository } from './utils/base-mongo-repository';
+import * as crypto from 'crypto';
 
 const MODULE_NAME = 'RUNTIME-STATE-MONGO-REPOSITORY';
 const COLLECTION_NAME = 'runtime-state';
@@ -39,6 +41,45 @@ export class RuntimeStateMongoRepository<T extends RuntimeState>
       if (result.modifiedCount + result.upsertedCount > 0) {
         return { ...data, id: result.id } as T;
       }
+    } catch (e) {
+      throw getCamsError(e, MODULE_NAME);
+    }
+  }
+
+  async atomicDecrement(
+    documentType: RuntimeStateDocumentType,
+    field: keyof T & string,
+    initialValue: number,
+  ): Promise<number> {
+    try {
+      const adapter = this.getAdapter<T>();
+      const query = doc('documentType').equals(documentType);
+
+      // Seed the counter on first use. Mongo rejects $inc and $setOnInsert on
+      // the same path in one update, so we seed in a separate upsert and then
+      // do the atomic $inc. Both round-trips are race-safe at the document
+      // level; a concurrent caller either finds the seeded doc or seeds it
+      // itself, and the subsequent $inc is always atomic.
+      await adapter.findOneAndUpdate(
+        query,
+        {
+          $set: { documentType },
+          $setOnInsert: { [field]: initialValue, id: crypto.randomUUID() },
+        },
+        { upsert: true },
+      );
+
+      const result = await adapter.findOneAndUpdate(
+        query,
+        { $inc: { [field]: -1 } },
+        { returnDocument: 'after' },
+      );
+      if (!result) {
+        throw new UnknownError(MODULE_NAME, {
+          message: `atomicDecrement returned no document for ${documentType}.`,
+        });
+      }
+      return result[field] as number;
     } catch (e) {
       throw getCamsError(e, MODULE_NAME);
     }

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
@@ -56,6 +56,8 @@ describe('Mongo adapter', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    // adapter and spies are constructed at module scope, so restoreAllMocks() alone
+    // does not reset call history between tests — clearAllMocks() handles that.
     vi.clearAllMocks();
   });
 

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
@@ -13,7 +13,6 @@ const ADAPTER_MODULE_NAME = MODULE_NAME + '_ADAPTER';
 
 const find = vi.fn();
 const findOne = vi.fn();
-const paginate = vi.fn();
 const replaceOne = vi.fn();
 const updateOne = vi.fn();
 const findOneAndUpdate = vi.fn();
@@ -23,11 +22,13 @@ const deleteOne = vi.fn();
 const deleteMany = vi.fn();
 const countDocuments = vi.fn();
 const aggregate = vi.fn();
+const upsertOne = vi.fn();
+const updateMany = vi.fn();
+const bulkWrite = vi.fn();
 
 const spies = {
   find,
   findOne,
-  paginate,
   replaceOne,
   updateOne,
   findOneAndUpdate,
@@ -37,6 +38,9 @@ const spies = {
   deleteMany,
   countDocuments,
   aggregate,
+  upsertOne,
+  updateMany,
+  bulkWrite,
 };
 
 type TestType = {
@@ -50,8 +54,9 @@ describe('Mongo adapter', () => {
   const humbleCollection = spies as unknown as CollectionHumble<TestType>;
   const adapter = new MongoCollectionAdapter<TestType>(MODULE_NAME, humbleCollection);
 
-  afterEach(() => {
+  beforeEach(() => {
     vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   test('should return an instance of the adapter from newAdapter', () => {
@@ -276,11 +281,17 @@ describe('Mongo adapter', () => {
     },
   );
 
-  test('should return a single Id from insertOne', async () => {
-    const id = '123456';
-    insertOne.mockResolvedValue({ acknowledged: true, insertedId: id });
+  test('should return a generated id from insertOne', async () => {
+    insertOne.mockResolvedValue({ acknowledged: true, insertedId: '123456' });
     const result = await adapter.insertOne({});
-    expect(result.split('-').length).toEqual(5);
+    expect(result).toEqual(expect.any(String));
+  });
+
+  test('should return the provided id from insertOne when useProvidedId is true', async () => {
+    const providedId = 'pre-assigned-id';
+    insertOne.mockResolvedValue({ acknowledged: true, insertedId: providedId });
+    const result = await adapter.insertOne({ id: providedId } as TestType, { useProvidedId: true });
+    expect(result).toEqual(providedId);
   });
 
   test('should throw an error if insertOne does not insert.', async () => {
@@ -503,6 +514,64 @@ describe('Mongo adapter', () => {
       }),
     );
     await expect(adapter.paginate(testQuery)).rejects.toThrow(GatewayTimeoutError);
+  });
+
+  test('should resolve when upsertOne is acknowledged', async () => {
+    upsertOne.mockResolvedValue({ acknowledged: true });
+    await expect(
+      adapter.upsertOne(testQuery, { foo: 'new' }, { foo: 'initial' }),
+    ).resolves.toBeUndefined();
+  });
+
+  test('should throw when upsertOne is not acknowledged', async () => {
+    upsertOne.mockResolvedValue({ acknowledged: false });
+    await expect(adapter.upsertOne(testQuery, { foo: 'new' }, { foo: 'initial' })).rejects.toThrow(
+      'Failed to insert document into database.',
+    );
+  });
+
+  test('should return matchedCount and modifiedCount from updateMany when acknowledged', async () => {
+    updateMany.mockResolvedValue({ acknowledged: true, matchedCount: 3, modifiedCount: 3 });
+    const result = await adapter.updateMany(testQuery, { $set: { foo: 'bar' } });
+    expect(result).toEqual({ matchedCount: 3, modifiedCount: 3 });
+  });
+
+  test('should throw when updateMany is not acknowledged', async () => {
+    updateMany.mockResolvedValue({ acknowledged: false, matchedCount: 0, modifiedCount: 0 });
+    await expect(adapter.updateMany(testQuery, { $set: { foo: 'bar' } })).rejects.toThrow(
+      'Failed to update documents in database.',
+    );
+  });
+
+  test('should return bulkWrite result from bulkReplace', async () => {
+    const expectedResult = {
+      insertedCount: 0,
+      matchedCount: 2,
+      modifiedCount: 2,
+      deletedCount: 0,
+      upsertedCount: 0,
+      upsertedIds: {},
+    };
+    bulkWrite.mockResolvedValue(expectedResult);
+    const replacements = [
+      { filter: testQuery, replacement: { foo: 'a' } as TestType },
+      { filter: testQuery, replacement: { foo: 'b' } as TestType },
+    ];
+    const result = await adapter.bulkReplace(replacements);
+    expect(result).toEqual(expectedResult);
+    expect(bulkWrite).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ replaceOne: expect.objectContaining({ upsert: true }) }),
+      ]),
+    );
+  });
+
+  test('should throw when bulkReplace driver fails', async () => {
+    const driverError = new Error('bulk-failure');
+    bulkWrite.mockRejectedValue(driverError);
+    await expect(
+      adapter.bulkReplace([{ filter: testQuery, replacement: {} as TestType }]),
+    ).rejects.toThrow(expect.objectContaining({ isCamsError: true }));
   });
 
   test('should handle errors', async () => {

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.test.ts
@@ -16,6 +16,7 @@ const findOne = vi.fn();
 const paginate = vi.fn();
 const replaceOne = vi.fn();
 const updateOne = vi.fn();
+const findOneAndUpdate = vi.fn();
 const insertOne = vi.fn();
 const insertMany = vi.fn();
 const deleteOne = vi.fn();
@@ -29,6 +30,7 @@ const spies = {
   paginate,
   replaceOne,
   updateOne,
+  findOneAndUpdate,
   insertOne,
   insertMany,
   deleteOne,
@@ -307,6 +309,38 @@ describe('Mongo adapter', () => {
     updateOne.mockResolvedValue({ ...expectedResult, acknowledged: true });
     const result = await adapter.updateOne(testQuery, {});
     expect(result).toEqual(expectedResult);
+  });
+
+  test('should pass query, update, and options through to humble layer for findOneAndUpdate', async () => {
+    const update = { $inc: { foo: -1 }, $setOnInsert: { foo: 100 } };
+    const options = { upsert: true, returnDocument: 'after' as const };
+    findOneAndUpdate.mockResolvedValue({ id: 'a', foo: 99 });
+
+    const result = await adapter.findOneAndUpdate(testQuery, update, options);
+    expect(findOneAndUpdate).toHaveBeenCalledWith(expect.anything(), update, options);
+    expect(result).toEqual({ id: 'a', foo: 99 });
+  });
+
+  test('should return null when findOneAndUpdate humble layer returns null', async () => {
+    findOneAndUpdate.mockResolvedValue(null);
+    const result = await adapter.findOneAndUpdate(testQuery, {}, { upsert: true });
+    expect(result).toBeNull();
+  });
+
+  test('should rethrow via handleError on findOneAndUpdate driver error', async () => {
+    const driverError = new Error('driver-failure');
+    findOneAndUpdate.mockRejectedValue(driverError);
+    await expect(adapter.findOneAndUpdate(testQuery, {})).rejects.toThrow(
+      expect.objectContaining({
+        isCamsError: true,
+        camsStack: [
+          expect.objectContaining({
+            module: ADAPTER_MODULE_NAME,
+            message: expect.any(String),
+          }),
+        ],
+      }),
+    );
   });
 
   test('should return a list of Ids from insertMany', async () => {

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
@@ -226,6 +226,24 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
     }
   }
 
+  public async findOneAndUpdate(
+    query: Query<T>,
+    update: MongoDocument,
+    options: { upsert?: boolean; returnDocument?: 'before' | 'after' } = {},
+  ): Promise<T | null> {
+    const mongoQuery = toMongoQuery<T>(query);
+    try {
+      const result = await this.collectionHumble.findOneAndUpdate(mongoQuery, update, options);
+      return (result as T | null) ?? null;
+    } catch (originalError) {
+      throw this.handleError(
+        originalError,
+        `Failed to findOneAndUpdate. ${originalError.message}`,
+        { query, update, options },
+      );
+    }
+  }
+
   public async updateOne(query: Query<T>, itemProperties: Partial<T>): Promise<UpdateResult> {
     const mongoQuery = toMongoQuery(query);
 

--- a/backend/lib/humble-objects/mongo-humble.ts
+++ b/backend/lib/humble-objects/mongo-humble.ts
@@ -46,6 +46,18 @@ export class CollectionHumble<T> {
     );
   }
 
+  public async findOneAndUpdate(
+    query: DocumentQuery,
+    update: MongoDocument,
+    options: { upsert?: boolean; returnDocument?: 'before' | 'after' } = {},
+  ) {
+    return this.collection.findOneAndUpdate(
+      query,
+      update as Parameters<Collection<T>['findOneAndUpdate']>[1],
+      options,
+    );
+  }
+
   public async updateMany(query: DocumentQuery, update: MongoDocument) {
     return this.collection.updateMany(query, update);
   }

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -69,6 +69,9 @@ export class MockMongoRepository
   private professionalIds = new Map<string, TrusteeProfessionalId>();
   private runtimeStateCounters = new Map<string, number>();
 
+  // Collapses the real two-phase seed+decrement into a single call.
+  // Returns initialValue - 1 on first use to match the first value the real
+  // implementation produces after seeding at initialValue then decrementing.
   async atomicDecrement(
     documentType: string,
     field: string,

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -67,6 +67,19 @@ export class MockMongoRepository
     UserGroupsRepository
 {
   private professionalIds = new Map<string, TrusteeProfessionalId>();
+  private runtimeStateCounters = new Map<string, number>();
+
+  async atomicDecrement(
+    documentType: string,
+    field: string,
+    initialValue: number,
+  ): Promise<number> {
+    const key = `${documentType}:${field}`;
+    const current = this.runtimeStateCounters.get(key) ?? initialValue;
+    const next = current - 1;
+    this.runtimeStateCounters.set(key, next);
+    return next;
+  }
 
   release() {
     return;

--- a/backend/lib/use-cases/dataflows/trustee-migration-state.service.test.ts
+++ b/backend/lib/use-cases/dataflows/trustee-migration-state.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, afterEach, vi, Mocked } from 'vitest';
+import { describe, expect, test, beforeEach, vi, Mocked } from 'vitest';
 import {
   getOrCreateMigrationState,
   updateMigrationState,
@@ -17,6 +17,7 @@ describe('trustee-migration-state.service', () => {
   let mockRepository: Mocked<RuntimeStateRepository<TrusteeMigrationState>>;
 
   beforeEach(async () => {
+    vi.restoreAllMocks();
     context = await createMockApplicationContext();
 
     mockRepository = {
@@ -26,10 +27,6 @@ describe('trustee-migration-state.service', () => {
     };
 
     vi.spyOn(factory, 'getRuntimeStateRepository').mockReturnValue(mockRepository);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe('getOrCreateMigrationState', () => {
@@ -68,6 +65,7 @@ describe('trustee-migration-state.service', () => {
       expect(result.data?.lastTrusteeId).toBeNull();
       expect(result.data?.processedCount).toBe(0);
       expect(result.data?.appointmentsProcessedCount).toBe(0);
+      expect(result.data?.ambiguousCount).toBe(0);
       expect(result.data?.errors).toBe(0);
       expect(result.data?.status).toBe('IN_PROGRESS');
       expect(result.data?.divisionMappingVersion).toBe('1.0.0');
@@ -86,6 +84,7 @@ describe('trustee-migration-state.service', () => {
       expect(result.data?.lastTrusteeId).toBeNull();
       expect(result.data?.processedCount).toBe(0);
       expect(result.data?.appointmentsProcessedCount).toBe(0);
+      expect(result.data?.ambiguousCount).toBe(0);
       expect(result.data?.errors).toBe(0);
       expect(result.data?.status).toBe('IN_PROGRESS');
       expect(result.data?.divisionMappingVersion).toBe('1.0.0');
@@ -223,6 +222,28 @@ describe('trustee-migration-state.service', () => {
         }),
       );
     });
+
+    test('should return error when state does not exist', async () => {
+      const state: TrusteeMigrationState = {
+        documentType: 'TRUSTEE_MIGRATION_STATE',
+        lastTrusteeId: 200,
+        processedCount: 200,
+        appointmentsProcessedCount: 300,
+        ambiguousCount: 0,
+        errors: 0,
+        startedAt: '2024-01-01T00:00:00Z',
+        lastUpdatedAt: '2024-01-02T00:00:00Z',
+        status: 'IN_PROGRESS',
+        divisionMappingVersion: '1.0.0',
+      };
+
+      mockRepository.read.mockResolvedValue(null);
+
+      const result = await completeMigration(context, state);
+
+      expect(result.error).toBeDefined();
+      expect(mockRepository.upsert).not.toHaveBeenCalled();
+    });
   });
 
   describe('failMigration', () => {
@@ -261,6 +282,28 @@ describe('trustee-migration-state.service', () => {
         }),
       );
     });
+
+    test('should return error when state does not exist', async () => {
+      const state: TrusteeMigrationState = {
+        documentType: 'TRUSTEE_MIGRATION_STATE',
+        lastTrusteeId: 100,
+        processedCount: 100,
+        appointmentsProcessedCount: 150,
+        ambiguousCount: 0,
+        errors: 5,
+        startedAt: '2024-01-01T00:00:00Z',
+        lastUpdatedAt: '2024-01-02T00:00:00Z',
+        status: 'IN_PROGRESS',
+        divisionMappingVersion: '1.0.0',
+      };
+
+      mockRepository.read.mockResolvedValue(null);
+
+      const result = await failMigration(context, state, 'some failure');
+
+      expect(result.error).toBeDefined();
+      expect(mockRepository.upsert).not.toHaveBeenCalled();
+    });
   });
 
   describe('resetMigrationState', () => {
@@ -277,6 +320,7 @@ describe('trustee-migration-state.service', () => {
           lastTrusteeId: null,
           processedCount: 0,
           appointmentsProcessedCount: 0,
+          ambiguousCount: 0,
           errors: 0,
           status: 'IN_PROGRESS',
           divisionMappingVersion: '1.0.0',

--- a/backend/lib/use-cases/dataflows/trustee-migration-state.service.test.ts
+++ b/backend/lib/use-cases/dataflows/trustee-migration-state.service.test.ts
@@ -22,6 +22,7 @@ describe('trustee-migration-state.service', () => {
     mockRepository = {
       read: vi.fn(),
       upsert: vi.fn(),
+      atomicDecrement: vi.fn(),
     };
 
     vi.spyOn(factory, 'getRuntimeStateRepository').mockReturnValue(mockRepository);

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -195,7 +195,13 @@ export interface ArchivedCasesRepository extends Releasable {
 }
 
 export interface RuntimeStateRepository<T extends RuntimeState = RuntimeState>
-  extends Reads<T>, Upserts<T, T> {}
+  extends Reads<T>, Upserts<T, T> {
+  atomicDecrement(
+    documentType: RuntimeStateDocumentType,
+    field: keyof T & string,
+    initialValue: number,
+  ): Promise<number>;
+}
 
 export interface CaseDocketGateway {
   getCaseDocket(context: ApplicationContext, caseId: string): Promise<CaseDocket>;
@@ -501,7 +507,8 @@ export type RuntimeStateDocumentType =
   | 'TRUSTEE_NOTES_METRICS_STATE'
   | 'DELETED_CASES_SYNC_STATE'
   | 'ZOOM_CSV_IMPORT_STATE'
-  | 'TRUSTEE_APPOINTMENTS_DOWNSTREAM_BACKFILL_STATE';
+  | 'TRUSTEE_APPOINTMENTS_DOWNSTREAM_BACKFILL_STATE'
+  | 'PROFESSIONAL_ID_COUNTER';
 
 export type RuntimeState = {
   id?: string;
@@ -582,6 +589,11 @@ export type TrusteeNotesMetricsState = RuntimeState & {
 export type DeletedCasesSyncState = RuntimeState & {
   documentType: 'DELETED_CASES_SYNC_STATE';
   lastChangeDate: string;
+};
+
+export type ProfessionalIdCounterState = RuntimeState & {
+  documentType: 'PROFESSIONAL_ID_COUNTER';
+  lastAssigned: number;
 };
 
 export interface DocumentCollectionAdapter<T> {

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -41,6 +41,11 @@ describe('TrusteesUseCase tests', () => {
       const trusteeHistorySpy = vi
         .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
         .mockResolvedValue();
+      const atomicDecrementSpy = vi.spyOn(MockMongoRepository.prototype, 'atomicDecrement');
+      const createProfessionalIdSpy = vi.spyOn(
+        MockMongoRepository.prototype,
+        'createProfessionalId',
+      );
 
       const actual = await trusteesUseCase.createTrustee(context, trustee);
       expect(createTrusteeSpy).toHaveBeenCalledWith(trustee, userRef);
@@ -66,6 +71,84 @@ describe('TrusteesUseCase tests', () => {
           createdBy: context.session.user,
         }),
       );
+
+      expect(atomicDecrementSpy).toHaveBeenCalledWith(
+        'PROFESSIONAL_ID_COUNTER',
+        'lastAssigned',
+        100000,
+      );
+      expect(createProfessionalIdSpy).toHaveBeenCalledWith(actual.trusteeId, 'ZZ-99999', {
+        id: 'SYSTEM',
+        name: 'CAMS System',
+      });
+      expect(trusteeHistorySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trusteeId: actual.trusteeId,
+          documentType: 'AUDIT_PROFESSIONAL_ID_ASSIGNED',
+          before: undefined,
+          after: 'ZZ-99999',
+          createdBy: { id: 'SYSTEM', name: 'CAMS System' },
+        }),
+      );
+    });
+
+    test('should zero-pad professional code below 10000', async () => {
+      const trustee = MockData.getTrusteeInput();
+      const userRef = getCamsUserReference(context.session.user);
+
+      vi.spyOn(MockMongoRepository.prototype, 'createTrustee').mockResolvedValue(
+        MockData.getTrustee({ ...trustee, createdBy: userRef, updatedBy: userRef }),
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'atomicDecrement').mockResolvedValue(9999);
+      const createProfessionalIdSpy = vi.spyOn(
+        MockMongoRepository.prototype,
+        'createProfessionalId',
+      );
+
+      const actual = await trusteesUseCase.createTrustee(context, trustee);
+
+      expect(createProfessionalIdSpy).toHaveBeenCalledWith(
+        actual.trusteeId,
+        'ZZ-09999',
+        expect.anything(),
+      );
+    });
+
+    test('should throw when atomicDecrement counter fails', async () => {
+      const trustee = MockData.getTrusteeInput();
+      const userRef = getCamsUserReference(context.session.user);
+
+      vi.spyOn(MockMongoRepository.prototype, 'createTrustee').mockResolvedValue(
+        MockData.getTrustee({ ...trustee, createdBy: userRef, updatedBy: userRef }),
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'atomicDecrement').mockRejectedValue(
+        new Error('counter failed'),
+      );
+
+      const actualError = await getTheThrownError(() =>
+        trusteesUseCase.createTrustee(context, trustee),
+      );
+      expect(actualError.isCamsError).toBe(true);
+    });
+
+    test('should throw when createProfessionalId fails', async () => {
+      const trustee = MockData.getTrusteeInput();
+      const userRef = getCamsUserReference(context.session.user);
+
+      vi.spyOn(MockMongoRepository.prototype, 'createTrustee').mockResolvedValue(
+        MockData.getTrustee({ ...trustee, createdBy: userRef, updatedBy: userRef }),
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'createProfessionalId').mockRejectedValue(
+        new Error('prof-id write failed'),
+      );
+
+      const actualError = await getTheThrownError(() =>
+        trusteesUseCase.createTrustee(context, trustee),
+      );
+      expect(actualError.isCamsError).toBe(true);
     });
 
     test('should create a trustee with company name in public contact information', async () => {

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -21,12 +21,9 @@ describe('TrusteesUseCase tests', () => {
 
   describe('createTrustee', () => {
     beforeEach(async () => {
+      vi.restoreAllMocks();
       context = await createMockApplicationContext();
       trusteesUseCase = new TrusteesUseCase(context);
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
     });
 
     test('should create a trustee', async () => {
@@ -254,13 +251,10 @@ describe('TrusteesUseCase tests', () => {
     ];
 
     beforeEach(async () => {
+      vi.restoreAllMocks();
       context = await createMockApplicationContext();
       trusteesUseCase = new TrusteesUseCase(context);
       vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue(mockCourts);
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
     });
 
     test('should return TrusteeListItem[] with appointments attached per trustee', async () => {
@@ -412,6 +406,17 @@ describe('TrusteesUseCase tests', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].trusteeId).toBe('inactive-1');
+      expect(MockMongoRepository.prototype.getTrusteeIdsByStatuses).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          'inactive',
+          'voluntarily-suspended',
+          'involuntarily-suspended',
+          'deceased',
+          'resigned',
+          'terminated',
+          'removed',
+        ]),
+      );
     });
 
     test('should return all trustees when status is all', async () => {
@@ -446,12 +451,9 @@ describe('TrusteesUseCase tests', () => {
 
   describe('listTrusteeHistory', () => {
     beforeEach(async () => {
+      vi.restoreAllMocks();
       context = await createMockApplicationContext();
       trusteesUseCase = new TrusteesUseCase(context);
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
     });
 
     test('should return trustee history', async () => {
@@ -481,12 +483,9 @@ describe('TrusteesUseCase tests', () => {
 
   describe('getTrustee', () => {
     beforeEach(async () => {
+      vi.restoreAllMocks();
       context = await createMockApplicationContext();
       trusteesUseCase = new TrusteesUseCase(context);
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
     });
 
     test('should return a single trustee', async () => {
@@ -519,12 +518,9 @@ describe('TrusteesUseCase tests', () => {
 
   describe('updateTrustee', () => {
     beforeEach(async () => {
+      vi.restoreAllMocks();
       context = await createMockApplicationContext();
       trusteesUseCase = new TrusteesUseCase(context);
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
     });
 
     const trusteeId = 'trustee-123';
@@ -734,6 +730,65 @@ describe('TrusteesUseCase tests', () => {
           after: 'New Software',
         }),
       );
+    });
+
+    test('should use raw softwareId as audit before-value when previous software is not found (404)', async () => {
+      const oldSoftwareId = 'sw-old-gone';
+      const newSoftwareId = 'sw-new';
+      const trusteeWithOldSoftware = MockData.getTrustee({ softwareId: oldSoftwareId });
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithOldSoftware);
+
+      // loadAndValidateSoftware looks up newSoftwareId first, then resolveSoftwareName looks up oldSoftwareId
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById')
+        .mockResolvedValueOnce({
+          id: newSoftwareId,
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'New Software',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        })
+        .mockRejectedValueOnce(
+          new NotFoundError('BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY', {
+            message: 'No matching item found.',
+          }),
+        );
+
+      const updatedTrustee = { ...trusteeWithOldSoftware, softwareId: newSoftwareId };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+      const historyCreateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
+        .mockResolvedValue();
+
+      await trusteesUseCase.updateTrustee(context, trusteeId, { softwareId: newSoftwareId });
+
+      expect(historyCreateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: 'AUDIT_SOFTWARE',
+          before: oldSoftwareId,
+          after: 'New Software',
+        }),
+      );
+    });
+
+    test('should propagate non-404 error from resolveSoftwareName', async () => {
+      const oldSoftwareId = 'sw-old';
+      const newSoftwareId = 'sw-new';
+      const trusteeWithOldSoftware = MockData.getTrustee({ softwareId: oldSoftwareId });
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithOldSoftware);
+
+      const operationalError = new CamsError('BANKRUPTCY-SOFTWARE-MONGO-REPOSITORY', {
+        status: 500,
+        message: 'Internal database error.',
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockRejectedValue(
+        operationalError,
+      );
+
+      const actualError = await getTheThrownError(() =>
+        trusteesUseCase.updateTrustee(context, trusteeId, { softwareId: newSoftwareId }),
+      );
+      expect(actualError.isCamsError).toBe(true);
     });
 
     test('should throw BadRequestError when softwareId does not exist', async () => {
@@ -1148,53 +1203,28 @@ describe('TrusteesUseCase tests', () => {
         expect(error.message).toContain(FIELD_VALIDATION_MESSAGES.ZOOM_LINK);
       });
 
-      test('should throw BadRequestError for zoomInfo with invalid meeting ID (too short)', async () => {
-        const invalidZoomInfo = {
-          link: 'https://us02web.zoom.us/j/1234567890',
-          phone: '123-456-7890',
-          meetingId: '12345678',
-          passcode: MockData.randomAlphaNumeric(10),
-        };
-        const updateData = { zoomInfo: invalidZoomInfo };
+      test.each([
+        ['too short', '12345678'],
+        ['too long', '123456789012'],
+        ['non-numeric', 'INVALID'],
+      ])(
+        'should throw BadRequestError for zoomInfo with invalid meeting ID (%s)',
+        async (_label, meetingId) => {
+          const invalidZoomInfo = {
+            link: 'https://us02web.zoom.us/j/1234567890',
+            phone: '123-456-7890',
+            meetingId,
+            passcode: MockData.randomAlphaNumeric(10),
+          };
+          const updateData = { zoomInfo: invalidZoomInfo };
 
-        const error = await getTheThrownError(() =>
-          trusteesUseCase.updateTrustee(context, trusteeId, updateData),
-        );
-        expect(error.isCamsError).toBe(true);
-        expect(error.message).toContain(FIELD_VALIDATION_MESSAGES.ZOOM_MEETING_ID);
-      });
-
-      test('should throw BadRequestError for zoomInfo with invalid meeting ID (too long)', async () => {
-        const invalidZoomInfo = {
-          link: 'https://us02web.zoom.us/j/1234567890',
-          phone: '123-456-7890',
-          meetingId: '123456789012',
-          passcode: MockData.randomAlphaNumeric(10),
-        };
-        const updateData = { zoomInfo: invalidZoomInfo };
-
-        const error = await getTheThrownError(() =>
-          trusteesUseCase.updateTrustee(context, trusteeId, updateData),
-        );
-        expect(error.isCamsError).toBe(true);
-        expect(error.message).toContain(FIELD_VALIDATION_MESSAGES.ZOOM_MEETING_ID);
-      });
-
-      test('should throw BadRequestError for zoomInfo with non-numeric meeting ID', async () => {
-        const invalidZoomInfo = {
-          link: 'https://us02web.zoom.us/j/1234567890',
-          phone: '123-456-7890',
-          meetingId: 'INVALID',
-          passcode: MockData.randomAlphaNumeric(10),
-        };
-        const updateData = { zoomInfo: invalidZoomInfo };
-
-        const error = await getTheThrownError(() =>
-          trusteesUseCase.updateTrustee(context, trusteeId, updateData),
-        );
-        expect(error.isCamsError).toBe(true);
-        expect(error.message).toContain(FIELD_VALIDATION_MESSAGES.ZOOM_MEETING_ID);
-      });
+          const error = await getTheThrownError(() =>
+            trusteesUseCase.updateTrustee(context, trusteeId, updateData),
+          );
+          expect(error.isCamsError).toBe(true);
+          expect(error.message).toContain(FIELD_VALIDATION_MESSAGES.ZOOM_MEETING_ID);
+        },
+      );
 
       test('should throw BadRequestError for zoomInfo with link exceeding max length', async () => {
         const invalidZoomInfo = {

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -38,7 +38,9 @@ describe('TrusteesUseCase tests', () => {
       const trusteeHistorySpy = vi
         .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
         .mockResolvedValue();
-      const atomicDecrementSpy = vi.spyOn(MockMongoRepository.prototype, 'atomicDecrement');
+      const atomicDecrementSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'atomicDecrement')
+        .mockResolvedValue(99999);
       const createProfessionalIdSpy = vi.spyOn(
         MockMongoRepository.prototype,
         'createProfessionalId',

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -4,7 +4,11 @@ import {
   TrusteeAssistantsRepository,
   TrusteeAppointmentsRepository,
   BankruptcySoftwareRepository,
+  RuntimeStateRepository,
+  TrusteeProfessionalIdsRepository,
+  ProfessionalIdCounterState,
 } from '../gateways.types';
+import { CamsUserReference } from '@common/cams/users';
 import { getCamsUserReference } from '@common/cams/session';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
 import { isCamsError } from '../../common-errors/cams-error';
@@ -48,6 +52,17 @@ import { Address, ContactInformation, PhoneNumber } from '@common/cams/contact';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 const MODULE_NAME = 'TRUSTEES-USE-CASE';
+
+const SYSTEM_USER: CamsUserReference = {
+  id: 'SYSTEM',
+  name: 'CAMS System',
+};
+
+const PROFESSIONAL_ID_COUNTER_INITIAL = 100000;
+
+function formatProfessionalCode(value: number): string {
+  return `ZZ-${String(value).padStart(5, '0')}`;
+}
 
 const addressSpec: ValidationSpec<Address> = {
   address1: [addressLine1],
@@ -94,6 +109,8 @@ export class TrusteesUseCase {
   private readonly trusteeAssistantsRepository: TrusteeAssistantsRepository;
   private readonly trusteeAppointmentsRepository: TrusteeAppointmentsRepository;
   private readonly softwareRepository: BankruptcySoftwareRepository;
+  private readonly runtimeStateRepository: RuntimeStateRepository<ProfessionalIdCounterState>;
+  private readonly trusteeProfessionalIdsRepository: TrusteeProfessionalIdsRepository;
   private readonly courtsUseCase: CourtsUseCase;
 
   constructor(context: ApplicationContext) {
@@ -101,6 +118,9 @@ export class TrusteesUseCase {
     this.trusteeAssistantsRepository = factory.getTrusteeAssistantsRepository(context);
     this.trusteeAppointmentsRepository = factory.getTrusteeAppointmentsRepository(context);
     this.softwareRepository = factory.getBankruptcySoftwareRepository(context);
+    this.runtimeStateRepository =
+      factory.getRuntimeStateRepository<ProfessionalIdCounterState>(context);
+    this.trusteeProfessionalIdsRepository = factory.getTrusteeProfessionalIdsRepository(context);
     this.courtsUseCase = new CourtsUseCase();
   }
 
@@ -178,6 +198,8 @@ export class TrusteesUseCase {
         ),
       );
 
+      await this.assignProfessionalCode(createdTrustee.trusteeId);
+
       // TODO: 12/17/25 We are only using the trusteeId on the front end after creation, so we only need to return the trusteeId, not the full trustee record.
       return createdTrustee;
     } catch (originalError) {
@@ -185,6 +207,35 @@ export class TrusteesUseCase {
         camsStackInfo: { module: MODULE_NAME, message: 'Failed to create trustee.' },
       });
     }
+  }
+
+  private async assignProfessionalCode(trusteeId: string): Promise<string> {
+    const codeNumber = await this.runtimeStateRepository.atomicDecrement(
+      'PROFESSIONAL_ID_COUNTER',
+      'lastAssigned',
+      PROFESSIONAL_ID_COUNTER_INITIAL,
+    );
+    const acmsProfessionalId = formatProfessionalCode(codeNumber);
+
+    await this.trusteeProfessionalIdsRepository.createProfessionalId(
+      trusteeId,
+      acmsProfessionalId,
+      SYSTEM_USER,
+    );
+
+    await this.trusteesRepository.createTrusteeHistory(
+      createAuditRecord(
+        {
+          documentType: 'AUDIT_PROFESSIONAL_ID_ASSIGNED',
+          trusteeId,
+          before: undefined,
+          after: acmsProfessionalId,
+        },
+        SYSTEM_USER,
+      ),
+    );
+
+    return acmsProfessionalId;
   }
 
   async listTrustees(

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -12,6 +12,7 @@ import { CamsUserReference } from '@common/cams/users';
 import { getCamsUserReference } from '@common/cams/session';
 import { getCamsErrorWithStack } from '../../common-errors/error-utilities';
 import { isCamsError } from '../../common-errors/cams-error';
+import { UnknownError } from '../../common-errors/unknown-error';
 import factory from '../../factory';
 import { ValidationSpec, validateObject, flatten, ValidatorResult } from '@common/cams/validation';
 import { BadRequestError } from '../../common-errors/bad-request';
@@ -215,6 +216,11 @@ export class TrusteesUseCase {
       'lastAssigned',
       PROFESSIONAL_ID_COUNTER_INITIAL,
     );
+    if (codeNumber < 1) {
+      throw new UnknownError(MODULE_NAME, {
+        message: `Professional ID counter exhausted (value: ${codeNumber}). Cannot assign a valid ZZ-NNNNN code.`,
+      });
+    }
     const acmsProfessionalId = formatProfessionalCode(codeNumber);
 
     await this.trusteeProfessionalIdsRepository.createProfessionalId(

--- a/common/src/cams/trustees.ts
+++ b/common/src/cams/trustees.ts
@@ -235,6 +235,10 @@ export type TrusteeAppointmentHistory = AbstractTrusteeHistory<AppointmentData, 
   appointmentId: string;
 };
 
+export type TrusteeProfessionalIdHistory = AbstractTrusteeHistory<string, string> & {
+  documentType: 'AUDIT_PROFESSIONAL_ID_ASSIGNED';
+};
+
 export type TrusteeHistory =
   | TrusteeNameHistory
   | TrusteePublicContactHistory
@@ -245,4 +249,5 @@ export type TrusteeHistory =
   | TrusteeZoomInfoHistory
   | TrusteeOversightHistory
   | TrusteeAppointmentHistory
-  | TrusteeUpcomingKeyDatesHistory;
+  | TrusteeUpcomingKeyDatesHistory
+  | TrusteeProfessionalIdHistory;


### PR DESCRIPTION
# Purpose

Trustees created via the public form now receive a sequential `acmsProfessionalId` in the format `ZZ-NNNNN`. Without this code, the existing ACMS-CAMS-TRANSITION downstream pipeline skips newly created trustees entirely.

# Major Changes

* Added `findOneAndUpdate` to `CollectionHumble` and `MongoCollectionAdapter` to support atomic read-modify-write operations
* Added `atomicDecrement` to `RuntimeStateRepository` using a seed-then-`$inc` pair (Mongo rejects `$inc` and `$setOnInsert` on the same path in a single update)
* Added `PROFESSIONAL_ID_COUNTER` document type and `ProfessionalIdCounterState` to the runtime state schema
* `TrusteesUseCase.createTrustee` now calls a private `assignProfessionalCode` helper that decrements the counter, formats the code as `ZZ-NNNNN` (zero-padded 5 digits), writes a `TrusteeProfessionalId` mapping record, and writes an `AUDIT_PROFESSIONAL_ID_ASSIGNED` history entry — all authored by `SYSTEM_USER`
* Extended the `TrusteeHistory` union in `common` with `TrusteeProfessionalIdHistory`
* Fixed test quality issues surfaced by spec review: moved `vi.restoreAllMocks()` from `afterEach` to `beforeEach` across affected test files, added missing coverage for `upsertOne`/`updateMany`/`bulkReplace`, added error-path tests for `completeMigration`/`failMigration`, consolidated redundant zoom meeting-ID tests, and added `resolveSoftwareName` fallback tests

# Testing/Validation

Implemented using TDD. Unit tests cover `createTrustee` professional ID assignment, `atomicDecrement` success and error paths, `findOneAndUpdate` adapter behavior, and all newly identified coverage gaps from spec review. All 1090 unit and BDD tests pass.

# Notes

Migration-created trustees keep their existing ACMS group codes (e.g., `NY-`, `WA-`); the migration dataflow is unchanged. Downstream `sync-trustee-appointments` and `acms-cams-transition` handlers are agnostic to the group designator and require no changes.

The seed-then-`$inc` split in `atomicDecrement` works around a MongoDB/Cosmos limitation: `$inc` and `$setOnInsert` cannot target the same path in a single `findOneAndUpdate` operation.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application