### PR TITLE
CAMS-768 Slice 2: Appointment save notification triggers

### DIFF
--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
@@ -69,6 +69,27 @@ describe('compileTrusteeChangeTemplate', () => {
 
       expect(result.subject).toBe('Trustee Appointment Changed: Henry Green');
     });
+
+    test('strips CRLF from subjectOverride to prevent header injection', () => {
+      const result = compileTrusteeChangeTemplate(
+        buildChangeSet(
+          [
+            {
+              label: 'Chapter',
+              before: '7',
+              after: '11',
+              category: 'profile',
+              section: 'appointment',
+            },
+          ],
+          { subjectOverride: 'Appointment Changed\r\nBcc: attacker@evil.test' },
+        ),
+      );
+
+      expect(result.subject).toBe('Appointment Changed  Bcc: attacker@evil.test');
+      expect(result.subject).not.toContain('\r');
+      expect(result.subject).not.toContain('\n');
+    });
   });
 
   describe('html', () => {

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
@@ -34,6 +34,41 @@ describe('compileTrusteeChangeTemplate', () => {
 
       expect(result.subject).toBe('Trustee Information Changed: Smith & Co');
     });
+
+    test('uses the default subject when subjectOverride is not set', () => {
+      const result = compileTrusteeChangeTemplate(
+        buildChangeSet([
+          {
+            label: 'Public Email',
+            before: 'a@b.test',
+            after: 'c@d.test',
+            category: 'profile',
+            section: 'appointment',
+          },
+        ]),
+      );
+
+      expect(result.subject).toBe('Trustee Information Changed: Henry Green');
+    });
+
+    test('uses subjectOverride when provided', () => {
+      const result = compileTrusteeChangeTemplate(
+        buildChangeSet(
+          [
+            {
+              label: 'Chapter',
+              before: '7',
+              after: '11 Subchapter V',
+              category: 'profile',
+              section: 'appointment',
+            },
+          ],
+          { subjectOverride: 'Trustee Appointment Changed: Henry Green' },
+        ),
+      );
+
+      expect(result.subject).toBe('Trustee Appointment Changed: Henry Green');
+    });
   });
 
   describe('html', () => {

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
@@ -113,8 +113,12 @@ export function compileTrusteeChangeTemplate(changeSet: TrusteeChangeSet): Compi
     .replaceAll('{{appointment_info_rows}}', appointmentRows)
     .replaceAll('{{meeting_info_rows}}', meetingRows);
 
+  const subject =
+    changeSet.subjectOverride ??
+    `Trustee Information Changed: ${changeSet.trusteeName.replace(/[\r\n]/g, ' ')}`;
+
   return {
-    subject: `Trustee Information Changed: ${changeSet.trusteeName.replace(/[\r\n]/g, ' ')}`,
+    subject,
     html: stripTrailingWhitespace(rendered),
     text: buildPlaintext(changeSet),
   };

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
@@ -113,9 +113,9 @@ export function compileTrusteeChangeTemplate(changeSet: TrusteeChangeSet): Compi
     .replaceAll('{{appointment_info_rows}}', appointmentRows)
     .replaceAll('{{meeting_info_rows}}', meetingRows);
 
-  const subject =
-    changeSet.subjectOverride ??
-    `Trustee Information Changed: ${changeSet.trusteeName.replace(/[\r\n]/g, ' ')}`;
+  const rawSubject =
+    changeSet.subjectOverride ?? `Trustee Information Changed: ${changeSet.trusteeName}`;
+  const subject = rawSubject.replace(/[\r\n]/g, ' ');
 
   return {
     subject,

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.test.ts
@@ -148,4 +148,41 @@ describe('buildAppointmentChangeSet', () => {
     expect(statusField!.before).toBe('Active');
     expect(statusField!.after).toBe('Voluntarily Suspended');
   });
+
+  test('detects an appointmentType change', () => {
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: baseSnapshot,
+      after: { ...baseSnapshot, appointmentType: 'off-panel' },
+    });
+
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0]).toEqual({
+      label: 'Appointment Type',
+      before: 'Panel',
+      after: 'Off Panel',
+      category: 'profile',
+      section: 'appointment',
+    });
+    expect(result.subjectOverride).toBe('Trustee Appointment Changed: Henry Green');
+  });
+
+  test('detects an appointedDate change', () => {
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: baseSnapshot,
+      after: { ...baseSnapshot, appointedDate: '2025-03-01' },
+    });
+
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0]).toEqual({
+      label: 'Appointed Date',
+      before: '2024-01-15',
+      after: '2025-03-01',
+      category: 'profile',
+      section: 'appointment',
+    });
+  });
 });

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.test.ts
@@ -1,0 +1,151 @@
+import {
+  buildAppointmentChangeSet,
+  AppointmentFieldSnapshot,
+} from './build-appointment-change-set';
+
+describe('buildAppointmentChangeSet', () => {
+  const baseSnapshot: AppointmentFieldSnapshot = {
+    chapter: '7',
+    appointmentType: 'panel',
+    courtId: 'court-001',
+    divisionCodes: ['001'],
+    appointedDate: '2024-01-15',
+    status: 'active',
+    effectiveDate: '2024-01-15',
+  };
+
+  test('detects a single field change (chapter CH7 to Sub-V)', () => {
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: baseSnapshot,
+      after: { ...baseSnapshot, chapter: '11-subchapter-v' },
+    });
+
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0]).toEqual({
+      label: 'Chapter',
+      before: '7',
+      after: '11 Subchapter V',
+      category: 'profile',
+      section: 'appointment',
+    });
+    expect(result.subjectOverride).toBe('Trustee Appointment Changed: Henry Green');
+    expect(result.primaryChapter).toBe('11-subchapter-v');
+  });
+
+  test('detects multiple field changes (status + effective date)', () => {
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: baseSnapshot,
+      after: {
+        ...baseSnapshot,
+        status: 'inactive',
+        effectiveDate: '2025-06-01',
+      },
+    });
+
+    expect(result.fields).toHaveLength(2);
+    expect(result.fields[0].label).toBe('Status');
+    expect(result.fields[0].before).toBe('Active');
+    expect(result.fields[0].after).toBe('Inactive');
+    expect(result.fields[1].label).toBe('Status Effective Date');
+    expect(result.subjectOverride).toBe('Trustee Appointment Changed: Henry Green');
+  });
+
+  test('returns empty fields array when nothing changes', () => {
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: baseSnapshot,
+      after: { ...baseSnapshot },
+    });
+
+    expect(result.fields).toHaveLength(0);
+    expect(result.subjectOverride).toBeUndefined();
+  });
+
+  test('emits all fields as new when before is undefined (create)', () => {
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: undefined,
+      after: baseSnapshot,
+    });
+
+    expect(result.fields.length).toBeGreaterThanOrEqual(7);
+    for (const field of result.fields) {
+      expect(field.before).toBe('');
+      expect(field.after).not.toBe('');
+      expect(field.category).toBe('profile');
+      expect(field.section).toBe('appointment');
+    }
+    expect(result.subjectOverride).toBe('New Trustee Appointment: Henry Green');
+    expect(result.primaryChapter).toBe('7');
+  });
+
+  test('renders multiple divisions comma-separated with stackValues', () => {
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: { ...baseSnapshot, divisionCodes: ['001'] },
+      after: { ...baseSnapshot, divisionCodes: ['001', '002'] },
+    });
+
+    const divisionField = result.fields.find((f) => f.label === 'Division');
+    expect(divisionField).toBeDefined();
+    expect(divisionField!.before).toBe('001');
+    expect(divisionField!.after).toBe('001, 002');
+    expect(divisionField!.stackValues).toBe(true);
+  });
+
+  test('uses courtNameResolver for District field', () => {
+    const resolver = (courtId: string) =>
+      courtId === 'court-xyz' ? 'Eastern District of Missouri' : undefined;
+
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: { ...baseSnapshot, courtId: 'court-001' },
+      after: { ...baseSnapshot, courtId: 'court-xyz' },
+      courtNameResolver: resolver,
+    });
+
+    const districtField = result.fields.find((f) => f.label === 'District');
+    expect(districtField).toBeDefined();
+    expect(districtField!.before).toBe('court-001');
+    expect(districtField!.after).toBe('Eastern District of Missouri');
+  });
+
+  test('falls back to raw courtId when resolver returns undefined', () => {
+    const resolver = () => undefined;
+
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: { ...baseSnapshot, courtId: 'court-A' },
+      after: { ...baseSnapshot, courtId: 'court-B' },
+      courtNameResolver: resolver,
+    });
+
+    const districtField = result.fields.find((f) => f.label === 'District');
+    expect(districtField).toBeDefined();
+    expect(districtField!.before).toBe('court-A');
+    expect(districtField!.after).toBe('court-B');
+  });
+
+  test('formats hyphenated status values as title case', () => {
+    const result = buildAppointmentChangeSet({
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      before: { ...baseSnapshot, status: 'active' },
+      after: { ...baseSnapshot, status: 'voluntarily-suspended' },
+    });
+
+    const statusField = result.fields.find((f) => f.label === 'Status');
+    expect(statusField).toBeDefined();
+    expect(statusField!.before).toBe('Active');
+    expect(statusField!.after).toBe('Voluntarily Suspended');
+  });
+});

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
@@ -6,6 +6,7 @@ import {
   formatChapterType,
   formatAppointmentType,
 } from '@common/cams/trustees';
+import { formatAppointmentStatus } from '@common/cams/trustee-appointments';
 
 export type AppointmentFieldSnapshot = {
   chapter: AppointmentChapterType;
@@ -89,8 +90,8 @@ export function buildAppointmentChangeSet(params: {
     });
   }
 
-  const beforeStatus = before ? formatStatus(before.status) : '';
-  const afterStatus = formatStatus(after.status);
+  const beforeStatus = before ? formatAppointmentStatus(before.status) : '';
+  const afterStatus = formatAppointmentStatus(after.status);
   if (beforeStatus !== afterStatus) {
     fields.push({
       label: 'Status',
@@ -127,11 +128,4 @@ export function buildAppointmentChangeSet(params: {
     primaryChapter: after.chapter,
     subjectOverride,
   };
-}
-
-function formatStatus(status: AppointmentStatus): string {
-  return status
-    .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
 }

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
@@ -18,6 +18,23 @@ export type AppointmentFieldSnapshot = {
   effectiveDate: string;
 };
 
+function diffField(
+  label: string,
+  beforeValue: string,
+  afterValue: string,
+  options?: { stackValues?: boolean },
+): TrusteeChangeField | undefined {
+  if (beforeValue === afterValue) return undefined;
+  return {
+    label,
+    before: beforeValue,
+    after: afterValue,
+    category: 'profile',
+    section: 'appointment',
+    ...(options?.stackValues && { stackValues: true }),
+  };
+}
+
 export function buildAppointmentChangeSet(params: {
   trusteeId: string;
   trusteeName: string;
@@ -26,93 +43,40 @@ export function buildAppointmentChangeSet(params: {
   courtNameResolver?: (courtId: string) => string | undefined;
 }): TrusteeChangeSet {
   const { trusteeId, trusteeName, before, after, courtNameResolver } = params;
-  const fields: TrusteeChangeField[] = [];
-
-  const beforeChapter = before ? formatChapterType(before.chapter) : '';
-  const afterChapter = formatChapterType(after.chapter);
-  if (beforeChapter !== afterChapter) {
-    fields.push({
-      label: 'Chapter',
-      before: beforeChapter,
-      after: afterChapter,
-      category: 'profile',
-      section: 'appointment',
-    });
-  }
-
-  const beforeType = before ? formatAppointmentType(before.appointmentType) : '';
-  const afterType = formatAppointmentType(after.appointmentType);
-  if (beforeType !== afterType) {
-    fields.push({
-      label: 'Appointment Type',
-      before: beforeType,
-      after: afterType,
-      category: 'profile',
-      section: 'appointment',
-    });
-  }
-
   const resolveCourtName = courtNameResolver ?? ((id: string) => id);
-  const beforeCourt = before ? (resolveCourtName(before.courtId) ?? before.courtId) : '';
-  const afterCourt = resolveCourtName(after.courtId) ?? after.courtId;
-  if (beforeCourt !== afterCourt) {
-    fields.push({
-      label: 'District',
-      before: beforeCourt,
-      after: afterCourt,
-      category: 'profile',
-      section: 'appointment',
-    });
-  }
 
-  const beforeDivisions = before?.divisionCodes?.join(', ') ?? '';
-  const afterDivisions = after.divisionCodes?.join(', ') ?? '';
-  if (beforeDivisions !== afterDivisions) {
-    fields.push({
-      label: 'Division',
-      before: beforeDivisions,
-      after: afterDivisions,
-      category: 'profile',
-      section: 'appointment',
-      stackValues: true,
-    });
-  }
+  const candidates = [
+    diffField(
+      'Chapter',
+      before ? formatChapterType(before.chapter) : '',
+      formatChapterType(after.chapter),
+    ),
+    diffField(
+      'Appointment Type',
+      before ? formatAppointmentType(before.appointmentType) : '',
+      formatAppointmentType(after.appointmentType),
+    ),
+    diffField(
+      'District',
+      before ? (resolveCourtName(before.courtId) ?? before.courtId) : '',
+      resolveCourtName(after.courtId) ?? after.courtId,
+    ),
+    diffField(
+      'Division',
+      before?.divisionCodes?.join(', ') ?? '',
+      after.divisionCodes?.join(', ') ?? '',
+      { stackValues: true },
+    ),
+    diffField('Appointed Date', before?.appointedDate ?? '', after.appointedDate),
+    diffField(
+      'Status',
+      before ? formatAppointmentStatus(before.status) : '',
+      formatAppointmentStatus(after.status),
+    ),
+    diffField('Status Effective Date', before?.effectiveDate ?? '', after.effectiveDate),
+  ];
 
-  const beforeDate = before?.appointedDate ?? '';
-  const afterDate = after.appointedDate;
-  if (beforeDate !== afterDate) {
-    fields.push({
-      label: 'Appointed Date',
-      before: beforeDate,
-      after: afterDate,
-      category: 'profile',
-      section: 'appointment',
-    });
-  }
-
-  const beforeStatus = before ? formatAppointmentStatus(before.status) : '';
-  const afterStatus = formatAppointmentStatus(after.status);
-  if (beforeStatus !== afterStatus) {
-    fields.push({
-      label: 'Status',
-      before: beforeStatus,
-      after: afterStatus,
-      category: 'profile',
-      section: 'appointment',
-    });
-  }
-
-  const beforeEffective = before?.effectiveDate ?? '';
-  const afterEffective = after.effectiveDate;
-  if (beforeEffective !== afterEffective) {
-    fields.push({
-      label: 'Status Effective Date',
-      before: beforeEffective,
-      after: afterEffective,
-      category: 'profile',
-      section: 'appointment',
-    });
-  }
+  const fields = candidates.filter((f): f is TrusteeChangeField => f !== undefined);
 
   const isCreate = !before;
   const subjectOverride = isCreate

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
@@ -1,0 +1,137 @@
+import { TrusteeChangeSet, TrusteeChangeField } from '@common/cams/notifications';
+import {
+  AppointmentChapterType,
+  AppointmentType,
+  AppointmentStatus,
+  formatChapterType,
+  formatAppointmentType,
+} from '@common/cams/trustees';
+
+export type AppointmentFieldSnapshot = {
+  chapter: AppointmentChapterType;
+  appointmentType: AppointmentType;
+  courtId: string;
+  divisionCodes?: string[];
+  appointedDate: string;
+  status: AppointmentStatus;
+  effectiveDate: string;
+};
+
+export function buildAppointmentChangeSet(params: {
+  trusteeId: string;
+  trusteeName: string;
+  before?: AppointmentFieldSnapshot;
+  after: AppointmentFieldSnapshot;
+  courtNameResolver?: (courtId: string) => string | undefined;
+}): TrusteeChangeSet {
+  const { trusteeId, trusteeName, before, after, courtNameResolver } = params;
+  const fields: TrusteeChangeField[] = [];
+
+  const beforeChapter = before ? formatChapterType(before.chapter) : '';
+  const afterChapter = formatChapterType(after.chapter);
+  if (beforeChapter !== afterChapter) {
+    fields.push({
+      label: 'Chapter',
+      before: beforeChapter,
+      after: afterChapter,
+      category: 'profile',
+      section: 'appointment',
+    });
+  }
+
+  const beforeType = before ? formatAppointmentType(before.appointmentType) : '';
+  const afterType = formatAppointmentType(after.appointmentType);
+  if (beforeType !== afterType) {
+    fields.push({
+      label: 'Appointment Type',
+      before: beforeType,
+      after: afterType,
+      category: 'profile',
+      section: 'appointment',
+    });
+  }
+
+  const resolveCourtName = courtNameResolver ?? ((id: string) => id);
+  const beforeCourt = before ? (resolveCourtName(before.courtId) ?? before.courtId) : '';
+  const afterCourt = resolveCourtName(after.courtId) ?? after.courtId;
+  if (beforeCourt !== afterCourt) {
+    fields.push({
+      label: 'District',
+      before: beforeCourt,
+      after: afterCourt,
+      category: 'profile',
+      section: 'appointment',
+    });
+  }
+
+  const beforeDivisions = before?.divisionCodes?.join(', ') ?? '';
+  const afterDivisions = after.divisionCodes?.join(', ') ?? '';
+  if (beforeDivisions !== afterDivisions) {
+    fields.push({
+      label: 'Division',
+      before: beforeDivisions,
+      after: afterDivisions,
+      category: 'profile',
+      section: 'appointment',
+      stackValues: true,
+    });
+  }
+
+  const beforeDate = before?.appointedDate ?? '';
+  const afterDate = after.appointedDate;
+  if (beforeDate !== afterDate) {
+    fields.push({
+      label: 'Appointed Date',
+      before: beforeDate,
+      after: afterDate,
+      category: 'profile',
+      section: 'appointment',
+    });
+  }
+
+  const beforeStatus = before ? formatStatus(before.status) : '';
+  const afterStatus = formatStatus(after.status);
+  if (beforeStatus !== afterStatus) {
+    fields.push({
+      label: 'Status',
+      before: beforeStatus,
+      after: afterStatus,
+      category: 'profile',
+      section: 'appointment',
+    });
+  }
+
+  const beforeEffective = before?.effectiveDate ?? '';
+  const afterEffective = after.effectiveDate;
+  if (beforeEffective !== afterEffective) {
+    fields.push({
+      label: 'Status Effective Date',
+      before: beforeEffective,
+      after: afterEffective,
+      category: 'profile',
+      section: 'appointment',
+    });
+  }
+
+  const isCreate = !before;
+  const subjectOverride = isCreate
+    ? `New Trustee Appointment: ${trusteeName}`
+    : fields.length > 0
+      ? `Trustee Appointment Changed: ${trusteeName}`
+      : undefined;
+
+  return {
+    trusteeId,
+    trusteeName,
+    fields,
+    primaryChapter: after.chapter,
+    subjectOverride,
+  };
+}
+
+function formatStatus(status: AppointmentStatus): string {
+  return status
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -1147,6 +1147,7 @@ describe('TrusteeAppointmentsUseCase tests', () => {
     beforeEach(async () => {
       vi.restoreAllMocks();
       context = await createMockApplicationContext();
+      context.featureFlags['trustee-change-notifications-enabled'] = true;
       trusteeAppointmentsUseCase = new TrusteeAppointmentsUseCase(context);
       MockNotificationGateway.getInstance().clear();
 
@@ -1181,6 +1182,43 @@ describe('TrusteeAppointmentsUseCase tests', () => {
 
     afterEach(() => {
       MockNotificationGateway.getInstance().clear();
+    });
+
+    test('does not dispatch when feature flag is disabled', async () => {
+      context.featureFlags['trustee-change-notifications-enabled'] = false;
+
+      const existingAppointment = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+      const updatedAppointment = {
+        ...existingAppointment,
+        status: 'voluntarily-suspended' as const,
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(existingAppointment);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(
+        updatedAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'voluntarily-suspended',
+        effectiveDate: '2024-01-15',
+      });
+
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
     });
 
     test('dispatches one notification when appointment status changes', async () => {
@@ -1385,6 +1423,7 @@ describe('TrusteeAppointmentsUseCase tests', () => {
     beforeEach(async () => {
       vi.restoreAllMocks();
       context = await createMockApplicationContext();
+      context.featureFlags['trustee-change-notifications-enabled'] = true;
       trusteeAppointmentsUseCase = new TrusteeAppointmentsUseCase(context);
       MockNotificationGateway.getInstance().clear();
 
@@ -1419,6 +1458,39 @@ describe('TrusteeAppointmentsUseCase tests', () => {
 
     afterEach(() => {
       MockNotificationGateway.getInstance().clear();
+    });
+
+    test('does not dispatch when feature flag is disabled', async () => {
+      context.featureFlags['trustee-change-notifications-enabled'] = false;
+
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const mockCreatedAppointment = MockData.getTrusteeAppointment({
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createAppointment').mockResolvedValue(
+        mockCreatedAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.createAppointment(context, trusteeId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
     });
 
     test('dispatches a notification when a new appointment is created', async () => {

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -6,6 +6,7 @@ import { TrusteeAppointmentsUseCase } from './trustee-appointments';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import { TrusteeAppointmentInput } from '@common/cams/trustee-appointments';
 import { AppointmentType } from '@common/cams/trustees';
+import { MockNotificationGateway } from '../../adapters/gateways/notifications/mock-notification.gateway';
 
 describe('TrusteeAppointmentsUseCase tests', () => {
   let context: ApplicationContext;
@@ -1135,6 +1136,391 @@ describe('TrusteeAppointmentsUseCase tests', () => {
 
       expect(actualError.isCamsError).toBe(true);
       expect(actualError.message).toContain('At least one division must be specified');
+    });
+  });
+
+  describe('updateAppointment notification dispatch (CAMS-768 Slice 2)', () => {
+    const trusteeId = 'trustee-notify-apt';
+    const appointmentId = 'appointment-notify-1';
+
+    beforeEach(async () => {
+      vi.restoreAllMocks();
+      context = await createMockApplicationContext();
+      trusteeAppointmentsUseCase = new TrusteeAppointmentsUseCase(context);
+      MockNotificationGateway.getInstance().clear();
+
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+
+      vi.spyOn(MockMongoRepository.prototype, 'findRecipientByKey').mockImplementation(
+        async (key: string) => {
+          if (key === 'chapter:11-subchapter-v') {
+            return {
+              key: 'chapter:11-subchapter-v',
+              recipientAddress: 'subv@example.test',
+              displayName: 'Sub-V Oversight',
+            };
+          }
+          if (key === 'chapter:7') {
+            return {
+              key: 'chapter:7',
+              recipientAddress: 'ch7-oversight@example.test',
+              displayName: 'CH7 Oversight',
+            };
+          }
+          return null;
+        },
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'getDefaultRecipient').mockResolvedValue({
+        key: 'default',
+        recipientAddress: 'default-oversight@example.test',
+        displayName: 'Default Oversight',
+      });
+    });
+
+    afterEach(() => {
+      MockNotificationGateway.getInstance().clear();
+    });
+
+    test('dispatches one notification when appointment chapter changes', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const existingAppointment = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+      const updatedAppointment = {
+        ...existingAppointment,
+        chapter: '11-subchapter-v' as const,
+        appointmentType: 'pool' as const,
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(existingAppointment);
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(
+        updatedAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '11-subchapter-v',
+        appointmentType: 'pool',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].subject).toContain('Trustee Appointment Changed');
+      expect(recorded[0].html).toContain('Chapter');
+    });
+
+    test('notification failure does not fail the appointment save', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const existingAppointment = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+      const updatedAppointment = {
+        ...existingAppointment,
+        status: 'voluntarily-suspended' as const,
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(existingAppointment);
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(
+        updatedAppointment,
+      );
+      vi.spyOn(MockNotificationGateway.prototype, 'send').mockRejectedValue(
+        new Error('Simulated provider failure'),
+      );
+
+      const result = await trusteeAppointmentsUseCase.updateAppointment(
+        context,
+        trusteeId,
+        appointmentId,
+        {
+          chapter: '7',
+          appointmentType: 'panel',
+          courtId: '081',
+          divisionCode: '001',
+          appointedDate: '2024-01-15',
+          status: 'voluntarily-suspended',
+          effectiveDate: '2024-01-15',
+        },
+      );
+
+      expect(result).toEqual(updatedAppointment);
+    });
+
+    test('no notification when appointment does not change', async () => {
+      const existingAppointment = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(existingAppointment);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(
+        existingAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
+    });
+
+    test('routes to Sub-V mailbox when chapter changes to 11-subchapter-v', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const existingAppointment = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+      const updatedAppointment = {
+        ...existingAppointment,
+        chapter: '11-subchapter-v' as const,
+        appointmentType: 'pool' as const,
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(existingAppointment);
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(
+        updatedAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '11-subchapter-v',
+        appointmentType: 'pool',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].to).toBe('subv@example.test');
+    });
+
+    test('falls back to default recipient when no chapter-specific routing exists', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const existingAppointment = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        chapter: '12',
+        appointmentType: 'case-by-case',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+      const updatedAppointment = {
+        ...existingAppointment,
+        status: 'inactive' as const,
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(existingAppointment);
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(
+        updatedAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '12',
+        appointmentType: 'case-by-case',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'inactive',
+        effectiveDate: '2024-01-15',
+      });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].to).toBe('default-oversight@example.test');
+    });
+  });
+
+  describe('createAppointment notification dispatch (CAMS-768 Slice 2)', () => {
+    const trusteeId = 'trustee-notify-create';
+
+    beforeEach(async () => {
+      vi.restoreAllMocks();
+      context = await createMockApplicationContext();
+      trusteeAppointmentsUseCase = new TrusteeAppointmentsUseCase(context);
+      MockNotificationGateway.getInstance().clear();
+
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+
+      vi.spyOn(MockMongoRepository.prototype, 'findRecipientByKey').mockImplementation(
+        async (key: string) => {
+          if (key === 'chapter:7') {
+            return {
+              key: 'chapter:7',
+              recipientAddress: 'ch7-oversight@example.test',
+              displayName: 'CH7 Oversight',
+            };
+          }
+          if (key === 'chapter:13') {
+            return {
+              key: 'chapter:13',
+              recipientAddress: 'ch13-oversight@example.test',
+              displayName: 'CH13 Oversight',
+            };
+          }
+          return null;
+        },
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'getDefaultRecipient').mockResolvedValue({
+        key: 'default',
+        recipientAddress: 'default-oversight@example.test',
+        displayName: 'Default Oversight',
+      });
+    });
+
+    afterEach(() => {
+      MockNotificationGateway.getInstance().clear();
+    });
+
+    test('dispatches a notification when a new appointment is created', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const mockCreatedAppointment = MockData.getTrusteeAppointment({
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createAppointment').mockResolvedValue(
+        mockCreatedAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.createAppointment(context, trusteeId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].subject).toContain('New Trustee Appointment');
+      expect(recorded[0].html).toContain('Chapter');
+      expect(recorded[0].html).toContain('Status');
+    });
+
+    test('notification failure does not fail appointment creation', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const mockCreatedAppointment = MockData.getTrusteeAppointment({
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createAppointment').mockResolvedValue(
+        mockCreatedAppointment,
+      );
+      vi.spyOn(MockNotificationGateway.prototype, 'send').mockRejectedValue(
+        new Error('Simulated provider failure'),
+      );
+
+      const result = await trusteeAppointmentsUseCase.createAppointment(context, trusteeId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      expect(result).toEqual(mockCreatedAppointment);
+    });
+
+    test('routes to the created appointment chapter mailbox', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const mockCreatedAppointment = MockData.getTrusteeAppointment({
+        trusteeId,
+        chapter: '13',
+        appointmentType: 'standing',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createAppointment').mockResolvedValue(
+        mockCreatedAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.createAppointment(context, trusteeId, {
+        chapter: '13',
+        appointmentType: 'standing',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].to).toBe('ch13-oversight@example.test');
     });
   });
 });

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -7,6 +7,7 @@ import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repo
 import { TrusteeAppointmentInput } from '@common/cams/trustee-appointments';
 import { AppointmentType } from '@common/cams/trustees';
 import { MockNotificationGateway } from '../../adapters/gateways/notifications/mock-notification.gateway';
+import { CourtsUseCase } from '../courts/courts';
 
 describe('TrusteeAppointmentsUseCase tests', () => {
   let context: ApplicationContext;
@@ -1150,7 +1151,7 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       MockNotificationGateway.getInstance().clear();
 
       vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
-      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue([]);
 
       vi.spyOn(MockMongoRepository.prototype, 'findRecipientByKey').mockImplementation(
         async (key: string) => {
@@ -1389,7 +1390,7 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       MockNotificationGateway.getInstance().clear();
 
       vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
-      vi.spyOn(trusteeAppointmentsUseCase['courtsUseCase'], 'getCourts').mockResolvedValue([]);
+      vi.spyOn(CourtsUseCase.prototype, 'getCourts').mockResolvedValue([]);
 
       vi.spyOn(MockMongoRepository.prototype, 'findRecipientByKey').mockImplementation(
         async (key: string) => {

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -1140,7 +1140,7 @@ describe('TrusteeAppointmentsUseCase tests', () => {
     });
   });
 
-  describe('updateAppointment notification dispatch (CAMS-768 Slice 2)', () => {
+  describe('updateAppointment notification dispatch', () => {
     const trusteeId = 'trustee-notify-apt';
     const appointmentId = 'appointment-notify-1';
 
@@ -1183,7 +1183,7 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       MockNotificationGateway.getInstance().clear();
     });
 
-    test('dispatches one notification when appointment chapter changes', async () => {
+    test('dispatches one notification when appointment status changes', async () => {
       const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
       const existingAppointment = MockData.getTrusteeAppointment({
         id: appointmentId,
@@ -1198,8 +1198,7 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       });
       const updatedAppointment = {
         ...existingAppointment,
-        chapter: '11-subchapter-v' as const,
-        appointmentType: 'pool' as const,
+        status: 'voluntarily-suspended' as const,
       };
 
       vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(existingAppointment);
@@ -1209,19 +1208,19 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       );
 
       await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
-        chapter: '11-subchapter-v',
-        appointmentType: 'pool',
+        chapter: '7',
+        appointmentType: 'panel',
         courtId: '081',
         divisionCode: '001',
         appointedDate: '2024-01-15',
-        status: 'active',
+        status: 'voluntarily-suspended',
         effectiveDate: '2024-01-15',
       });
 
       const recorded = MockNotificationGateway.getInstance().getRecorded();
       expect(recorded).toHaveLength(1);
       expect(recorded[0].subject).toContain('Trustee Appointment Changed');
-      expect(recorded[0].html).toContain('Chapter');
+      expect(recorded[0].html).toContain('Status');
     });
 
     test('notification failure does not fail the appointment save', async () => {
@@ -1380,7 +1379,7 @@ describe('TrusteeAppointmentsUseCase tests', () => {
     });
   });
 
-  describe('createAppointment notification dispatch (CAMS-768 Slice 2)', () => {
+  describe('createAppointment notification dispatch', () => {
     const trusteeId = 'trustee-notify-create';
 
     beforeEach(async () => {

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -129,12 +129,13 @@ export class TrusteeAppointmentsUseCase {
     userReference: CamsUserReference,
     before: AppointmentSnapshot | undefined,
     after: AppointmentSnapshot | undefined,
+    courts?: CourtDivisionDetails[],
   ): Promise<Creatable<TrusteeAppointmentHistory>> {
-    const courts = await this.courtsUseCase.getCourts(context);
+    const resolvedCourts = courts ?? (await this.courtsUseCase.getCourts(context));
 
     const withCourtInfo = (snap?: AppointmentSnapshot) => {
       if (!snap) return undefined;
-      const courtName = this.findCourtDistrict(courts, snap.courtId);
+      const courtName = this.findCourtDistrict(resolvedCourts, snap.courtId);
       return {
         ...snap,
         courtName,
@@ -231,6 +232,8 @@ export class TrusteeAppointmentsUseCase {
         userReference,
       );
 
+      const courts = await this.courtsUseCase.getCourts(context);
+
       const history = await this.buildAppointmentHistory(
         context,
         trusteeId,
@@ -247,12 +250,12 @@ export class TrusteeAppointmentsUseCase {
           status: createdAppointment.status,
           effectiveDate: createdAppointment.effectiveDate,
         },
+        courts,
       );
 
       await this.trusteesRepository.createTrusteeHistory(history as Creatable<TrusteeHistory>);
 
       try {
-        const courts = await this.courtsUseCase.getCourts(context);
         const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
         const changeSet = buildAppointmentChangeSet({
           trusteeId,
@@ -324,6 +327,8 @@ export class TrusteeAppointmentsUseCase {
       );
 
       if (this.hasAppointmentChanged(existingAppointment, updatedAppointment)) {
+        const courts = await this.courtsUseCase.getCourts(context);
+
         const history = await this.buildAppointmentHistory(
           context,
           trusteeId,
@@ -349,13 +354,13 @@ export class TrusteeAppointmentsUseCase {
             status: updatedAppointment.status,
             effectiveDate: updatedAppointment.effectiveDate,
           },
+          courts,
         );
 
         await this.trusteesRepository.createTrusteeHistory(history as Creatable<TrusteeHistory>);
 
         try {
           const trustee = await this.trusteesRepository.read(trusteeId);
-          const courts = await this.courtsUseCase.getCourts(context);
           const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
           const changeSet = buildAppointmentChangeSet({
             trusteeId,

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -23,6 +23,8 @@ import { Creatable } from '@common/cams/creatable';
 import DateHelper from '@common/date-helper';
 import { validateObject } from '@common/cams/validation';
 import { CamsError } from '../../common-errors/cams-error';
+import { buildAppointmentChangeSet } from './build-appointment-change-set';
+import { TrusteeChangeNotificationUseCase } from '../notifications/trustee-change-notification';
 
 const MODULE_NAME = 'TRUSTEE-APPOINTMENTS-USE-CASE';
 
@@ -206,8 +208,10 @@ export class TrusteeAppointmentsUseCase {
     appointmentData: TrusteeAppointmentInput,
   ): Promise<TrusteeAppointment> {
     try {
+      let trusteeName: string;
       try {
-        await this.trusteesRepository.read(trusteeId);
+        const trustee = await this.trusteesRepository.read(trusteeId);
+        trusteeName = trustee.name;
       } catch (_e) {
         throw new NotFoundError(MODULE_NAME, {
           message: `Trustee with ID ${trusteeId} not found.`,
@@ -246,6 +250,36 @@ export class TrusteeAppointmentsUseCase {
       );
 
       await this.trusteesRepository.createTrusteeHistory(history as Creatable<TrusteeHistory>);
+
+      try {
+        const courts = await this.courtsUseCase.getCourts(context);
+        const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
+        const changeSet = buildAppointmentChangeSet({
+          trusteeId,
+          trusteeName,
+          before: undefined,
+          after: {
+            chapter: createdAppointment.chapter,
+            appointmentType: createdAppointment.appointmentType,
+            courtId: createdAppointment.courtId,
+            divisionCodes: createdAppointment.divisionCodes,
+            appointedDate: createdAppointment.appointedDate,
+            status: createdAppointment.status,
+            effectiveDate: createdAppointment.effectiveDate,
+          },
+          courtNameResolver,
+        });
+        if (changeSet.fields.length > 0) {
+          const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
+          await notificationUseCase.notify(context, changeSet);
+        }
+      } catch (notificationError) {
+        context.logger.error(
+          MODULE_NAME,
+          'Failed to dispatch new appointment notification.',
+          notificationError,
+        );
+      }
 
       context.logger.info(
         MODULE_NAME,
@@ -318,6 +352,45 @@ export class TrusteeAppointmentsUseCase {
         );
 
         await this.trusteesRepository.createTrusteeHistory(history as Creatable<TrusteeHistory>);
+
+        try {
+          const trustee = await this.trusteesRepository.read(trusteeId);
+          const courts = await this.courtsUseCase.getCourts(context);
+          const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
+          const changeSet = buildAppointmentChangeSet({
+            trusteeId,
+            trusteeName: trustee.name,
+            before: {
+              chapter: existingAppointment.chapter,
+              appointmentType: existingAppointment.appointmentType,
+              courtId: existingAppointment.courtId,
+              divisionCodes: existingAppointment.divisionCodes,
+              appointedDate: existingAppointment.appointedDate,
+              status: existingAppointment.status,
+              effectiveDate: existingAppointment.effectiveDate,
+            },
+            after: {
+              chapter: updatedAppointment.chapter,
+              appointmentType: updatedAppointment.appointmentType,
+              courtId: updatedAppointment.courtId,
+              divisionCodes: updatedAppointment.divisionCodes,
+              appointedDate: updatedAppointment.appointedDate,
+              status: updatedAppointment.status,
+              effectiveDate: updatedAppointment.effectiveDate,
+            },
+            courtNameResolver,
+          });
+          if (changeSet.fields.length > 0) {
+            const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
+            await notificationUseCase.notify(context, changeSet);
+          }
+        } catch (notificationError) {
+          context.logger.error(
+            MODULE_NAME,
+            'Failed to dispatch appointment change notification.',
+            notificationError,
+          );
+        }
       }
 
       context.logger.info(MODULE_NAME, `Updated appointment ${appointmentId}`);

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -23,7 +23,10 @@ import { Creatable } from '@common/cams/creatable';
 import DateHelper from '@common/date-helper';
 import { validateObject } from '@common/cams/validation';
 import { CamsError } from '../../common-errors/cams-error';
-import { buildAppointmentChangeSet } from './build-appointment-change-set';
+import {
+  buildAppointmentChangeSet,
+  AppointmentFieldSnapshot,
+} from './build-appointment-change-set';
 import { TrusteeChangeNotificationUseCase } from '../notifications/trustee-change-notification';
 
 const MODULE_NAME = 'TRUSTEE-APPOINTMENTS-USE-CASE';
@@ -38,6 +41,19 @@ type AppointmentSnapshot = {
   status: AppointmentStatus;
   effectiveDate: string;
 };
+
+function snapshotFrom(apt: TrusteeAppointment): AppointmentSnapshot & AppointmentFieldSnapshot {
+  return {
+    chapter: apt.chapter,
+    appointmentType: apt.appointmentType,
+    courtId: apt.courtId,
+    divisionCode: apt.divisionCode,
+    divisionCodes: apt.divisionCodes,
+    appointedDate: apt.appointedDate,
+    status: apt.status,
+    effectiveDate: apt.effectiveDate,
+  };
+}
 
 export class TrusteeAppointmentsUseCase {
   private readonly trusteeAppointmentsRepository: TrusteeAppointmentsRepository;
@@ -234,22 +250,15 @@ export class TrusteeAppointmentsUseCase {
 
       const courts = await this.courtsUseCase.getCourts(context);
 
+      const createdSnapshot = snapshotFrom(createdAppointment);
+
       const history = await this.buildAppointmentHistory(
         context,
         trusteeId,
         createdAppointment.id,
         userReference,
         undefined,
-        {
-          chapter: createdAppointment.chapter,
-          appointmentType: createdAppointment.appointmentType,
-          courtId: createdAppointment.courtId,
-          divisionCode: createdAppointment.divisionCode,
-          divisionCodes: createdAppointment.divisionCodes,
-          appointedDate: createdAppointment.appointedDate,
-          status: createdAppointment.status,
-          effectiveDate: createdAppointment.effectiveDate,
-        },
+        createdSnapshot,
         courts,
       );
 
@@ -261,15 +270,7 @@ export class TrusteeAppointmentsUseCase {
           trusteeId,
           trusteeName,
           before: undefined,
-          after: {
-            chapter: createdAppointment.chapter,
-            appointmentType: createdAppointment.appointmentType,
-            courtId: createdAppointment.courtId,
-            divisionCodes: createdAppointment.divisionCodes,
-            appointedDate: createdAppointment.appointedDate,
-            status: createdAppointment.status,
-            effectiveDate: createdAppointment.effectiveDate,
-          },
+          after: createdSnapshot,
           courtNameResolver,
         });
         if (changeSet.fields.length > 0) {
@@ -329,31 +330,16 @@ export class TrusteeAppointmentsUseCase {
       if (this.hasAppointmentChanged(existingAppointment, updatedAppointment)) {
         const courts = await this.courtsUseCase.getCourts(context);
 
+        const beforeSnapshot = snapshotFrom(existingAppointment);
+        const afterSnapshot = snapshotFrom(updatedAppointment);
+
         const history = await this.buildAppointmentHistory(
           context,
           trusteeId,
           appointmentId,
           userReference,
-          {
-            chapter: existingAppointment.chapter,
-            appointmentType: existingAppointment.appointmentType,
-            courtId: existingAppointment.courtId,
-            divisionCode: existingAppointment.divisionCode,
-            divisionCodes: existingAppointment.divisionCodes,
-            appointedDate: existingAppointment.appointedDate,
-            status: existingAppointment.status,
-            effectiveDate: existingAppointment.effectiveDate,
-          },
-          {
-            chapter: updatedAppointment.chapter,
-            appointmentType: updatedAppointment.appointmentType,
-            courtId: updatedAppointment.courtId,
-            divisionCode: updatedAppointment.divisionCode,
-            divisionCodes: updatedAppointment.divisionCodes,
-            appointedDate: updatedAppointment.appointedDate,
-            status: updatedAppointment.status,
-            effectiveDate: updatedAppointment.effectiveDate,
-          },
+          beforeSnapshot,
+          afterSnapshot,
           courts,
         );
 
@@ -365,24 +351,8 @@ export class TrusteeAppointmentsUseCase {
           const changeSet = buildAppointmentChangeSet({
             trusteeId,
             trusteeName: trustee.name,
-            before: {
-              chapter: existingAppointment.chapter,
-              appointmentType: existingAppointment.appointmentType,
-              courtId: existingAppointment.courtId,
-              divisionCodes: existingAppointment.divisionCodes,
-              appointedDate: existingAppointment.appointedDate,
-              status: existingAppointment.status,
-              effectiveDate: existingAppointment.effectiveDate,
-            },
-            after: {
-              chapter: updatedAppointment.chapter,
-              appointmentType: updatedAppointment.appointmentType,
-              courtId: updatedAppointment.courtId,
-              divisionCodes: updatedAppointment.divisionCodes,
-              appointedDate: updatedAppointment.appointedDate,
-              status: updatedAppointment.status,
-              effectiveDate: updatedAppointment.effectiveDate,
-            },
+            before: beforeSnapshot,
+            after: afterSnapshot,
             courtNameResolver,
           });
           if (changeSet.fields.length > 0) {

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -264,25 +264,27 @@ export class TrusteeAppointmentsUseCase {
 
       await this.trusteesRepository.createTrusteeHistory(history as Creatable<TrusteeHistory>);
 
-      try {
-        const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
-        const changeSet = buildAppointmentChangeSet({
-          trusteeId,
-          trusteeName,
-          before: undefined,
-          after: createdSnapshot,
-          courtNameResolver,
-        });
-        if (changeSet.fields.length > 0) {
-          const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
-          await notificationUseCase.notify(context, changeSet);
+      if (context.featureFlags['trustee-change-notifications-enabled']) {
+        try {
+          const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
+          const changeSet = buildAppointmentChangeSet({
+            trusteeId,
+            trusteeName,
+            before: undefined,
+            after: createdSnapshot,
+            courtNameResolver,
+          });
+          if (changeSet.fields.length > 0) {
+            const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
+            await notificationUseCase.notify(context, changeSet);
+          }
+        } catch (notificationError) {
+          context.logger.error(
+            MODULE_NAME,
+            'Failed to dispatch new appointment notification.',
+            notificationError,
+          );
         }
-      } catch (notificationError) {
-        context.logger.error(
-          MODULE_NAME,
-          'Failed to dispatch new appointment notification.',
-          notificationError,
-        );
       }
 
       context.logger.info(
@@ -345,26 +347,28 @@ export class TrusteeAppointmentsUseCase {
 
         await this.trusteesRepository.createTrusteeHistory(history as Creatable<TrusteeHistory>);
 
-        try {
-          const trustee = await this.trusteesRepository.read(trusteeId);
-          const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
-          const changeSet = buildAppointmentChangeSet({
-            trusteeId,
-            trusteeName: trustee.name,
-            before: beforeSnapshot,
-            after: afterSnapshot,
-            courtNameResolver,
-          });
-          if (changeSet.fields.length > 0) {
-            const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
-            await notificationUseCase.notify(context, changeSet);
+        if (context.featureFlags['trustee-change-notifications-enabled']) {
+          try {
+            const trustee = await this.trusteesRepository.read(trusteeId);
+            const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
+            const changeSet = buildAppointmentChangeSet({
+              trusteeId,
+              trusteeName: trustee.name,
+              before: beforeSnapshot,
+              after: afterSnapshot,
+              courtNameResolver,
+            });
+            if (changeSet.fields.length > 0) {
+              const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
+              await notificationUseCase.notify(context, changeSet);
+            }
+          } catch (notificationError) {
+            context.logger.error(
+              MODULE_NAME,
+              'Failed to dispatch appointment change notification.',
+              notificationError,
+            );
           }
-        } catch (notificationError) {
-          context.logger.error(
-            MODULE_NAME,
-            'Failed to dispatch appointment change notification.',
-            notificationError,
-          );
         }
       }
 

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -1742,6 +1742,7 @@ describe('TrusteesUseCase tests', () => {
     beforeEach(async () => {
       vi.restoreAllMocks();
       context = await createMockApplicationContext();
+      context.featureFlags['trustee-change-notifications-enabled'] = true;
       trusteesUseCase = new TrusteesUseCase(context);
       MockNotificationGateway.getInstance().clear();
 
@@ -1776,6 +1777,17 @@ describe('TrusteesUseCase tests', () => {
           appointedDate: '2020-01-15',
         }),
       ]);
+    });
+
+    test('does not dispatch when feature flag is disabled', async () => {
+      context.featureFlags['trustee-change-notifications-enabled'] = false;
+
+      const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+
+      await trusteesUseCase.updateTrustee(context, trusteeId, { name: 'Henry G. Green' });
+
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
     });
 
     test('dispatches one notification to the chapter:7 recipient on a profile-only change', async () => {

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -411,7 +411,10 @@ export class TrusteesUseCase {
         software,
       );
 
-      if (changeSet.fields.length > 0) {
+      if (
+        context.featureFlags['trustee-change-notifications-enabled'] &&
+        changeSet.fields.length > 0
+      ) {
         try {
           changeSet.primaryChapter = await this.resolvePrimaryChapter(trusteeId);
           const notificationUseCase = new TrusteeChangeNotificationUseCase(context);

--- a/common/src/cams/notifications.ts
+++ b/common/src/cams/notifications.ts
@@ -48,4 +48,6 @@ export type TrusteeChangeSet = {
   fields: TrusteeChangeField[];
   /** Chapter type used for routing. Read from the trustee's primary appointment; undefined when no appointment exists. */
   primaryChapter?: AppointmentChapterType;
+  /** When set, overrides the default subject line. Used by appointment notifications. */
+  subjectOverride?: string;
 };

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -27,4 +27,5 @@ export const testFeatureFlags: FeatureFlagSet = {
   'view-trustee-on-case': true,
   'downstream-staff-assignments-enabled': true,
   'downstream-trustee-appointments-enabled': true,
+  'trustee-change-notifications-enabled': true,
 };

--- a/dev-tools/db_scripts/scenarios/notification-routing.ts
+++ b/dev-tools/db_scripts/scenarios/notification-routing.ts
@@ -37,7 +37,7 @@ export async function generate(_ctx: SeedContext): Promise<SeedOperation[]> {
           id: 'notification-routing-chapter-11-subchapter-v',
           key: 'chapter:11-subchapter-v',
           recipientAddress: 'subv@example.test',
-          displayName: 'Sub-V Oversight (Debbie)',
+          displayName: 'Subchapter V Oversight',
         },
         {
           id: 'notification-routing-chapter-12',

--- a/dev-tools/db_scripts/scenarios/notification-routing.ts
+++ b/dev-tools/db_scripts/scenarios/notification-routing.ts
@@ -5,9 +5,9 @@
  * Seeds the NOTIFICATION_ROUTING collection used by
  * TrusteeChangeNotificationUseCase to resolve email recipients.
  *
- * Slice 1 seeds two rows: chapter:7 (CH7 oversight mailbox) and default
- * (catch-all). Slice 2 will extend with chapter:11, chapter:11-subchapter-v,
- * chapter:12, chapter:13, and category:zoom-341.
+ * Slice 1: chapter:7 and default.
+ * Slice 2: chapter:11, chapter:11-subchapter-v, chapter:12, chapter:13,
+ *           and category:zoom-341.
  *
  * Idempotent — re-running against an already-seeded database is a no-op
  * because the runner upserts on the `id` field via mongoUpsert.
@@ -26,6 +26,36 @@ export async function generate(_ctx: SeedContext): Promise<SeedOperation[]> {
           key: 'chapter:7',
           recipientAddress: 'ch7-oversight@example.test',
           displayName: 'CH7 Oversight Office',
+        },
+        {
+          id: 'notification-routing-chapter-11',
+          key: 'chapter:11',
+          recipientAddress: 'ch11-oversight@example.test',
+          displayName: 'CH11 Oversight Office',
+        },
+        {
+          id: 'notification-routing-chapter-11-subchapter-v',
+          key: 'chapter:11-subchapter-v',
+          recipientAddress: 'subv@example.test',
+          displayName: 'Sub-V Oversight (Debbie)',
+        },
+        {
+          id: 'notification-routing-chapter-12',
+          key: 'chapter:12',
+          recipientAddress: 'ch12-oversight@example.test',
+          displayName: 'CH12 Oversight Office',
+        },
+        {
+          id: 'notification-routing-chapter-13',
+          key: 'chapter:13',
+          recipientAddress: 'ch13-oversight@example.test',
+          displayName: 'CH13 Oversight Office',
+        },
+        {
+          id: 'notification-routing-category-zoom-341',
+          key: 'category:zoom-341',
+          recipientAddress: 'ustp-help@example.test',
+          displayName: 'USTP Help',
         },
         {
           id: 'notification-routing-default',


### PR DESCRIPTION
# Purpose

Extend trustee change notifications to fire when appointment records are created or updated, completing the second vertical slice of CAMS-768. Oversight offices are now notified of appointment-level changes (chapter, status, district, division, effective date) in addition to the profile-level changes delivered in Slice 1.

# Major Changes

* Added `subjectOverride` field to `TrusteeChangeSet` so appointment notifications use distinct subject lines ("Trustee Appointment Changed" / "New Trustee Appointment") vs profile notifications
* Created `buildAppointmentChangeSet` — a pure function that compares before/after appointment snapshots and emits per-field diffs with formatted labels
* Wired fire-and-forget notification dispatch into both `TrusteeAppointmentsUseCase.updateAppointment` and `.createAppointment` with failure isolation (try/catch — notification errors never fail the save)
* Extended the routing seed with `chapter:11`, `chapter:11-subchapter-v`, `chapter:12`, `chapter:13`, and `category:zoom-341` rows. Sub-V routes to Debbie's mailbox; zoom-341 to USTP Help

# Testing/Validation

Implemented using TDD. 18 new tests across 3 files:
- 2 tests for `subjectOverride` template behavior
- 8 tests for `buildAppointmentChangeSet` (single change, multi-field, no change, create, division stacking, court resolver, resolver fallback, status formatting)
- 5 tests for `updateAppointment` notification dispatch (dispatch, failure isolation, no-op, Sub-V routing, default-recipient fallback)
- 3 tests for `createAppointment` notification dispatch (dispatch, failure isolation, chapter routing)

All 2982 backend tests and 1095 common tests pass. Typecheck and lint clean.

# Notes

- Routing uses the appointment's own chapter for key resolution (not `resolvePrimaryChapter`) — simpler and semantically correct since we have the chapter directly available
- For creates, all fields render as additions (before = empty); for updates, only changed fields appear
- The notification try/catch in `updateAppointment` also wraps the trustee-name read (needed for the notification subject) so existing tests that don't mock it are unaffected
- Feature scenarios covered: "Changing an appointment chapter from CH7 to Sub-V routes to debbie's mailbox"; zoom-341 routing activated by seed row
- `vi.restoreAllMocks()` placed in `beforeEach` per project convention (not `afterEach`)

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add trustee appointment-level notification generation and routing when appointments are created or updated.

New Features:
- Send trustee change notifications for appointment creations and updates using appointment-specific change sets and subject lines.

Enhancements:
- Introduce an appointment change-set builder to derive per-field diffs and notification metadata from before/after appointment snapshots.
- Ensure notification dispatch failures for appointment events are logged but do not affect appointment persistence.
- Extend notification routing seed data to cover additional chapters and a new zoom-341 support category.

Tests:
- Add tests covering appointment notification dispatch behavior, failure isolation, routing, and template subject override handling.