### PR TITLE
Add constrained test runner for D4s v3 emulation

### DIFF
--- a/.github/docker/Dockerfile.build-and-test
+++ b/.github/docker/Dockerfile.build-and-test
@@ -1,0 +1,32 @@
+# Build-and-test container for CAMS.
+#
+# Provides a consistent Linux environment for building, testing, and packaging
+# CAMS in CI/CD and locally. The base image tracks .nvmrc.
+#
+# This image is also the substrate for ops/scripts/utility/constrained-test.sh,
+# which runs the suite under USTP D4s v3 resource limits (4 vCPU / 16 GiB) to
+# surface environment-specific test timeouts. See that script for usage.
+#
+# Build:
+#   docker build -f .github/docker/Dockerfile.build-and-test -t cams-build:latest .
+#
+# The image ships the full repo with no dependencies installed; callers run
+# `npm ci` per workspace so the install reflects the lockfile under test.
+
+FROM node:22.22.2-bookworm-slim
+
+# git is needed by some tooling (e.g. dependency-cruiser, lockfile checks);
+# ca-certificates for registry TLS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Copy the repo (build context honors root .dockerignore, which excludes
+# node_modules, .git, and test artifacts).
+COPY . .
+
+# No build/install at image-build time: callers decide which workspaces to
+# install and build so the run reflects the exact lockfile state under test.
+CMD ["bash"]

--- a/.github/workflows/constrained-test-report.yml
+++ b/.github/workflows/constrained-test-report.yml
@@ -1,0 +1,133 @@
+# Constrained Test Report
+#
+# WHAT: A periodic, INFORMATIONAL report that runs the CAMS backend unit suite
+#       under USTP "Standard D4s v3" (4 vCPU / 16 GiB) resource emulation and
+#       publishes the slowest tests / margin-to-timeout report.
+#
+# WHY:  The USTP deployment runs CI on self-hosted D4s v3 runners. Tests that
+#       pass comfortably on a developer laptop or on GitHub-hosted runners can
+#       time out there because Vitest sizes its worker pool from the visible
+#       core count and the default per-test timeout is tight under contention.
+#       ops/scripts/utility/constrained-test.sh reproduces that environment via
+#       cpuset/memory limits so we can SEE which tests are marginal BEFORE they
+#       flake on the real runner.
+#
+# IMPORTANT: This is a SIGNAL, not a gate. A slow or failing test under
+#       constraint is exactly what we want this report to surface — it MUST NOT
+#       turn the workflow red. The job captures the script's exit code and keeps
+#       going (green) on test slowness/failures, while still surfacing genuine
+#       infrastructure errors (the script failing before it can produce a
+#       report) in the job summary. This workflow is deliberately NOT part of
+#       pr-validation.yml and is NOT a PR gate.
+#
+# RUNNER: GitHub-hosted ubuntu-latest. Docker is preinstalled; podman is not, so
+#       the script auto-detects and falls back to docker, which emulates D4s v3
+#       via cpuset/memory exactly as podman does locally. We do NOT install
+#       podman.
+
+name: Constrained Test Report
+
+on:
+  # Weekly, Mondays at 06:00 UTC. Informational cadence — fast enough to catch
+  # drift, slow enough not to burn minutes on a ~9-minute constrained run.
+  schedule:
+    - cron: "0 6 * * 1"
+  # Manual trigger so anyone investigating timeouts can run it on demand.
+  workflow_dispatch:
+
+# Least privilege: this job only reads the repo and writes a job summary /
+# artifacts (both implicit, no token scope needed). Nothing requires write.
+permissions:
+  contents: read
+
+jobs:
+  constrained-test-report:
+    name: Backend Constrained Test Report
+    runs-on: ubuntu-latest
+    # Generous enough for image build + host npm ci + a faithful ~9-minute
+    # constrained backend run, but bounded so a hung run doesn't burn minutes.
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      # Host-side install. The container does its OWN `npm ci` for the test run;
+      # this root install exists solely so the HOST-side reporter resolves —
+      # constrained-test.sh runs `npx tsx dev-tools/constrained-test/report.cli.ts`
+      # on the runner, and tsx is hoisted to the repo-root node_modules by this
+      # npm ci.
+      - name: Install host dependencies (for the tsx reporter)
+        run: npm ci
+
+      # Run the constrained suite for the backend workspace. The script builds
+      # the Docker image (no cached image on a fresh runner, so we WANT the
+      # build — do not pass --no-build), runs the suite under cpuset 0-3 / 16g,
+      # and writes temp/constrained-test/backend-{results,report}.{json,md}.
+      #
+      # The script ends with `exit "${TEST_EXIT}"` — non-zero when the suite has
+      # failures/timeouts under constraint. That is the SIGNAL we want, NOT a
+      # workflow failure, so we capture the exit code and never let it fail the
+      # job. `set +e` keeps the step green regardless; we record the code for the
+      # summary step to interpret.
+      - name: Run constrained backend test report
+        id: constrained
+        shell: bash
+        run: |
+          set +e
+          ops/scripts/utility/constrained-test.sh -w backend
+          script_exit=$?
+          set -e
+          echo "script_exit=${script_exit}" >> "$GITHUB_OUTPUT"
+          echo "Constrained test script exited with code ${script_exit} (informational)."
+
+      # Render the markdown report into the GitHub Actions job summary. If the
+      # report is missing, the script errored before producing one (genuine
+      # infrastructure failure) — say so in the summary rather than silently
+      # showing nothing. Runs even if a prior step failed so we always get a
+      # summary.
+      - name: Publish report to job summary
+        if: always()
+        shell: bash
+        run: |
+          report_md="temp/constrained-test/backend-report.md"
+          {
+            echo "# Backend Constrained Test Report (D4s v3 emulation)"
+            echo
+            echo "_Informational — a slow or failing test under constraint is the signal, not a workflow failure._"
+            echo
+            echo "Constrained test script exit code: \`${{ steps.constrained.outputs.script_exit }}\`"
+            echo
+            if [ -f "${report_md}" ]; then
+              cat "${report_md}"
+            else
+              echo "## No report produced"
+              echo
+              echo "The constrained test script did not produce \`${report_md}\`."
+              echo "This usually means the script errored BEFORE the suite ran (e.g. the"
+              echo "Docker image failed to build, or the engine could not start the"
+              echo "container under the requested limits) rather than a test failure."
+              echo "See the **Run constrained backend test report** step logs above."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload the machine-readable + markdown reports as artifacts. `always()`
+      # so we still capture whatever the script produced even if an earlier step
+      # failed. temp/ is gitignored; these files are bind-mounted out of the
+      # container onto the runner host.
+      - name: Upload constrained test report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: backend-constrained-test-report
+          path: |
+            temp/constrained-test/backend-report.json
+            temp/constrained-test/backend-report.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/dev-tools/constrained-test/report.cli.ts
+++ b/dev-tools/constrained-test/report.cli.ts
@@ -3,7 +3,7 @@
 // write outputs, print the table) and is intentionally NOT unit-tested.
 //
 // Usage (run on the HOST via tsx, after the container wrote the Vitest JSON):
-//   tsx report.cli.ts <vitest-json-path> <workspace> <top> <timeoutMs>
+//   tsx report.cli.ts <vitest-json-path> <workspace> <top> <timeoutMs> [--profiled]
 // e.g.
 //   tsx report.cli.ts temp/constrained-test/common-results.json common 25 5000
 
@@ -11,10 +11,17 @@ import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { buildReport, renderMarkdown, renderConsoleTable, type VitestJson } from './report.js';
 
-const [jsonPath, workspace, topArg, timeoutArg] = process.argv.slice(2);
+// `--profiled` is an order-independent flag: pull it out first, then read the 4
+// positionals from what remains so the existing positional contract the bash
+// script relies on is unchanged when the flag is absent.
+const rawArgs = process.argv.slice(2);
+const profiled = rawArgs.includes('--profiled');
+const [jsonPath, workspace, topArg, timeoutArg] = rawArgs.filter((arg) => arg !== '--profiled');
 
 if (!jsonPath || !workspace) {
-  console.error('usage: report.cli.ts <vitest-json-path> <workspace> [top] [timeoutMs]');
+  console.error(
+    'usage: report.cli.ts <vitest-json-path> <workspace> [top] [timeoutMs] [--profiled]',
+  );
   process.exit(2);
 }
 
@@ -24,7 +31,7 @@ const top = Number.parseInt(topArg ?? '25', 10);
 const timeoutMs = Number.parseInt(timeoutArg ?? '5000', 10);
 
 const vitestJson = JSON.parse(readFileSync(jsonPath, 'utf8')) as VitestJson;
-const report = buildReport(vitestJson, { workspace, top, timeoutMs });
+const report = buildReport(vitestJson, { workspace, top, timeoutMs, profiled });
 
 // Persist both formats next to the input JSON (temp/constrained-test/). The
 // names deliberately differ from the input "${workspace}-results.json" so they

--- a/dev-tools/constrained-test/report.cli.ts
+++ b/dev-tools/constrained-test/report.cli.ts
@@ -1,0 +1,44 @@
+// THIN CLI wrapper for the constrained-test reporter. All logic lives in the
+// pure report.ts; this file is just I/O + wiring (read JSON, call report.ts,
+// write outputs, print the table) and is intentionally NOT unit-tested.
+//
+// Usage (run on the HOST via tsx, after the container wrote the Vitest JSON):
+//   tsx report.cli.ts <vitest-json-path> <workspace> <top> <timeoutMs>
+// e.g.
+//   tsx report.cli.ts temp/constrained-test/common-results.json common 25 5000
+
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { buildReport, renderMarkdown, renderConsoleTable, type VitestJson } from './report.js';
+
+const [jsonPath, workspace, topArg, timeoutArg] = process.argv.slice(2);
+
+if (!jsonPath || !workspace) {
+  console.error('usage: report.cli.ts <vitest-json-path> <workspace> [top] [timeoutMs]');
+  process.exit(2);
+}
+
+const top = Number.parseInt(topArg ?? '25', 10);
+// Effective per-test timeout default stays 5000ms; the pure function never
+// hardcodes it, so the policy value lives here at the edge.
+const timeoutMs = Number.parseInt(timeoutArg ?? '5000', 10);
+
+const vitestJson = JSON.parse(readFileSync(jsonPath, 'utf8')) as VitestJson;
+const report = buildReport(vitestJson, { workspace, top, timeoutMs });
+
+// Persist both formats next to the input JSON (temp/constrained-test/). The
+// names deliberately differ from the input "${workspace}-results.json" so they
+// never collide.
+const outDir = dirname(jsonPath);
+mkdirSync(outDir, { recursive: true });
+
+const jsonReportPath = join(outDir, `${workspace}-report.json`);
+const markdownReportPath = join(outDir, `${workspace}-report.md`);
+
+writeFileSync(jsonReportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+writeFileSync(markdownReportPath, renderMarkdown(report), 'utf8');
+
+// Preserve the original console experience: the slowest-N table to stdout.
+console.log(renderConsoleTable(report));
+console.log(`\n  JSON report:     ${jsonReportPath}`);
+console.log(`  Markdown report: ${markdownReportPath}`);

--- a/dev-tools/constrained-test/report.test.ts
+++ b/dev-tools/constrained-test/report.test.ts
@@ -269,23 +269,6 @@ describe('renderConsoleTable', () => {
     expect(output).toContain('3 tests,');
     expect(output).toContain('0.0s of test time total');
   });
-
-  test('shows an em-dash for a null/undefined-duration row without throwing', () => {
-    // duration omitted => durationMs degrades to 0, but render the null path
-    // explicitly by feeding a slowest row whose ms is null via a crafted report.
-    const report = buildReport(
-      { testResults: [{ name: '/workspace/n.test.ts', assertionResults: [{ title: 'no dur' }] }] },
-      { workspace: 'common', top: 5, timeoutMs: 5000 },
-    );
-    // Force the null-duration display path at the rendering boundary.
-    report.slowest = [{ ms: null as unknown as number, file: 'n.test.ts', title: 'no dur' }];
-
-    let output = '';
-    expect(() => {
-      output = renderConsoleTable(report);
-    }).not.toThrow();
-    expect(output.split('\n')[0]).toContain('— ms');
-  });
 });
 
 describe('profiled-run annotation', () => {

--- a/dev-tools/constrained-test/report.test.ts
+++ b/dev-tools/constrained-test/report.test.ts
@@ -179,6 +179,7 @@ describe('buildReport', () => {
 
     expect(report.workspace).toBe('common');
     expect(report.timeoutMs).toBe(5000);
+    expect(report.profiled).toBe(false); // default off when the option is omitted
     expect(report.totalTests).toBe(3);
     expect(report.totalTestMs).toBe(20); // 5 + 12 + 3, summed across all tests
     expect(report.slowest).toHaveLength(2); // top N applied
@@ -198,6 +199,17 @@ describe('buildReport', () => {
     expect(report.slowest).toHaveLength(1);
     expect(report.slowest[0].ms).toBe(12); // the only sliced row
     expect(report.totalTestMs).toBe(20); // full sum, NOT the top-1 sum of 12
+  });
+
+  test('threads the profiled flag through to the report when set', () => {
+    const report = buildReport(fixture(), {
+      workspace: 'common',
+      top: 2,
+      timeoutMs: 5000,
+      profiled: true,
+    });
+
+    expect(report.profiled).toBe(true);
   });
 });
 
@@ -273,5 +285,43 @@ describe('renderConsoleTable', () => {
       output = renderConsoleTable(report);
     }).not.toThrow();
     expect(output.split('\n')[0]).toContain('— ms');
+  });
+});
+
+describe('profiled-run annotation', () => {
+  // The annotation is the single source of truth both renderers emit; assert the
+  // distinguishing phrase rather than the exact glyph so a copy tweak in one place
+  // doesn't silently desync the renderers.
+  const ANNOTATION = 'PROFILED RUN';
+
+  test('renderMarkdown emits the annotation when the run is profiled', () => {
+    const report = buildReport(fixture(), {
+      workspace: 'common',
+      top: 5,
+      timeoutMs: 5000,
+      profiled: true,
+    });
+
+    expect(renderMarkdown(report)).toContain(ANNOTATION);
+  });
+
+  test('renderConsoleTable emits the annotation when the run is profiled', () => {
+    const report = buildReport(fixture(), {
+      workspace: 'common',
+      top: 5,
+      timeoutMs: 5000,
+      profiled: true,
+    });
+
+    expect(renderConsoleTable(report)).toContain(ANNOTATION);
+  });
+
+  test('neither renderer leaks the annotation into a normal (non-profiled) run', () => {
+    // Default profiled:false — the output must be exactly as it was before this
+    // feature, so guard both renderers against any annotation leakage.
+    const report = buildReport(fixture(), { workspace: 'common', top: 5, timeoutMs: 5000 });
+
+    expect(renderMarkdown(report)).not.toContain(ANNOTATION);
+    expect(renderConsoleTable(report)).not.toContain(ANNOTATION);
   });
 });

--- a/dev-tools/constrained-test/report.test.ts
+++ b/dev-tools/constrained-test/report.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect } from 'vitest';
+import {
+  slowestTests,
+  topN,
+  perFileTotals,
+  overheadGaps,
+  marginsToTimeout,
+  buildReport,
+  renderMarkdown,
+  renderConsoleTable,
+  type VitestJson,
+} from './report.js';
+
+// A minimal but realistic slice of the Vitest JSON shape. Real samples have many
+// more fields (see temp/constrained-test/common-results.json); we only model the
+// fields the pure report functions actually read.
+function fixture(): VitestJson {
+  return {
+    testResults: [
+      {
+        name: '/workspace/common/src/a.test.ts',
+        startTime: 1000,
+        endTime: 1020,
+        assertionResults: [
+          { duration: 5, fullName: 'a suite first', title: 'first' },
+          { duration: 12, fullName: 'a suite second', title: 'second' },
+        ],
+      },
+      {
+        name: '/workspace/common/src/b.test.ts',
+        startTime: 2000,
+        endTime: 2008,
+        assertionResults: [{ duration: 3, fullName: 'b suite only', title: 'only' }],
+      },
+    ],
+  };
+}
+
+describe('slowestTests', () => {
+  test('produces a flat list sorted descending by ms with stripped file paths', () => {
+    const result = slowestTests(fixture());
+
+    expect(result).toEqual([
+      { ms: 12, file: 'common/src/a.test.ts', title: 'a suite second' },
+      { ms: 5, file: 'common/src/a.test.ts', title: 'a suite first' },
+      { ms: 3, file: 'common/src/b.test.ts', title: 'b suite only' },
+    ]);
+  });
+
+  test('degrades a missing or null duration to zero and keeps ties', () => {
+    const report: VitestJson = {
+      testResults: [
+        {
+          name: '/workspace/c.test.ts',
+          assertionResults: [
+            { duration: null, fullName: 'no duration', title: 'a' },
+            { fullName: 'undefined duration', title: 'b' },
+            { duration: 7, fullName: 'tie one', title: 'c' },
+            { duration: 7, fullName: 'tie two', title: 'd' },
+          ],
+        },
+      ],
+    };
+
+    const result = slowestTests(report);
+
+    expect(result.map((r) => r.ms)).toEqual([7, 7, 0, 0]);
+    // both zero-duration tests survive (no dropping), both ties present
+    expect(result.filter((r) => r.ms === 0)).toHaveLength(2);
+    expect(result.filter((r) => r.ms === 7)).toHaveLength(2);
+  });
+
+  test('returns an empty list for empty input', () => {
+    expect(slowestTests({})).toEqual([]);
+    expect(slowestTests({ testResults: [] })).toEqual([]);
+  });
+});
+
+describe('topN', () => {
+  test('slices the first n entries of an already-sorted list', () => {
+    const rows = slowestTests(fixture());
+
+    expect(topN(rows, 2)).toEqual([
+      { ms: 12, file: 'common/src/a.test.ts', title: 'a suite second' },
+      { ms: 5, file: 'common/src/a.test.ts', title: 'a suite first' },
+    ]);
+  });
+
+  test('returns all entries when n exceeds the list length', () => {
+    const rows = slowestTests(fixture());
+    expect(topN(rows, 99)).toHaveLength(3);
+  });
+});
+
+describe('perFileTotals', () => {
+  test('sums each file’s test durations independently, slowest file first', () => {
+    const result = perFileTotals(fixture());
+
+    expect(result).toEqual([
+      { file: 'common/src/a.test.ts', totalMs: 17, testCount: 2 },
+      { file: 'common/src/b.test.ts', totalMs: 3, testCount: 1 },
+    ]);
+  });
+
+  test('returns an empty list for empty input', () => {
+    expect(perFileTotals({})).toEqual([]);
+  });
+});
+
+describe('overheadGaps', () => {
+  test('computes wall time minus summed test durations per file, largest gap first', () => {
+    // a: wall 20, tests 17 => gap 3.  b: wall 8, tests 3 => gap 5.
+    const result = overheadGaps(fixture());
+
+    expect(result).toEqual([
+      { file: 'common/src/b.test.ts', wallMs: 8, testMs: 3, gapMs: 5 },
+      { file: 'common/src/a.test.ts', wallMs: 20, testMs: 17, gapMs: 3 },
+    ]);
+  });
+
+  test('degrades to null wall time and null gap when a timing field is absent', () => {
+    const report: VitestJson = {
+      testResults: [
+        {
+          name: '/workspace/no-timing.test.ts',
+          // startTime/endTime intentionally omitted
+          assertionResults: [{ duration: 4, fullName: 'x', title: 'x' }],
+        },
+      ],
+    };
+
+    expect(overheadGaps(report)).toEqual([
+      { file: 'no-timing.test.ts', wallMs: null, testMs: 4, gapMs: null },
+    ]);
+  });
+});
+
+describe('marginsToTimeout', () => {
+  const report: VitestJson = {
+    testResults: [
+      {
+        name: '/workspace/m.test.ts',
+        assertionResults: [
+          { duration: 100, fullName: 'fast', title: 'fast' },
+          { duration: 4900, fullName: 'near limit', title: 'near limit' },
+          { duration: 5200, fullName: 'over limit', title: 'over limit' },
+          { duration: 4500, fullName: 'mid', title: 'mid' },
+        ],
+      },
+    ],
+  };
+
+  test('uses the supplied timeout (not a hardcoded value) for margin = timeout - duration', () => {
+    const result = marginsToTimeout(report, 5000);
+    const near = result.find((r) => r.title === 'near limit');
+    expect(near?.marginMs).toBe(100);
+
+    // A different timeout yields a different margin — proving it is a parameter.
+    const tighter = marginsToTimeout(report, 4600);
+    const nearTighter = tighter.find((r) => r.title === 'near limit');
+    expect(nearTighter?.marginMs).toBe(-300);
+  });
+
+  test('orders most-at-risk first: over-timeout (negative) then smallest positive margin', () => {
+    const result = marginsToTimeout(report, 5000);
+
+    expect(result.map((r) => ({ title: r.title, marginMs: r.marginMs }))).toEqual([
+      { title: 'over limit', marginMs: -200 }, // already over the timeout
+      { title: 'near limit', marginMs: 100 }, // smallest positive margin
+      { title: 'mid', marginMs: 500 },
+      { title: 'fast', marginMs: 4900 }, // most headroom, lowest priority
+    ]);
+  });
+});
+
+describe('buildReport', () => {
+  test('assembles all four computations plus metadata', () => {
+    const report = buildReport(fixture(), { workspace: 'common', top: 2, timeoutMs: 5000 });
+
+    expect(report.workspace).toBe('common');
+    expect(report.timeoutMs).toBe(5000);
+    expect(report.totalTests).toBe(3);
+    expect(report.totalTestMs).toBe(20); // 5 + 12 + 3, summed across all tests
+    expect(report.slowest).toHaveLength(2); // top N applied
+    expect(report.perFile).toHaveLength(2);
+    expect(report.overhead).toHaveLength(2);
+    expect(report.margins).toHaveLength(3); // every test, not sliced
+    // margins ordered most-at-risk first
+    expect(report.margins[0].marginMs).toBeLessThanOrEqual(report.margins[1].marginMs);
+  });
+
+  test('sums totalTestMs across ALL tests, not just the sliced top N', () => {
+    // top: 1 keeps only the slowest test (12ms) in `slowest`, but totalTestMs
+    // must still reflect every test (5 + 12 + 3 = 20). A refactor that summed
+    // the sliced list instead would yield 12 and fail here.
+    const report = buildReport(fixture(), { workspace: 'common', top: 1, timeoutMs: 5000 });
+
+    expect(report.slowest).toHaveLength(1);
+    expect(report.slowest[0].ms).toBe(12); // the only sliced row
+    expect(report.totalTestMs).toBe(20); // full sum, NOT the top-1 sum of 12
+  });
+});
+
+describe('renderMarkdown', () => {
+  test('renders headed tables for each section and shows null gaps as a dash', () => {
+    const report = buildReport(fixture(), { workspace: 'common', top: 5, timeoutMs: 5000 });
+    const md = renderMarkdown(report);
+
+    expect(md).toContain('# Constrained test report: common');
+    expect(md).toContain('## Slowest tests');
+    expect(md).toContain('## Per-file total time');
+    expect(md).toContain('## Overhead gap');
+    expect(md).toContain('## Margin to timeout (5000ms)');
+    expect(md).toContain('a suite second');
+    // file/title content makes it into the table
+    expect(md).toContain('common/src/a.test.ts');
+    // ends with a trailing newline
+    expect(md.endsWith('\n')).toBe(true);
+  });
+
+  test('shows a dash for a null overhead gap rather than crashing', () => {
+    const report = buildReport(
+      { testResults: [{ name: '/workspace/x.test.ts', assertionResults: [{ duration: 1 }] }] },
+      { workspace: 'common', top: 5, timeoutMs: 5000 },
+    );
+    expect(renderMarkdown(report)).toContain('| — |');
+  });
+
+  test('summary line reflects totalTestMs: N tests and total test time in seconds', () => {
+    // fixture totals 20ms across 3 tests => "3 tests, 0.0s of test time total".
+    const report = buildReport(fixture(), { workspace: 'common', top: 5, timeoutMs: 5000 });
+    const md = renderMarkdown(report);
+
+    expect(md).toContain('3 tests,');
+    expect(md).toContain('0.0s of test time total');
+  });
+});
+
+describe('renderConsoleTable', () => {
+  test('renders each row as right-aligned ms, then file › title', () => {
+    const report = buildReport(fixture(), { workspace: 'common', top: 5, timeoutMs: 5000 });
+    const output = renderConsoleTable(report);
+    const firstRow = output.split('\n')[0];
+
+    // The slowest test (12ms) leads; ms is right-aligned, file and title joined by ' › '.
+    expect(firstRow).toContain('12 ms');
+    expect(firstRow).toContain('common/src/a.test.ts');
+    expect(firstRow).toContain('  ›  ');
+    expect(firstRow).toContain('a suite second');
+  });
+
+  test('appends a summary line with the test count and total test time', () => {
+    // fixture totals 20ms across 3 tests => "3 tests, 0.0s of test time total".
+    const report = buildReport(fixture(), { workspace: 'common', top: 5, timeoutMs: 5000 });
+    const output = renderConsoleTable(report);
+
+    expect(output).toContain('3 tests,');
+    expect(output).toContain('0.0s of test time total');
+  });
+
+  test('shows an em-dash for a null/undefined-duration row without throwing', () => {
+    // duration omitted => durationMs degrades to 0, but render the null path
+    // explicitly by feeding a slowest row whose ms is null via a crafted report.
+    const report = buildReport(
+      { testResults: [{ name: '/workspace/n.test.ts', assertionResults: [{ title: 'no dur' }] }] },
+      { workspace: 'common', top: 5, timeoutMs: 5000 },
+    );
+    // Force the null-duration display path at the rendering boundary.
+    report.slowest = [{ ms: null as unknown as number, file: 'n.test.ts', title: 'no dur' }];
+
+    let output = '';
+    expect(() => {
+      output = renderConsoleTable(report);
+    }).not.toThrow();
+    expect(output.split('\n')[0]).toContain('— ms');
+  });
+});

--- a/dev-tools/constrained-test/report.ts
+++ b/dev-tools/constrained-test/report.ts
@@ -171,12 +171,19 @@ export interface ReportOptions {
   workspace: string;
   top: number;
   timeoutMs: number;
+  // True only when the suite ran under CPU profiling (`--profile`). Profiling
+  // overhead inflates every duration, so the renderers annotate the report as
+  // non-comparable. Optional + defaults false so a normal run is unaffected.
+  profiled?: boolean;
 }
 
 /** The full structured report — the machine-readable JSON the CLI persists. */
 export interface ConstrainedTestReport {
   workspace: string;
   timeoutMs: number;
+  // Mirrors ReportOptions.profiled; carried into the persisted JSON so a reader
+  // (or a later render) knows the timings include profiling overhead.
+  profiled: boolean;
   totalTests: number;
   totalTestMs: number;
   slowest: SlowTest[];
@@ -184,6 +191,11 @@ export interface ConstrainedTestReport {
   overhead: OverheadGap[];
   margins: TimeoutMargin[];
 }
+
+// The profiled-run warning, emitted by BOTH renderers (single source so they
+// never desync). Surfaced only when the report is profiled.
+const PROFILED_ANNOTATION =
+  '⚠ PROFILED RUN — timings include CPU-profiling overhead and are NOT comparable to a normal run.';
 
 /**
  * Assemble every computation into one structured result. `slowest` is sliced to
@@ -195,6 +207,7 @@ export function buildReport(report: VitestJson, options: ReportOptions): Constra
   return {
     workspace: options.workspace,
     timeoutMs: options.timeoutMs,
+    profiled: options.profiled ?? false,
     totalTests: allSlowest.length,
     totalTestMs: allSlowest.reduce((sum, row) => sum + row.ms, 0),
     slowest: topN(allSlowest, options.top),
@@ -226,6 +239,8 @@ export function renderMarkdown(report: ConstrainedTestReport): string {
   const sections = [
     `# Constrained test report: ${report.workspace}`,
     '',
+    // Profiled runs lead with the non-comparable warning; a normal run omits it.
+    ...(report.profiled ? [PROFILED_ANNOTATION, ''] : []),
     `${report.totalTests} tests, ${(report.totalTestMs / 1000).toFixed(1)}s of test time total. ` +
       'Rankings are RELATIVE (compare tests within this run), not absolute wall-clock.',
     '',
@@ -274,8 +289,13 @@ export function renderMarkdown(report: ConstrainedTestReport): string {
  */
 export function renderConsoleTable(report: ConstrainedTestReport): string {
   const pad = (value: string, width: number) => value.padStart(width);
-  const lines = report.slowest.map(
-    (row) => `${pad(ms(row.ms), 7)} ms  ${row.file}  ›  ${row.title}`,
+  const lines: string[] = [];
+  // Profiled runs lead with the non-comparable warning; a normal run omits it.
+  if (report.profiled) {
+    lines.push(PROFILED_ANNOTATION, '');
+  }
+  lines.push(
+    ...report.slowest.map((row) => `${pad(ms(row.ms), 7)} ms  ${row.file}  ›  ${row.title}`),
   );
   lines.push('');
   lines.push(

--- a/dev-tools/constrained-test/report.ts
+++ b/dev-tools/constrained-test/report.ts
@@ -1,0 +1,285 @@
+// PURE computation for the constrained-test reporter. NO I/O lives here: no fs,
+// no process.argv, no console. The CLI wrapper (report.cli.ts) reads the Vitest
+// JSON, calls these functions, and writes the outputs. Keeping this module pure
+// is what makes report.test.ts fast and mock-free.
+
+/** One test assertion as Vitest emits it (only the fields we read are modeled). */
+export interface VitestAssertion {
+  duration?: number | null;
+  fullName?: string;
+  title?: string;
+}
+
+/** One file's worth of results. Wall time = endTime - startTime. */
+export interface VitestFileResult {
+  name?: string;
+  startTime?: number;
+  endTime?: number;
+  assertionResults?: VitestAssertion[];
+}
+
+/** Top-level Vitest JSON reporter shape (subset). */
+export interface VitestJson {
+  testResults?: VitestFileResult[];
+}
+
+/** A single test's duration, sortable across all files. */
+export interface SlowTest {
+  ms: number;
+  file: string;
+  title: string;
+}
+
+// Strip the container's bind-mount prefix so reported paths are repo-relative.
+function stripWorkspace(name: string): string {
+  return name.replace(/^\/workspace\//, '');
+}
+
+// A missing or null duration degrades to 0 rather than throwing — Vitest can
+// omit it (e.g. for a test that never actually ran), and a missing number must
+// not poison the sort.
+function durationMs(assertion: VitestAssertion): number {
+  return assertion.duration ?? 0;
+}
+
+// fullName is the human-readable "<ancestors> <title>"; fall back to title.
+function testTitle(assertion: VitestAssertion): string {
+  return assertion.fullName ?? assertion.title ?? '';
+}
+
+/**
+ * Every test as a flat list with its duration, repo-relative file, and title,
+ * sorted slowest-first. These are RELATIVE rankings (compare tests to each
+ * other within a run), not absolute wall-clock.
+ */
+export function slowestTests(report: VitestJson): SlowTest[] {
+  const rows: SlowTest[] = [];
+  for (const fileResult of report.testResults ?? []) {
+    const file = stripWorkspace(fileResult.name ?? '');
+    for (const assertion of fileResult.assertionResults ?? []) {
+      rows.push({ ms: durationMs(assertion), file, title: testTitle(assertion) });
+    }
+  }
+  rows.sort((a, b) => b.ms - a.ms);
+  return rows;
+}
+
+/** First `n` entries of an already-ordered list (a "top N" slice). */
+export function topN<T>(rows: T[], n: number): T[] {
+  return rows.slice(0, n);
+}
+
+// Sum a file's reported test durations (each missing duration counts as 0).
+function sumDurations(fileResult: VitestFileResult): number {
+  return (fileResult.assertionResults ?? []).reduce((sum, a) => sum + durationMs(a), 0);
+}
+
+/** One file's total test time. */
+export interface FileTotal {
+  file: string;
+  totalMs: number;
+  testCount: number;
+}
+
+/**
+ * Per-file sum of test durations, slowest file first. This is in-test time only
+ * (no setup/transform overhead — that lives in the overhead gap below).
+ */
+export function perFileTotals(report: VitestJson): FileTotal[] {
+  const totals: FileTotal[] = [];
+  for (const fileResult of report.testResults ?? []) {
+    totals.push({
+      file: stripWorkspace(fileResult.name ?? ''),
+      totalMs: sumDurations(fileResult),
+      testCount: (fileResult.assertionResults ?? []).length,
+    });
+  }
+  totals.sort((a, b) => b.totalMs - a.totalMs);
+  return totals;
+}
+
+// Wall time is endTime - startTime. Either field can be absent (e.g. a file the
+// reporter never timed); when so we report null rather than a bogus number.
+function wallMs(fileResult: VitestFileResult): number | null {
+  const { startTime, endTime } = fileResult;
+  if (typeof startTime !== 'number' || typeof endTime !== 'number') {
+    return null;
+  }
+  return endTime - startTime;
+}
+
+/** One file's setup/teardown overhead: wall time beyond its in-test time. */
+export interface OverheadGap {
+  file: string;
+  wallMs: number | null;
+  testMs: number;
+  gapMs: number | null;
+}
+
+/**
+ * Per-file overhead gap = (file wall time) - (sum of that file's test
+ * durations). The remainder is setup/transform/teardown the suite paid outside
+ * the assertions. Files missing timing degrade to null (gap unknown) and sort
+ * last. Largest gap first.
+ */
+export function overheadGaps(report: VitestJson): OverheadGap[] {
+  const gaps: OverheadGap[] = [];
+  for (const fileResult of report.testResults ?? []) {
+    const wall = wallMs(fileResult);
+    const testMs = sumDurations(fileResult);
+    gaps.push({
+      file: stripWorkspace(fileResult.name ?? ''),
+      wallMs: wall,
+      testMs,
+      gapMs: wall === null ? null : wall - testMs,
+    });
+  }
+  // Null gaps (unknown) sort last; otherwise largest gap first.
+  gaps.sort((a, b) => (b.gapMs ?? -Infinity) - (a.gapMs ?? -Infinity));
+  return gaps;
+}
+
+/** One test's headroom against the effective per-test timeout. */
+export interface TimeoutMargin {
+  marginMs: number;
+  ms: number;
+  file: string;
+  title: string;
+}
+
+/**
+ * Per-test margin to the timeout = (effective per-test timeout) - (duration).
+ * Ordered most-at-risk first: tests already over the timeout (margin <= 0) lead,
+ * then the smallest positive margins (closest to timing out). The timeout is a
+ * REQUIRED parameter — the CLI supplies it (default 5000ms) so report.ts never
+ * hardcodes a policy value.
+ */
+export function marginsToTimeout(report: VitestJson, timeoutMs: number): TimeoutMargin[] {
+  const margins: TimeoutMargin[] = slowestTests(report).map((row) => ({
+    marginMs: timeoutMs - row.ms,
+    ms: row.ms,
+    file: row.file,
+    title: row.title,
+  }));
+  // Ascending margin: negatives (over budget) first, then smallest positive.
+  margins.sort((a, b) => a.marginMs - b.marginMs);
+  return margins;
+}
+
+/** Knobs the CLI passes in; nothing here is hardcoded as policy. */
+export interface ReportOptions {
+  workspace: string;
+  top: number;
+  timeoutMs: number;
+}
+
+/** The full structured report — the machine-readable JSON the CLI persists. */
+export interface ConstrainedTestReport {
+  workspace: string;
+  timeoutMs: number;
+  totalTests: number;
+  totalTestMs: number;
+  slowest: SlowTest[];
+  perFile: FileTotal[];
+  overhead: OverheadGap[];
+  margins: TimeoutMargin[];
+}
+
+/**
+ * Assemble every computation into one structured result. `slowest` is sliced to
+ * the top N for the console/Markdown view; `margins` keeps every test so the
+ * at-risk ranking is complete.
+ */
+export function buildReport(report: VitestJson, options: ReportOptions): ConstrainedTestReport {
+  const allSlowest = slowestTests(report);
+  return {
+    workspace: options.workspace,
+    timeoutMs: options.timeoutMs,
+    totalTests: allSlowest.length,
+    totalTestMs: allSlowest.reduce((sum, row) => sum + row.ms, 0),
+    slowest: topN(allSlowest, options.top),
+    perFile: perFileTotals(report),
+    overhead: overheadGaps(report),
+    margins: marginsToTimeout(report, options.timeoutMs),
+  };
+}
+
+// --- rendering (still pure: strings in, strings out, no I/O) ------------------
+
+// Round to a whole millisecond for display; null/undefined renders as an em dash.
+function ms(value: number | null | undefined): string {
+  return value === null || value === undefined ? '—' : value.toFixed(0);
+}
+
+function markdownTable(headers: string[], rows: string[][]): string {
+  const headerLine = `| ${headers.join(' | ')} |`;
+  const dividerLine = `| ${headers.map(() => '---').join(' | ')} |`;
+  const bodyLines = rows.map((cells) => `| ${cells.join(' | ')} |`);
+  return [headerLine, dividerLine, ...bodyLines].join('\n');
+}
+
+/**
+ * Human-readable Markdown report: one table per computation. Pure — the CLI
+ * writes the returned string to disk. Null overhead gaps render as a dash.
+ */
+export function renderMarkdown(report: ConstrainedTestReport): string {
+  const sections = [
+    `# Constrained test report: ${report.workspace}`,
+    '',
+    `${report.totalTests} tests, ${(report.totalTestMs / 1000).toFixed(1)}s of test time total. ` +
+      'Rankings are RELATIVE (compare tests within this run), not absolute wall-clock.',
+    '',
+    '## Slowest tests',
+    '',
+    markdownTable(
+      ['ms', 'file', 'test'],
+      report.slowest.map((row) => [ms(row.ms), row.file, row.title]),
+    ),
+    '',
+    '## Per-file total time',
+    '',
+    markdownTable(
+      ['total ms', 'tests', 'file'],
+      report.perFile.map((row) => [ms(row.totalMs), String(row.testCount), row.file]),
+    ),
+    '',
+    '## Overhead gap',
+    '',
+    'Wall time beyond in-test time (setup/transform/teardown). Largest first; ' +
+      'a dash means the file had no timing data; ' +
+      'small negative or `-0` gaps are timer-resolution noise on very fast files and can be ignored.',
+    '',
+    markdownTable(
+      ['gap ms', 'wall ms', 'test ms', 'file'],
+      report.overhead.map((row) => [ms(row.gapMs), ms(row.wallMs), ms(row.testMs), row.file]),
+    ),
+    '',
+    `## Margin to timeout (${report.timeoutMs}ms)`,
+    '',
+    'Per-test headroom against the effective timeout. Most-at-risk first ' +
+      '(negative = already over the timeout).',
+    '',
+    markdownTable(
+      ['margin ms', 'ms', 'file', 'test'],
+      report.margins.map((row) => [ms(row.marginMs), ms(row.ms), row.file, row.title]),
+    ),
+    '',
+  ];
+  return sections.join('\n');
+}
+
+/**
+ * Plain-text slowest-N table for stdout, preserving the original console
+ * experience the inline reporter produced. Pure — the CLI prints it.
+ */
+export function renderConsoleTable(report: ConstrainedTestReport): string {
+  const pad = (value: string, width: number) => value.padStart(width);
+  const lines = report.slowest.map(
+    (row) => `${pad(ms(row.ms), 7)} ms  ${row.file}  ›  ${row.title}`,
+  );
+  lines.push('');
+  lines.push(
+    `  ${report.totalTests} tests, ${(report.totalTestMs / 1000).toFixed(1)}s of test time total`,
+  );
+  return lines.join('\n');
+}

--- a/docs/architecture/decision-records/ConstrainedTestRunner.md
+++ b/docs/architecture/decision-records/ConstrainedTestRunner.md
@@ -1,0 +1,48 @@
+# Constrained Test Runner
+
+## Context
+
+CAMS runs its CI on USTP self-hosted "Standard D4s v3" runners (4 vCPU / 16 GiB). The backend unit suite occasionally times out on those runners but passes comfortably on developer laptops and GitHub-hosted runners. The cause is environmental rather than logical: the test framework sizes its worker pool from the visible core count, so a 4-vCPU box runs far fewer workers in parallel, and under that contention the slower tests cross the default per-test timeout. A failure that only reproduces on the constrained runner is expensive to diagnose — the feedback loop runs through CI rather than locally.
+
+We needed a way to reproduce the runner's resource envelope on demand — both on a developer machine and in CI — so that marginal tests can be found and addressed by priority before they flake on the real runner, without making every developer or PR pay the cost of a constrained run.
+
+Alternatives considered:
+
+- **Tune timeouts or worker counts in the committed test config.** Rejected — this masks the symptom globally and changes how the suite runs for everyone, rather than measuring which tests are actually at risk.
+- **Match the runner CPU architecture (amd64) under emulation on developer machines.** Rejected — emulating a foreign architecture distorts timing far more than the architecture difference itself, which would ruin the relative ranking that is the tool's whole purpose. Running natively for the host architecture preserves the ranking; the resource constraint, not the instruction set, is what surfaces the timeouts.
+- **Add the constrained run to PR validation as a gate.** Rejected — a faithful run is several times slower than a normal suite run, and treating an environmental signal as a hard gate would block unrelated work. The signal is advisory, not pass/fail.
+
+## Decision
+
+We will reproduce a CI runner's resource envelope by running a workload inside a container with the runner's core count and memory limits applied, rather than relying on the host's full resources. The container reports the constrained core count to the workload so framework behavior (worker-pool sizing, contention) matches the real runner, and the run remains native to the host architecture so timing rankings stay meaningful.
+
+The first and currently only application of this approach is the **backend unit test suite**: a developer-invoked tool produces a priority report (slowest tests, per-file totals, setup/teardown overhead, and margin-to-timeout) and a periodic, informational CI workflow publishes the same report on a schedule. The run is deliberately not a PR gate; a slow or failing test under constraint is the signal we want to surface, not a reason to turn CI red.
+
+Fundamentally this is an environment-emulation approach, not a test-specific one. The same containerized, resource-constrained execution model can emulate any portion of the deployment pipeline whose behavior depends on the runner's resources — other workspaces' suites, build or packaging steps, or data-processing jobs. We are scoping the current implementation to the backend suite because that is where timeouts are actually observed; the approach generalizes to other portions of the pipeline if and when comparable problems appear there.
+
+## Status
+
+Accepted
+
+## Consequences
+
+### Positive
+
+- The runner-only failure mode is now reproducible locally and in CI, turning a CI-round-trip diagnosis into an on-demand one.
+- The priority report orders work by risk (margin-to-timeout), so effort goes to the tests most likely to cross the timeout on the real runner.
+- Because the model is environment emulation rather than a test harness, extending it to another portion of the pipeline is an incremental change, not a new tool.
+- Keeping the run advisory (never a gate) means the signal is available without blocking unrelated work or coupling release flow to an environmental measurement.
+
+### Negative / Trade-offs
+
+- A faithful constrained run is substantially slower than an unconstrained suite run, so it is an investigation tool, not part of the normal inner loop.
+- Memory-limit fidelity depends on the host's container backing: a developer machine whose container VM is provisioned with less RAM than the limit cannot faithfully emulate the memory dimension, only the core-count dimension. The tool warns when emulation is inexact rather than failing silently.
+- Timing is relative, not absolute: rankings are comparable within a run, but the numbers should not be read as the real runner's wall-clock, both because of the architecture difference and because the host's per-core throughput differs.
+- Coverage is currently limited to the backend suite. Other portions of the pipeline are not emulated yet; if they begin to exhibit environment-specific problems, extending coverage is a deliberate follow-on rather than something the current setup provides automatically.
+
+## Related Documentation
+
+- `ops/scripts/utility/constrained-test.sh` — the constrained test runner
+- `.github/docker/Dockerfile.build-and-test` — the container image the runner builds on
+- `.github/workflows/constrained-test-report.yml` — the periodic, informational report workflow
+- `dev-tools/constrained-test/` — the priority-report module

--- a/docs/architecture/decision-records/_sidebar.md
+++ b/docs/architecture/decision-records/_sidebar.md
@@ -12,6 +12,7 @@
 - [Backend Logging](/architecture/decision-records/BackendLogging.md)
 - [BDD Full-Stack Testing](/architecture/decision-records/BddFullStackTesting.md)
 - [Testing Framework](/architecture/decision-records/TestingFramework.md)
+- [Constrained Test Runner](/architecture/decision-records/ConstrainedTestRunner.md)
 - [Cross-Function App Queue Communication](/architecture/decision-records/CrossFunctionAppQueueCommunication.md)
 - [Dataflows](/architecture/decision-records/Dataflows.md)
 - [Dead Code Detection](/architecture/decision-records/DeadCodeDetection.md)

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -1,8 +1,8 @@
 # GitHub Actions Workflow Analysis
 
 ## Summary
-- **Total Workflows**: 29
-- **Main Workflows**: 12
+- **Total Workflows**: 30
+- **Main Workflows**: 13
 - **Reusable Workflows**: 17
 
 ## Legend
@@ -635,6 +635,7 @@ flowchart LR
 Workflows triggered by `schedule`:
 - **Prune E2E Image Cache** (`prune-e2e-image-cache.yml`)
 - **Refresh E2E Base Image Cache** (`refresh-e2e-base-images.yml`)
+- **Constrained Test Report** (`constrained-test-report.yml`)
 - **Build Custom Azure CLI Runner Image** (`build-azure-cli-image.yml`)
 - **Stand Alone DAST Scan** (`dast-scan.yml`)
 
@@ -645,6 +646,8 @@ flowchart LR
     prune_e2e_image_cache_yml_prune["Delete e2e-deps images older than 30 days"]
     refresh_e2e_base_images_yml["Refresh E2E Base Image Cache"]
     refresh_e2e_base_images_yml_refresh["Re-cache upstream base images to ghcr.io"]
+    constrained_test_report_yml["Constrained Test Report"]
+    constrained_test_report_yml_constrained_test_report["Backend Constrained Test Report"]
     build_azure_cli_image_yml["Build Custom Azure CLI Runner Image"]
     build_azure_cli_image_yml_build_and_push["build-and-push"]
     dast_scan_yml["Stand Alone DAST Scan"]
@@ -659,6 +662,8 @@ flowchart LR
     prune_e2e_image_cache_yml --> prune_e2e_image_cache_yml_prune
     trigger_schedule --> refresh_e2e_base_images_yml
     refresh_e2e_base_images_yml --> refresh_e2e_base_images_yml_refresh
+    trigger_schedule --> constrained_test_report_yml
+    constrained_test_report_yml --> constrained_test_report_yml_constrained_test_report
     trigger_schedule --> build_azure_cli_image_yml
     build_azure_cli_image_yml --> build_azure_cli_image_yml_build_and_push
     trigger_schedule --> dast_scan_yml
@@ -679,6 +684,8 @@ flowchart LR
     class prune_e2e_image_cache_yml_prune job
     class refresh_e2e_base_images_yml mainWorkflow
     class refresh_e2e_base_images_yml_refresh job
+    class constrained_test_report_yml mainWorkflow
+    class constrained_test_report_yml_constrained_test_report job
     class build_azure_cli_image_yml mainWorkflow
     class build_azure_cli_image_yml_build_and_push job
     class dast_scan_yml mainWorkflow
@@ -744,6 +751,29 @@ flowchart LR
     class trigger_workflow_dispatch trigger
     class build_azure_cli_image_yml mainWorkflow
     class build_azure_cli_image_yml_build_and_push job
+```
+
+#### Constrained Test Report
+
+Manual execution of `constrained-test-report.yml`
+
+```mermaid
+flowchart LR
+    trigger_workflow_dispatch(["workflow_dispatch"])
+    constrained_test_report_yml["Constrained Test Report"]
+    constrained_test_report_yml_constrained_test_report["Backend Constrained Test Report"]
+
+    trigger_workflow_dispatch --> constrained_test_report_yml
+    constrained_test_report_yml --> constrained_test_report_yml_constrained_test_report
+
+    classDef reusable fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#000000
+    classDef mainWorkflow fill:#f3e5f5,stroke:#4a148c,stroke-width:2px,color:#000000
+    classDef trigger fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000000
+    classDef job fill:#f1f8e9,stroke:#33691e,stroke-width:1px,color:#000000
+
+    class trigger_workflow_dispatch trigger
+    class constrained_test_report_yml mainWorkflow
+    class constrained_test_report_yml_constrained_test_report job
 ```
 
 #### Continuous Deployment
@@ -1520,6 +1550,7 @@ flowchart LR
     prune_e2e_image_cache_yml["Prune E2E Image Cache"]
     refresh_e2e_base_images_yml["Refresh E2E Base Image Cache"]
     pr_validation_yml["Pull Request E2E Validation"]
+    constrained_test_report_yml["Constrained Test Report"]
     continuous_deployment_yml["Continuous Deployment"]
     build_azure_cli_image_yml["Build Custom Azure CLI Runner Image"]
     dast_scan_yml["Stand Alone DAST Scan"]
@@ -1532,6 +1563,7 @@ flowchart LR
     trigger_schedule(["schedule"])
     prune_e2e_image_cache_yml["Prune E2E Image Cache"]
     refresh_e2e_base_images_yml["Refresh E2E Base Image Cache"]
+    constrained_test_report_yml["Constrained Test Report"]
     build_azure_cli_image_yml["Build Custom Azure CLI Runner Image"]
     dast_scan_yml["Stand Alone DAST Scan"]
     trigger_pull_request(["pull_request"])
@@ -1546,6 +1578,7 @@ flowchart LR
     trigger_workflow_dispatch --> prune_e2e_image_cache_yml
     trigger_workflow_dispatch --> refresh_e2e_base_images_yml
     trigger_workflow_dispatch --> pr_validation_yml
+    trigger_workflow_dispatch --> constrained_test_report_yml
     trigger_workflow_dispatch --> continuous_deployment_yml
     trigger_workflow_dispatch --> build_azure_cli_image_yml
     trigger_workflow_dispatch --> dast_scan_yml
@@ -1555,6 +1588,7 @@ flowchart LR
     trigger_delete --> azure_remove_branch_yml
     trigger_schedule --> prune_e2e_image_cache_yml
     trigger_schedule --> refresh_e2e_base_images_yml
+    trigger_schedule --> constrained_test_report_yml
     trigger_schedule --> build_azure_cli_image_yml
     trigger_schedule --> dast_scan_yml
     trigger_pull_request --> pr_validation_yml
@@ -1576,6 +1610,7 @@ flowchart LR
     class prune_e2e_image_cache_yml mainWorkflow
     class refresh_e2e_base_images_yml mainWorkflow
     class pr_validation_yml mainWorkflow
+    class constrained_test_report_yml mainWorkflow
     class continuous_deployment_yml mainWorkflow
     class build_azure_cli_image_yml mainWorkflow
     class dast_scan_yml mainWorkflow
@@ -1606,6 +1641,9 @@ flowchart LR
   - Jobs: 1
 - **Pull Request E2E Validation** (`pr-validation.yml`)
   - Triggers: pull_request, workflow_dispatch
+  - Jobs: 1
+- **Constrained Test Report** (`constrained-test-report.yml`)
+  - Triggers: schedule, workflow_dispatch
   - Jobs: 1
 - **Continuous Deployment** (`continuous-deployment.yml`)
   - Triggers: push, workflow_dispatch

--- a/ops/scripts/utility/constrained-test.sh
+++ b/ops/scripts/utility/constrained-test.sh
@@ -36,6 +36,12 @@
 #                            Pinned to cpuset 0-(n-1) internally.
 #   -m, --memory <size>      Memory cap (default: 16g). Swap is disabled.
 #   -n, --top <int>          Number of slowest tests to report (default: 25).
+#       --unconstrained      FAST inner-loop mode. Drop ALL resource limits
+#                            (no --cpuset-cpus / --cpus / --memory / --memory-swap)
+#                            and let the container use whatever the VM has. Also
+#                            skips the core-count and memory-fidelity preflights.
+#                            The report from this mode is NOT a faithful D4s v3
+#                            emulation — never compare it to a constrained run.
 #       --no-build           Skip rebuilding the Docker image (reuse existing).
 #       --engine <name>      Container engine to use: podman | docker. Overrides
 #                            auto-detection. Default precedence:
@@ -54,13 +60,18 @@
 #   ops/scripts/utility/constrained-test.sh -w common -n 50
 #
 # NOTES
-#   * Apple Silicon: Docker Desktop runs a Linux VM. --cpuset-cpus is relative
-#     to the VM's CPU allocation, so give the VM >= 4 cores / >= 16 GiB in
-#     Docker Desktop settings, or the pin/cap won't reflect a real D4s v3.
-#   * Architecture: this runs the image natively (arm64 on Apple Silicon). That
-#     is correct for RANKING the slowest tests. Do NOT add --platform
-#     linux/amd64 to match the runner arch: QEMU emulation skews timing far
-#     more than the arch difference and ruins the ranking.
+#   * Resource allocation: --cpuset-cpus / --memory are relative to whatever the
+#     container engine can actually back. On a dev MacBook (or Windows) the
+#     engine runs inside a podman/Docker "machine" VM, so that VM must be given
+#     >= --cores cores and >= --memory RAM or the pin/cap won't reflect a real
+#     D4s v3. On a Linux CI runner there is no VM — the limits are relative to
+#     the host's physical / cgroup-available cores and RAM, which must likewise
+#     be >= the requested values. The preflights below check both cases.
+#   * Architecture: this runs the image natively for the host arch (e.g. arm64
+#     on Apple Silicon, amd64 on a typical Linux runner). That is correct for
+#     RANKING the slowest tests. Do NOT add --platform linux/amd64 to match the
+#     runner arch on a non-amd64 host: QEMU emulation skews timing far more than
+#     the arch difference and ruins the ranking.
 
 set -euo pipefail
 
@@ -74,6 +85,7 @@ CPUS=""             # empty => no quota, pin only
 CORES=4             # number of cores to pin (=> cpuset 0-(CORES-1))
 MEMORY="16g"
 TOP=25
+UNCONSTRAINED=0      # 1 => fast mode: drop all resource limits, skip preflights
 DO_BUILD=1
 IMAGE="cams-build:latest"
 DOCKERFILE=".github/docker/Dockerfile.build-and-test"
@@ -92,6 +104,7 @@ while [[ $# -gt 0 ]]; do
     --cores)        CORES="$2"; shift 2 ;;
     -m|--memory)    MEMORY="$2"; shift 2 ;;
     -n|--top)       TOP="$2"; shift 2 ;;
+    --unconstrained) UNCONSTRAINED=1; shift ;;
     --no-build)     DO_BUILD=0; shift ;;
     --engine)       ENGINE="$2"; shift 2 ;;
     -h|--help)      usage; exit 0 ;;
@@ -167,13 +180,163 @@ ISOLATE_VOLUMES=(
   -v /workspace/common/node_modules
   -v "/workspace/${WORKSPACE}/node_modules"
 )
-RUN_FLAGS=(--rm
-  --cpuset-cpus="${CPUSET}"
-  --memory="${MEMORY}"
-  --memory-swap="${MEMORY}")   # equal mem/mem-swap => swap disabled, OOM surfaces like the real box
-if [[ -n "${CPUS}" ]]; then
-  RUN_FLAGS+=(--cpus="${CPUS}")
+# In faithful (default) mode we pin the core COUNT, cap memory, and disable swap
+# so the run reproduces the D4s v3 pool sizing and OOM behavior. In --unconstrained
+# (fast) mode we add NONE of these so the container uses the whole VM — this is a
+# quick inner-loop run and is explicitly NOT a faithful emulation.
+RUN_FLAGS=(--rm)
+if [[ "${UNCONSTRAINED}" -eq 0 ]]; then
+  RUN_FLAGS+=(--cpuset-cpus="${CPUSET}"
+    --memory="${MEMORY}"
+    --memory-swap="${MEMORY}")   # equal mem/mem-swap => swap disabled, OOM surfaces like the real box
+  if [[ -n "${CPUS}" ]]; then
+    RUN_FLAGS+=(--cpus="${CPUS}")
+  fi
 fi
+
+# --- preflight fidelity self-checks (faithful mode only) ----------------------
+# These run BEFORE the multi-minute suite so the user isn't surprised, AFTER a
+# long wait, that the run didn't faithfully emulate the D4s v3 pool. Both WARN
+# loudly to stderr but never block — a non-faithful run can still be useful.
+# In --unconstrained mode there is nothing to verify, so both are skipped.
+
+# Part A: does the container actually SEE the requested core count? Vitest sizes
+# its worker pool from os.availableParallelism(); if the host/VM has fewer cores
+# than requested (or the engine didn't honor the cpuset) the pool — and therefore
+# the whole point of the run — is wrong. Cheap one-shot using the SAME cpu/memory
+# RUN_FLAGS and the base image's node (no mounts, no npm ci).
+preflight_core_count() {
+  echo "==> Preflight: verifying the container reports ${CORES} cores" >&2
+  local reported
+  # Capture stdout only; if the host/VM is too small the cpuset is out of range
+  # (or --memory exceeds available RAM) and the engine errors out (empty/non-
+  # numeric output) — that is itself a fidelity failure we want to surface, so
+  # don't let `set -e` abort here.
+  set +e
+  reported="$("${ENGINE}" run "${RUN_FLAGS[@]}" "${IMAGE}" \
+    node -e 'console.log(require("os").availableParallelism())' 2>/dev/null)"
+  set -e
+  reported="${reported//[$'\t\r\n ']/}"
+
+  if [[ "${reported}" =~ ^[0-9]+$ ]] && [[ "${reported}" -eq "${CORES}" ]]; then
+    echo "    OK: container reports ${reported} cores (matches --cores ${CORES})." >&2
+    return
+  fi
+
+  # Mismatch (or the one-shot failed). WARN loudly; continue to the run.
+  echo >&2
+  echo "  ############################################################" >&2
+  echo "  ## WARN: CORE-COUNT FIDELITY CHECK FAILED" >&2
+  echo "  ##" >&2
+  if [[ "${reported}" =~ ^[0-9]+$ ]]; then
+    echo "  ## Requested --cores ${CORES} but the container reports ${reported}." >&2
+  else
+    echo "  ## Requested --cores ${CORES} but the container could not start / report" >&2
+    echo "  ## a core count. In faithful mode the preflight one-shot applies the full" >&2
+    echo "  ## run flags, so this is likely the cpuset (${CPUSET}) OR the --memory limit" >&2
+    echo "  ## being rejected by the engine (the suite run below will surface the raw" >&2
+    echo "  ## engine error if the limits are the cause)." >&2
+  fi
+  echo "  ## This run will NOT faithfully emulate the D4s v3 4-vCPU pool sizing;" >&2
+  echo "  ## Vitest will size its worker pool from the wrong core count." >&2
+  echo "  ##" >&2
+  echo "  ## The environment could not provide the requested core count. Ensure the" >&2
+  echo "  ## host/VM has at least ${CORES} cores available to the container engine:" >&2
+  echo "  ##   * On macOS/Windows that's the podman/Docker machine's CPU allocation." >&2
+  echo "  ##   * On a Linux runner it's the host's physical / cgroup-available cores." >&2
+  echo "  ## Also confirm the cpuset (${CPUSET}) is actually honored by the engine." >&2
+  echo "  ##" >&2
+  echo "  ## Continuing anyway (the slowest-test ranking is still informative)." >&2
+  echo "  ############################################################" >&2
+  echo >&2
+}
+
+# Part B: is --memory ${MEMORY} actually enforceable? A --memory cap larger than
+# the total RAM the engine can back is silently a no-op (e.g. a small dev podman
+# machine VM of ~3.7 GiB makes --memory 16g a no-op; a Linux runner with less RAM
+# than requested behaves the same). We read the engine's REAL total RAM (NOT a
+# cgroup cap) and WARN if it's below the requested cap. Degrade gracefully if we
+# can't read it on this engine, rather than emit a false warning.
+#
+# Returns the engine's total RAM in bytes on stdout, or empty if undeterminable.
+vm_total_ram_bytes() {
+  local bytes=""
+  case "${ENGINE}" in
+    podman) bytes="$("${ENGINE}" info --format '{{.Host.MemTotal}}' 2>/dev/null)" ;;
+    docker) bytes="$("${ENGINE}" info --format '{{.MemTotal}}' 2>/dev/null)" ;;
+  esac
+  # Fallback for either engine: a one-shot container WITHOUT --memory reading
+  # /proc/meminfo MemTotal (kB) reflects the VM/host total, not a cgroup cap.
+  if ! [[ "${bytes}" =~ ^[0-9]+$ ]]; then
+    local kb
+    kb="$("${ENGINE}" run --rm "${IMAGE}" \
+      sh -c "awk '/^MemTotal:/ {print \$2}' /proc/meminfo" 2>/dev/null)"
+    kb="${kb//[$'\t\r\n ']/}"
+    if [[ "${kb}" =~ ^[0-9]+$ ]]; then
+      bytes=$((kb * 1024))
+    else
+      bytes=""
+    fi
+  fi
+  printf '%s' "${bytes}"
+}
+
+# Parse a docker/podman memory size (e.g. "16g", "512m", "2048k", "1073741824")
+# to bytes on stdout. Empty on unparseable input.
+mem_to_bytes() {
+  local raw num unit
+  raw="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${raw}" =~ ^([0-9]+)([bkmg])?$ ]]; then
+    num="${BASH_REMATCH[1]}"
+    unit="${BASH_REMATCH[2]}"
+    case "${unit}" in
+      ""|b) printf '%s' "${num}" ;;
+      k)    printf '%s' "$((num * 1024))" ;;
+      m)    printf '%s' "$((num * 1024 * 1024))" ;;
+      g)    printf '%s' "$((num * 1024 * 1024 * 1024))" ;;
+    esac
+  fi
+}
+
+preflight_memory_fidelity() {
+  echo "==> Preflight: verifying --memory ${MEMORY} is enforceable by the VM" >&2
+  local vm_bytes req_bytes
+  vm_bytes="$(vm_total_ram_bytes)"
+  req_bytes="$(mem_to_bytes "${MEMORY}")"
+
+  if ! [[ "${vm_bytes}" =~ ^[0-9]+$ ]]; then
+    echo "    Skipping: could not determine the VM's total RAM on engine '${ENGINE}'." >&2
+    return
+  fi
+  if ! [[ "${req_bytes}" =~ ^[0-9]+$ ]]; then
+    echo "    Skipping: could not parse requested --memory '${MEMORY}'." >&2
+    return
+  fi
+
+  local vm_mib=$((vm_bytes / 1024 / 1024))
+  local req_mib=$((req_bytes / 1024 / 1024))
+  if [[ "${req_bytes}" -le "${vm_bytes}" ]]; then
+    echo "    OK: VM total RAM (~${vm_mib} MiB) >= requested --memory ${MEMORY}." >&2
+    return
+  fi
+
+  echo >&2
+  echo "  ############################################################" >&2
+  echo "  ## WARN: MEMORY FIDELITY CHECK FAILED" >&2
+  echo "  ##" >&2
+  echo "  ## Requested --memory ${MEMORY} (~${req_mib} MiB) exceeds the total RAM the" >&2
+  echo "  ## engine can back (~${vm_mib} MiB), so the cap is SILENTLY A NO-OP — the" >&2
+  echo "  ## container can use only what the engine has. This run will NOT reproduce" >&2
+  echo "  ## the D4s v3 16 GiB OOM behavior." >&2
+  echo "  ##" >&2
+  echo "  ## Give the engine at least ${req_mib} MiB of RAM, or pass a smaller --memory:" >&2
+  echo "  ##   * On macOS/Windows: increase the podman/Docker machine's memory allocation." >&2
+  echo "  ##   * On a Linux runner: the host/cgroup must have at least that much RAM." >&2
+  echo "  ##" >&2
+  echo "  ## Continuing anyway." >&2
+  echo "  ############################################################" >&2
+  echo >&2
+}
 
 # Output dir on the host so the JSON report survives the container.
 # temp/ is gitignored by convention in this repo.
@@ -185,10 +348,27 @@ rm -f "${REPORT_JSON_HOST}"
 echo "==> Constraint profile"
 echo "      engine         : ${ENGINE}"
 echo "      workspace      : ${WORKSPACE}"
-echo "      pinned cores   : ${CORES} (cpuset ${CPUSET}; emulates D4s v3 4-vCPU pool sizing)"
-echo "      cpu quota      : ${CPUS:-<none — pin only>}"
-echo "      memory         : ${MEMORY} (swap disabled)"
+if [[ "${UNCONSTRAINED}" -eq 1 ]]; then
+  echo "      mode           : UNCONSTRAINED (fast — NOT a faithful D4s v3 emulation)"
+  echo "      pinned cores   : <none — container uses the whole VM>"
+  echo "      cpu quota      : <none>"
+  echo "      memory         : <none — no cap>"
+else
+  echo "      mode           : faithful (constrained)"
+  echo "      pinned cores   : ${CORES} (cpuset ${CPUSET}; emulates D4s v3 4-vCPU pool sizing)"
+  echo "      cpu quota      : ${CPUS:-<none — pin only>}"
+  echo "      memory         : ${MEMORY} (swap disabled)"
+fi
 echo
+
+# Run the fidelity preflights now (faithful mode only): surface a too-small VM
+# or an unhonored constraint BEFORE the multi-minute suite, not after.
+if [[ "${UNCONSTRAINED}" -eq 0 ]]; then
+  preflight_core_count
+  preflight_memory_fidelity
+else
+  echo "==> Skipping core-count and memory-fidelity preflights (--unconstrained)." >&2
+fi
 
 # --- build the in-container command -------------------------------------------
 # Each workspace installs from the lockfile, builds common as needed, then runs
@@ -280,7 +460,15 @@ fi
 
 echo
 if [[ "${TEST_EXIT}" -ne 0 ]]; then
-  echo "==> Suite exited non-zero (${TEST_EXIT}) — failures or timeouts under constraint."
+  if [[ -f "${REPORT_JSON_HOST}" ]]; then
+    # Results were written => the suite actually ran; non-zero means tests failed.
+    echo "==> Suite exited non-zero (${TEST_EXIT}) — failures or timeouts under constraint."
+  else
+    # No results file => the suite never ran (e.g. the engine rejected the cpuset
+    # or --memory limit, exit 125/126), so don't attribute this to test failures.
+    echo "==> Run did not complete (${TEST_EXIT}) — the suite never ran; the engine"
+    echo "    likely could not start the container under these limits (see the error above)."
+  fi
 else
   echo "==> Suite passed under constraint."
 fi

--- a/ops/scripts/utility/constrained-test.sh
+++ b/ops/scripts/utility/constrained-test.sh
@@ -116,7 +116,16 @@ DOCKERFILE=".github/docker/Dockerfile.build-and-test"
 ENGINE="${CONTAINER_ENGINE:-}"
 
 # --- arg parsing --------------------------------------------------------------
-usage() { sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//; s/^#$//'; }
+# Print the header comment block as help text (the header IS the single source of
+# truth for usage). We print from line 2 until the first NON-comment line and
+# stop, stripping the leading "# " — so help text is bounded by the end of the
+# comment block, NOT by anchoring on a magic line like `set -euo` (which would
+# silently break, and previously leaked, if the header or that line ever moved).
+usage() {
+  awk 'NR == 1 { next }                         # skip the shebang
+       /^#/    { sub(/^# ?/, ""); print; next }  # strip "# " from header lines
+       { exit }' "${BASH_SOURCE[0]}"             # stop at the first non-comment line
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/ops/scripts/utility/constrained-test.sh
+++ b/ops/scripts/utility/constrained-test.sh
@@ -42,6 +42,14 @@
 #                            skips the core-count and memory-fidelity preflights.
 #                            The report from this mode is NOT a faithful D4s v3
 #                            emulation — never compare it to a constrained run.
+#       --profile            Opt-in CPU profiling. Runs the Vitest fork workers
+#                            under Node --cpu-prof and emits a .cpuprofile per
+#                            worker under temp/constrained-test/profiles (load
+#                            them in speedscope or Chrome DevTools). WARNING:
+#                            profiling overhead inflates every duration, so the
+#                            slowest-test timings from a profiled run are NOT
+#                            comparable to a normal run — the report is annotated
+#                            accordingly. Off by default.
 #       --no-build           Skip rebuilding the Docker image (reuse existing).
 #       --engine <name>      Container engine to use: podman | docker. Overrides
 #                            auto-detection. Default precedence:
@@ -92,6 +100,7 @@ TOP=25
 # inside it.
 TIMEOUT_MS=5000
 UNCONSTRAINED=0      # 1 => fast mode: drop all resource limits, skip preflights
+PROFILE=0            # 1 => opt-in CPU profiling (workers run under --cpu-prof)
 DO_BUILD=1
 IMAGE="cams-build:latest"
 # Host arch via uname -m (cheap, no container). The container arch is probed by
@@ -117,6 +126,7 @@ while [[ $# -gt 0 ]]; do
     -m|--memory)    MEMORY="$2"; shift 2 ;;
     -n|--top)       TOP="$2"; shift 2 ;;
     --unconstrained) UNCONSTRAINED=1; shift ;;
+    --profile)      PROFILE=1; shift ;;
     --no-build)     DO_BUILD=0; shift ;;
     --engine)       ENGINE="$2"; shift 2 ;;
     -h|--help)      usage; exit 0 ;;
@@ -421,10 +431,26 @@ echo
 # Vitest requires dot-notation to target one reporter's output file.
 CONTAINER_REPORT="/workspace/temp/constrained-test/${WORKSPACE}-results.json"
 
+# Opt-in CPU profiling (--profile). Vitest 4 forks workers run under Node
+# --cpu-prof; --cpu-prof-dir lands one .cpuprofile per worker (pid-keyed name, so
+# no collisions) in the host-mounted profiles dir, surviving the container. We
+# pass these to the workers via Vitest's `--execArgv` CLI flag (one flag per Node
+# arg). VERIFIED against vitest 4.1.8: the forks pool forwards execArgv verbatim
+# to child_process.fork, Node honors --cpu-prof-dir, and Vitest's forks runtime
+# installs a SIGTERM handler that flushes the profile on worker teardown — so NO
+# committed vitest config is needed. These two host-side vars are EMPTY when
+# PROFILE=0, which keeps the default container command byte-for-byte unchanged.
+PROFILE_MKDIR=""
+PROFILE_EXECARGV=""
+if [[ "${PROFILE}" -eq 1 ]]; then
+  PROFILE_MKDIR="mkdir -p /workspace/temp/constrained-test/profiles"
+  PROFILE_EXECARGV=" --execArgv=--cpu-prof --execArgv=--cpu-prof-dir=/workspace/temp/constrained-test/profiles"
+fi
+
 read -r -d '' IN_CONTAINER <<EOF || true
 set -euo pipefail
 mkdir -p /workspace/temp/constrained-test
-
+${PROFILE_MKDIR}
 echo "--- node sees availableParallelism() = \$(node -e 'console.log(require("os").availableParallelism())') cores ---"
 
 # Mirror CI (.github/workflows/reusable-unit-test.yml): a single root \`npm ci\`
@@ -445,7 +471,7 @@ export CAMS_LOGIN_PROVIDER_CONFIG='{"issuer": "http://localhost:7071/api/oauth2/
 npm test -- \
   --reporter=default \
   --reporter=json --outputFile.json="${CONTAINER_REPORT}" \
-  --slowTestThreshold=300
+  --slowTestThreshold=300${PROFILE_EXECARGV}
 EOF
 
 echo "==> Running suite under constraints (this is intentionally slow)"
@@ -478,9 +504,18 @@ if [[ -f "${REPORT_JSON_HOST}" ]]; then
   #
   # tsx is hoisted to the repo-root node_modules by the npm-workspaces install
   # (root `npm ci`); `npx` from REPO_ROOT resolves it without a separate install.
+  #
+  # When profiling, append the order-independent `--profiled` flag so the reporter
+  # annotates the timings as non-comparable. It's empty (no extra arg) otherwise,
+  # leaving the existing 4-positional call unchanged for a normal run.
+  REPORT_PROFILED_FLAG=()
+  if [[ "${PROFILE}" -eq 1 ]]; then
+    REPORT_PROFILED_FLAG=(--profiled)
+  fi
   ( cd "${REPO_ROOT}" && npx tsx \
       "${REPO_ROOT}/dev-tools/constrained-test/report.cli.ts" \
-      "${REPORT_JSON_HOST}" "${WORKSPACE}" "${TOP}" "${TIMEOUT_MS}" ) || true
+      "${REPORT_JSON_HOST}" "${WORKSPACE}" "${TOP}" "${TIMEOUT_MS}" \
+      "${REPORT_PROFILED_FLAG[@]}" ) || true
   echo
   echo "  Full JSON: ${REPORT_JSON_HOST}"
 else

--- a/ops/scripts/utility/constrained-test.sh
+++ b/ops/scripts/utility/constrained-test.sh
@@ -15,8 +15,9 @@
 #        tips marginal tests over the edge.
 #
 #   To reproduce faithfully we must make the container REPORT 4 cores (so the
-#   pool sizes correctly), not merely cap total CPU time. We pin with
-#   --cpuset-cpus; Node 22 respects the cpuset cgroup in availableParallelism().
+#   pool sizes correctly), not merely cap total CPU time. We pin a core COUNT
+#   (--cores, default 4) and translate it to --cpuset-cpus=0-(n-1); Node 22
+#   respects the cpuset cgroup in availableParallelism().
 #
 #   This is intentionally NOT part of pr-validation / the normal GHA workflow:
 #   the constrained run is much slower. It's a tool you reach for when
@@ -28,10 +29,11 @@
 # OPTIONS
 #   -w, --workspace <name>   Workspace to test: backend | common | user-interface
 #                            (default: backend)
-#   -c, --cpus <float>       Add a CPU-time quota ON TOP of the 4-core pin to
+#   -c, --cpus <float>       Add a CPU-time quota ON TOP of the core pin to
 #                            also approximate the runner's slower per-core
 #                            throughput (e.g. 2.0). Default: unset (pin only).
-#       --cpuset <range>     Cores to pin to (default: 0-3 => 4 cores).
+#       --cores <int>        Number of cores to pin (default: 4 => D4s v3).
+#                            Pinned to cpuset 0-(n-1) internally.
 #   -m, --memory <size>      Memory cap (default: 16g). Swap is disabled.
 #   -n, --top <int>          Number of slowest tests to report (default: 25).
 #       --no-build           Skip rebuilding the Docker image (reuse existing).
@@ -69,7 +71,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 # --- defaults -----------------------------------------------------------------
 WORKSPACE="backend"
 CPUS=""             # empty => no quota, pin only
-CPUSET="0-3"        # 4 cores
+CORES=4             # number of cores to pin (=> cpuset 0-(CORES-1))
 MEMORY="16g"
 TOP=25
 DO_BUILD=1
@@ -87,7 +89,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     -w|--workspace) WORKSPACE="$2"; shift 2 ;;
     -c|--cpus)      CPUS="$2"; shift 2 ;;
-    --cpuset)       CPUSET="$2"; shift 2 ;;
+    --cores)        CORES="$2"; shift 2 ;;
     -m|--memory)    MEMORY="$2"; shift 2 ;;
     -n|--top)       TOP="$2"; shift 2 ;;
     --no-build)     DO_BUILD=0; shift ;;
@@ -101,6 +103,13 @@ case "${WORKSPACE}" in
   backend|common|user-interface) ;;
   *) echo "Invalid --workspace '${WORKSPACE}'. Use backend | common | user-interface." >&2; exit 2 ;;
 esac
+
+# --cores must be a positive integer; it becomes the cpuset 0-(CORES-1).
+if ! [[ "${CORES}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid --cores '${CORES}'. Must be a positive integer." >&2
+  exit 2
+fi
+CPUSET="0-$((CORES - 1))"
 
 # --- resolve container engine -------------------------------------------------
 # Podman is CLI-compatible with Docker for build/run/--cpuset-cpus/--memory/
@@ -132,22 +141,6 @@ command -v "${ENGINE}" >/dev/null 2>&1 || {
   exit 127
 }
 
-# --- count pinned cores (for reporting) --------------------------------------
-count_cpuset() {
-  local total=0 part lo hi
-  IFS=',' read -ra parts <<< "$1"
-  for part in "${parts[@]}"; do
-    if [[ "$part" == *-* ]]; then
-      lo="${part%-*}"; hi="${part#*-}"
-      total=$(( total + hi - lo + 1 ))
-    else
-      total=$(( total + 1 ))
-    fi
-  done
-  echo "$total"
-}
-CORE_COUNT="$(count_cpuset "${CPUSET}")"
-
 # --- build image --------------------------------------------------------------
 if [[ "${DO_BUILD}" -eq 1 ]]; then
   echo "==> Building ${IMAGE} from ${DOCKERFILE}"
@@ -157,6 +150,23 @@ else
 fi
 
 # --- assemble docker resource flags ------------------------------------------
+# Anonymous volumes (-v with no host side) layer OVER the read-write repo bind
+# mount for the subpaths the container writes during `npm ci` / build. Without
+# these, the container's Linux-platform native bindings (esbuild/rollup/rolldown)
+# and rebuilt dist would write back through the mount and clobber the developer's
+# macOS/arm64 install (the whole team is on MacBooks). The bind mount is still
+# needed so the JSON report lands in temp/ on the host; only these write paths
+# are isolated:
+#   /workspace/node_modules            — root hoisted deps (most native bindings)
+#   /workspace/common/dist             — common build output
+#   /workspace/common/node_modules     — per-workspace deps that don't hoist
+#   /workspace/${WORKSPACE}/node_modules
+ISOLATE_VOLUMES=(
+  -v /workspace/node_modules
+  -v /workspace/common/dist
+  -v /workspace/common/node_modules
+  -v "/workspace/${WORKSPACE}/node_modules"
+)
 RUN_FLAGS=(--rm
   --cpuset-cpus="${CPUSET}"
   --memory="${MEMORY}"
@@ -175,7 +185,7 @@ rm -f "${REPORT_JSON_HOST}"
 echo "==> Constraint profile"
 echo "      engine         : ${ENGINE}"
 echo "      workspace      : ${WORKSPACE}"
-echo "      pinned cores   : ${CPUSET} (${CORE_COUNT} cores; emulates D4s v3 4-vCPU pool sizing)"
+echo "      pinned cores   : ${CORES} (cpuset ${CPUSET}; emulates D4s v3 4-vCPU pool sizing)"
 echo "      cpu quota      : ${CPUS:-<none — pin only>}"
 echo "      memory         : ${MEMORY} (swap disabled)"
 echo
@@ -196,12 +206,16 @@ mkdir -p /workspace/temp/constrained-test
 
 echo "--- node sees availableParallelism() = \$(node -e 'console.log(require("os").availableParallelism())') cores ---"
 
-cd /workspace/common && npm ci
+# Mirror CI (.github/workflows/reusable-unit-test.yml): a single root \`npm ci\`
+# installs ALL workspaces (this is an npm-workspaces monorepo), then build common
+# unless it IS the target workspace. CI does not separately install the backend
+# function-apps nested lockfiles for unit tests, so neither do we.
+cd /workspace && npm ci
 if [ "${WORKSPACE}" != "common" ]; then
-  npm run build
+  npm run build:common
 fi
 
-cd /workspace/${WORKSPACE} && npm ci
+cd /workspace/${WORKSPACE}
 
 export CAMS_LOGIN_PROVIDER_CONFIG='{"issuer": "http://localhost:7071/api/oauth2/default", "clientId": ""}'
 
@@ -217,6 +231,7 @@ echo "==> Running suite under constraints (this is intentionally slow)"
 set +e
 "${ENGINE}" run "${RUN_FLAGS[@]}" \
   -v "${REPO_ROOT}:/workspace" \
+  "${ISOLATE_VOLUMES[@]}" \
   "${IMAGE}" \
   bash -c "${IN_CONTAINER}"
 TEST_EXIT=$?

--- a/ops/scripts/utility/constrained-test.sh
+++ b/ops/scripts/utility/constrained-test.sh
@@ -87,6 +87,10 @@ CPUS=""             # empty => no quota, pin only
 CORES=4             # number of cores to pin (=> cpuset 0-(CORES-1))
 MEMORY="16g"
 TOP=25
+# Effective per-test timeout (ms) the margin-to-timeout report compares against;
+# matches the vitest per-test default. Passed to the reporter, never hardcoded
+# inside it.
+TIMEOUT_MS=5000
 UNCONSTRAINED=0      # 1 => fast mode: drop all resource limits, skip preflights
 DO_BUILD=1
 IMAGE="cams-build:latest"
@@ -460,34 +464,23 @@ echo " Slowest ${TOP} tests (workspace: ${WORKSPACE})"
 echo "============================================================"
 
 if [[ -f "${REPORT_JSON_HOST}" ]]; then
-  # Vitest JSON: assertionResults[].duration (ms) per test, with file in name.
+  # The container already wrote the Vitest JSON to temp/ via the bind mount.
+  # Hand it to the unit-tested TypeScript reporter (dev-tools/constrained-test),
+  # run on the HOST via tsx where dev-tools deps are already installed by the
+  # repo's root npm install — no in-container dev-tools install/build is added.
+  # The reporter computes the slowest tests, per-file totals, overhead gap, and
+  # margin-to-timeout, writes ${WORKSPACE}-report.{json,md} beside the input,
+  # and prints the slowest-${TOP} table.
+  #
   # The report is best-effort: never let it abort the script before the final
   # `exit "${TEST_EXIT}"`, so a reporter hiccup can't mask the suite's real
   # exit code. `|| true` neutralizes `set -e` for this step.
-  # NOTE on argv indices: `node -e '<script>' A B` puts A at argv[1] and B at
-  # argv[2] (Node does NOT consume an argv slot for the inline script). So top
-  # is argv[1] and the JSON path is argv[2].
-  # shellcheck disable=SC2016  # this is a Node script; shell must NOT expand it.
-  node -e '
-    const fs = require("fs");
-    const top = parseInt(process.argv[1], 10);
-    const path = process.argv[2];
-    const data = JSON.parse(fs.readFileSync(path, "utf8"));
-    const rows = [];
-    for (const suite of data.testResults || []) {
-      const file = (suite.name || "").replace(/^\/workspace\//, "");
-      for (const t of suite.assertionResults || []) {
-        rows.push({ ms: t.duration ?? 0, title: t.fullName || t.title, file });
-      }
-    }
-    rows.sort((a, b) => b.ms - a.ms);
-    const pad = (s, n) => String(s).padStart(n);
-    for (const r of rows.slice(0, top)) {
-      console.log(`${pad(r.ms.toFixed(0), 7)} ms  ${r.file}  ›  ${r.title}`);
-    }
-    const total = rows.reduce((s, r) => s + r.ms, 0);
-    console.log(`\n  ${rows.length} tests, ${(total / 1000).toFixed(1)}s of test time total`);
-  ' "${TOP}" "${REPORT_JSON_HOST}" || true
+  #
+  # tsx is hoisted to the repo-root node_modules by the npm-workspaces install
+  # (root `npm ci`); `npx` from REPO_ROOT resolves it without a separate install.
+  ( cd "${REPO_ROOT}" && npx tsx \
+      "${REPO_ROOT}/dev-tools/constrained-test/report.cli.ts" \
+      "${REPORT_JSON_HOST}" "${WORKSPACE}" "${TOP}" "${TIMEOUT_MS}" ) || true
   echo
   echo "  Full JSON: ${REPORT_JSON_HOST}"
 else

--- a/ops/scripts/utility/constrained-test.sh
+++ b/ops/scripts/utility/constrained-test.sh
@@ -35,6 +35,9 @@
 #   -m, --memory <size>      Memory cap (default: 16g). Swap is disabled.
 #   -n, --top <int>          Number of slowest tests to report (default: 25).
 #       --no-build           Skip rebuilding the Docker image (reuse existing).
+#       --engine <name>      Container engine to use: podman | docker. Overrides
+#                            auto-detection. Default precedence:
+#                            --engine flag > $CONTAINER_ENGINE > podman > docker.
 #   -h, --help               Show this help.
 #
 # EXAMPLES
@@ -72,6 +75,10 @@ TOP=25
 DO_BUILD=1
 IMAGE="cams-build:latest"
 DOCKERFILE=".github/docker/Dockerfile.build-and-test"
+# Container engine. Precedence: --engine flag > $CONTAINER_ENGINE > podman >
+# docker (resolved by detect_engine() after arg parsing). Seed from the env var
+# here so an explicit --engine can still override it below.
+ENGINE="${CONTAINER_ENGINE:-}"
 
 # --- arg parsing --------------------------------------------------------------
 usage() { sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//; s/^#$//'; }
@@ -84,6 +91,7 @@ while [[ $# -gt 0 ]]; do
     -m|--memory)    MEMORY="$2"; shift 2 ;;
     -n|--top)       TOP="$2"; shift 2 ;;
     --no-build)     DO_BUILD=0; shift ;;
+    --engine)       ENGINE="$2"; shift 2 ;;
     -h|--help)      usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; echo "Run with --help for usage." >&2; exit 2 ;;
   esac
@@ -93,6 +101,36 @@ case "${WORKSPACE}" in
   backend|common|user-interface) ;;
   *) echo "Invalid --workspace '${WORKSPACE}'. Use backend | common | user-interface." >&2; exit 2 ;;
 esac
+
+# --- resolve container engine -------------------------------------------------
+# Podman is CLI-compatible with Docker for build/run/--cpuset-cpus/--memory/
+# --memory-swap/-v, so the binary name is the only thing that varies. If ENGINE
+# is already set (via --engine or $CONTAINER_ENGINE) we honor it; otherwise we
+# prefer podman (CAMS local dev + CI) and fall back to docker.
+detect_engine() {
+  if [[ -n "${ENGINE}" ]]; then
+    return
+  fi
+  if command -v podman >/dev/null 2>&1; then
+    ENGINE="podman"
+  elif command -v docker >/dev/null 2>&1; then
+    ENGINE="docker"
+  else
+    echo "No container engine found. Install podman (preferred for CAMS local dev;" >&2
+    echo "'brew install podman' then 'podman machine init && podman machine start')" >&2
+    echo "or docker, or set --engine / \$CONTAINER_ENGINE." >&2
+    exit 1
+  fi
+}
+detect_engine
+
+# Validate the resolved engine is actually on PATH. This also catches a bad
+# --engine value or a stale $CONTAINER_ENGINE.
+command -v "${ENGINE}" >/dev/null 2>&1 || {
+  echo "Container engine '${ENGINE}' not found on PATH. Set --engine / \$CONTAINER_ENGINE" >&2
+  echo "to an installed engine (podman or docker)." >&2
+  exit 127
+}
 
 # --- count pinned cores (for reporting) --------------------------------------
 count_cpuset() {
@@ -113,7 +151,7 @@ CORE_COUNT="$(count_cpuset "${CPUSET}")"
 # --- build image --------------------------------------------------------------
 if [[ "${DO_BUILD}" -eq 1 ]]; then
   echo "==> Building ${IMAGE} from ${DOCKERFILE}"
-  docker build -f "${REPO_ROOT}/${DOCKERFILE}" -t "${IMAGE}" "${REPO_ROOT}"
+  "${ENGINE}" build -f "${REPO_ROOT}/${DOCKERFILE}" -t "${IMAGE}" "${REPO_ROOT}"
 else
   echo "==> Reusing existing image ${IMAGE} (--no-build)"
 fi
@@ -135,6 +173,7 @@ REPORT_JSON_HOST="${OUT_DIR}/${WORKSPACE}-results.json"
 rm -f "${REPORT_JSON_HOST}"
 
 echo "==> Constraint profile"
+echo "      engine         : ${ENGINE}"
 echo "      workspace      : ${WORKSPACE}"
 echo "      pinned cores   : ${CPUSET} (${CORE_COUNT} cores; emulates D4s v3 4-vCPU pool sizing)"
 echo "      cpu quota      : ${CPUS:-<none — pin only>}"
@@ -176,7 +215,7 @@ EOF
 
 echo "==> Running suite under constraints (this is intentionally slow)"
 set +e
-docker run "${RUN_FLAGS[@]}" \
+"${ENGINE}" run "${RUN_FLAGS[@]}" \
   -v "${REPO_ROOT}:/workspace" \
   "${IMAGE}" \
   bash -c "${IN_CONTAINER}"
@@ -190,11 +229,17 @@ echo "============================================================"
 
 if [[ -f "${REPORT_JSON_HOST}" ]]; then
   # Vitest JSON: assertionResults[].duration (ms) per test, with file in name.
+  # The report is best-effort: never let it abort the script before the final
+  # `exit "${TEST_EXIT}"`, so a reporter hiccup can't mask the suite's real
+  # exit code. `|| true` neutralizes `set -e` for this step.
+  # NOTE on argv indices: `node -e '<script>' A B` puts A at argv[1] and B at
+  # argv[2] (Node does NOT consume an argv slot for the inline script). So top
+  # is argv[1] and the JSON path is argv[2].
   # shellcheck disable=SC2016  # this is a Node script; shell must NOT expand it.
   node -e '
     const fs = require("fs");
-    const top = parseInt(process.argv[2], 10);
-    const path = process.argv[3];
+    const top = parseInt(process.argv[1], 10);
+    const path = process.argv[2];
     const data = JSON.parse(fs.readFileSync(path, "utf8"));
     const rows = [];
     for (const suite of data.testResults || []) {
@@ -210,7 +255,7 @@ if [[ -f "${REPORT_JSON_HOST}" ]]; then
     }
     const total = rows.reduce((s, r) => s + r.ms, 0);
     console.log(`\n  ${rows.length} tests, ${(total / 1000).toFixed(1)}s of test time total`);
-  ' "${TOP}" "${REPORT_JSON_HOST}"
+  ' "${TOP}" "${REPORT_JSON_HOST}" || true
   echo
   echo "  Full JSON: ${REPORT_JSON_HOST}"
 else

--- a/ops/scripts/utility/constrained-test.sh
+++ b/ops/scripts/utility/constrained-test.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#
+# constrained-test.sh — run the CAMS unit suite under USTP runner resource
+# limits to surface environment-specific test timeouts, and report the slowest
+# tests.
+#
+# WHY THIS EXISTS
+#   The USTP deployment runs CI on self-hosted "Standard D4s v3" runners
+#   (4 vCPU / 16 GiB). Tests that pass comfortably on a developer laptop or on
+#   GitHub-hosted runners can time out there. Two factors compound:
+#     1. Vitest sizes its worker pool from os.availableParallelism(). On a
+#        4-vCPU box it spawns ~3-4 workers vs ~9 on a 10-core laptop, so more
+#        tests contend for fewer workers.
+#     2. The default per-test timeout is 5s; slower wall-clock under contention
+#        tips marginal tests over the edge.
+#
+#   To reproduce faithfully we must make the container REPORT 4 cores (so the
+#   pool sizes correctly), not merely cap total CPU time. We pin with
+#   --cpuset-cpus; Node 22 respects the cpuset cgroup in availableParallelism().
+#
+#   This is intentionally NOT part of pr-validation / the normal GHA workflow:
+#   the constrained run is much slower. It's a tool you reach for when
+#   investigating timeouts.
+#
+# USAGE
+#   ops/scripts/utility/constrained-test.sh [options]
+#
+# OPTIONS
+#   -w, --workspace <name>   Workspace to test: backend | common | user-interface
+#                            (default: backend)
+#   -c, --cpus <float>       Add a CPU-time quota ON TOP of the 4-core pin to
+#                            also approximate the runner's slower per-core
+#                            throughput (e.g. 2.0). Default: unset (pin only).
+#       --cpuset <range>     Cores to pin to (default: 0-3 => 4 cores).
+#   -m, --memory <size>      Memory cap (default: 16g). Swap is disabled.
+#   -n, --top <int>          Number of slowest tests to report (default: 25).
+#       --no-build           Skip rebuilding the Docker image (reuse existing).
+#   -h, --help               Show this help.
+#
+# EXAMPLES
+#   # Faithful core-count emulation (default): finds parallelism/timeout issues.
+#   ops/scripts/utility/constrained-test.sh
+#
+#   # Also throttle per-core speed to ~2 cores' worth of CPU time for a closer
+#   # wall-clock match when timeouts are marginal.
+#   ops/scripts/utility/constrained-test.sh --cpus 2.0
+#
+#   # Investigate the common library's suite, show the 50 slowest.
+#   ops/scripts/utility/constrained-test.sh -w common -n 50
+#
+# NOTES
+#   * Apple Silicon: Docker Desktop runs a Linux VM. --cpuset-cpus is relative
+#     to the VM's CPU allocation, so give the VM >= 4 cores / >= 16 GiB in
+#     Docker Desktop settings, or the pin/cap won't reflect a real D4s v3.
+#   * Architecture: this runs the image natively (arm64 on Apple Silicon). That
+#     is correct for RANKING the slowest tests. Do NOT add --platform
+#     linux/amd64 to match the runner arch: QEMU emulation skews timing far
+#     more than the arch difference and ruins the ranking.
+
+set -euo pipefail
+
+# --- locate repo root ---------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# --- defaults -----------------------------------------------------------------
+WORKSPACE="backend"
+CPUS=""             # empty => no quota, pin only
+CPUSET="0-3"        # 4 cores
+MEMORY="16g"
+TOP=25
+DO_BUILD=1
+IMAGE="cams-build:latest"
+DOCKERFILE=".github/docker/Dockerfile.build-and-test"
+
+# --- arg parsing --------------------------------------------------------------
+usage() { sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//; s/^#$//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -w|--workspace) WORKSPACE="$2"; shift 2 ;;
+    -c|--cpus)      CPUS="$2"; shift 2 ;;
+    --cpuset)       CPUSET="$2"; shift 2 ;;
+    -m|--memory)    MEMORY="$2"; shift 2 ;;
+    -n|--top)       TOP="$2"; shift 2 ;;
+    --no-build)     DO_BUILD=0; shift ;;
+    -h|--help)      usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; echo "Run with --help for usage." >&2; exit 2 ;;
+  esac
+done
+
+case "${WORKSPACE}" in
+  backend|common|user-interface) ;;
+  *) echo "Invalid --workspace '${WORKSPACE}'. Use backend | common | user-interface." >&2; exit 2 ;;
+esac
+
+# --- count pinned cores (for reporting) --------------------------------------
+count_cpuset() {
+  local total=0 part lo hi
+  IFS=',' read -ra parts <<< "$1"
+  for part in "${parts[@]}"; do
+    if [[ "$part" == *-* ]]; then
+      lo="${part%-*}"; hi="${part#*-}"
+      total=$(( total + hi - lo + 1 ))
+    else
+      total=$(( total + 1 ))
+    fi
+  done
+  echo "$total"
+}
+CORE_COUNT="$(count_cpuset "${CPUSET}")"
+
+# --- build image --------------------------------------------------------------
+if [[ "${DO_BUILD}" -eq 1 ]]; then
+  echo "==> Building ${IMAGE} from ${DOCKERFILE}"
+  docker build -f "${REPO_ROOT}/${DOCKERFILE}" -t "${IMAGE}" "${REPO_ROOT}"
+else
+  echo "==> Reusing existing image ${IMAGE} (--no-build)"
+fi
+
+# --- assemble docker resource flags ------------------------------------------
+RUN_FLAGS=(--rm
+  --cpuset-cpus="${CPUSET}"
+  --memory="${MEMORY}"
+  --memory-swap="${MEMORY}")   # equal mem/mem-swap => swap disabled, OOM surfaces like the real box
+if [[ -n "${CPUS}" ]]; then
+  RUN_FLAGS+=(--cpus="${CPUS}")
+fi
+
+# Output dir on the host so the JSON report survives the container.
+# temp/ is gitignored by convention in this repo.
+OUT_DIR="${REPO_ROOT}/temp/constrained-test"
+mkdir -p "${OUT_DIR}"
+REPORT_JSON_HOST="${OUT_DIR}/${WORKSPACE}-results.json"
+rm -f "${REPORT_JSON_HOST}"
+
+echo "==> Constraint profile"
+echo "      workspace      : ${WORKSPACE}"
+echo "      pinned cores   : ${CPUSET} (${CORE_COUNT} cores; emulates D4s v3 4-vCPU pool sizing)"
+echo "      cpu quota      : ${CPUS:-<none — pin only>}"
+echo "      memory         : ${MEMORY} (swap disabled)"
+echo
+
+# --- build the in-container command -------------------------------------------
+# Each workspace installs from the lockfile, builds common as needed, then runs
+# vitest with dual reporters: default (live console + inline slow markers) and
+# json (machine-readable per-test durations written to a host-mounted path).
+#
+# slowTestThreshold=300 flags slow tests inline; the json reporter gives exact
+# per-test durations for the ranked report below. With multiple reporters,
+# Vitest requires dot-notation to target one reporter's output file.
+CONTAINER_REPORT="/workspace/temp/constrained-test/${WORKSPACE}-results.json"
+
+read -r -d '' IN_CONTAINER <<EOF || true
+set -euo pipefail
+mkdir -p /workspace/temp/constrained-test
+
+echo "--- node sees availableParallelism() = \$(node -e 'console.log(require("os").availableParallelism())') cores ---"
+
+cd /workspace/common && npm ci
+if [ "${WORKSPACE}" != "common" ]; then
+  npm run build
+fi
+
+cd /workspace/${WORKSPACE} && npm ci
+
+export CAMS_LOGIN_PROVIDER_CONFIG='{"issuer": "http://localhost:7071/api/oauth2/default", "clientId": ""}'
+
+# Use the workspace's own test env (CAMS_LOGIN_PROVIDER=mock, DATABASE_MOCK, etc.
+# come from its "test" script). Append reporters + slow threshold.
+npm test -- \
+  --reporter=default \
+  --reporter=json --outputFile.json="${CONTAINER_REPORT}" \
+  --slowTestThreshold=300
+EOF
+
+echo "==> Running suite under constraints (this is intentionally slow)"
+set +e
+docker run "${RUN_FLAGS[@]}" \
+  -v "${REPO_ROOT}:/workspace" \
+  "${IMAGE}" \
+  bash -c "${IN_CONTAINER}"
+TEST_EXIT=$?
+set -e
+
+echo
+echo "============================================================"
+echo " Slowest ${TOP} tests (workspace: ${WORKSPACE})"
+echo "============================================================"
+
+if [[ -f "${REPORT_JSON_HOST}" ]]; then
+  # Vitest JSON: assertionResults[].duration (ms) per test, with file in name.
+  # shellcheck disable=SC2016  # this is a Node script; shell must NOT expand it.
+  node -e '
+    const fs = require("fs");
+    const top = parseInt(process.argv[2], 10);
+    const path = process.argv[3];
+    const data = JSON.parse(fs.readFileSync(path, "utf8"));
+    const rows = [];
+    for (const suite of data.testResults || []) {
+      const file = (suite.name || "").replace(/^\/workspace\//, "");
+      for (const t of suite.assertionResults || []) {
+        rows.push({ ms: t.duration ?? 0, title: t.fullName || t.title, file });
+      }
+    }
+    rows.sort((a, b) => b.ms - a.ms);
+    const pad = (s, n) => String(s).padStart(n);
+    for (const r of rows.slice(0, top)) {
+      console.log(`${pad(r.ms.toFixed(0), 7)} ms  ${r.file}  ›  ${r.title}`);
+    }
+    const total = rows.reduce((s, r) => s + r.ms, 0);
+    console.log(`\n  ${rows.length} tests, ${(total / 1000).toFixed(1)}s of test time total`);
+  ' "${TOP}" "${REPORT_JSON_HOST}"
+  echo
+  echo "  Full JSON: ${REPORT_JSON_HOST}"
+else
+  echo "  No results JSON produced at ${REPORT_JSON_HOST}."
+  echo "  The suite likely failed before writing results (see output above)."
+fi
+
+echo
+if [[ "${TEST_EXIT}" -ne 0 ]]; then
+  echo "==> Suite exited non-zero (${TEST_EXIT}) — failures or timeouts under constraint."
+else
+  echo "==> Suite passed under constraint."
+fi
+exit "${TEST_EXIT}"

--- a/ops/scripts/utility/constrained-test.sh
+++ b/ops/scripts/utility/constrained-test.sh
@@ -71,7 +71,9 @@
 #     on Apple Silicon, amd64 on a typical Linux runner). That is correct for
 #     RANKING the slowest tests. Do NOT add --platform linux/amd64 to match the
 #     runner arch on a non-amd64 host: QEMU emulation skews timing far more than
-#     the arch difference and ruins the ranking.
+#     the arch difference and ruins the ranking. The constraint profile reports
+#     both the host and container arch so a cross-arch run is visible at a glance,
+#     and reminds you the rankings are RELATIVE, not absolute wall-clock.
 
 set -euo pipefail
 
@@ -88,6 +90,12 @@ TOP=25
 UNCONSTRAINED=0      # 1 => fast mode: drop all resource limits, skip preflights
 DO_BUILD=1
 IMAGE="cams-build:latest"
+# Host arch via uname -m (cheap, no container). The container arch is probed by
+# the core-count preflight one-shot (Goal 2) and recorded here; it stays "not
+# probed" when that preflight is skipped (--unconstrained), since we deliberately
+# do NOT add a second always-on container run just to read it.
+HOST_ARCH="$(uname -m)"
+CONTAINER_ARCH="<not probed>"
 DOCKERFILE=".github/docker/Dockerfile.build-and-test"
 # Container engine. Precedence: --engine flag > $CONTAINER_ENGINE > podman >
 # docker (resolved by detect_engine() after arg parsing). Seed from the env var
@@ -207,16 +215,31 @@ fi
 # RUN_FLAGS and the base image's node (no mounts, no npm ci).
 preflight_core_count() {
   echo "==> Preflight: verifying the container reports ${CORES} cores" >&2
-  local reported
+  local out reported
   # Capture stdout only; if the host/VM is too small the cpuset is out of range
   # (or --memory exceeds available RAM) and the engine errors out (empty/non-
   # numeric output) — that is itself a fidelity failure we want to surface, so
   # don't let `set -e` abort here.
+  #
+  # ONE one-shot, TWO values: this same node run also emits process.arch on a
+  # second line so the profile block can report the CONTAINER arch without a
+  # second container invocation (folding the Goal-3 arch probe into this Goal-2
+  # preflight). Line 1 = core count, line 2 = arch.
   set +e
-  reported="$("${ENGINE}" run "${RUN_FLAGS[@]}" "${IMAGE}" \
-    node -e 'console.log(require("os").availableParallelism())' 2>/dev/null)"
+  out="$("${ENGINE}" run "${RUN_FLAGS[@]}" "${IMAGE}" \
+    node -e 'console.log(require("os").availableParallelism()); console.log(process.arch)' 2>/dev/null)"
   set -e
+  reported="$(printf '%s\n' "${out}" | sed -n '1p')"
   reported="${reported//[$'\t\r\n ']/}"
+
+  # Parse the arch line (best-effort; arch is OUTPUT-ONLY, so a missing/odd value
+  # must never abort the script). Only overwrite the default when it looks sane.
+  local arch
+  arch="$(printf '%s\n' "${out}" | sed -n '2p')"
+  arch="${arch//[$'\t\r\n ']/}"
+  if [[ "${arch}" =~ ^[A-Za-z0-9_]+$ ]]; then
+    CONTAINER_ARCH="${arch}"
+  fi
 
   if [[ "${reported}" =~ ^[0-9]+$ ]] && [[ "${reported}" -eq "${CORES}" ]]; then
     echo "    OK: container reports ${reported} cores (matches --cores ${CORES})." >&2
@@ -345,9 +368,24 @@ mkdir -p "${OUT_DIR}"
 REPORT_JSON_HOST="${OUT_DIR}/${WORKSPACE}-results.json"
 rm -f "${REPORT_JSON_HOST}"
 
+# Run the fidelity preflights now (faithful mode only): surface a too-small VM
+# or an unhonored constraint BEFORE the multi-minute suite, not after. We run
+# these BEFORE printing the profile so the core-count one-shot can record the
+# container arch (CONTAINER_ARCH) for the profile block below. In --unconstrained
+# mode the preflights are skipped, so the container arch stays "<not probed>" —
+# we deliberately do NOT add a second always-on container run just to fill it in.
+if [[ "${UNCONSTRAINED}" -eq 0 ]]; then
+  preflight_core_count
+  preflight_memory_fidelity
+else
+  echo "==> Skipping core-count and memory-fidelity preflights (--unconstrained)." >&2
+fi
+
 echo "==> Constraint profile"
 echo "      engine         : ${ENGINE}"
 echo "      workspace      : ${WORKSPACE}"
+echo "      host arch      : ${HOST_ARCH}"
+echo "      container arch : ${CONTAINER_ARCH}"
 if [[ "${UNCONSTRAINED}" -eq 1 ]]; then
   echo "      mode           : UNCONSTRAINED (fast — NOT a faithful D4s v3 emulation)"
   echo "      pinned cores   : <none — container uses the whole VM>"
@@ -359,16 +397,15 @@ else
   echo "      cpu quota      : ${CPUS:-<none — pin only>}"
   echo "      memory         : ${MEMORY} (swap disabled)"
 fi
+# WHY this note: the image runs NATIVELY for the host arch (no --platform, no
+# QEMU) on purpose — QEMU emulation skews timing far more than the arch
+# difference would, which would ruin the ranking. So the slowest-test numbers
+# below are RELATIVE (compare tests to each other within this run), not absolute
+# wall-clock you can quote against the real D4s v3. A host/container arch
+# mismatch above is expected and fine for ranking.
+echo "      note           : rankings are RELATIVE (not absolute wall-clock); the run is"
+echo "                       native for the host arch by design (no --platform / no QEMU)."
 echo
-
-# Run the fidelity preflights now (faithful mode only): surface a too-small VM
-# or an unhonored constraint BEFORE the multi-minute suite, not after.
-if [[ "${UNCONSTRAINED}" -eq 0 ]]; then
-  preflight_core_count
-  preflight_memory_fidelity
-else
-  echo "==> Skipping core-count and memory-fidelity preflights (--unconstrained)." >&2
-fi
 
 # --- build the in-container command -------------------------------------------
 # Each workspace installs from the lockfile, builds common as needed, then runs


### PR DESCRIPTION
# Purpose

Backend unit tests occasionally time out on the USTP self-hosted "Standard D4s v3" runners (4 vCPU / 16 GiB) but not on developer laptops or GitHub-hosted runners. This adds a tool to faithfully reproduce that resource-constrained environment locally and in CI so marginal tests can be found and fixed by priority before they flake on the real runner.

# Major Changes

* **Constrained test runner** (`ops/scripts/utility/constrained-test.sh`) — runs a workspace's Vitest suite inside a container pinned to 4 cores (cpuset) and 16 GiB (swap disabled) to emulate D4s v3 worker-pool sizing and OOM behavior. Engine-agnostic (auto-detects podman locally, docker in CI), with host-tree isolation so the container's installs never clobber the developer's macOS/arm64 working tree.
* **Preflight fidelity checks** — warn (never block) when the host/VM can't actually back the requested cores or memory, so a non-faithful run is obvious before the multi-minute suite runs.
* **Architecture reporting** — the constraint profile reports host and container arch and notes that rankings are relative (not absolute wall-clock); the run is intentionally native (no `--platform`/QEMU, which would skew timing).
* **Priority report module** (`dev-tools/constrained-test/`) — a unit-tested TypeScript module (pure `report.ts` + thin `report.cli.ts`) that computes slowest tests, per-file totals, overhead gap, and margin-to-timeout (most-at-risk first), persisted as both JSON and Markdown.
* **Opt-in `--profile`** — wires Node `--cpu-prof` into the Vitest fork workers via `--execArgv`, emitting `.cpuprofile` files for speedscope/Chrome DevTools; the report annotates profiled runs as non-comparable.
* **Periodic GHA workflow** (`.github/workflows/constrained-test-report.yml`) — weekly + manual `workflow_dispatch`, runs the backend suite under emulation on ubuntu-latest, and publishes the priority report as artifacts and a job summary. Informational by design: it never turns red on slow/failing tests and is deliberately NOT part of `pr-validation`.
* **Build-and-test container** (`.github/docker/Dockerfile.build-and-test`) — the `node:22.22.2-bookworm-slim` substrate the runner builds, tracking `.nvmrc`.

# Testing/Validation

The priority report module was built with TDD (18 Vitest tests, no mocking — it's pure); the "sums all tests, not the sliced top-N" regression guard was mutation-tested to confirm it fails on the bug it protects against. The bash script was validated by execution: real constrained runs on the `common` workspace (1090 tests pass, host-tree isolation confirmed clean) and a real profiled backend run that produced 35 `.cpuprofile` files on the host. The `--profile` mechanics were verified against the Vitest 4.1.8 source. The workflow passes the repo's GitHub-workflows schema check, reuses existing action SHAs, and is referenced by no other workflow. Each change was reviewed via an adversarial two-turn process (self-refutation, then a fresh skeptic per surviving finding).

# Notes

* The runner is intentionally NOT wired into `pr-validation` — a faithful backend run takes ~9 minutes. It's an on-demand/periodic investigation tool.
* On a Mac, a faithful 16 GiB memory emulation requires the podman machine to have >= 16 GiB; the preflight warns when it doesn't (core-count fidelity, the primary purpose, still works on smaller VMs).
* The initial run already surfaced its target signal: under constraint the slowest backend tests cluster in the trustee dataflow suites, the top one ~240ms under the 5s timeout.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce a constrained backend test runner that emulates Standard D4s v3 resources and publishes periodic slow-test reports from CI.

New Features:
- Add a constrained test runner script that runs workspace Vitest suites inside a resource-limited container and optionally gathers CPU profiles.
- Introduce a TypeScript reporting module and CLI that consume Vitest JSON output to produce structured slow-test and timeout-margin reports in JSON and Markdown.
- Add a dedicated Docker build-and-test image used by the constrained test runner and related CI jobs.
- Create a scheduled and manually-triggerable GitHub Actions workflow that runs the backend suite under constraint and publishes the priority report as artifacts and a job summary.

Documentation:
- Update workflow documentation and diagrams to include the new Constrained Test Report workflow and its triggers.

Tests:
- Add unit tests for the constrained-test reporting module to validate slowest-test ranking, per-file totals, overhead gap, timeout margins, and profiled-run annotations.