### PR TITLE
CAMS-775 Fix pagination rendering 0 when totalPages is zero or undefined

### DIFF
--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -2986,6 +2986,27 @@ describe('TrusteesList Component', () => {
       expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
     });
 
+    test('scrolls to top of page when navigating to a new page', async () => {
+      const trustees = makeTrustees(50);
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });
+      const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId('pagination-button-page-2-results'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
+      });
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+      scrollToSpy.mockRestore();
+    });
+
     test('changing status filter resets to page 1', async () => {
       const trustees = makeTrustees(50);
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -3143,6 +3143,32 @@ describe('TrusteesList Component', () => {
       vi.useRealTimers();
     });
 
+    test('changing sort direction resets to page 1', async () => {
+      const trustees = makeTrustees(50);
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: trustees });
+
+      renderWithRouter(<TrusteesList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('trustees-table')).toBeInTheDocument();
+      });
+
+      // Navigate to page 2 (ascending: Last025 is first item on page 2)
+      await userEvent.click(screen.getByTestId('pagination-button-page-2-results'));
+      await waitFor(() => {
+        expect(screen.queryByText('Last000, First0')).not.toBeInTheDocument();
+      });
+
+      // Click the Name column header to switch to descending sort
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('columnheader', { name: /name/i }));
+
+      // After sort change, page resets to 1 — Last049 is the first item in descending order
+      await waitFor(() => {
+        expect(screen.getByText('Last049, First49')).toBeInTheDocument();
+      });
+    });
+
     test('count label shows total filtered count, not page count', async () => {
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: makeTrustees(50) });
 

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -371,7 +371,14 @@ export default function TrusteesList() {
 
   useEffect(() => {
     setOffset(DEFAULT_SEARCH_OFFSET);
-  }, [statusFilter, selectedDistricts, selectedDivisions, selectedChapters, nameSearch]);
+  }, [
+    statusFilter,
+    selectedDistricts,
+    selectedDivisions,
+    selectedChapters,
+    nameSearch,
+    sortDirection,
+  ]);
 
   const pagedTrustees = useMemo(
     () => filteredTrustees.slice(offset, offset + limit),

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -396,6 +396,8 @@ export default function TrusteesList() {
     };
   }, [pagedTrustees, filteredTrustees, offset, limit]);
 
+  const hasMultiplePages = (paginationValues.totalPages ?? 0) > 1;
+
   useEffect(() => {
     if (!isDefaultApplied.current) return;
     const defaults = defaultDistrictsRef.current;
@@ -670,7 +672,7 @@ export default function TrusteesList() {
               </div>
             </div>
           )}
-          {(paginationValues.totalPages ?? 0) > 1 && (
+          {hasMultiplePages && (
             <div aria-live="off" aria-atomic="false">
               <Pagination<{ limit: number; offset: number }>
                 paginationValues={paginationValues}

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -662,7 +662,7 @@ export default function TrusteesList() {
               </div>
             </div>
           )}
-          {paginationValues.totalPages && paginationValues.totalPages > 1 && (
+          {(paginationValues.totalPages ?? 0) > 1 && (
             <div aria-live="off" aria-atomic="false">
               <Pagination<{ limit: number; offset: number }>
                 paginationValues={paginationValues}

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -215,6 +215,7 @@ export default function TrusteesList() {
   const handlePaginationChange = ({ limit, offset }: { limit: number; offset: number }) => {
     setOffset(offset);
     setLimit(limit);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const combinedDistrictDivisionOptions = useMemo((): ComboOption[] => {


### PR DESCRIPTION
# Bug

When `totalPages` was `0` or `undefined`, the Trustees list pagination section rendered a visible `0` character in the HTML. This is the classic React `0 &&` pitfall where a falsy numeric value short-circuits the expression and JSX renders it as a literal character.

Additionally, changing the sort direction or navigating to a new page did not provide good UX — sort left users on a stale mid-list page, and page navigation left the viewport scrolled to the middle of the previous page.

# Purpose

1. Prevent the number `0` from appearing as stray text in the UI when there are no pages to paginate.
2. Reset to page 1 when sort direction changes, consistent with how filter changes already behave.
3. Scroll to the top of the page when navigating to a new page of results.
4. Extract pagination render condition into a named boolean for readability (code review follow-up).

# Major Changes

* Replaced `paginationValues.totalPages && paginationValues.totalPages > 1` with `(paginationValues.totalPages ?? 0) > 1` — always evaluates to a boolean, so React never renders `0`
* Added `sortDirection` to the pagination-reset `useEffect` dependency array so that toggling the Name column sort returns the user to page 1
* Added `window.scrollTo({ top: 0, behavior: 'smooth' })` in `handlePaginationChange` so the viewport returns to the top on every page navigation
* Extracted `(paginationValues.totalPages ?? 0) > 1` into a named `hasMultiplePages` boolean to make the JSX render condition more readable and self-documenting

# Testing/Validation

All 82 unit tests for `TrusteesList` pass, including:
- `'changing sort direction resets to page 1'` — navigates to page 2, toggles sort, asserts page 1 content in descending order is visible
- `'scrolls to top of page when navigating to a new page'` — navigates to page 2 and asserts `window.scrollTo` was called with `{ top: 0, behavior: 'smooth' }`

# Notes

The `??` nullish coalescing operator handles the `undefined` case required by the TypeScript type, while the `> 1` comparison ensures the result is always boolean — avoiding the React rendering pitfall entirely.

The sort reset and scroll-to-top both follow patterns already established elsewhere in the component (filter changes reset pagination; `window.scrollTo` is used in other parts of the app).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application