### PR TITLE
Add eslint-plugin-sonarjs to ESLint config

### DIFF
--- a/eslint-shared.config.mjs
+++ b/eslint-shared.config.mjs
@@ -6,6 +6,7 @@ const eslint = require('@eslint/js');
 const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
 const vitest = require('@vitest/eslint-plugin');
 const jsonc = require('eslint-plugin-jsonc');
+const sonarjs = require('eslint-plugin-sonarjs');
 
 /**
  * eslintJsConfig
@@ -27,6 +28,7 @@ export const eslintJsConfig = tsEslint.config(
 export const eslintTsConfig = tsEslint.config(
   eslintJsConfig,
   tsEslint.configs.recommended,
+  sonarjs.configs.recommended,
   {
     ignores: ['**/build/**/*', '**/dist/**/*', '**/node_modules/**/*'],
   },
@@ -52,6 +54,65 @@ export const eslintTsConfig = tsEslint.config(
           ignoreRestSiblings: true,
         },
       ],
+    },
+  },
+  // ---------------------------------------------------------------------------
+  // eslint-plugin-sonarjs deviations from `sonarjs.configs.recommended`
+  //
+  // The plugin was adopted primarily to gate cognitive complexity. Its
+  // `recommended` config sets every rule to `error`, which surfaced ~413
+  // pre-existing violations across the codebase that would immediately break
+  // the `--quiet` lint gate. Rather than block PRs on existing debt, every
+  // sonarjs rule with pre-existing violations is downgraded to `warn` below so
+  // the findings stay VISIBLE for incremental cleanup without failing CI. The
+  // ~230 sonarjs rules with zero current violations remain at `error` (their
+  // recommended severity) so they block NEW problems.
+  //
+  // As violations for a given rule are remediated to zero, promote that rule
+  // back to `error` (delete its line here) to lock in the improvement.
+  // ---------------------------------------------------------------------------
+  {
+    rules: {
+      // Headline gate: keep cognitive-complexity visible but non-blocking for now.
+      'sonarjs/cognitive-complexity': 'warn',
+
+      // Pre-existing violations — downgraded to non-blocking until remediated.
+      'sonarjs/prefer-specific-assertions': 'warn',
+      'sonarjs/no-clear-text-protocols': 'warn',
+      'sonarjs/todo-tag': 'warn',
+      'sonarjs/no-unused-vars': 'warn',
+      'sonarjs/no-nested-conditional': 'warn',
+      'sonarjs/assertions-in-tests': 'warn',
+      'sonarjs/no-ignored-exceptions': 'warn',
+      'sonarjs/super-linear-regex': 'warn',
+      'sonarjs/no-duplicate-test-title': 'warn',
+      'sonarjs/no-skipped-tests': 'warn',
+      'sonarjs/no-identical-functions': 'warn',
+      'sonarjs/pseudo-random': 'warn',
+      'sonarjs/no-nested-template-literals': 'warn',
+      'sonarjs/regex-complexity': 'warn',
+      'sonarjs/duplicates-in-character-class': 'warn',
+      'sonarjs/no-duplicated-branches': 'warn',
+      'sonarjs/constructor-for-side-effects': 'warn',
+      'sonarjs/single-char-in-character-classes': 'warn',
+      'sonarjs/no-nested-functions': 'warn',
+      'sonarjs/concise-regex': 'warn',
+      'sonarjs/no-trivial-assertions': 'warn',
+      'sonarjs/public-static-readonly': 'warn',
+      'sonarjs/async-test-assertions': 'warn',
+      'sonarjs/single-character-alternation': 'warn',
+      'sonarjs/use-type-alias': 'warn',
+      'sonarjs/hardcoded-secret-signatures': 'warn',
+      'sonarjs/no-identical-expressions': 'warn',
+      'sonarjs/redundant-type-aliases': 'warn',
+      'sonarjs/no-hardcoded-ip': 'warn',
+      'sonarjs/no-redundant-jump': 'warn',
+      'sonarjs/no-hardcoded-passwords': 'warn', // pragma: allowlist secret
+      'sonarjs/no-redundant-boolean': 'warn',
+      'sonarjs/no-unused-collection': 'warn',
+      'sonarjs/no-redundant-assignments': 'warn',
+      'sonarjs/no-small-switch': 'warn',
+      'sonarjs/no-redundant-optional': 'warn',
     },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-jsonc": "3.2.0",
         "eslint-plugin-jsx-a11y": "6.10.2",
         "eslint-plugin-prettier": "5.5.6",
+        "eslint-plugin-sonarjs": "4.1.0",
         "eslint-plugin-testing-library": "7.16.2",
         "knip": "6.16.0",
         "prettier": "3.8.3",
@@ -9617,6 +9618,19 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -11304,6 +11318,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.1.0.tgz",
+      "integrity": "sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.6.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.8.4",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-testing-library": {
       "version": "7.16.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.16.2.tgz",
@@ -12017,6 +12069,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -13412,6 +13471,16 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/jwa": {
@@ -16361,6 +16430,19 @@
         "@redis/time-series": "1.1.0"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -16382,6 +16464,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/regexp-tree": {
@@ -17127,6 +17223,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/semaphore": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-jsonc": "3.2.0",
     "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-prettier": "5.5.6",
+    "eslint-plugin-sonarjs": "4.1.0",
     "eslint-plugin-testing-library": "7.16.2",
     "knip": "6.16.0",
     "prettier": "3.8.3",


### PR DESCRIPTION
# Purpose

Adopt eslint-plugin-sonarjs to gain cognitive-complexity and related code-quality/bug-detection rules across the monorepo.

# Major Changes

* Added `eslint-plugin-sonarjs@4.1.0` as an exact dev dependency.
* Wired `sonarjs.configs.recommended` into the shared TypeScript ESLint config so it applies across backend, common, dev-tools, e2e, and the UI configs that extend it.
* Added a documented deviation block: every sonarjs rule with pre-existing violations is downgraded to `warn` (each listed inline with rationale); the ~230 rules with zero current violations remain at `error` to block new problems.
* Cognitive-complexity is set to `warn` so it stays visible without failing CI yet.

# Testing/Validation

Ran `npx eslint .` across the repo to assess impact: the change introduces 0 new lint errors (the `--quiet` gate stays green) while surfacing 413 sonarjs findings as warnings, 41 of which are cognitive-complexity. No source/behavioral code was changed — config and dependencies only.

# Notes

The recommended preset sets every rule to `error`, which surfaced ~413 pre-existing violations that would immediately break the `--quiet` lint gate. Downgrading existing-violation rules to `warn` avoids blocking PRs on existing debt while keeping the findings visible for incremental cleanup. As violations for a given rule are remediated to zero, that rule can be promoted back to `error` (delete its line in the deviation block) to lock in the improvement.

**Follow-up deferred:** Because the lint gate runs with `--quiet`, warnings (including cognitive-complexity) are currently suppressed from output and exit code. A follow-up decision is needed on how to make cognitive-complexity visible/enforced — e.g. a dedicated non-quiet report script, or promoting it to `error` with a raised threshold. The `--quiet` flag also masks ~469 pre-existing react-hooks / eslint-react / testing-library migration warnings unrelated to this change.

A `pragma: allowlist secret` comment was added on the `sonarjs/no-hardcoded-passwords` config line to satisfy the detect-secrets pre-commit hook (false positive on the keyword).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Adopt eslint-plugin-sonarjs across the shared TypeScript ESLint configuration while keeping existing violations non-blocking.

New Features:
- Enable eslint-plugin-sonarjs recommended rules in the shared TypeScript ESLint config used across the monorepo.

Enhancements:
- Configure sonarjs rules so that those with existing violations are downgraded to warnings, keeping new violations as errors to guard code quality.
- Document the sonarjs deviation policy within the shared ESLint config for incremental cleanup of existing issues.

Build:
- Add eslint-plugin-sonarjs as an exact devDependency in the root package.json.