### PR TITLE
CAMS-778 Fix Rules of Hooks violation in PrivilegedIdentity

### DIFF
--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.test.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.test.tsx
@@ -64,6 +64,7 @@ describe('Privileged Identity screen tests', () => {
   }
 
   beforeEach(async () => {
+    vi.restoreAllMocks();
     process.env = {
       ...env,
       CAMS_USE_FAKE_API: 'true',
@@ -99,10 +100,6 @@ describe('Privileged Identity screen tests', () => {
     vi.spyOn(Api2, 'getPrivilegedIdentityUsers').mockResolvedValue({
       data: MockData.buildArray(MockData.getCamsUserReference, 5),
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   function renderWithoutProps() {
@@ -146,10 +143,9 @@ describe('Privileged Identity screen tests', () => {
   });
 
   test('should load form when feature flag resolves from false to true', async () => {
-    const flagsRef = { 'privileged-identity-management': false as boolean };
-    const flagsSpy = vi
-      .spyOn(FeatureFlagHook, 'default')
-      .mockImplementation(() => ({ ...flagsRef }));
+    vi.spyOn(FeatureFlagHook, 'default')
+      .mockReturnValueOnce({ 'privileged-identity-management': false })
+      .mockReturnValue({ 'privileged-identity-management': true });
 
     const { rerender } = render(<PrivilegedIdentity />);
 
@@ -158,15 +154,13 @@ describe('Privileged Identity screen tests', () => {
     ).toBeInTheDocument();
     expect(Api2.getRoleAndOfficeGroupNames).not.toHaveBeenCalled();
 
-    flagsRef['privileged-identity-management'] = true;
-    flagsSpy.mockImplementation(() => ({ ...flagsRef }));
     rerender(<PrivilegedIdentity />);
 
     await waitFor(() => {
       expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
     });
 
-    expect(Api2.getRoleAndOfficeGroupNames).toHaveBeenCalled();
+    expect(Api2.getRoleAndOfficeGroupNames).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('user-list-option-item-4')).toBeInTheDocument();
   });
 

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.test.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.test.tsx
@@ -145,6 +145,31 @@ describe('Privileged Identity screen tests', () => {
     ).toBeInTheDocument();
   });
 
+  test('should load form when feature flag resolves from false to true', async () => {
+    const flagsRef = { 'privileged-identity-management': false as boolean };
+    const flagsSpy = vi
+      .spyOn(FeatureFlagHook, 'default')
+      .mockImplementation(() => ({ ...flagsRef }));
+
+    const { rerender } = render(<PrivilegedIdentity />);
+
+    expect(
+      screen.getByTestId('alert-container-privileged-identity-disabled-alert'),
+    ).toBeInTheDocument();
+    expect(Api2.getRoleAndOfficeGroupNames).not.toHaveBeenCalled();
+
+    flagsRef['privileged-identity-management'] = true;
+    flagsSpy.mockImplementation(() => ({ ...flagsRef }));
+    rerender(<PrivilegedIdentity />);
+
+    await waitFor(() => {
+      expect(document.querySelector('.loading-spinner-caption')).not.toBeInTheDocument();
+    });
+
+    expect(Api2.getRoleAndOfficeGroupNames).toHaveBeenCalled();
+    expect(screen.getByTestId('user-list-option-item-4')).toBeInTheDocument();
+  });
+
   test('should initially load screen with form disabled until a user is selected', async () => {
     renderWithoutProps();
 

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
@@ -56,41 +56,45 @@ export function PrivilegedIdentity() {
 
   const alert = useGlobalAlert();
 
+  const privilegedIdentityEnabled = flags[PRIVILEGED_IDENTITY_MANAGEMENT];
+
   useEffect(() => {
-    if (!flags[PRIVILEGED_IDENTITY_MANAGEMENT]) return;
+    if (!privilegedIdentityEnabled) return;
     setIsLoaded(false);
-    Api2.getRoleAndOfficeGroupNames().then((groups) => {
-      // Sort the office names.
-      const officeMap = new Map<string, string>();
-      groups.data.offices.forEach((officeName) => {
-        const parts = officeName.split(' ');
-        parts[3] = parts[3].padStart(2, '0');
-        const sortableOfficeName = parts.join(' ');
+    (async () => {
+      try {
+        const groups = await Api2.getRoleAndOfficeGroupNames();
 
-        officeMap.set(sortableOfficeName, officeName);
-      });
-      const offices = Array.from(officeMap.keys())
-        .sort()
-        .map((key) => officeMap.get(key)!);
+        // Sort the office names.
+        const officeMap = new Map<string, string>();
+        groups.data.offices.forEach((officeName) => {
+          const parts = officeName.split(' ');
+          parts[3] = parts[3].padStart(2, '0');
+          const sortableOfficeName = parts.join(' ');
 
-      // Sort and filter the role names.
-      const rolesToExclude = ['USTP CAMS Super User', 'USTP CAMS Privileged Identity Management'];
-      const roles = groups.data.roles
-        .filter((roleName) => !rolesToExclude.includes(roleName))
-        .sort();
+          officeMap.set(sortableOfficeName, officeName);
+        });
+        const offices = Array.from(officeMap.keys())
+          .sort()
+          .map((key) => officeMap.get(key)!);
 
-      setGroupNames({
-        roles,
-        offices,
-      });
+        // Sort and filter the role names.
+        const rolesToExclude = ['USTP CAMS Super User', 'USTP CAMS Privileged Identity Management'];
+        const roles = groups.data.roles
+          .filter((roleName) => !rolesToExclude.includes(roleName))
+          .sort();
 
-      // Get the eligible users.
-      Api2.getPrivilegedIdentityUsers().then((res) => {
+        setGroupNames({ roles, offices });
+
+        const res = await Api2.getPrivilegedIdentityUsers();
         setUserList(res.data.sort(sortUserList));
         setIsLoaded(true);
-      });
-    });
-  }, [flags[PRIVILEGED_IDENTITY_MANAGEMENT]]);
+      } catch (e) {
+        alert?.error(`Failed to load Privileged Identity data. ${(e as Error).message}`);
+        setIsLoaded(true);
+      }
+    })();
+  }, [privilegedIdentityEnabled]);
 
   // Stop if the feature is disabled.
   if (!flags[PRIVILEGED_IDENTITY_MANAGEMENT]) {

--- a/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
+++ b/user-interface/src/admin/privileged-identity/PrivilegedIdentity.tsx
@@ -56,6 +56,42 @@ export function PrivilegedIdentity() {
 
   const alert = useGlobalAlert();
 
+  useEffect(() => {
+    if (!flags[PRIVILEGED_IDENTITY_MANAGEMENT]) return;
+    setIsLoaded(false);
+    Api2.getRoleAndOfficeGroupNames().then((groups) => {
+      // Sort the office names.
+      const officeMap = new Map<string, string>();
+      groups.data.offices.forEach((officeName) => {
+        const parts = officeName.split(' ');
+        parts[3] = parts[3].padStart(2, '0');
+        const sortableOfficeName = parts.join(' ');
+
+        officeMap.set(sortableOfficeName, officeName);
+      });
+      const offices = Array.from(officeMap.keys())
+        .sort()
+        .map((key) => officeMap.get(key)!);
+
+      // Sort and filter the role names.
+      const rolesToExclude = ['USTP CAMS Super User', 'USTP CAMS Privileged Identity Management'];
+      const roles = groups.data.roles
+        .filter((roleName) => !rolesToExclude.includes(roleName))
+        .sort();
+
+      setGroupNames({
+        roles,
+        offices,
+      });
+
+      // Get the eligible users.
+      Api2.getPrivilegedIdentityUsers().then((res) => {
+        setUserList(res.data.sort(sortUserList));
+        setIsLoaded(true);
+      });
+    });
+  }, [flags[PRIVILEGED_IDENTITY_MANAGEMENT]]);
+
   // Stop if the feature is disabled.
   if (!flags[PRIVILEGED_IDENTITY_MANAGEMENT]) {
     return (
@@ -209,41 +245,6 @@ export function PrivilegedIdentity() {
     oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
     return getIsoDate(oneYearFromNow);
   }
-
-  useEffect(() => {
-    setIsLoaded(false);
-    Api2.getRoleAndOfficeGroupNames().then((groups) => {
-      // Sort the office names.
-      const officeMap = new Map<string, string>();
-      groups.data.offices.forEach((officeName) => {
-        const parts = officeName.split(' ');
-        parts[3] = parts[3].padStart(2, '0');
-        const sortableOfficeName = parts.join(' ');
-
-        officeMap.set(sortableOfficeName, officeName);
-      });
-      const offices = Array.from(officeMap.keys())
-        .sort()
-        .map((key) => officeMap.get(key)!);
-
-      // Sort and filter the role names.
-      const rolesToExclude = ['USTP CAMS Super User', 'USTP CAMS Privileged Identity Management'];
-      const roles = groups.data.roles
-        .filter((roleName) => !rolesToExclude.includes(roleName))
-        .sort();
-
-      setGroupNames({
-        roles,
-        offices,
-      });
-
-      // Get the eligible users.
-      Api2.getPrivilegedIdentityUsers().then((res) => {
-        setUserList(res.data.sort(sortUserList));
-        setIsLoaded(true);
-      });
-    });
-  }, []);
 
   return (
     <div className="privileged-identity-admin-panel">

--- a/user-interface/src/lib/testing/testing-utilities.ts
+++ b/user-interface/src/lib/testing/testing-utilities.ts
@@ -165,7 +165,7 @@ async function toggleComboBoxItemSelection(id: string, itemIndex: number = 0, se
       if (selected) {
         expect(input!.value).toBe(itemLabel);
       } else {
-        expect(input!.value).not.toBe(itemLabel);
+        expect(input!.value).toBe('');
       }
     }
   });

--- a/user-interface/src/lib/testing/testing-utilities.ts
+++ b/user-interface/src/lib/testing/testing-utilities.ts
@@ -146,15 +146,27 @@ async function toggleComboBoxItemSelection(id: string, itemIndex: number = 0, se
   });
 
   const listItem = screen.getByTestId(testId);
+  const itemLabel = listItem.textContent ?? '';
 
   await userEvent.click(listItem);
   await waitFor(() => {
     const currentItem = document.querySelector(`[data-testid="${testId}"]`);
-    expect(currentItem).not.toBeNull();
-    if (selected) {
-      expect(currentItem).toHaveClass('selected');
+    if (currentItem) {
+      // Item still in DOM (multi-select keeps dropdown open) — check class
+      if (selected) {
+        expect(currentItem).toHaveClass('selected');
+      } else {
+        expect(currentItem).not.toHaveClass('selected');
+      }
     } else {
-      expect(currentItem).not.toHaveClass('selected');
+      // Item left the DOM (single-select closed the dropdown) — check input value
+      const input = document.querySelector(`#${id}-combo-box-input`) as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      if (selected) {
+        expect(input!.value).toBe(itemLabel);
+      } else {
+        expect(input!.value).not.toBe(itemLabel);
+      }
     }
   });
 }


### PR DESCRIPTION
# Bug

On full page load of the Privileged Identity admin screen, the component threw a React Rules of Hooks violation: `useEffect` was declared after a conditional early return gated on a feature flag. When the flag was initially falsy (LaunchDarkly not yet resolved), the component returned early, skipping the hook. On the next render after the flag resolved to true, React detected a change in hook order and threw an error, causing the \"Something went wrong\" error boundary to render.

A secondary bug caused a loading loop: after moving `useEffect` before the early return, the effect's dependency array was `[]`, so it ran once on mount — but at that point the flag was still falsy and the effect's guard bailed early. The effect never re-ran when the flag resolved, leaving the screen stuck on the loading spinner.

# Purpose

Allow the Privileged Identity screen to load correctly on a full page refresh, when LaunchDarkly feature flags resolve asynchronously after initial render.

# Major Changes

- Moved `useEffect` before the feature flag conditional early return so all hooks are always called in consistent order
- Added `flags[PRIVILEGED_IDENTITY_MANAGEMENT]` guard inside the effect body to skip API calls when the flag is disabled
- Added `flags[PRIVILEGED_IDENTITY_MANAGEMENT]` to the effect's dependency array so the effect re-fires when the flag transitions from falsy to true
- Added unit test covering the flag-false-to-true transition scenario
- Fixed an unrelated flaky accessibility test from `testing-utilities.ts` testing `ComboBox` functionality

# Testing/Validation

Manually verified the fix resolves the loading loop on full page refresh. Unit test added to guard against regression: the new test renders the component with the flag initially `false`, confirms no API calls were made, then rerenders with the flag `true` and asserts the form loads successfully.

# Notes

The root cause is a classic Rules of Hooks violation — hooks must be called unconditionally on every render. The correct fix is always to move the hook before the early return and guard the side effects inside the hook body, not to conditionally call the hook itself.

The dependency array change is load-bearing: without it, the effect runs once at mount time (when the flag is still unresolved), the guard exits early, and the effect never fires again — even after the flag becomes true. Adding the flag to the deps array ensures the effect re-runs when LaunchDarkly delivers its response.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Fix Privileged Identity admin screen loading behavior and hook usage around the feature flag.

Bug Fixes:
- Resolve React Rules of Hooks violation in PrivilegedIdentity by ensuring hooks are always called regardless of feature flag state.
- Prevent the Privileged Identity screen from getting stuck or erroring when the feature flag resolves from false to true on full page load.

Tests:
- Add a unit test that verifies the Privileged Identity form loads correctly when the feature flag changes from false to true during runtime.