### PR TITLE
Force docker engine in constrained test workflow

### DIFF
--- a/.github/workflows/constrained-test-report.yml
+++ b/.github/workflows/constrained-test-report.yml
@@ -20,10 +20,15 @@
 #       report) in the job summary. This workflow is deliberately NOT part of
 #       pr-validation.yml and is NOT a PR gate.
 #
-# RUNNER: GitHub-hosted ubuntu-latest. Docker is preinstalled; podman is not, so
-#       the script auto-detects and falls back to docker, which emulates D4s v3
-#       via cpuset/memory exactly as podman does locally. We do NOT install
-#       podman.
+# ENGINE: We pass --engine docker explicitly. The GitHub-hosted ubuntu runner
+#       ships BOTH podman and docker, and the script's auto-detection prefers
+#       podman — but rootless podman + crun on the runner cannot apply
+#       --cpuset-cpus (it errors "the requested cgroup controller `cpuset` is
+#       not available"), so the cpuset pin, and the run, fail before any test
+#       executes. Rootful Docker on the same runner honors the cpuset pin, so
+#       forcing docker preserves the 4-core emulation. (Docker Engine on a Linux
+#       CI runner is license-free; the local Podman preference is about avoiding
+#       Docker Desktop licensing, which does not apply here.)
 
 name: Constrained Test Report
 
@@ -67,9 +72,12 @@ jobs:
         run: npm ci
 
       # Run the constrained suite for the backend workspace. The script builds
-      # the Docker image (no cached image on a fresh runner, so we WANT the
+      # the container image (no cached image on a fresh runner, so we WANT the
       # build — do not pass --no-build), runs the suite under cpuset 0-3 / 16g,
       # and writes temp/constrained-test/backend-{results,report}.{json,md}.
+      #
+      # --engine docker: see the ENGINE note in the header — rootless podman on
+      # the runner cannot apply the cpuset pin, rootful docker can.
       #
       # The script ends with `exit "${TEST_EXIT}"` — non-zero when the suite has
       # failures/timeouts under constraint. That is the SIGNAL we want, NOT a
@@ -81,7 +89,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          ops/scripts/utility/constrained-test.sh -w backend
+          ops/scripts/utility/constrained-test.sh -w backend --engine docker
           script_exit=$?
           set -e
           echo "script_exit=${script_exit}" >> "$GITHUB_OUTPUT"
@@ -111,7 +119,7 @@ jobs:
               echo
               echo "The constrained test script did not produce \`${report_md}\`."
               echo "This usually means the script errored BEFORE the suite ran (e.g. the"
-              echo "Docker image failed to build, or the engine could not start the"
+              echo "container image failed to build, or the engine could not start the"
               echo "container under the requested limits) rather than a test failure."
               echo "See the **Run constrained backend test report** step logs above."
             fi


### PR DESCRIPTION
# Bug

The `constrained-test-report.yml` workflow (added in #2541) failed on every run: the job finished in ~1 minute having never run the suite, produced no report, and logged `OCI runtime error: crun: the requested cgroup controller \`cpuset\` is not available` (script exit 126). The GitHub-hosted ubuntu runner ships both podman and docker, and the script's engine auto-detection prefers podman — but rootless podman + crun on the runner cannot apply `--cpuset-cpus`, so the 4-core pin (and therefore the whole run) failed before any test executed. The original review assumed the runner would use docker; it does not.

# Purpose

Make the periodic constrained test report actually run on the GitHub-hosted runner so it produces the backend timing report it was built to publish.

# Major Changes

* Pass `--engine docker` to `constrained-test.sh` in the workflow's run step. Rootful Docker on the runner honors the `--cpuset-cpus` pin, preserving the 4-core D4s v3 emulation, whereas rootless podman cannot.
* Correct the workflow's header comment, which wrongly claimed podman is not installed on the runner (it is, and it is the auto-detected default).

# Testing/Validation

Diagnosed empirically with a temporary docker-vs-podman matrix probe dispatched against this branch: on the `ubuntu-latest` runner, rootless podman rejected the cpuset pin (exit 126, the exact production error) while rootful Docker applied the cpuset+memory pin successfully. After applying the fix, a real `workflow_dispatch` run completed in ~5 minutes, the preflight confirmed `OK: container reports 4 cores (matches --cores 4)`, the full backend suite ran under constraint, and the `backend-constrained-test-report` artifact was produced. The probe and its diagram churn were squashed out; this branch is a single, workflow-only commit.

https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/actions/runs/28052058545

# Notes

Docker Engine on a Linux CI runner is license-free, so forcing docker here does not conflict with Flexion's local Podman preference (which exists to avoid Docker Desktop licensing — not applicable on a CI runner). The engine auto-detection precedence (podman > docker) remains the right default for local developer use; CI simply overrides it.

Separately noted during this work (not addressed here): a GitHub-hosted Linux runner is already 4 vCPU / 16 GiB — the same resource shape as the USTP D4s v3 ADO runners — so the cpuset pin is largely redundant in CI, and this workflow is unlikely to reproduce the *absolute* ADO timeouts (which appear environmental: per-core speed / contention / IO on shared self-hosted agents, not core count). The report remains useful for relative ranking; reproducing the ADO failure is being investigated separately via diagnostics added to the ADO pipeline.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Force the constrained test report workflow to use Docker explicitly so the backend suite runs successfully under CPU constraints on GitHub-hosted runners.

CI:
- Update the constrained-test-report workflow to invoke the constrained-test script with --engine docker to avoid cpuset failures with rootless Podman on GitHub runners.
- Clarify workflow comments to describe the container engine behavior on GitHub-hosted runners and use container-agnostic terminology in log messages.