### PR TITLE
CAMS-775 Add client-side pagination to trustee list

### DIFF
--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -3058,7 +3058,8 @@ describe('TrusteesList Component', () => {
 
       const districtCombobox = await screen.findByRole('combobox', { name: /district/i });
       await user.click(districtCombobox);
-      const nyOption = await screen.findByRole('option', {
+      const listbox = await screen.findByRole('listbox', { name: /district/i });
+      const nyOption = within(listbox).getByRole('option', {
         name: /Southern District of New York/i,
       });
       await user.click(nyOption);

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2969,15 +2969,17 @@ describe('TrusteesList Component', () => {
         expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
       });
 
-      const rowsPage1 = document.querySelectorAll('.trustee-group');
-      expect(rowsPage1).toHaveLength(25);
+      // Subtract 1 for the header row
+      const table = screen.getByTestId('trustees-table');
+      const rowsPage1 = within(table).getAllByRole('row');
+      expect(rowsPage1).toHaveLength(26); // 25 data rows + 1 header row
 
       const page2Button = screen.getByTestId('pagination-button-page-2-results');
       await userEvent.click(page2Button);
 
       await waitFor(() => {
-        const rowsPage2 = document.querySelectorAll('.trustee-group');
-        expect(rowsPage2).toHaveLength(25);
+        const rowsPage2 = within(screen.getByTestId('trustees-table')).getAllByRole('row');
+        expect(rowsPage2).toHaveLength(26); // 25 data rows + 1 header row
       });
 
       // page 1 trustee should no longer be in the table
@@ -3017,6 +3019,59 @@ describe('TrusteesList Component', () => {
     });
 
     test('changing district filter resets to page 1', async () => {
+      // makeTrustees uses the default appointment which has divisionCode '081'.
+      // Providing a court with courtDivisionCode '081' makes "Southern District of New York"
+      // appear as a selectable option in the District combobox.
+      const trustees = makeTrustees(50);
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({
+        data: [
+          {
+            courtId: '0208',
+            courtName: 'Southern District of New York',
+            officeCode: '081',
+            officeName: 'Manhattan',
+            courtDivisionCode: '081',
+            courtDivisionName: 'Manhattan',
+            groupDesignator: 'NY',
+            regionId: '02',
+            regionName: 'New York Region',
+          },
+        ],
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      // Navigate to page 2
+      await userEvent.click(screen.getByTestId('pagination-button-page-2-results'));
+      await waitFor(() => {
+        expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
+      });
+
+      // Open filters and change district via the combobox
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+
+      const districtCombobox = await screen.findByRole('combobox', { name: /district/i });
+      await user.click(districtCombobox);
+      const nyOption = await screen.findByRole('option', {
+        name: /Southern District of New York/i,
+      });
+      await user.click(nyOption);
+
+      // After district change, page resets to 1 — first trustee from the list is visible again
+      await waitFor(() => {
+        expect(screen.getByText('Last000, First0')).toBeInTheDocument();
+      });
+    });
+
+    test('changing chapter filter resets to page 1', async () => {
+      // All trustees in makeTrustees use the default appointment (chapter '7'),
+      // so selecting Chapter 7 returns all of them, still landing on page 1.
       const trustees = makeTrustees(50);
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });
 
@@ -3032,9 +3087,18 @@ describe('TrusteesList Component', () => {
         expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
       });
 
-      // Navigating to page 2 changed offset; verify max rows per page is still enforced
+      // Open filters and change chapter via the combobox
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+
+      const chapterCombobox = await screen.findByRole('combobox', { name: /chapter/i });
+      await user.click(chapterCombobox);
+      const chapter7Option = await screen.findByRole('option', { name: /Chapter 7/i });
+      await user.click(chapter7Option);
+
+      // After chapter change, page resets to 1 — first trustee from the list is visible again
       await waitFor(() => {
-        expect(document.querySelectorAll('.trustee-group').length).toBeLessThanOrEqual(25);
+        expect(screen.getByText('Last000, First0')).toBeInTheDocument();
       });
     });
 
@@ -3070,9 +3134,10 @@ describe('TrusteesList Component', () => {
 
       await waitFor(() => {
         // After name search resolves, we should be back on page 1 (first trustee visible)
-        const rowCount = document.querySelectorAll('.trustee-group').length;
-        expect(rowCount).toBeGreaterThan(0);
-        expect(rowCount).toBeLessThanOrEqual(25);
+        const rows = within(screen.getByTestId('trustees-table')).getAllByRole('row');
+        const dataRowCount = rows.length - 1; // subtract header row
+        expect(dataRowCount).toBeGreaterThan(0);
+        expect(dataRowCount).toBeLessThanOrEqual(25);
       });
 
       vi.useRealTimers();

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -3058,11 +3058,10 @@ describe('TrusteesList Component', () => {
 
       const districtCombobox = await screen.findByRole('combobox', { name: /district/i });
       await user.click(districtCombobox);
+      // Click the first option regardless of name — works whether TRUSTEE_DISTRICT_DIVISION
+      // flag is on (options like "Southern District of New York (All)") or off.
       const listbox = await screen.findByRole('listbox', { name: /district/i });
-      const nyOption = within(listbox).getByRole('option', {
-        name: /Southern District of New York/i,
-      });
-      await user.click(nyOption);
+      await user.click(within(listbox).getAllByRole('option')[0]);
 
       // After district change, page resets to 1 — first trustee from the list is visible again
       await waitFor(() => {

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2919,6 +2919,190 @@ describe('TrusteesList Component', () => {
     });
   });
 
+  describe('Pagination', () => {
+    function makeTrustees(count: number): TrusteeListItem[] {
+      return Array.from({ length: count }, (_, i) =>
+        makeListItem({
+          trusteeId: `trustee-page-${i}`,
+          firstName: `First${i}`,
+          lastName: `Last${String(i).padStart(3, '0')}`,
+          name: `First${i} Last${String(i).padStart(3, '0')}`,
+        }),
+      );
+    }
+
+    beforeEach(() => {
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [] });
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+    });
+
+    test('renders pagination when filtered results exceed 25', async () => {
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: makeTrustees(26) });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('navigation', { name: /pagination/i })).toBeInTheDocument();
+    });
+
+    test('does not render pagination when filtered results are 25 or fewer', async () => {
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: makeTrustees(25) });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('navigation', { name: /pagination/i })).not.toBeInTheDocument();
+    });
+
+    test('page 1 shows first 25 trustees and page 2 shows the next slice', async () => {
+      const trustees = makeTrustees(50);
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      const rowsPage1 = document.querySelectorAll('.trustee-group');
+      expect(rowsPage1).toHaveLength(25);
+
+      const page2Button = screen.getByTestId('pagination-button-page-2-results');
+      await userEvent.click(page2Button);
+
+      await waitFor(() => {
+        const rowsPage2 = document.querySelectorAll('.trustee-group');
+        expect(rowsPage2).toHaveLength(25);
+      });
+
+      // page 1 trustee should no longer be in the table
+      expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
+    });
+
+    test('changing status filter resets to page 1', async () => {
+      const trustees = makeTrustees(50);
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      // Go to page 2
+      await userEvent.click(screen.getByTestId('pagination-button-page-2-results'));
+      await waitFor(() => {
+        expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
+      });
+
+      // Open filters and change status via the combobox
+      const user = userEvent.setup();
+      const toggleButton = screen.getByRole('button', { name: /filters/i });
+      await user.click(toggleButton);
+
+      const statusCombobox = await screen.findByRole('combobox', { name: /status/i });
+      await user.click(statusCombobox);
+      const inactiveOption = await screen.findByRole('option', { name: /inactive/i });
+      await user.click(inactiveOption);
+
+      // After status change, page resets — at most 25 rows visible
+      await waitFor(() => {
+        const rowCount = document.querySelectorAll('.trustee-group').length;
+        expect(rowCount).toBeLessThanOrEqual(25);
+      });
+    });
+
+    test('changing district filter resets to page 1', async () => {
+      const trustees = makeTrustees(50);
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      // Navigate to page 2
+      await userEvent.click(screen.getByTestId('pagination-button-page-2-results'));
+      await waitFor(() => {
+        expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
+      });
+
+      // Navigating to page 2 changed offset; verify max rows per page is still enforced
+      await waitFor(() => {
+        expect(document.querySelectorAll('.trustee-group').length).toBeLessThanOrEqual(25);
+      });
+    });
+
+    test('entering a name search resets to page 1', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const trustees = makeTrustees(50);
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });
+      vi.spyOn(Api2, 'searchTrustees').mockResolvedValue({
+        data: trustees
+          .slice(0, 30)
+          .map((t) => ({ ...t, appointments: [], matchType: 'exact' as const })),
+      });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      // Navigate to page 2
+      await userEvent.click(screen.getByTestId('pagination-button-page-2-results'));
+      await waitFor(() => {
+        expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
+      });
+
+      // Open filters and type a name
+      const user = userEvent.setup({ delay: null });
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+      await user.type(await screen.findByRole('textbox', { name: /trustee name/i }), 'Fi');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        // After name search resolves, we should be back on page 1 (first trustee visible)
+        const rowCount = document.querySelectorAll('.trustee-group').length;
+        expect(rowCount).toBeGreaterThan(0);
+        expect(rowCount).toBeLessThanOrEqual(25);
+      });
+
+      vi.useRealTimers();
+    });
+
+    test('count label shows total filtered count, not page count', async () => {
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: makeTrustees(50) });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('50 Trustees', { selector: 'p' })).toBeInTheDocument();
+      });
+    });
+
+    test('no pagination renders on fetch error', async () => {
+      vi.spyOn(Api2, 'getTrustees').mockRejectedValue(new Error('Network error'));
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Error loading trustees')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('navigation', { name: /pagination/i })).not.toBeInTheDocument();
+    });
+  });
+
   describe('Name Filter Input Rendering', () => {
     test('should not auto-announce input value when accordion expands with content', async () => {
       const trustee = makeListItem({

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -191,10 +191,8 @@ describe('TrusteesList Component', () => {
     expect(screen.getByText('District of Vermont')).toBeInTheDocument();
     expect(screen.getByText('Panel')).toBeInTheDocument();
     expect(screen.getByText('Case by Case')).toBeInTheDocument();
-    const statusCells = document.querySelectorAll('[data-cell="Status"]');
-    const statusTexts = Array.from(statusCells).map((c) => c.textContent);
-    expect(statusTexts).toContain('Active');
-    expect(statusTexts).toContain('Inactive');
+    expect(within(screen.getByTestId('trustees-table')).getByText('Active')).toBeInTheDocument();
+    expect(within(screen.getByTestId('trustees-table')).getByText('Inactive')).toBeInTheDocument();
   });
 
   test('should format District correctly using courtName only', async () => {
@@ -307,9 +305,9 @@ describe('TrusteesList Component', () => {
     renderWithRouter(<TrusteesList />);
 
     await waitFor(() => {
-      const chapterCells = document.querySelectorAll('[data-cell="Chapter"]');
-      const chapterTexts = Array.from(chapterCells).map((c) => c.textContent);
-      expect(chapterTexts).toContain('11 Subchapter V');
+      expect(
+        within(screen.getByTestId('trustees-table')).getByText('11 Subchapter V'),
+      ).toBeInTheDocument();
     });
 
     expect(screen.getByText('Pool')).toBeInTheDocument();
@@ -1266,9 +1264,10 @@ describe('TrusteesList Component', () => {
         await vi.advanceTimersByTimeAsync(300);
       });
 
-      // Should NOT silently show "0 Trustees" — either full list restored or error surfaced
+      // Error handler clears nameSearch to '', restoring the full unfiltered list
       await waitFor(() => {
-        expect(screen.queryByText('0 Trustees', { selector: 'p' })).not.toBeInTheDocument();
+        expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Smith, Alice')).toBeInTheDocument();
       });
     });
 
@@ -2370,7 +2369,7 @@ describe('TrusteesList Component', () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(nysbSession);
     });
 
-    test('filterTrustees: filters by specific division code when flag ON and combined filter selected', async () => {
+    test('flag ON: filters by specific division code when combined filter selected', async () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       const apptManhattan = makeAppointment({
@@ -2436,7 +2435,7 @@ describe('TrusteesList Component', () => {
       });
     });
 
-    test('filterTrustees: "All Divisions" trustee (empty divisionCodes) always matches any division selection', async () => {
+    test('flag ON: "All Divisions" trustee (empty divisionCodes) always matches any division selection', async () => {
       vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
 
       const apptAllDivisions = makeAppointment({
@@ -3011,10 +3010,9 @@ describe('TrusteesList Component', () => {
       const inactiveOption = await screen.findByRole('option', { name: /inactive/i });
       await user.click(inactiveOption);
 
-      // After status change, page resets — at most 25 rows visible
+      // After status change, page resets to 1 — first trustee from the list is visible again
       await waitFor(() => {
-        const rowCount = document.querySelectorAll('.trustee-group').length;
-        expect(rowCount).toBeLessThanOrEqual(25);
+        expect(screen.getByText('Last000, First0')).toBeInTheDocument();
       });
     });
 

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -125,6 +125,7 @@ export default function TrusteesList() {
   const [nameSearchLoading, setNameSearchLoading] = useState(false);
   const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]);
   const [offset, setOffset] = useState(DEFAULT_SEARCH_OFFSET);
+  const [limit, setLimit] = useState(DEFAULT_SEARCH_LIMIT);
   const flags = useFeatureFlags();
   const districtDivisionEnabled = !!flags[TRUSTEE_DISTRICT_DIVISION];
   const COLUMN_HEADERS = districtDivisionEnabled ? DIVISION_COLUMN_HEADERS : BASE_COLUMN_HEADERS;
@@ -211,8 +212,9 @@ export default function TrusteesList() {
     setNameSearch(name);
   };
 
-  const handlePaginationChange = (predicate: { limit: number; offset: number }) => {
-    setOffset(predicate.offset);
+  const handlePaginationChange = ({ limit, offset }: { limit: number; offset: number }) => {
+    setOffset(offset);
+    setLimit(limit);
   };
 
   const combinedDistrictDivisionOptions = useMemo((): ComboOption[] => {
@@ -372,19 +374,19 @@ export default function TrusteesList() {
   }, [statusFilter, selectedDistricts, selectedDivisions, selectedChapters, nameSearch]);
 
   const pagedTrustees = useMemo(
-    () => filteredTrustees.slice(offset, offset + DEFAULT_SEARCH_LIMIT),
-    [filteredTrustees, offset],
+    () => filteredTrustees.slice(offset, offset + limit),
+    [filteredTrustees, offset, limit],
   );
 
   const paginationValues = useMemo((): PaginationModel => {
     return {
       count: pagedTrustees.length,
-      limit: DEFAULT_SEARCH_LIMIT,
-      currentPage: Math.floor(offset / DEFAULT_SEARCH_LIMIT) + 1,
-      totalPages: Math.ceil(filteredTrustees.length / DEFAULT_SEARCH_LIMIT),
+      limit,
+      currentPage: Math.floor(offset / limit) + 1,
+      totalPages: Math.ceil(filteredTrustees.length / limit),
       totalCount: filteredTrustees.length,
     };
-  }, [pagedTrustees, filteredTrustees, offset]);
+  }, [pagedTrustees, filteredTrustees, offset, limit]);
 
   useEffect(() => {
     if (!isDefaultApplied.current) return;
@@ -664,7 +666,7 @@ export default function TrusteesList() {
             <div aria-live="off" aria-atomic="false">
               <Pagination<{ limit: number; offset: number }>
                 paginationValues={paginationValues}
-                searchPredicate={{ limit: DEFAULT_SEARCH_LIMIT, offset }}
+                searchPredicate={{ limit, offset }}
                 retrievePage={handlePaginationChange}
               />
             </div>

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -24,6 +24,9 @@ import {
 } from '@/lib/utils/court-utils';
 import useFeatureFlags, { TRUSTEE_DISTRICT_DIVISION } from '@/lib/hooks/UseFeatureFlags';
 import { CourtDivisionDetails } from '@common/cams/courts';
+import { Pagination } from '@/lib/components/uswds/Pagination';
+import { Pagination as PaginationModel } from '@common/api/pagination';
+import { DEFAULT_SEARCH_LIMIT, DEFAULT_SEARCH_OFFSET } from '@common/api/search';
 
 const BASE_COLUMN_HEADERS = ['Name', 'District', 'Chapter', 'Type', 'Status'];
 const DIVISION_COLUMN_HEADERS = ['Name', 'District', 'Division', 'Chapter', 'Type', 'Status'];
@@ -121,6 +124,7 @@ export default function TrusteesList() {
   const [nameSearchIds, setNameSearchIds] = useState<Set<string>>(new Set());
   const [nameSearchLoading, setNameSearchLoading] = useState(false);
   const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]);
+  const [offset, setOffset] = useState(DEFAULT_SEARCH_OFFSET);
   const flags = useFeatureFlags();
   const districtDivisionEnabled = !!flags[TRUSTEE_DISTRICT_DIVISION];
   const COLUMN_HEADERS = districtDivisionEnabled ? DIVISION_COLUMN_HEADERS : BASE_COLUMN_HEADERS;
@@ -205,6 +209,10 @@ export default function TrusteesList() {
     lastFilterChanged.current = 'name';
     if (name.length >= 2) setNameSearchLoading(true);
     setNameSearch(name);
+  };
+
+  const handlePaginationChange = (predicate: { limit: number; offset: number }) => {
+    setOffset(predicate.offset);
   };
 
   const combinedDistrictDivisionOptions = useMemo((): ComboOption[] => {
@@ -358,6 +366,25 @@ export default function TrusteesList() {
       filteredTrustees: sortedWithAppointments,
     };
   }, [baseFilteredTrustees, nameSearch, nameSearchIds, sortDirection]);
+
+  useEffect(() => {
+    setOffset(DEFAULT_SEARCH_OFFSET);
+  }, [statusFilter, selectedDistricts, selectedDivisions, selectedChapters, nameSearch]);
+
+  const pagedTrustees = useMemo(
+    () => filteredTrustees.slice(offset, offset + DEFAULT_SEARCH_LIMIT),
+    [filteredTrustees, offset],
+  );
+
+  const paginationValues = useMemo((): PaginationModel => {
+    return {
+      count: pagedTrustees.length,
+      limit: DEFAULT_SEARCH_LIMIT,
+      currentPage: Math.floor(offset / DEFAULT_SEARCH_LIMIT) + 1,
+      totalPages: Math.ceil(filteredTrustees.length / DEFAULT_SEARCH_LIMIT),
+      totalCount: filteredTrustees.length,
+    };
+  }, [pagedTrustees, filteredTrustees, offset]);
 
   useEffect(() => {
     if (!isDefaultApplied.current) return;
@@ -555,7 +582,7 @@ export default function TrusteesList() {
                 {nameSearchLoading ? (
                   <LoadingSpinner caption="Searching trustees..." />
                 ) : (
-                  filteredTrustees.map((trustee) => {
+                  pagedTrustees.map((trustee) => {
                     const rows = trustee.appointments.length === 0 ? [null] : trustee.appointments;
 
                     return (
@@ -631,6 +658,15 @@ export default function TrusteesList() {
                   })
                 )}
               </div>
+            </div>
+          )}
+          {paginationValues.totalPages && paginationValues.totalPages > 1 && (
+            <div aria-live="off" aria-atomic="false">
+              <Pagination<{ limit: number; offset: number }>
+                paginationValues={paginationValues}
+                searchPredicate={{ limit: DEFAULT_SEARCH_LIMIT, offset }}
+                retrievePage={handlePaginationChange}
+              />
             </div>
           )}
         </>


### PR DESCRIPTION
# Purpose

Enable USTP staff to navigate a large trustee list without being overwhelmed by a single unbounded table. Displays 25 trustees per page using the existing in-memory filtered result set — no backend changes required.

# Major Changes

- Added client-side pagination to `TrusteesList.tsx`: offset state, `pagedTrustees` and `paginationValues` useMemos, and `handlePaginationChange` handler
- Renders the existing `Pagination` component below the table when total pages > 1; hidden when results are ≤ 25
- All filters (status, district, division, chapter) and name search reset offset to page 1 via a single declarative `useEffect`
- Count label continues to show total filtered count, not page count

# Testing/Validation

Implemented using TDD. 79 unit tests pass covering: pagination renders/hides at the 25 boundary, correct page slices, page 1 reset on all filter types, count label accuracy, and no pagination on fetch error.

# Notes

Client-side pagination was chosen over server-side to avoid backend changes — the trustee list is small enough to hold in memory, and the existing `filteredTrustees` useMemo chain already has the full filtered result available. `TrusteeCaseList.tsx` was used as the reference implementation for `Pagination` component wiring.

Page navigation does not show a loading spinner — the slice is a synchronous in-memory operation that renders in the same frame.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add client-side pagination to the trustees list and ensure filters and search reset pagination while preserving accurate result counts.

New Features:
- Introduce client-side pagination for the trustees list, showing a fixed-size page of trustees from the in-memory filtered results.
- Render a pagination control beneath the trustees table when the filtered result set spans multiple pages.

Enhancements:
- Reset the current page to the first page whenever status, district, division, chapter filters, or name search criteria change.
- Refine trustee list tests to target table content via test IDs and clarify feature flag test names.
- Ensure the trustee count label reflects the total filtered results rather than the current page size and remains hidden on fetch errors.

Tests:
- Add pagination-focused test coverage verifying render thresholds, page slicing, filter/search reset behavior, count label semantics, and absence of pagination on fetch error.