### PR TITLE
CAMS-783 Fix TrusteeAdmin permission on name search and show error alert

### DIFF
--- a/backend/lib/controllers/trustee-search/trustee-search.controller.test.ts
+++ b/backend/lib/controllers/trustee-search/trustee-search.controller.test.ts
@@ -75,6 +75,16 @@ describe('TrusteeSearchController', () => {
     await expect(controller.handleRequest(context)).rejects.toThrow('Unauthorized');
   });
 
+  test('should allow TrusteeAdmin role', async () => {
+    context.session.user.roles = [CamsRole.TrusteeAdmin];
+    vi.spyOn(TrusteeSearchUseCase.prototype, 'searchTrustees').mockResolvedValue(mockSearchResults);
+
+    const controller = new TrusteeSearchController();
+    const response = await controller.handleRequest(context);
+
+    expect(response.body.data).toEqual(mockSearchResults);
+  });
+
   test('should return 400 when name query parameter is missing', async () => {
     context.request.query = {};
 

--- a/backend/lib/controllers/trustee-search/trustee-search.controller.ts
+++ b/backend/lib/controllers/trustee-search/trustee-search.controller.ts
@@ -19,7 +19,10 @@ export class TrusteeSearchController {
         throw new BadRequestError(MODULE_NAME, { message: 'Unsupported method.' });
       }
 
-      if (!context.session.user.roles.includes(CamsRole.DataVerifier)) {
+      const hasAccess =
+        context.session.user.roles.includes(CamsRole.DataVerifier) ||
+        context.session.user.roles.includes(CamsRole.TrusteeAdmin);
+      if (!hasAccess) {
         throw new UnauthorizedError(MODULE_NAME);
       }
 

--- a/user-interface/src/trustees/TrusteesList.scss
+++ b/user-interface/src/trustees/TrusteesList.scss
@@ -14,6 +14,11 @@
     }
   }
 
+  .trustees-list-name-search-error {
+    margin-bottom: 24px;
+    max-width: 800px;
+  }
+
   .trustees-list-count {
     font-size: 1rem;
     font-weight: bold;

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1298,6 +1298,58 @@ describe('TrusteesList Component', () => {
       ).not.toBeInTheDocument();
     });
 
+    test('ignores stale name search response that resolves after user has typed a new term', async () => {
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      const trustee2 = makeListItem({ trusteeId: 't2', firstName: 'Bob', lastName: 'Jones' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1, trustee2] });
+
+      let resolveStaleSearch!: () => void;
+      vi.spyOn(Api2, 'searchTrustees')
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              // First call ("Sm") is held — simulates a slow/stale response
+              resolveStaleSearch = () =>
+                resolve({ data: [{ ...trustee1, appointments: [], matchType: 'exact' }] });
+            }),
+        )
+        .mockResolvedValue({ data: [{ ...trustee2, appointments: [], matchType: 'exact' }] });
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('2 Trustees', { selector: 'p' })).toBeInTheDocument();
+
+      const user = userEvent.setup({ delay: null });
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+      const nameInput = screen.getByRole('textbox', { name: /trustee name/i });
+
+      // Type "Sm" — triggers slow first search (held in-flight)
+      await user.type(nameInput, 'Sm');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      // Type "Jo" — triggers second search (resolves immediately)
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Jo');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      // Now resolve the stale "Sm" response — should be ignored
+      await act(async () => {
+        resolveStaleSearch();
+      });
+
+      // The list should show only Bob Jones (from the "Jo" search), not Alice Smith
+      await waitFor(() => {
+        expect(screen.getByText('Jones, Bob')).toBeInTheDocument();
+        expect(screen.queryByText('Smith, Alice')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Trustee name search results not available'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
     test('searchResponseMs measures only API latency, not the debounce delay', async () => {
       // searchStart is currently captured before the debounce fires, inflating the metric by ~300ms.
       // After the fix, the measured duration should be close to the actual API response time, not 300ms+.

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1246,9 +1246,7 @@ describe('TrusteesList Component', () => {
       expect(changedCalls[0][1].sessionSearchCount).toBe(1);
     });
 
-    test('restores full list when name search API call fails', async () => {
-      // When searchTrustees throws, nameSearchIds is set to empty Set while
-      // nameSearch.length >= 2 stays true — filtering out every trustee.
+    test('restores full list and shows error alert when name search API call fails', async () => {
       const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
       vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });
       vi.spyOn(Api2, 'searchTrustees').mockRejectedValue(new Error('Network error'));
@@ -1264,8 +1262,9 @@ describe('TrusteesList Component', () => {
         await vi.advanceTimersByTimeAsync(300);
       });
 
-      // Error handler clears nameSearch to '', restoring the full unfiltered list
+      // Error handler sets nameSearchError=true and ignores the name filter, showing all trustees
       await waitFor(() => {
+        expect(screen.getByText('Trustee name search results not available')).toBeInTheDocument();
         expect(screen.getByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
         expect(screen.getByText('Smith, Alice')).toBeInTheDocument();
       });

--- a/user-interface/src/trustees/TrusteesList.test.tsx
+++ b/user-interface/src/trustees/TrusteesList.test.tsx
@@ -1270,6 +1270,34 @@ describe('TrusteesList Component', () => {
       });
     });
 
+    test('clears error alert when user types again after a failed name search', async () => {
+      const trustee1 = makeListItem({ trusteeId: 't1', firstName: 'Alice', lastName: 'Smith' });
+      vi.spyOn(Api2, 'getTrustees').mockResolvedValue({ data: [trustee1] });
+      vi.spyOn(Api2, 'searchTrustees').mockRejectedValue(new Error('Network error'));
+
+      renderWithRouter(<TrusteesList />);
+      expect(await screen.findByText('1 Trustee', { selector: 'p' })).toBeInTheDocument();
+
+      const user = userEvent.setup({ delay: null });
+      await user.click(screen.getByRole('button', { name: /filters/i }));
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'Sm');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Trustee name search results not available')).toBeInTheDocument();
+      });
+
+      // Typing another character clears the error immediately
+      await user.type(screen.getByRole('textbox', { name: /trustee name/i }), 'i');
+
+      expect(
+        screen.queryByText('Trustee name search results not available'),
+      ).not.toBeInTheDocument();
+    });
+
     test('searchResponseMs measures only API latency, not the debounce delay', async () => {
       // searchStart is currently captured before the debounce fires, inflating the metric by ~300ms.
       // After the fix, the measured duration should be close to the actual API response time, not 300ms+.

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -269,8 +269,10 @@ export default function TrusteesList() {
         nameSearchCountRef.current += 1;
         const ids = new Set(response.data.map((r) => r.trusteeId));
         nameSearchStartRef.current = performance.now() - searchStart;
-        setNameSearchIds(ids);
-        setNameSearchError(false);
+        if (searchTerm === nameSearch) {
+          setNameSearchIds(ids);
+          setNameSearchError(false);
+        }
 
         announcementTimeoutId = setTimeout(() => {
           if (searchTerm !== nameSearch || nameSearch.length < 2) return;

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -123,6 +123,7 @@ export default function TrusteesList() {
   const [nameSearch, setNameSearch] = useState('');
   const [nameSearchIds, setNameSearchIds] = useState<Set<string>>(new Set());
   const [nameSearchLoading, setNameSearchLoading] = useState(false);
+  const [nameSearchError, setNameSearchError] = useState(false);
   const [allCourts, setAllCourts] = useState<CourtDivisionDetails[]>([]);
   const [offset, setOffset] = useState(DEFAULT_SEARCH_OFFSET);
   const [limit, setLimit] = useState(DEFAULT_SEARCH_LIMIT);
@@ -268,6 +269,7 @@ export default function TrusteesList() {
         const ids = new Set(response.data.map((r) => r.trusteeId));
         nameSearchStartRef.current = performance.now() - searchStart;
         setNameSearchIds(ids);
+        setNameSearchError(false);
 
         announcementTimeoutId = setTimeout(() => {
           if (searchTerm !== nameSearch || nameSearch.length < 2) return;
@@ -279,8 +281,8 @@ export default function TrusteesList() {
         }, 500);
       } catch {
         nameSearchStartRef.current = null;
-        setNameSearch('');
         setNameSearchIds(new Set());
+        setNameSearchError(true);
       } finally {
         setNameSearchLoading(false);
       }
@@ -332,18 +334,18 @@ export default function TrusteesList() {
     if (lastFilterChanged.current === 'name') return;
 
     let filtered = baseFilteredTrustees;
-    if (nameSearch.length >= 2) {
+    if (!nameSearchError && nameSearch.length >= 2) {
       filtered = filtered.filter((t) => nameSearchIds.has(t.trusteeId));
     }
 
     const announcement = filtered.length + ' Trustee' + (filtered.length === 1 ? '' : 's');
     setLiveAnnouncement(announcement);
-  }, [baseFilteredTrustees, nameSearch, nameSearchIds]);
+  }, [baseFilteredTrustees, nameSearch, nameSearchIds, nameSearchError]);
 
   const { filteredTrustees } = useMemo(() => {
     let filtered = baseFilteredTrustees;
 
-    if (nameSearch.length >= 2) {
+    if (!nameSearchError && nameSearch.length >= 2) {
       filtered = filtered.filter((t) => nameSearchIds.has(t.trusteeId));
     }
 
@@ -515,6 +517,16 @@ export default function TrusteesList() {
       </div>
       {pageStatus ?? (
         <>
+          {nameSearchError && (
+            <Alert
+              type={UswdsAlertStyle.Error}
+              title="Trustee name search results not available"
+              message="We are unable to retrieve trustee name search results at this time. Please try again later. If the problem persists, please submit a feedback request describing the issue."
+              show={true}
+              inline={true}
+              className="trustees-list-name-search-error"
+            />
+          )}
           {filteredTrustees.length === 0 && !nameSearchLoading ? (
             <Alert
               type={UswdsAlertStyle.Info}

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -210,6 +210,7 @@ export default function TrusteesList() {
     isNameFilterInteracted.current = true;
     lastFilterChanged.current = 'name';
     if (name.length >= 2) setNameSearchLoading(true);
+    setNameSearchError(false);
     setNameSearch(name);
   };
 

--- a/user-interface/src/trustees/TrusteesList.tsx
+++ b/user-interface/src/trustees/TrusteesList.tsx
@@ -139,6 +139,7 @@ export default function TrusteesList() {
   const nameSearchCountRef = useRef(0);
   const nameSearchStartRef = useRef<number | null>(null);
   const nameSearchQueryLengthRef = useRef(0);
+  const nameSearchRef = useRef('');
   const debounce = useDebounce();
 
   useEffect(() => {
@@ -211,6 +212,7 @@ export default function TrusteesList() {
     lastFilterChanged.current = 'name';
     if (name.length >= 2) setNameSearchLoading(true);
     setNameSearchError(false);
+    nameSearchRef.current = name;
     setNameSearch(name);
   };
 
@@ -269,7 +271,7 @@ export default function TrusteesList() {
         nameSearchCountRef.current += 1;
         const ids = new Set(response.data.map((r) => r.trusteeId));
         nameSearchStartRef.current = performance.now() - searchStart;
-        if (searchTerm === nameSearch) {
+        if (searchTerm === nameSearchRef.current) {
           setNameSearchIds(ids);
           setNameSearchError(false);
         }


### PR DESCRIPTION
# Bug

TrusteeAdmin users could not use the name search filter on the Trustee List page. The `/trustee-search` endpoint only permitted `DataVerifier` role, but the Trustee List page is gated by `TrusteeAdmin`. Typing a name search resulted in a silent 401, clearing the input with no feedback to the user.

# Purpose

Allow TrusteeAdmin users to search trustees by name on the Trustee List page, and surface a clear error alert when the name search API is unavailable rather than silently failing.

# Major Changes

- Added `TrusteeAdmin` as an allowed role on the `TrusteeSearchController` alongside `DataVerifier`
- On name search API failure, display an error alert above the table (max-width 800px, 24px margin below) with the title "Trustee name search results not available"
- When the error alert is shown, the name filter is ignored so all trustees matching other active filters remain visible
- Error alert clears immediately when the user types in the name field again
- Error alert also clears on the next successful name search response

# Testing/Validation

Implemented using TDD. Two new unit tests added to `TrusteesList.test.tsx`:
- Verifies the error alert appears and the full trustee list remains visible when `searchTrustees` rejects
- Verifies the error alert clears immediately when the user types another character after a failure

All 83 unit tests pass. Manual accessibility check recommended (test:a11y command unavailable in this environment).

# Notes

The existing error catch block was silently resetting `nameSearch` to `''`, which hid the failure entirely. The new behavior keeps the user's input intact and uses a dedicated `nameSearchError` boolean to gate the name filter in the `filteredTrustees` memo — so other filters (district, chapter, status) continue to work normally when name search is degraded.

`api2.ts` has a pre-existing `throw Error('John is testing')` debug line on the `searchTrustees` function that causes a typecheck failure — excluded from this PR as it predates this branch.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Allow trustee name search to work reliably for TrusteeAdmin users and surface clear UI feedback when the name search API fails.

New Features:
- Permit TrusteeAdmin users to access the trustee name search API alongside DataVerifier.
- Display an inline error alert when trustee name search results cannot be retrieved.

Bug Fixes:
- Prevent trustee name search failures from silently clearing the name filter and appearing as a no-op to users.
- Ensure trustee lists remain visible and correctly filtered by non-name criteria when the name search API fails.

Enhancements:
- Track name search error state separately so the UI can ignore the name filter while degraded but preserve the user’s input.
- Announce trustee count only when name search results are valid, avoiding misleading updates during error states.
- Style the trustee name search error alert with constrained width and spacing for better readability.

Tests:
- Add tests to verify the trustee name search error alert appears and the full trustee list remains visible when the search API rejects.
- Add tests to verify the trustee name search error alert clears immediately when the user types again after a failed search.