### PR TITLE
Let Renovate manage test/* workspace dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,16 @@
   "separateMinorPatch": false,
   "rangeStrategy": "pin",
   "semanticCommits": "disabled",
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/*/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "constraints": {
     "node": "22.22.3"
   },


### PR DESCRIPTION
# Purpose

Stop shared dependencies in the `test/*` workspaces from silently drifting out of sync with the rest of the monorepo, which currently requires a manual fix on every Renovate PR.

# Major Changes

* Override `ignorePaths` in `renovate.json` with the `config:recommended` preset's default list, swapping `**/test/**` for `**/*/test/**`.
* The leading-segment requirement (`*/`) keeps nested test directories ignored while admitting any top-level `test/` workspace.

# Testing/Validation

Validated with Renovate's own tooling against the branch:

* `renovate-config-validator renovate.json` → "Config validated successfully".
* `renovate --platform=local --dry-run=extract` now extracts 11 npm package files (was 7), newly including `test/e2e`, `test/bdd`, `test/uswds`, and `test/integration`.
* Confirmed `mongodb` is now detected (currentValue `7.2.0`) inside the test workspaces, so future bumps will flow to them automatically.

# Notes

Root cause: `extends: ["config:recommended"]` pulls in the `:ignoreModulesAndTests` preset, whose default `ignorePaths` includes `**/test/**`. That filter runs at file-discovery time — before manager extraction, package rules, and `minimumReleaseAge` — so Renovate never saw the `test/*` `package.json` files at all. This is why mongodb (and other shared deps) repeatedly had to be hand-synced in `test/e2e` while every other workspace updated normally.

Two intentional side effects of the chosen glob:

* `test/integration` is now managed even though it is not in the root `workspaces` array — `ignorePaths` matches file paths, not npm workspace membership. This aligns with the goal of picking up new `test/` directories without further config changes.
* Because `ignorePaths` replaces (does not merge with) the preset value, the full default list is reproduced here so other exclusions (`vendor`, `__tests__`, `__fixtures__`, etc.) remain intact.

Pre-existing, unrelated: the validator still warns that the `customManagers` block uses the deprecated `fileMatch` key (now `managerFilePatterns`). Left out of scope for this change.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Build:
- Update Renovate ignorePaths configuration to treat top-level test/* workspaces as managed while still ignoring nested test directories and other default exclusions.