### PR TITLE
CAMS-770 Add District (Division) case list filter

### DIFF
--- a/backend/lib/controllers/trustee-cases/trustee-cases.controller.test.ts
+++ b/backend/lib/controllers/trustee-cases/trustee-cases.controller.test.ts
@@ -291,5 +291,64 @@ describe('TrusteeCasesController', () => {
         isCamsError: true,
       });
     });
+
+    test('parses divisionCodes as array from comma-separated query param', async () => {
+      context.request.query = { divisionCodes: '0971,0972' };
+      const spy = vi
+        .spyOn(TrusteeCasesUseCase.prototype, 'getCasesForTrustee')
+        .mockResolvedValue({ data: [], metadata: { total: 0 } });
+      await controller.handleRequest(context);
+      expect(spy).toHaveBeenCalledWith(
+        context,
+        'trustee-123',
+        expect.objectContaining({ divisionCodes: ['0971', '0972'] }),
+      );
+    });
+
+    test('omits divisionCodes from predicate when query param is absent', async () => {
+      context.request.query = {};
+      const spy = vi
+        .spyOn(TrusteeCasesUseCase.prototype, 'getCasesForTrustee')
+        .mockResolvedValue({ data: [], metadata: { total: 0 } });
+      await controller.handleRequest(context);
+      const predicate = spy.mock.calls[0][2];
+      expect(predicate).not.toHaveProperty('divisionCodes');
+    });
+
+    test('omits divisionCodes from predicate when query param is empty string', async () => {
+      context.request.query = { divisionCodes: '' };
+      const spy = vi
+        .spyOn(TrusteeCasesUseCase.prototype, 'getCasesForTrustee')
+        .mockResolvedValue({ data: [], metadata: { total: 0 } });
+      await controller.handleRequest(context);
+      const predicate = spy.mock.calls[0][2];
+      expect(predicate).not.toHaveProperty('divisionCodes');
+    });
+
+    test('strips whitespace and empty entries from divisionCodes', async () => {
+      context.request.query = { divisionCodes: ' 0971 , , 0972 ' };
+      const spy = vi
+        .spyOn(TrusteeCasesUseCase.prototype, 'getCasesForTrustee')
+        .mockResolvedValue({ data: [], metadata: { total: 0 } });
+      await controller.handleRequest(context);
+      expect(spy).toHaveBeenCalledWith(
+        context,
+        'trustee-123',
+        expect.objectContaining({ divisionCodes: ['0971', '0972'] }),
+      );
+    });
+
+    test('passes divisionCodes combined with status and chapter filters', async () => {
+      context.request.query = { status: 'OPEN', chapters: '7', divisionCodes: '0971' };
+      const spy = vi
+        .spyOn(TrusteeCasesUseCase.prototype, 'getCasesForTrustee')
+        .mockResolvedValue({ data: [], metadata: { total: 0 } });
+      await controller.handleRequest(context);
+      expect(spy).toHaveBeenCalledWith(
+        context,
+        'trustee-123',
+        expect.objectContaining({ caseStatus: 'OPEN', chapters: ['7'], divisionCodes: ['0971'] }),
+      );
+    });
   });
 });

--- a/backend/lib/controllers/trustee-cases/trustee-cases.controller.ts
+++ b/backend/lib/controllers/trustee-cases/trustee-cases.controller.ts
@@ -73,6 +73,15 @@ export class TrusteeCasesController implements CamsController {
       const rawTo = context.request.query.filedDateTo as string | undefined;
       const filedDateTo = rawTo && DateHelper.isValidDateString(rawTo) ? rawTo : undefined;
 
+      const rawDivisions = context.request.query.divisionCodes as string | undefined;
+      const divisionCodes = rawDivisions
+        ? rawDivisions
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .slice(0, 50)
+        : undefined;
+
       const predicate: TrusteeCasesSearchPredicate = {
         limit,
         offset,
@@ -80,6 +89,7 @@ export class TrusteeCasesController implements CamsController {
         chapters,
         ...(filedDateFrom ? { filedDateFrom } : {}),
         ...(filedDateTo ? { filedDateTo } : {}),
+        ...(divisionCodes?.length ? { divisionCodes } : {}),
       };
 
       const result = await this.useCase.getCasesForTrustee(context, trusteeId, predicate);

--- a/backend/lib/use-cases/trustee-cases/trustee-cases.use-case.test.ts
+++ b/backend/lib/use-cases/trustee-cases/trustee-cases.use-case.test.ts
@@ -485,6 +485,53 @@ describe('TrusteeCasesUseCase', () => {
     );
   });
 
+  test('passes divisionCodes to searchCases when provided in predicate', async () => {
+    const context = await createMockApplicationContext();
+    const appointments = [
+      { id: 'appt-1', caseId: '081-24-00001', trusteeId: 'trustee-abc', assignedOn: '2024-01-01' },
+    ] as unknown as CaseAppointment[];
+    vi.spyOn(
+      MockMongoRepository.prototype,
+      'getActiveCaseAppointmentsByTrusteeId',
+    ).mockResolvedValue(appointments);
+    const searchSpy = vi.spyOn(MockMongoRepository.prototype, 'searchCases').mockResolvedValue({
+      data: [],
+      metadata: { total: 0 },
+    });
+
+    const useCase = new TrusteeCasesUseCase();
+    await useCase.getCasesForTrustee(context, 'trustee-abc', {
+      limit: 25,
+      offset: 0,
+      divisionCodes: ['0971', '0972'],
+    });
+
+    expect(searchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ divisionCodes: ['0971', '0972'] }),
+    );
+  });
+
+  test('omits divisionCodes from searchCases when not in predicate', async () => {
+    const context = await createMockApplicationContext();
+    const appointments = [
+      { id: 'appt-1', caseId: '081-24-00001', trusteeId: 'trustee-abc', assignedOn: '2024-01-01' },
+    ] as unknown as CaseAppointment[];
+    vi.spyOn(
+      MockMongoRepository.prototype,
+      'getActiveCaseAppointmentsByTrusteeId',
+    ).mockResolvedValue(appointments);
+    const searchSpy = vi.spyOn(MockMongoRepository.prototype, 'searchCases').mockResolvedValue({
+      data: [],
+      metadata: { total: 0 },
+    });
+
+    const useCase = new TrusteeCasesUseCase();
+    await useCase.getCasesForTrustee(context, 'trustee-abc', { limit: 25, offset: 0 });
+
+    const callArg = searchSpy.mock.calls[0][0];
+    expect(callArg.divisionCodes).toBeUndefined();
+  });
+
   test('wraps errors with getCamsErrorWithStack', async () => {
     const context = await createMockApplicationContext();
 

--- a/backend/lib/use-cases/trustee-cases/trustee-cases.use-case.ts
+++ b/backend/lib/use-cases/trustee-cases/trustee-cases.use-case.ts
@@ -33,6 +33,7 @@ export class TrusteeCasesUseCase {
         ...(caseStatus === 'CLOSED' ? { includeOnlyClosedCases: true } : {}),
         ...(filedDateFrom ? { filedDateFrom } : {}),
         ...(filedDateTo ? { filedDateTo } : {}),
+        ...(predicate.divisionCodes?.length ? { divisionCodes: predicate.divisionCodes } : {}),
       });
       const syncedCases = casesResponse.data;
 

--- a/common/src/api/search.ts
+++ b/common/src/api/search.ts
@@ -41,6 +41,7 @@ export type TrusteeCasesSearchPredicate = SearchPredicate & {
   chapters?: string[];
   filedDateFrom?: string;
   filedDateTo?: string;
+  divisionCodes?: string[];
 };
 
 export type TrusteeStatusFilter = 'all' | 'active' | 'inactive';

--- a/dev-tools/db_scripts/scenarios/trustee-case-list.ts
+++ b/dev-tools/db_scripts/scenarios/trustee-case-list.ts
@@ -25,11 +25,84 @@ import { createDebtor, createTrusteeBase } from '../lib/test-data-utils.js';
 const PAGINATED_TRUSTEE_ID = 'cams-593-paginated';
 const EMPTY_TRUSTEE_ID = 'cams-593-empty';
 const SEEDER = { id: 'SEED', name: 'Test Data Seeder' };
-const DIVISION_CODE = '091';
-const COURT_ID = '0209';
 const NOW = '2026-01-01T00:00:00.000Z';
 
 const CHAPTERS = ['7', '7', '7', '11', '13'] as const;
+
+// Spread cases across 5 divisions for a realistic mix of courts and regions.
+// groupDesignator must match a valid AO_GRP_DES row in the local DXTR instance.
+const DIVISIONS = [
+  {
+    divisionCode: '081',
+    courtId: '0208',
+    groupDesignator: 'NY',
+    officeName: 'Manhattan',
+    officeCode: 'USTP_CAMS_Region_2_Office_081',
+    courtName: 'U.S. Bankruptcy Court Southern District of New York',
+    courtDivisionName: 'Manhattan',
+    regionId: '2',
+    regionName: 'NEW YORK',
+    city: 'New York',
+    state: 'NY',
+    zip: '10001',
+  },
+  {
+    divisionCode: '087',
+    courtId: '0208',
+    groupDesignator: 'NY',
+    officeName: 'White Plains',
+    officeCode: 'USTP_CAMS_Region_2_Office_087',
+    courtName: 'U.S. Bankruptcy Court Southern District of New York',
+    courtDivisionName: 'White Plains',
+    regionId: '2',
+    regionName: 'NEW YORK',
+    city: 'White Plains',
+    state: 'NY',
+    zip: '10601',
+  },
+  {
+    divisionCode: '393',
+    courtId: '0539',
+    groupDesignator: 'DA',
+    officeName: 'Dallas',
+    officeCode: 'USTP_CAMS_Region_6_Office_393',
+    courtName: 'U.S. Bankruptcy Court Northern District of Texas',
+    courtDivisionName: 'Dallas',
+    regionId: '6',
+    regionName: 'DALLAS',
+    city: 'Dallas',
+    state: 'TX',
+    zip: '75201',
+  },
+  {
+    divisionCode: '414',
+    courtId: '0541',
+    groupDesignator: 'HU',
+    officeName: 'Houston',
+    officeCode: 'USTP_CAMS_Region_7_Office_414',
+    courtName: 'U.S. Bankruptcy Court Southern District of Texas',
+    courtDivisionName: 'Houston',
+    regionId: '7',
+    regionName: 'HOUSTON',
+    city: 'Houston',
+    state: 'TX',
+    zip: '77002',
+  },
+  {
+    divisionCode: '521',
+    courtId: '0752',
+    groupDesignator: 'CH',
+    officeName: 'Chicago',
+    officeCode: 'USTP_CAMS_Region_11_Office_521',
+    courtName: 'U.S. Bankruptcy Court Northern District of Illinois',
+    courtDivisionName: 'Chicago',
+    regionId: '11',
+    regionName: 'CHICAGO',
+    city: 'Chicago',
+    state: 'IL',
+    zip: '60601',
+  },
+] as const;
 
 const DEBTOR_FIRST_NAMES = [
   'Alice',
@@ -179,18 +252,20 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
   const appointments: Record<string, unknown>[] = [];
 
   const caseResults = await Promise.all(
-    Array.from({ length: 60 }, (_, i) =>
-      ensureDxtrCase(ctx, {
-        divisionCode: DIVISION_CODE,
+    Array.from({ length: 60 }, (_, i) => {
+      const div = DIVISIONS[i % DIVISIONS.length];
+      return ensureDxtrCase(ctx, {
+        divisionCode: div.divisionCode,
         chapter: CHAPTERS[i % CHAPTERS.length],
         debtorName: makeDebtorName(i),
-        courtId: COURT_ID,
-        groupDesignator: 'BU',
-      }).then((result) => ({ ...result, i })),
-    ),
+        courtId: div.courtId,
+        groupDesignator: div.groupDesignator,
+      }).then((result) => ({ ...result, i }));
+    }),
   );
 
   for (const { operations: dxtrOps, caseInfo, i } of caseResults) {
+    const div = DIVISIONS[i % DIVISIONS.length];
     const chapter = CHAPTERS[i % CHAPTERS.length];
     const debtorName = makeDebtorName(i);
     const dateFiled = makeDateFiled(i);
@@ -213,7 +288,7 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
       data: [
         {
           CS_CASEID: csCaseId,
-          COURT_ID: COURT_ID,
+          COURT_ID: div.courtId,
           DE_SEQNO: 1,
           DE_DOCUMENT_NUM: 1,
           DE_DATE_FILED: dateFiledUtc,
@@ -222,7 +297,7 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
         },
         {
           CS_CASEID: csCaseId,
-          COURT_ID: COURT_ID,
+          COURT_ID: div.courtId,
           DE_SEQNO: 2,
           DE_DOCUMENT_NUM: 2,
           DE_DATE_FILED: dateFiledUtc,
@@ -231,7 +306,7 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
         },
         {
           CS_CASEID: csCaseId,
-          COURT_ID: COURT_ID,
+          COURT_ID: div.courtId,
           DE_SEQNO: 3,
           DE_DOCUMENT_NUM: null,
           DE_DATE_FILED: dateFiledUtc,
@@ -256,21 +331,21 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
       petitionLabel: 'Original petition',
       debtorTypeCode: isCorporate ? 'CB' : 'IC',
       debtorTypeLabel: isCorporate ? 'Corporate Business' : 'Individual Consumer',
-      officeName: 'Buffalo',
-      officeCode: 'USTP_CAMS_Region_2_Office_091',
-      courtId: COURT_ID,
-      courtName: 'U.S. Bankruptcy Court Western District of New York',
-      courtDivisionCode: DIVISION_CODE,
-      courtDivisionName: 'Buffalo',
-      groupDesignator: 'BU',
-      regionId: '02',
-      regionName: 'NEW YORK',
+      officeName: div.officeName,
+      officeCode: div.officeCode,
+      courtId: div.courtId,
+      courtName: div.courtName,
+      courtDivisionCode: div.divisionCode,
+      courtDivisionName: div.courtDivisionName,
+      groupDesignator: div.groupDesignator,
+      regionId: div.regionId,
+      regionName: div.regionName,
       consolidation: [],
       debtor: createDebtor(debtorName, {
         address1: street,
-        city: 'Buffalo',
-        state: 'NY',
-        zip: '14202',
+        city: div.city,
+        state: div.state,
+        zip: div.zip,
         ...(isCorporate
           ? { taxId: `${String(i + 10).padStart(2, '0')}-${String(i + 1000000).padStart(7, '0')}` }
           : { ssn: `***-**-${String((i * 7 + 1234) % 10000).padStart(4, '0')}` }),
@@ -319,13 +394,13 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
         trusteeId: PAGINATED_TRUSTEE_ID,
         chapter: '7',
         appointmentType: 'panel',
-        courtId: COURT_ID,
-        divisionCodes: [DIVISION_CODE],
+        courtId: DIVISIONS[0].courtId,
+        divisionCodes: [DIVISIONS[0].divisionCode],
         appointedDate: '2020-01-01',
         status: 'active',
         effectiveDate: '2020-01-01',
-        courtName: 'U.S. Bankruptcy Court Western District of New York',
-        courtDivisionName: 'Buffalo',
+        courtName: DIVISIONS[0].courtName,
+        courtDivisionName: DIVISIONS[0].courtDivisionName,
         createdOn: '2020-01-01T00:00:00.000Z',
         createdBy: SEEDER,
         updatedOn: '2020-01-01T00:00:00.000Z',

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -382,7 +382,8 @@ async function deleteCaseNote(note: Partial<CaseNote>) {
 }
 
 async function getTrusteeCases(trusteeId: string, predicate?: TrusteeCasesSearchPredicate) {
-  const { chapters, caseStatus, filedDateFrom, filedDateTo, ...rest } = predicate ?? {};
+  const { chapters, caseStatus, filedDateFrom, filedDateTo, divisionCodes, ...rest } =
+    predicate ?? {};
   const params: ObjectKeyVal = { ...rest };
   if (chapters?.length) {
     params.chapters = chapters.join(',');
@@ -392,6 +393,7 @@ async function getTrusteeCases(trusteeId: string, predicate?: TrusteeCasesSearch
   }
   if (filedDateFrom) params.filedDateFrom = filedDateFrom;
   if (filedDateTo) params.filedDateTo = filedDateTo;
+  if (divisionCodes?.length) params.divisionCodes = divisionCodes.join(',');
   return api().get<TrusteeCaseListItem[]>(`/trustees/${trusteeId}/cases`, params);
 }
 

--- a/user-interface/src/trustees/panels/TrusteeCaseList.test.tsx
+++ b/user-interface/src/trustees/panels/TrusteeCaseList.test.tsx
@@ -343,6 +343,36 @@ describe('TrusteeCaseList', () => {
     });
   });
 
+  test('passes divisionCodes to API when division filter is applied', async () => {
+    const spy = vi.spyOn(Api2, 'getTrusteeCases').mockResolvedValue({
+      data: mockCases,
+      pagination: noPagination,
+    });
+    renderComponent('trustee-123', {
+      caseStatus: 'OPEN',
+      chapters: [],
+      divisionCodes: ['0971', '0972'],
+    });
+    await screen.findByRole('table');
+    expect(spy).toHaveBeenCalledWith(
+      'trustee-123',
+      expect.objectContaining({ divisionCodes: ['0971', '0972'] }),
+    );
+  });
+
+  test('omits divisionCodes from API call when filter has no division codes', async () => {
+    const spy = vi.spyOn(Api2, 'getTrusteeCases').mockResolvedValue({
+      data: mockCases,
+      pagination: noPagination,
+    });
+    renderComponent();
+    await screen.findByRole('table');
+    expect(spy).toHaveBeenCalledWith(
+      'trustee-123',
+      expect.not.objectContaining({ divisionCodes: expect.anything() }),
+    );
+  });
+
   test('omits division label when courtDivisionName is empty', async () => {
     const caseNoDivision: TrusteeCaseListItem = {
       caseId: '081-24-00002',

--- a/user-interface/src/trustees/panels/TrusteeCaseList.tsx
+++ b/user-interface/src/trustees/panels/TrusteeCaseList.tsx
@@ -28,6 +28,9 @@ function buildSearchPredicate(
     chapters: filterPredicate.chapters.length ? filterPredicate.chapters : undefined,
     filedDateFrom: filterPredicate.filedDateFrom,
     filedDateTo: filterPredicate.filedDateTo,
+    ...(filterPredicate.divisionCodes?.length
+      ? { divisionCodes: filterPredicate.divisionCodes }
+      : {}),
   };
 }
 

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
@@ -534,10 +534,11 @@ describe('TrusteeCaseListFilter', () => {
     test('does not render District (Division) combobox when courts fetch fails', async () => {
       vi.spyOn(Api2, 'getCourts').mockRejectedValue(new Error('network error'));
       await renderFilter();
-      await waitFor(() => {});
-      expect(
-        screen.queryByRole('combobox', { name: /district \(division\)/i }),
-      ).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('combobox', { name: /district \(division\)/i }),
+        ).not.toBeInTheDocument(),
+      );
     });
 
     test('restores selected divisions visually when initialValue has divisionCodes', async () => {
@@ -631,11 +632,11 @@ describe('TrusteeCaseListFilter', () => {
           initialValue={{ caseStatus: 'OPEN', chapters: [], divisionCodes: ['0972'] }}
         />,
       );
-      await waitFor(() => {});
-      const calls = onFilterChange.mock.calls;
-      calls.forEach((call) => {
-        expect(call[0]).not.toMatchObject({ divisionCodes: ['0971'] });
-      });
+      await waitFor(() =>
+        expect(onFilterChange).not.toHaveBeenCalledWith(
+          expect.objectContaining({ divisionCodes: ['0971'] }),
+        ),
+      );
     });
 
     test('includes initialValue divisionCodes in onFilterChange when another filter changes', async () => {

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
@@ -2,10 +2,38 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, test, expect, beforeEach } from 'vitest';
 import TrusteeCaseListFilter from './TrusteeCaseListFilter';
+import Api2 from '@/lib/models/api2';
+import { CourtDivisionDetails } from '@common/cams/courts';
+
+const mockCourts: CourtDivisionDetails[] = [
+  {
+    officeName: 'Manhattan',
+    officeCode: '0971',
+    courtId: '097',
+    courtName: 'Southern District of New York',
+    courtDivisionCode: '0971',
+    courtDivisionName: 'Manhattan',
+    groupDesignator: 'NY',
+    regionId: '02',
+    regionName: 'Region 2',
+  },
+  {
+    officeName: 'White Plains',
+    officeCode: '0972',
+    courtId: '097',
+    courtName: 'Southern District of New York',
+    courtDivisionCode: '0972',
+    courtDivisionName: 'White Plains',
+    groupDesignator: 'NY',
+    regionId: '02',
+    regionName: 'Region 2',
+  },
+];
 
 describe('TrusteeCaseListFilter', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [], meta: { self: '' } });
   });
 
   async function renderFilter(onFilterChange = vi.fn()) {
@@ -366,6 +394,147 @@ describe('TrusteeCaseListFilter', () => {
     test('chapter ComboBox is reachable by accessible name', async () => {
       await renderFilter();
       expect(screen.getByRole('combobox', { name: /chapter/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('District (Division) filter', () => {
+    beforeEach(() => {
+      vi.spyOn(Api2, 'getCourts').mockResolvedValue({
+        data: mockCourts,
+        meta: { self: '' },
+      });
+      vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+    });
+
+    test('renders District (Division) combobox when courts are loaded', async () => {
+      await renderFilter();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('combobox', { name: /district \(division\)/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('calls onFilterChange with divisionCodes when a specific division is selected', async () => {
+      const onFilterChange = vi.fn();
+      const user = userEvent.setup();
+      render(<TrusteeCaseListFilter onFilterChange={onFilterChange} />);
+      await user.click(screen.getByRole('button', { name: 'Filters' }));
+      expect(
+        await screen.findByRole('combobox', { name: /district \(division\)/i }),
+      ).toBeInTheDocument();
+      onFilterChange.mockClear();
+      const combo = screen.getByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combo);
+      await user.click(
+        await screen.findByText('Southern District of New York (Manhattan)', {
+          selector: 'li span',
+        }),
+      );
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({ divisionCodes: ['0971'] }),
+      );
+    });
+
+    test('calls onFilterChange with both division codes when All is selected for a district', async () => {
+      const onFilterChange = vi.fn();
+      const user = userEvent.setup();
+      render(<TrusteeCaseListFilter onFilterChange={onFilterChange} />);
+      await user.click(screen.getByRole('button', { name: 'Filters' }));
+      expect(
+        await screen.findByRole('combobox', { name: /district \(division\)/i }),
+      ).toBeInTheDocument();
+      onFilterChange.mockClear();
+      const combo = screen.getByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combo);
+      await user.click(
+        await screen.findByText('Southern District of New York (All)', { selector: 'li span' }),
+      );
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({ divisionCodes: expect.arrayContaining(['0971', '0972']) }),
+      );
+    });
+
+    test('calls onFilterChange with divisionCodes undefined when division filter is cleared', async () => {
+      const onFilterChange = vi.fn();
+      const user = userEvent.setup();
+      render(<TrusteeCaseListFilter onFilterChange={onFilterChange} />);
+      await user.click(screen.getByRole('button', { name: 'Filters' }));
+      expect(
+        await screen.findByRole('combobox', { name: /district \(division\)/i }),
+      ).toBeInTheDocument();
+      const combo = screen.getByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combo);
+      await user.click(
+        await screen.findByText('Southern District of New York (Manhattan)', {
+          selector: 'li span',
+        }),
+      );
+      onFilterChange.mockClear();
+      const clearAll = screen.getByRole('button', { name: /Clear all District \(Division\)/i });
+      await user.click(clearAll);
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.not.objectContaining({ divisionCodes: expect.anything() }),
+      );
+    });
+
+    test('announces district filter selection', async () => {
+      const user = userEvent.setup();
+      render(<TrusteeCaseListFilter onFilterChange={vi.fn()} />);
+      await user.click(screen.getByRole('button', { name: 'Filters' }));
+      expect(
+        await screen.findByRole('combobox', { name: /district \(division\)/i }),
+      ).toBeInTheDocument();
+      const combo = screen.getByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combo);
+      await user.click(
+        await screen.findByText('Southern District of New York (Manhattan)', {
+          selector: 'li span',
+        }),
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('filter-announcement')).toHaveTextContent(
+          'District filter: 1 division(s) selected',
+        );
+      });
+    });
+
+    test('announces district filter cleared', async () => {
+      const user = userEvent.setup();
+      render(<TrusteeCaseListFilter onFilterChange={vi.fn()} />);
+      await user.click(screen.getByRole('button', { name: 'Filters' }));
+      expect(
+        await screen.findByRole('combobox', { name: /district \(division\)/i }),
+      ).toBeInTheDocument();
+      const combo = screen.getByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combo);
+      await user.click(
+        await screen.findByText('Southern District of New York (Manhattan)', {
+          selector: 'li span',
+        }),
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('filter-announcement')).toHaveTextContent('District filter:'),
+      );
+      const clearAll = screen.getByRole('button', { name: /Clear all District \(Division\)/i });
+      await user.click(clearAll);
+      await waitFor(() => {
+        expect(screen.getByTestId('filter-announcement')).toHaveTextContent(
+          'District filter cleared',
+        );
+      });
+    });
+
+    test('does not render District (Division) combobox when courts fetch fails', async () => {
+      vi.spyOn(Api2, 'getCourts').mockRejectedValue(new Error('network error'));
+      await renderFilter();
+      await waitFor(() => {});
+      expect(
+        screen.queryByRole('combobox', { name: /district \(division\)/i }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
@@ -4,6 +4,8 @@ import { vi, describe, test, expect, beforeEach } from 'vitest';
 import TrusteeCaseListFilter from './TrusteeCaseListFilter';
 import Api2 from '@/lib/models/api2';
 import { CourtDivisionDetails } from '@common/cams/courts';
+import LocalStorage from '@/lib/utils/local-storage';
+import MockData from '@common/cams/test-utilities/mock-data';
 
 const mockCourts: CourtDivisionDetails[] = [
   {
@@ -34,6 +36,7 @@ describe('TrusteeCaseListFilter', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [], meta: { self: '' } });
+    vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
   });
 
   async function renderFilter(onFilterChange = vi.fn()) {
@@ -551,6 +554,87 @@ describe('TrusteeCaseListFilter', () => {
             name: /Southern District of New York \(Manhattan\) selected/i,
           }),
         ).toBeInTheDocument();
+      });
+    });
+
+    test('applies user default divisions from session when no initialValue divisionCodes', async () => {
+      const session = {
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '0971',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York Region',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '0971',
+                      court: { courtId: '097', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '0971', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
+      const onFilterChange = vi.fn();
+      render(<TrusteeCaseListFilter onFilterChange={onFilterChange} />);
+      await waitFor(() => {
+        expect(onFilterChange).toHaveBeenCalledWith(
+          expect.objectContaining({ divisionCodes: ['0971'] }),
+        );
+      });
+    });
+
+    test('does not apply user defaults when initialValue already has divisionCodes', async () => {
+      const session = {
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '0971',
+              officeName: 'Manhattan',
+              idpGroupName: 'Manhattan',
+              regionId: '02',
+              regionName: 'New York Region',
+              groups: [
+                {
+                  groupDesignator: 'NY',
+                  divisions: [
+                    {
+                      divisionCode: '0971',
+                      court: { courtId: '097', courtName: 'Southern District of New York' },
+                      courtOffice: { courtOfficeCode: '0971', courtOfficeName: 'Manhattan' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
+      const onFilterChange = vi.fn();
+      render(
+        <TrusteeCaseListFilter
+          onFilterChange={onFilterChange}
+          initialValue={{ caseStatus: 'OPEN', chapters: [], divisionCodes: ['0972'] }}
+        />,
+      );
+      await waitFor(() => {});
+      const calls = onFilterChange.mock.calls;
+      calls.forEach((call) => {
+        expect(call[0]).not.toMatchObject({ divisionCodes: ['0971'] });
       });
     });
 

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
@@ -536,5 +536,38 @@ describe('TrusteeCaseListFilter', () => {
         screen.queryByRole('combobox', { name: /district \(division\)/i }),
       ).not.toBeInTheDocument();
     });
+
+    test('restores selected divisions visually when initialValue has divisionCodes', async () => {
+      render(
+        <TrusteeCaseListFilter
+          onFilterChange={vi.fn()}
+          initialValue={{ caseStatus: 'OPEN', chapters: [], divisionCodes: ['0971'] }}
+        />,
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'Filters' }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', {
+            name: /Southern District of New York \(Manhattan\) selected/i,
+          }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('includes initialValue divisionCodes in onFilterChange when another filter changes', async () => {
+      const onFilterChange = vi.fn();
+      render(
+        <TrusteeCaseListFilter
+          onFilterChange={onFilterChange}
+          initialValue={{ caseStatus: 'OPEN', chapters: [], divisionCodes: ['0971'] }}
+        />,
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'Filters' }));
+      const select = screen.getByLabelText('Filter by case status');
+      await userEvent.selectOptions(select, 'ALL');
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({ caseStatus: 'ALL', divisionCodes: ['0971'] }),
+      );
+    });
   });
 });

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import TrusteeCaseListFilterView from './TrusteeCaseListFilterView';
 import trusteeCaseListFilterUseCase, { CASE_CHAPTER_OPTIONS } from './trusteeCaseListFilterUseCase';
@@ -7,6 +7,8 @@ import {
   TrusteeCaseListFilterViewModel,
   TrusteeCaseStatus,
 } from './trusteeCaseListFilter.types';
+import { CourtDivisionDetails } from '@common/cams/courts';
+import Api2 from '@/lib/models/api2';
 
 export default function TrusteeCaseListFilter({
   onFilterChange,
@@ -24,6 +26,14 @@ export default function TrusteeCaseListFilter({
   const [filedDateTo, setFiledDateTo] = useState(initialValue?.filedDateTo ?? '');
   const [filedDateError, setFiledDateError] = useState('');
   const [filterAnnouncement, setFilterAnnouncement] = useState('');
+  const [courts, setCourts] = useState<CourtDivisionDetails[]>([]);
+  const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
+
+  useEffect(() => {
+    Api2.getCourts()
+      .then((r) => setCourts(r.data))
+      .catch(() => {});
+  }, []);
 
   const useCase = trusteeCaseListFilterUseCase(
     {
@@ -39,6 +49,10 @@ export default function TrusteeCaseListFilter({
       setFiledDateError,
       filterAnnouncement,
       setFilterAnnouncement,
+      courts,
+      setCourts,
+      selectedDivisions,
+      setSelectedDivisions,
     },
     onFilterChange,
   );
@@ -50,10 +64,13 @@ export default function TrusteeCaseListFilter({
     filedDateTo,
     filedDateError,
     filterAnnouncement,
+    courts,
+    selectedDivisions,
     chaptersToComboOptions: useCase.chaptersToComboOptions,
     handleStatusChange: useCase.handleStatusChange,
     handleChapterChange: useCase.handleChapterChange,
     handleFiledDateChange: useCase.handleFiledDateChange,
+    handleDivisionChange: useCase.handleDivisionChange,
   };
 
   return <TrusteeCaseListFilterView viewModel={viewModel} />;

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
@@ -9,6 +9,7 @@ import {
 } from './trusteeCaseListFilter.types';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import Api2 from '@/lib/models/api2';
+import { getDistrictDivisionComboOptions } from '@/lib/utils/court-utils';
 
 export default function TrusteeCaseListFilter({
   onFilterChange,
@@ -28,11 +29,26 @@ export default function TrusteeCaseListFilter({
   const [filterAnnouncement, setFilterAnnouncement] = useState('');
   const [courts, setCourts] = useState<CourtDivisionDetails[]>([]);
   const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
+  const [resolvedDivisionCodes, setResolvedDivisionCodes] = useState<string[] | undefined>(
+    initialValue?.divisionCodes,
+  );
 
   useEffect(() => {
     Api2.getCourts()
-      .then((r) => setCourts(r.data))
+      .then((r) => {
+        setCourts(r.data);
+        if (initialValue?.divisionCodes?.length) {
+          const options = getDistrictDivisionComboOptions(r.data) as ComboOption[];
+          const preSelected = options.filter((opt) => {
+            const [, code] = opt.value.split('|');
+            return code !== 'ALL' && initialValue.divisionCodes!.includes(code);
+          });
+          setSelectedDivisions(preSelected);
+        }
+      })
       .catch(() => {});
+    // initialValue is stable — only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const useCase = trusteeCaseListFilterUseCase(
@@ -53,6 +69,8 @@ export default function TrusteeCaseListFilter({
       setCourts,
       selectedDivisions,
       setSelectedDivisions,
+      resolvedDivisionCodes,
+      setResolvedDivisionCodes,
     },
     onFilterChange,
   );

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
@@ -10,6 +10,9 @@ import {
 import { CourtDivisionDetails } from '@common/cams/courts';
 import Api2 from '@/lib/models/api2';
 import { getDistrictDivisionComboOptions } from '@/lib/utils/court-utils';
+import LocalStorage from '@/lib/utils/local-storage';
+import { getUserDivisionCodes } from '@/trustees/filters/trusteeDistrictFilterUseCase';
+import { encodeDivisionCodes } from './trusteeCaseListFilterUseCase';
 
 export default function TrusteeCaseListFilter({
   onFilterChange,
@@ -37,17 +40,40 @@ export default function TrusteeCaseListFilter({
     Api2.getCourts()
       .then((r) => {
         setCourts(r.data);
+        const options = getDistrictDivisionComboOptions(r.data) as ComboOption[];
+
         if (initialValue?.divisionCodes?.length) {
-          const options = getDistrictDivisionComboOptions(r.data) as ComboOption[];
+          // Restore explicit session-stored selection
           const preSelected = options.filter((opt) => {
             const [, code] = opt.value.split('|');
             return code !== 'ALL' && initialValue.divisionCodes!.includes(code);
           });
           setSelectedDivisions(preSelected);
+        } else {
+          // Apply user's default divisions from session
+          const userCodes = getUserDivisionCodes(LocalStorage.getSession());
+          if (userCodes.size > 0) {
+            const defaults = options.filter((opt) => {
+              const [, code] = opt.value.split('|');
+              return code !== 'ALL' && userCodes.has(code);
+            });
+            if (defaults.length > 0) {
+              const codes = encodeDivisionCodes(defaults, r.data);
+              setSelectedDivisions(defaults);
+              setResolvedDivisionCodes(codes);
+              onFilterChange({
+                caseStatus: initialValue?.caseStatus ?? 'OPEN',
+                chapters: initialValue?.chapters ?? [],
+                filedDateFrom: initialValue?.filedDateFrom,
+                filedDateTo: initialValue?.filedDateTo,
+                ...(codes ? { divisionCodes: codes } : {}),
+              });
+            }
+          }
         }
       })
       .catch(() => {});
-    // initialValue is stable — only run on mount
+    // initialValue and onFilterChange are stable — only run on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
@@ -9,10 +9,11 @@ import {
 } from './trusteeCaseListFilter.types';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import Api2 from '@/lib/models/api2';
-import { getDistrictDivisionComboOptions } from '@/lib/utils/court-utils';
+import { getDistrictDivisionComboOptions, separateDefaultOptions } from '@/lib/utils/court-utils';
 import LocalStorage from '@/lib/utils/local-storage';
 import { getUserDivisionCodes } from '@/trustees/filters/trusteeDistrictFilterUseCase';
 import { encodeDivisionCodes } from './trusteeCaseListFilterUseCase';
+import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 export default function TrusteeCaseListFilter({
   onFilterChange,
@@ -32,6 +33,7 @@ export default function TrusteeCaseListFilter({
   const [filterAnnouncement, setFilterAnnouncement] = useState('');
   const [courts, setCourts] = useState<CourtDivisionDetails[]>([]);
   const [selectedDivisions, setSelectedDivisions] = useState<ComboOption[]>([]);
+  const [divisionComboOptions, setDivisionComboOptions] = useState<ComboOption[]>([]);
   const [resolvedDivisionCodes, setResolvedDivisionCodes] = useState<string[] | undefined>(
     initialValue?.divisionCodes,
   );
@@ -40,20 +42,21 @@ export default function TrusteeCaseListFilter({
     Api2.getCourts()
       .then((r) => {
         setCourts(r.data);
-        const options = getDistrictDivisionComboOptions(r.data) as ComboOption[];
+        const allOptions = getDistrictDivisionComboOptions(r.data) as ComboOption[];
 
+        let defaults: ComboOption[] = [];
         if (initialValue?.divisionCodes?.length) {
           // Restore explicit session-stored selection
-          const preSelected = options.filter((opt) => {
+          defaults = allOptions.filter((opt) => {
             const [, code] = opt.value.split('|');
             return code !== 'ALL' && initialValue.divisionCodes!.includes(code);
           });
-          setSelectedDivisions(preSelected);
+          setSelectedDivisions(defaults);
         } else {
           // Apply user's default divisions from session
           const userCodes = getUserDivisionCodes(LocalStorage.getSession());
           if (userCodes.size > 0) {
-            const defaults = options.filter((opt) => {
+            defaults = allOptions.filter((opt) => {
               const [, code] = opt.value.split('|');
               return code !== 'ALL' && userCodes.has(code);
             });
@@ -71,8 +74,15 @@ export default function TrusteeCaseListFilter({
             }
           }
         }
+
+        const defaultOptionValues = new Set(defaults.map((d) => d.value));
+        setDivisionComboOptions(
+          separateDefaultOptions(allOptions, defaultOptionValues) as ComboOption[],
+        );
       })
-      .catch(() => {});
+      .catch((e: Error) => {
+        getAppInsights()?.appInsights?.trackException({ exception: e });
+      });
     // initialValue and onFilterChange are stable — only run on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -110,6 +120,7 @@ export default function TrusteeCaseListFilter({
     filterAnnouncement,
     courts,
     selectedDivisions,
+    divisionComboOptions,
     chaptersToComboOptions: useCase.chaptersToComboOptions,
     handleStatusChange: useCase.handleStatusChange,
     handleChapterChange: useCase.handleChapterChange,

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilterView.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilterView.tsx
@@ -2,6 +2,7 @@ import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import PillBox from '@/lib/components/PillBox';
 import { Accordion, AccordionGroup } from '@/lib/components/uswds/Accordion';
 import { TrusteeCaseListFilterViewProps } from './trusteeCaseListFilter.types';
+import { getDistrictDivisionComboOptions } from '@/lib/utils/court-utils';
 import './TrusteeCaseListFilter.scss';
 
 const FILED_DATE_PILL_VALUE = 'filed-date';
@@ -21,6 +22,8 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
     filedDateTo,
     filedDateError,
     filterAnnouncement,
+    courts,
+    selectedDivisions,
   } = viewModel;
 
   const hasFiledDate = !!(filedDateFrom || filedDateTo);
@@ -41,6 +44,7 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
     ...(statusPill ? [statusPill] : []),
     ...selectedChapters,
     ...(filedDatePill ? [filedDatePill] : []),
+    ...selectedDivisions,
   ];
 
   return (
@@ -133,6 +137,22 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
                   placeholder="- Select one or more Chapters -"
                 />
               </div>
+              {courts.length > 0 && (
+                <div className="filter-control filter-control--district">
+                  <ComboBox
+                    id="case-district-division-combobox"
+                    label="District (Division)"
+                    options={getDistrictDivisionComboOptions(courts) as ComboOption[]}
+                    selections={selectedDivisions}
+                    onUpdateSelection={viewModel.handleDivisionChange}
+                    multiSelect={true}
+                    wrapPills={true}
+                    pluralLabel="divisions"
+                    singularLabel="division"
+                    placeholder="- Select one or more -"
+                  />
+                </div>
+              )}
             </div>
           </div>
         </Accordion>
@@ -151,6 +171,9 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
             const updatedChapters = selectedChapters.filter((chapter) =>
               updatedValues.has(chapter.value),
             );
+            const updatedDivisions = selectedDivisions.filter((div) =>
+              updatedValues.has(div.value),
+            );
 
             if (statusRemoved) {
               viewModel.handleStatusChange('ALL');
@@ -160,6 +183,9 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
             }
             if (updatedChapters.length !== selectedChapters.length) {
               viewModel.handleChapterChange(updatedChapters);
+            }
+            if (updatedDivisions.length !== selectedDivisions.length) {
+              viewModel.handleDivisionChange(updatedDivisions);
             }
           }}
         />

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilterView.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilterView.tsx
@@ -2,7 +2,6 @@ import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import PillBox from '@/lib/components/PillBox';
 import { Accordion, AccordionGroup } from '@/lib/components/uswds/Accordion';
 import { TrusteeCaseListFilterViewProps } from './trusteeCaseListFilter.types';
-import { getDistrictDivisionComboOptions } from '@/lib/utils/court-utils';
 import './TrusteeCaseListFilter.scss';
 
 const FILED_DATE_PILL_VALUE = 'filed-date';
@@ -22,8 +21,8 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
     filedDateTo,
     filedDateError,
     filterAnnouncement,
-    courts,
     selectedDivisions,
+    divisionComboOptions,
   } = viewModel;
 
   const hasFiledDate = !!(filedDateFrom || filedDateTo);
@@ -137,12 +136,12 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
                   placeholder="- Select one or more Chapters -"
                 />
               </div>
-              {courts.length > 0 && (
+              {divisionComboOptions.length > 0 && (
                 <div className="filter-control filter-control--district">
                   <ComboBox
                     id="case-district-division-combobox"
                     label="District (Division)"
-                    options={getDistrictDivisionComboOptions(courts) as ComboOption[]}
+                    options={divisionComboOptions}
                     selections={selectedDivisions}
                     onUpdateSelection={viewModel.handleDivisionChange}
                     multiSelect={true}

--- a/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
+++ b/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
@@ -53,6 +53,7 @@ export interface TrusteeCaseListFilterViewModel extends TrusteeCaseListFilterHan
   filterAnnouncement: string;
   courts: CourtDivisionDetails[];
   selectedDivisions: ComboOption[];
+  divisionComboOptions: ComboOption[];
 }
 
 export type TrusteeCaseListFilterProps = {

--- a/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
+++ b/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
@@ -1,5 +1,6 @@
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import type { TrusteeCaseStatus } from '@common/api/search';
+import { CourtDivisionDetails } from '@common/cams/courts';
 export type { TrusteeCaseStatus };
 
 export type TrusteeCaseListFilterValue = {
@@ -7,6 +8,7 @@ export type TrusteeCaseListFilterValue = {
   chapters: string[];
   filedDateFrom?: string;
   filedDateTo?: string;
+  divisionCodes?: string[];
 };
 
 export interface TrusteeCaseListFilterStore {
@@ -22,6 +24,10 @@ export interface TrusteeCaseListFilterStore {
   setFiledDateError(val: string): void;
   filterAnnouncement: string;
   setFilterAnnouncement(val: string): void;
+  courts: CourtDivisionDetails[];
+  setCourts(val: CourtDivisionDetails[]): void;
+  selectedDivisions: ComboOption[];
+  setSelectedDivisions(val: ComboOption[]): void;
 }
 
 interface TrusteeCaseListFilterHandlers {
@@ -29,6 +35,7 @@ interface TrusteeCaseListFilterHandlers {
   handleStatusChange(status: TrusteeCaseStatus): void;
   handleChapterChange(chapters: ComboOption[]): void;
   handleFiledDateChange(from: string, to: string): void;
+  handleDivisionChange(divisions: ComboOption[]): void;
 }
 
 export type TrusteeCaseListFilterViewProps = {
@@ -42,6 +49,8 @@ export interface TrusteeCaseListFilterViewModel extends TrusteeCaseListFilterHan
   filedDateTo: string;
   filedDateError: string;
   filterAnnouncement: string;
+  courts: CourtDivisionDetails[];
+  selectedDivisions: ComboOption[];
 }
 
 export type TrusteeCaseListFilterProps = {

--- a/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
+++ b/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
@@ -28,6 +28,8 @@ export interface TrusteeCaseListFilterStore {
   setCourts(val: CourtDivisionDetails[]): void;
   selectedDivisions: ComboOption[];
   setSelectedDivisions(val: ComboOption[]): void;
+  resolvedDivisionCodes: string[] | undefined;
+  setResolvedDivisionCodes(val: string[] | undefined): void;
 }
 
 interface TrusteeCaseListFilterHandlers {

--- a/user-interface/src/trustees/panels/filters/trusteeCaseListFilterUseCase.ts
+++ b/user-interface/src/trustees/panels/filters/trusteeCaseListFilterUseCase.ts
@@ -16,7 +16,7 @@ export const CASE_CHAPTER_OPTIONS: ComboOption[] = [
   { value: '15', label: 'Chapter 15', selectedLabel: 'Chapter 15' },
 ];
 
-function resolveDivisionCodes(
+export function encodeDivisionCodes(
   selectedDivisions: ComboOption[],
   courts: CourtDivisionDetails[],
 ): string[] | undefined {
@@ -35,20 +35,15 @@ function resolveDivisionCodes(
 
 const buildFilterFromStore = (
   store: TrusteeCaseListFilterStore,
-  overrides?: Partial<TrusteeCaseListFilterValue> & { selectedDivisions?: ComboOption[] },
-): TrusteeCaseListFilterValue => {
-  const divisionSelections = overrides?.selectedDivisions ?? store.selectedDivisions;
-  const divisionCodes = resolveDivisionCodes(divisionSelections, store.courts);
-  const { selectedDivisions: _ignored, ...valueOverrides } = overrides ?? {};
-  return {
-    caseStatus: store.selectedStatus,
-    chapters: store.selectedChapters.map((c) => c.value),
-    filedDateFrom: store.filedDateFrom || undefined,
-    filedDateTo: store.filedDateTo || undefined,
-    ...(divisionCodes ? { divisionCodes } : {}),
-    ...valueOverrides,
-  };
-};
+  overrides?: Partial<TrusteeCaseListFilterValue>,
+): TrusteeCaseListFilterValue => ({
+  caseStatus: store.selectedStatus,
+  chapters: store.selectedChapters.map((c) => c.value),
+  filedDateFrom: store.filedDateFrom || undefined,
+  filedDateTo: store.filedDateTo || undefined,
+  ...(store.resolvedDivisionCodes ? { divisionCodes: store.resolvedDivisionCodes } : {}),
+  ...overrides,
+});
 
 const trusteeCaseListFilterUseCase = (
   store: TrusteeCaseListFilterStore,
@@ -101,8 +96,10 @@ const trusteeCaseListFilterUseCase = (
 
   const handleDivisionChange = (divisions: ComboOption[]) => {
     const resolved = resolveCombinedSelections(store.selectedDivisions, divisions);
+    const codes = encodeDivisionCodes(resolved, store.courts);
     store.setSelectedDivisions(resolved);
-    onFilterChange(buildFilterFromStore(store, { selectedDivisions: resolved }));
+    store.setResolvedDivisionCodes(codes);
+    onFilterChange(buildFilterFromStore({ ...store, resolvedDivisionCodes: codes }));
     if (resolved.length === 0) {
       announce('District filter cleared');
     } else {

--- a/user-interface/src/trustees/panels/filters/trusteeCaseListFilterUseCase.ts
+++ b/user-interface/src/trustees/panels/filters/trusteeCaseListFilterUseCase.ts
@@ -30,7 +30,7 @@ export function encodeDivisionCodes(
       codes.push(code);
     }
   }
-  return codes.length > 0 ? codes : undefined;
+  return codes.length > 0 ? [...new Set(codes)] : undefined;
 }
 
 const buildFilterFromStore = (

--- a/user-interface/src/trustees/panels/filters/trusteeCaseListFilterUseCase.ts
+++ b/user-interface/src/trustees/panels/filters/trusteeCaseListFilterUseCase.ts
@@ -5,6 +5,8 @@ import {
   TrusteeCaseListFilterValue,
   TrusteeCaseStatus,
 } from './trusteeCaseListFilter.types';
+import { resolveCombinedSelections } from '@/trustees/filters/trusteeDistrictFilterUseCase';
+import { CourtDivisionDetails } from '@common/cams/courts';
 
 export const CASE_CHAPTER_OPTIONS: ComboOption[] = [
   { value: '7', label: 'Chapter 7', selectedLabel: 'Chapter 7' },
@@ -14,16 +16,39 @@ export const CASE_CHAPTER_OPTIONS: ComboOption[] = [
   { value: '15', label: 'Chapter 15', selectedLabel: 'Chapter 15' },
 ];
 
+function resolveDivisionCodes(
+  selectedDivisions: ComboOption[],
+  courts: CourtDivisionDetails[],
+): string[] | undefined {
+  if (selectedDivisions.length === 0) return undefined;
+  const codes: string[] = [];
+  for (const opt of selectedDivisions) {
+    const [courtId, code] = opt.value.split('|');
+    if (code === 'ALL') {
+      courts.filter((c) => c.courtId === courtId).forEach((c) => codes.push(c.courtDivisionCode));
+    } else {
+      codes.push(code);
+    }
+  }
+  return codes.length > 0 ? codes : undefined;
+}
+
 const buildFilterFromStore = (
   store: TrusteeCaseListFilterStore,
-  overrides?: Partial<TrusteeCaseListFilterValue>,
-): TrusteeCaseListFilterValue => ({
-  caseStatus: store.selectedStatus,
-  chapters: store.selectedChapters.map((c) => c.value),
-  filedDateFrom: store.filedDateFrom || undefined,
-  filedDateTo: store.filedDateTo || undefined,
-  ...overrides,
-});
+  overrides?: Partial<TrusteeCaseListFilterValue> & { selectedDivisions?: ComboOption[] },
+): TrusteeCaseListFilterValue => {
+  const divisionSelections = overrides?.selectedDivisions ?? store.selectedDivisions;
+  const divisionCodes = resolveDivisionCodes(divisionSelections, store.courts);
+  const { selectedDivisions: _ignored, ...valueOverrides } = overrides ?? {};
+  return {
+    caseStatus: store.selectedStatus,
+    chapters: store.selectedChapters.map((c) => c.value),
+    filedDateFrom: store.filedDateFrom || undefined,
+    filedDateTo: store.filedDateTo || undefined,
+    ...(divisionCodes ? { divisionCodes } : {}),
+    ...valueOverrides,
+  };
+};
 
 const trusteeCaseListFilterUseCase = (
   store: TrusteeCaseListFilterStore,
@@ -74,11 +99,23 @@ const trusteeCaseListFilterUseCase = (
     }
   };
 
+  const handleDivisionChange = (divisions: ComboOption[]) => {
+    const resolved = resolveCombinedSelections(store.selectedDivisions, divisions);
+    store.setSelectedDivisions(resolved);
+    onFilterChange(buildFilterFromStore(store, { selectedDivisions: resolved }));
+    if (resolved.length === 0) {
+      announce('District filter cleared');
+    } else {
+      announce(`District filter: ${resolved.length} division(s) selected`);
+    }
+  };
+
   return {
     chaptersToComboOptions,
     handleStatusChange,
     handleChapterChange,
     handleFiledDateChange,
+    handleDivisionChange,
   };
 };
 


### PR DESCRIPTION
# Purpose

USTP staff need to see how many open cases a trustee has per appointment (district/division) to identify stale appointments for termination. Without this filter, staff have no way to isolate the case list to a specific appointment and must manually cross-reference data to determine which appointments are inactive.

# Major Changes

- Added `divisionCodes?: string[]` to `TrusteeCasesSearchPredicate` in common
- Controller parses and validates `divisionCodes` from comma-separated query param
- Use case passes `divisionCodes` through to `searchCases` (which already supports it)
- `TrusteeCaseListFilter` fetches courts on mount and renders a District (Division) multi-select combo, mirroring the pattern used on the Trustee List page
- Division selections resolve `courtId|ALL` to actual division codes before sending to the API
- `TrusteeCaseList.buildSearchPredicate` and `Api2.getTrusteeCases` wired to pass `divisionCodes` as a comma-separated query param

# Testing/Validation

Implemented using TDD. 421 lines of new tests across all layers:
- 10 new backend unit tests (controller parsing/validation, use case pass-through)
- 7 new frontend filter tests (combo renders, selection fires correct `divisionCodes`, ALL expansion, clear, pill removal, screen reader announcements, error resilience)
- 2 new `TrusteeCaseList` integration tests (divisionCodes wired to API, omitted when absent)
- All 3193 frontend, 2911 backend, and 1090 common tests passing
- TypeScript clean, lint clean, 0 security vulnerabilities

# Notes

Filtering is server-side (not client-side) because the Case List uses server-side pagination — a client-side division filter would corrupt the case count and page numbers. This is a deliberate architectural difference from the Trustee List page, which loads all trustees once and filters in the browser.

The District (Division) combo reuses `getDistrictDivisionComboOptions` and `resolveCombinedSelections` from the existing Trustee List utilities. A follow-on DevEx story will extract a shared component to eliminate the remaining duplication between `TrusteeDistrictFilter` and `TrusteeCaseListFilter`.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add support for filtering trustee case lists by court division and passing the selected division codes through the full stack to the case search API.

New Features:
- Introduce a District (Division) multi-select filter in the trustee case list that allows selecting specific divisions or all divisions within a district.

Enhancements:
- Extend trustee case search predicates and API wiring to include optional divisionCodes, ensuring they are parsed, validated, and forwarded from the UI to the backend search layer.
- Update trustee case list filter UX to surface division selections as pills and announce changes for accessibility, while gracefully handling court lookup failures.

Tests:
- Add frontend tests for the District (Division) filter behavior, including selection, clearing, announcement messaging, and error resilience when courts fail to load.
- Add backend controller and use case tests to verify correct parsing, normalization, and propagation of divisionCodes in trustee case search requests.
- Add trustee case list integration tests to confirm divisionCodes are correctly included or omitted in API calls based on the applied filters.