### PR TITLE
Fix hoisting-dependent function app packaging

### DIFF
--- a/backend/Dockerfile.build
+++ b/backend/Dockerfile.build
@@ -1,4 +1,4 @@
-# Build dependencies on Linux for Azure deployment
+# Build a function app's production node_modules on Linux for Azure deployment.
 # Use Node 22 to match .nvmrc (v22.22.2)
 FROM node:22.22.2-slim
 
@@ -6,28 +6,23 @@ FROM node:22.22.2-slim
 ARG FUNCTION_APP
 WORKDIR /build
 
-# Copy root package.json (for overrides) and the function app's package.json
-COPY package.json ./root-package.json
-COPY backend/function-apps/${FUNCTION_APP}/package.json .
+# Copy the whole repo build context. node_modules and .git are excluded via .dockerignore.
+# A workspace-aware install needs every workspace's package.json plus the root lockfile, so we
+# copy the full source rather than cherry-picking manifests.
+COPY . .
 
-# IMPORTANT: Always use root package-lock.json for consistency
-# Individual function apps do NOT have their own package-lock.json files
-# This ensures identical dependency resolution across all environments
-COPY package-lock.json .
+# Reproducible, lockfile-driven, workspace-aware install. Unlike the previous standalone
+# `npm ci --workspaces=false`, this installs the real workspace tree, so every function app
+# dependency is present at its locked version regardless of how npm chooses to hoist it.
+RUN npm ci
 
-# Merge root overrides into the function app package.json so npm ci applies them
-# npm only reads overrides from the root package.json it operates on
-RUN node -e " \
-  const root = JSON.parse(require('fs').readFileSync('root-package.json', 'utf8')); \
-  const app = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); \
-  if (root.overrides) app.overrides = root.overrides; \
-  require('fs').writeFileSync('package.json', JSON.stringify(app, null, 2)); \
-" && rm root-package.json
+# Compute the function app's production dependency closure from the lockfile graph and assemble
+# it into a directory SEPARATE from the root install we copy from (writing into /build/node_modules
+# would clear the very tree we read). The app's package.json is placed alongside so the verifier
+# can derive its probe set (the app's declared externals) from it. pack.sh copies
+# /build/output/node_modules out of the container.
+RUN node backend/build-function-app-node-modules.mjs "${FUNCTION_APP}" /build/output/node_modules \
+ && cp "backend/function-apps/${FUNCTION_APP}/package.json" /build/output/package.json \
+ && node backend/verify-function-app-node-modules.mjs /build/output
 
-# Install dependencies (will build native modules for Linux)
-# Use npm ci for reproducible, lockfile-driven installs
-# Use --workspaces=false to create local node_modules (no symlinks)
-# NOTE: These flags must match pack.sh Linux path for consistency
-RUN npm ci --production --ignore-scripts=false --workspaces=false
-
-# Output will be in /build/node_modules
+# Output is in /build/output/node_modules

--- a/backend/TROUBLESHOOTING-AZURE-FUNCTIONS.md
+++ b/backend/TROUBLESHOOTING-AZURE-FUNCTIONS.md
@@ -510,42 +510,35 @@ FUNCTION_APP_PATH="backend/function-apps/<app>"
 
 # Detect OS and build node_modules accordingly
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  # CI/CD path: Build on Linux using root package-lock.json
+  # CI/CD path: build from the workspace-aware root install
   cd "$WORKSPACE_ROOT"
 
-  # Create unique temp directory (avoids race conditions in concurrent builds)
-  BUILD_TEMP=$(mktemp -d "/tmp/npm-ci-<app>.XXXXXX")
+  # Ensure a lockfile-faithful root install exists (CI runs `npm ci` before packaging).
+  [[ -d node_modules ]] || npm ci
 
-  # Copy package.json and root package-lock.json
-  cp "$FUNCTION_APP_PATH/package.json" "$BUILD_TEMP/"
-  cp package-lock.json "$BUILD_TEMP/"
+  # Compute the function app's production dependency closure from the lockfile graph and copy
+  # just that closure into the function app's node_modules (independent of npm hoisting).
+  node backend/build-function-app-node-modules.mjs <app> "$FUNCTION_APP_PATH/node_modules"
 
-  # Run npm ci with root lockfile
-  cd "$BUILD_TEMP"
-  npm ci --production --ignore-scripts=false --workspaces=false
-
-  # Move node_modules to function app
-  cd - > /dev/null
-  mv "$BUILD_TEMP/node_modules" "$FUNCTION_APP_PATH/"
-
-  # Clean up temp directory
-  rm -rf "$BUILD_TEMP"
+  # Fail the pack if the assembled node_modules cannot load every runtime dependency.
+  node backend/verify-function-app-node-modules.mjs "$FUNCTION_APP_PATH"
 
   cd "$FUNCTION_APP_PATH"
 
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  # Local development: Use Podman to build Linux-compatible node_modules
+  # Local development: use Podman to build inside Linux for parity with the deployment target
   if ! command -v podman &> /dev/null; then
     echo "Error: Podman is required but not found. Please install it."
     exit 1
   fi
 
-  # Build using Podman
+  # Build using Podman (the container runs the same build + verify scripts, writing the
+  # assembled closure to /build/output/node_modules)
   cd "$WORKSPACE_ROOT"
   podman build -t cams-<app>-builder:latest -f backend/Dockerfile.build \
     --build-arg FUNCTION_APP=<app> .
   CONTAINER_ID=$(podman create "cams-<app>-builder:latest")
-  podman cp "$CONTAINER_ID:/build/node_modules" "$FUNCTION_APP_PATH/"
+  podman cp "$CONTAINER_ID:/build/output/node_modules" "$FUNCTION_APP_PATH/"
   podman rm "$CONTAINER_ID"
 
   cd "$FUNCTION_APP_PATH"
@@ -556,11 +549,13 @@ zip -q -r <app>.zip ./dist ./node_modules ./package.json ./host.json
 ```
 
 **Key points:**
-- Uses root `package-lock.json` for all environments (Linux CI, macOS via Podman)
-- Path variables (WORKSPACE_ROOT, FUNCTION_APP_PATH) avoid hardcoded paths
-- `mktemp -d` creates unique temp directories to prevent race conditions
+- Uses the single root `package-lock.json` as the source of truth for all environments
+- The closure is computed from the lockfile dependency graph, so packaging does not depend on
+  where npm happens to hoist a package in the root install (a hoisting-dependent
+  `npm ci --workspaces=false` was the cause of historical "Missing: &lt;pkg&gt; from lock file" pack failures)
+- `verify-function-app-node-modules.mjs` load-tests the assembled tree (including lazily-required
+  drivers such as mssql → tedious) and fails the pack if anything cannot be resolved
 - Requires Podman on macOS (Docker Desktop is not authorized for use)
-- `npm ci --workspaces=false` creates local node_modules without workspace symlinks
 - Linux and Podman paths produce identical dependency trees
 
 ### Deployment Zip Contents
@@ -575,9 +570,9 @@ api.zip
 ├── node_modules/
 │   ├── @azure/
 │   │   └── functions/           # Required for v4 programming model
-│   ├── mongodb/                 # With Linux .node binaries
-│   ├── mssql/                   # With Linux .node binaries
-│   └── [280+ other packages]
+│   ├── mongodb/
+│   ├── mssql/                   # plus mssql/node_modules/commander (nested)
+│   └── [320+ other packages in the production closure]
 ├── package.json                 # With dependencies field
 └── host.json                    # Azure Functions config
 ```

--- a/backend/build-function-app-node-modules.mjs
+++ b/backend/build-function-app-node-modules.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// Build a function app's production node_modules for packaging.
+//
+// WHY THIS EXISTS
+// ---------------
+// Azure Function apps (backend/function-apps/<app>) are deployed as a zip containing a
+// bundled `dist/` plus a `node_modules/` holding only the dependencies esbuild leaves
+// EXTERNAL (see backend/esbuild-shared.mjs). The function apps are deliberately NOT npm
+// workspaces and have no lockfile of their own — npm workspaces support a single root
+// lockfile only.
+//
+// The previous approach copied the app's package.json + the root lockfile into a temp dir
+// and ran `npm ci --workspaces=false`, treating each app as a standalone root project. That
+// only worked when npm happened to hoist the app's externals to the top level of the root
+// install. npm's hoisting is not stable across npm versions or install sequences, so a
+// routine dependency bump could (and did) move a package out of the top level and break the
+// standalone `npm ci` with "Missing: <pkg> from lock file".
+//
+// WHAT THIS DOES INSTEAD
+// ----------------------
+// After a normal, workspace-aware install at the repo root (npm ci), every dependency the
+// function app needs already exists — correctly resolved and at the locked version — inside
+// the root node_modules tree. This script:
+//   1. Reads the app's declared production dependencies as closure seeds.
+//   2. Walks the production dependency graph encoded in package-lock.json (NOT Node's
+//      resolver — the lockfile graph is authoritative and avoids exports-field /
+//      trailing-slash resolution quirks that silently drop packages).
+//   3. Copies each package in that closure from the root install into the destination
+//      node_modules, preserving the exact (possibly nested) install layout so that, e.g.,
+//      node_modules/mssql/node_modules/commander lands where Node will find it.
+//
+// The result is faithful to the lockfile, independent of hoisting, and needs no second
+// lockfile and no standalone install.
+//
+// USAGE
+//   node build-function-app-node-modules.mjs <app> <destNodeModulesDir>
+// where <app> is "api" or "dataflows" and <destNodeModulesDir> is created/overwritten.
+
+import { readFileSync, existsSync, cpSync, rmSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+// ---------------------------------------------------------------------------
+// Pure closure logic (exported for unit testing; no filesystem access here).
+// ---------------------------------------------------------------------------
+
+// Resolve a dependency `dep` required by the package installed at lockfile path `fromPath`,
+// against a lockfile `packages` map. npm resolution walks node_modules from the requiring
+// package upward to the root, so we try fromPath/node_modules/dep first, then each ancestor,
+// then the root node_modules. Returns the resolved lockfile key, or null if not present.
+export function resolveDep(packages, fromPath, dep) {
+  let base = fromPath;
+  const candidates = [];
+  while (true) {
+    candidates.push(base ? `${base}/node_modules/${dep}` : `node_modules/${dep}`);
+    const idx = base.lastIndexOf('/node_modules/');
+    if (idx === -1) {
+      if (base === '') break;
+      base = ''; // a top-level workspace (e.g. "backend") falls back to the root
+    } else {
+      base = base.slice(0, idx);
+    }
+  }
+  candidates.push(`node_modules/${dep}`); // ensure root is always considered
+  for (const candidate of candidates) {
+    if (packages[candidate]) return candidate;
+  }
+  return null;
+}
+
+// Compute the production dependency closure (a set of lockfile keys) reachable from `seeds`
+// when those seeds are required by a package at `fromPrefix`. Walks production +
+// optional dependencies. `unresolved` collects edges with no matching package (expected for
+// optionalDependencies that are absent for the platform).
+export function computeClosure(packages, seeds, fromPrefix, unresolved = []) {
+  const closure = new Set();
+
+  function walk(pkgPath) {
+    const node = packages[pkgPath];
+    if (!node) return;
+    const deps = { ...(node.dependencies || {}), ...(node.optionalDependencies || {}) };
+    for (const dep of Object.keys(deps)) {
+      const resolved = resolveDep(packages, pkgPath, dep);
+      if (!resolved) {
+        unresolved.push(`${dep} (required by ${pkgPath})`);
+        continue;
+      }
+      if (closure.has(resolved)) continue;
+      closure.add(resolved);
+      walk(resolved);
+    }
+  }
+
+  for (const seed of seeds) {
+    const resolved = resolveDep(packages, fromPrefix, seed);
+    if (!resolved) {
+      throw new Error(`Seed dependency "${seed}" not found in lockfile. Is the root install up to date?`);
+    }
+    if (!closure.has(resolved)) {
+      closure.add(resolved);
+      walk(resolved);
+    }
+  }
+  return closure;
+}
+
+// Map a lockfile key to its slot inside the function app's flat node_modules. A lockfile key
+// locates a package under some node_modules tree — rooted at the repo root
+// ("node_modules/...") or under a workspace ("backend/node_modules/...") — and the package may
+// itself be nested ("node_modules/mssql/node_modules/commander"). The app's node_modules needs
+// everything AFTER the FIRST "node_modules/" segment, which strips any workspace prefix while
+// preserving nesting:
+//   node_modules/mssql/node_modules/commander -> mssql/node_modules/commander
+//   backend/node_modules/mssql               -> mssql
+export function installSlotFor(lockfileKey) {
+  const firstNm = lockfileKey.indexOf('node_modules/');
+  return lockfileKey.slice(firstNm + 'node_modules/'.length);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point.
+// ---------------------------------------------------------------------------
+
+// Only run the build when invoked directly (not when imported by a test).
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+if (invokedDirectly) {
+  main();
+}
+
+function main() {
+const app = process.argv[2];
+const destDir = process.argv[3];
+
+if (!app || !destDir) {
+  console.error('Usage: node build-function-app-node-modules.mjs <app> <destNodeModulesDir>');
+  process.exit(1);
+}
+
+// This script lives in backend/; the repo root is its parent.
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+const lockPath = path.join(REPO_ROOT, 'package-lock.json');
+const appPjPath = path.join(REPO_ROOT, 'backend', 'function-apps', app, 'package.json');
+
+if (!existsSync(lockPath)) {
+  console.error(`Lockfile not found at ${lockPath}. Run "npm ci" at the repo root first.`);
+  process.exit(1);
+}
+if (!existsSync(appPjPath)) {
+  console.error(`Function app package.json not found at ${appPjPath}.`);
+  process.exit(1);
+}
+
+const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+const pkgs = lock.packages;
+if (!pkgs) {
+  console.error('Unsupported lockfile: expected a v2/v3 "packages" map.');
+  process.exit(1);
+}
+
+const appPj = JSON.parse(readFileSync(appPjPath, 'utf8'));
+const seeds = Object.keys(appPj.dependencies || {});
+
+// The function app is not in the lockfile; it inherits dependency resolution from the
+// "backend" workspace (whose lockfile node-prefix is "backend"). Resolve seeds as if they
+// were required by a package installed at "backend".
+const BACKEND_PREFIX = 'backend';
+
+const unresolved = [];
+let closure;
+try {
+  closure = computeClosure(pkgs, seeds, BACKEND_PREFIX, unresolved);
+} catch (e) {
+  console.error(e.message);
+  process.exit(1);
+}
+
+// The destination must not be the root install we copy FROM — clearing it would delete the
+// source mid-build. (pack.sh targets the function app's own node_modules; guard anyway.)
+const rootNodeModules = path.join(REPO_ROOT, 'node_modules');
+if (path.resolve(destDir) === rootNodeModules) {
+  console.error(`Refusing to build into the root install at ${rootNodeModules}; choose a separate destination.`);
+  process.exit(1);
+}
+
+// Copy each closure package, preserving its install-relative path. Exclude each package's
+// own nested node_modules — those nested packages are themselves separate closure entries
+// and are copied at their own paths, so excluding them here avoids copying anything twice.
+rmSync(destDir, { recursive: true, force: true });
+mkdirSync(destDir, { recursive: true });
+
+let copied = 0;
+const missing = [];
+const destClaims = new Map(); // dest install-key -> source lockfile path (collision guard)
+for (const rel of [...closure].sort()) {
+  const src = path.join(REPO_ROOT, rel);
+  if (!existsSync(src)) {
+    missing.push(rel);
+    continue;
+  }
+  const relInsideNodeModules = installSlotFor(rel);
+
+  // Two different source paths must never flatten onto the same destination key — that would
+  // mean the closure picked two different installs of the same package for one install slot,
+  // which would silently ship the wrong version. Fail loudly instead.
+  const claimed = destClaims.get(relInsideNodeModules);
+  if (claimed && claimed !== rel) {
+    console.error(`ERROR: closure maps two packages to the same slot "${relInsideNodeModules}":`);
+    console.error(`  ${claimed}`);
+    console.error(`  ${rel}`);
+    process.exit(1);
+  }
+  destClaims.set(relInsideNodeModules, rel);
+
+  const dest = path.join(destDir, relInsideNodeModules);
+  cpSync(src, dest, {
+    recursive: true,
+    filter: (s) => {
+      const r = path.relative(src, s);
+      return !(r === 'node_modules' || r.startsWith('node_modules' + path.sep));
+    },
+  });
+  copied++;
+}
+
+if (missing.length) {
+  console.error(`ERROR: ${missing.length} closure package(s) missing from the root install:`);
+  for (const m of missing.slice(0, 20)) console.error(`  ${m}`);
+  console.error('Run "npm ci" at the repo root before packaging.');
+  process.exit(1);
+}
+
+console.log(`Built ${app} node_modules: ${copied} package(s) into ${destDir}`);
+if (unresolved.length) {
+  // Optional/absent dependencies are expected; surface them at low volume for transparency.
+  const unique = [...new Set(unresolved)];
+  console.log(`Note: ${unique.length} optional/unresolved dependency edge(s) skipped (expected for optionalDependencies).`);
+}
+}

--- a/backend/build-function-app-node-modules.mjs
+++ b/backend/build-function-app-node-modules.mjs
@@ -114,7 +114,34 @@ export function computeClosure(packages, seeds, fromPrefix, unresolved = []) {
 //   backend/node_modules/mssql               -> mssql
 export function installSlotFor(lockfileKey) {
   const firstNm = lockfileKey.indexOf('node_modules/');
+  // Every key we map originates from the lockfile's node_modules graph, so the segment must
+  // be present. If it ever isn't, slicing at a bogus offset would silently produce a wrong
+  // path; fail loudly instead so an unexpected key is easy to diagnose.
+  if (firstNm === -1) {
+    throw new Error(`Lockfile key has no "node_modules/" segment: "${lockfileKey}"`);
+  }
   return lockfileKey.slice(firstNm + 'node_modules/'.length);
+}
+
+// Derive the workspace a function app resolves its dependencies against, from the lockfile's
+// own workspace metadata rather than a hardcoded name. The function apps are not workspaces
+// themselves; each inherits resolution from the workspace directory that contains it (e.g.
+// "backend/function-apps/api" inherits from the "backend" workspace). We pick the longest
+// workspace path that is an ancestor of the app's directory; if none matches, resolution
+// falls back to the repo root (""). `appDirRel` is the app dir relative to the repo root,
+// POSIX-separated (e.g. "backend/function-apps/api").
+export function workspacePrefixFor(packages, appDirRel) {
+  const stripTrailingSlash = (p) => p.replace(/\/+$/, '');
+  const appRel = stripTrailingSlash(appDirRel);
+  const workspaces = (packages[''] && packages[''].workspaces) || [];
+  let best = '';
+  for (const ws of workspaces) {
+    const w = stripTrailingSlash(ws);
+    if ((appRel === w || appRel.startsWith(`${w}/`)) && w.length > best.length) {
+      best = w;
+    }
+  }
+  return best;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,14 +189,16 @@ const appPj = JSON.parse(readFileSync(appPjPath, 'utf8'));
 const seeds = Object.keys(appPj.dependencies || {});
 
 // The function app is not in the lockfile; it inherits dependency resolution from the
-// "backend" workspace (whose lockfile node-prefix is "backend"). Resolve seeds as if they
-// were required by a package installed at "backend".
-const BACKEND_PREFIX = 'backend';
+// workspace directory that contains it. Derive that workspace from the lockfile's own
+// workspace metadata (rather than hardcoding "backend") so a future layout change is picked
+// up automatically. Resolve seeds as if they were required by a package installed there.
+const appDirRel = path.posix.join('backend', 'function-apps', app);
+const workspacePrefix = workspacePrefixFor(pkgs, appDirRel);
 
 const unresolved = [];
 let closure;
 try {
-  closure = computeClosure(pkgs, seeds, BACKEND_PREFIX, unresolved);
+  closure = computeClosure(pkgs, seeds, workspacePrefix, unresolved);
 } catch (e) {
   console.error(e.message);
   process.exit(1);

--- a/backend/build-function-app-node-modules.test.ts
+++ b/backend/build-function-app-node-modules.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 // The packaging helper is plain ESM JavaScript shared with pack.sh / Dockerfile.build.
-import { resolveDep, computeClosure, installSlotFor } from './build-function-app-node-modules.mjs';
+import {
+  resolveDep,
+  computeClosure,
+  installSlotFor,
+  workspacePrefixFor,
+} from './build-function-app-node-modules.mjs';
 
 // A minimal lockfile "packages" map modeling the real failure mode: the function app's
 // external (mssql) plus its nested dependency (commander). We test that resolution and the
@@ -47,6 +52,21 @@ describe('resolveDep', () => {
     const pkgs = lockfileWithMssqlAt('node_modules/mssql');
     // tedious is only at the root; a package nested under mssql still resolves it.
     expect(resolveDep(pkgs, 'node_modules/mssql', 'tedious')).toBe('node_modules/tedious');
+  });
+
+  test('prefers an intermediate ancestor over the root in deep nesting', () => {
+    // a -> b -> c, where the dep "dep" is installed at BOTH an intermediate ancestor (under a)
+    // and the root. A package nested at a/.../b must resolve to the nearer intermediate copy.
+    const pkgs = {
+      'node_modules/a': { name: 'a' },
+      'node_modules/a/node_modules/dep': { name: 'dep', version: '2.0.0' },
+      'node_modules/a/node_modules/b': { name: 'b' },
+      'node_modules/a/node_modules/b/node_modules/c': { name: 'c' },
+      'node_modules/dep': { name: 'dep', version: '1.0.0' },
+    };
+    expect(resolveDep(pkgs, 'node_modules/a/node_modules/b/node_modules/c', 'dep')).toBe(
+      'node_modules/a/node_modules/dep',
+    );
   });
 
   test('returns null for an absent dependency', () => {
@@ -113,5 +133,38 @@ describe('installSlotFor', () => {
     expect(installSlotFor('backend/node_modules/mssql/node_modules/commander')).toBe(
       'mssql/node_modules/commander',
     );
+  });
+
+  test('throws on a key with no node_modules segment instead of truncating', () => {
+    // A bogus key must fail loudly, not silently yield a wrong (offset-sliced) slot.
+    expect(() => installSlotFor('backend')).toThrow(/no "node_modules\/" segment/);
+  });
+});
+
+describe('workspacePrefixFor', () => {
+  const packages = {
+    '': { name: 'cams', workspaces: ['common', 'backend', 'user-interface', 'test/bdd'] },
+  };
+
+  test('derives the containing workspace for a function app directory', () => {
+    expect(workspacePrefixFor(packages, 'backend/function-apps/api')).toBe('backend');
+  });
+
+  test('chooses the longest matching workspace when paths are nested', () => {
+    const pkgs = { '': { workspaces: ['test', 'test/bdd'] } };
+    expect(workspacePrefixFor(pkgs, 'test/bdd/helpers')).toBe('test/bdd');
+  });
+
+  test('matches a directory that is itself a workspace', () => {
+    expect(workspacePrefixFor(packages, 'backend')).toBe('backend');
+  });
+
+  test('falls back to the repo root when no workspace contains the directory', () => {
+    expect(workspacePrefixFor(packages, 'some/other/place')).toBe('');
+  });
+
+  test('does not match a workspace that is only a path-prefix string, not an ancestor', () => {
+    // "backend-tools" must not match the "backend" workspace.
+    expect(workspacePrefixFor(packages, 'backend-tools/thing')).toBe('');
   });
 });

--- a/backend/build-function-app-node-modules.test.ts
+++ b/backend/build-function-app-node-modules.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+// The packaging helper is plain ESM JavaScript shared with pack.sh / Dockerfile.build.
+import { resolveDep, computeClosure, installSlotFor } from './build-function-app-node-modules.mjs';
+
+// A minimal lockfile "packages" map modeling the real failure mode: the function app's
+// external (mssql) plus its nested dependency (commander). We test that resolution and the
+// closure walk behave identically whether mssql is HOISTED to the root node_modules or
+// UN-HOISTED under the backend workspace — the hoisting-independence that the previous
+// `npm ci --workspaces=false` packaging lacked, which is what broke when a dependency bump
+// changed npm's hoisting decision.
+function lockfileWithMssqlAt(mssqlKey: string) {
+  return {
+    '': { name: 'cams', workspaces: ['backend'] },
+    backend: { name: 'node', dependencies: { mssql: '12.5.5' } },
+    [mssqlKey]: {
+      name: 'mssql',
+      version: '12.5.5',
+      dependencies: { commander: '^11.0.0', tedious: '^19.0.0' },
+    },
+    [`${mssqlKey}/node_modules/commander`]: { name: 'commander', version: '11.1.0' },
+    'node_modules/tedious': { name: 'tedious', version: '19.2.0', dependencies: {} },
+    // A different top-level commander (e.g. pulled by tooling) must NOT be chosen for mssql.
+    'node_modules/commander': { name: 'commander', version: '14.0.3' },
+  };
+}
+
+describe('resolveDep', () => {
+  test('resolves a dependency hoisted to the root node_modules', () => {
+    const pkgs = lockfileWithMssqlAt('node_modules/mssql');
+    expect(resolveDep(pkgs, 'backend', 'mssql')).toBe('node_modules/mssql');
+  });
+
+  test('resolves a dependency un-hoisted under the backend workspace', () => {
+    const pkgs = lockfileWithMssqlAt('backend/node_modules/mssql');
+    expect(resolveDep(pkgs, 'backend', 'mssql')).toBe('backend/node_modules/mssql');
+  });
+
+  test('prefers a nested dependency over a different top-level version', () => {
+    const pkgs = lockfileWithMssqlAt('node_modules/mssql');
+    // commander required BY mssql must resolve to mssql's nested 11.x, not top-level 14.x.
+    expect(resolveDep(pkgs, 'node_modules/mssql', 'commander')).toBe(
+      'node_modules/mssql/node_modules/commander',
+    );
+  });
+
+  test('walks up node_modules ancestors before falling back to the root', () => {
+    const pkgs = lockfileWithMssqlAt('node_modules/mssql');
+    // tedious is only at the root; a package nested under mssql still resolves it.
+    expect(resolveDep(pkgs, 'node_modules/mssql', 'tedious')).toBe('node_modules/tedious');
+  });
+
+  test('returns null for an absent dependency', () => {
+    const pkgs = lockfileWithMssqlAt('node_modules/mssql');
+    expect(resolveDep(pkgs, 'backend', 'does-not-exist')).toBeNull();
+  });
+});
+
+describe('computeClosure', () => {
+  test('produces the same closure whether mssql is hoisted or un-hoisted', () => {
+    const hoisted = computeClosure(lockfileWithMssqlAt('node_modules/mssql'), ['mssql'], 'backend');
+    const unhoisted = computeClosure(
+      lockfileWithMssqlAt('backend/node_modules/mssql'),
+      ['mssql'],
+      'backend',
+    );
+
+    // Same packages reach the closure in both layouts (only their lockfile keys differ).
+    const slots = (set: Set<string>) => [...set].map(installSlotFor).sort();
+    expect(slots(hoisted)).toEqual(slots(unhoisted));
+    // Both include mssql, its nested commander@11, and tedious.
+    expect(slots(hoisted)).toEqual(['mssql', 'mssql/node_modules/commander', 'tedious']);
+  });
+
+  test('records unresolved optional dependency edges without throwing', () => {
+    const pkgs = {
+      backend: { name: 'node', dependencies: { mssql: '12.5.5' } },
+      'node_modules/mssql': {
+        name: 'mssql',
+        version: '12.5.5',
+        optionalDependencies: { 'platform-only-thing': '^1.0.0' },
+      },
+    };
+    const unresolved: string[] = [];
+    const closure = computeClosure(pkgs, ['mssql'], 'backend', unresolved);
+    expect([...closure]).toEqual(['node_modules/mssql']);
+    expect(unresolved).toEqual(['platform-only-thing (required by node_modules/mssql)']);
+  });
+
+  test('throws when a seed dependency is not in the lockfile', () => {
+    const pkgs = { backend: { name: 'node', dependencies: {} } };
+    expect(() => computeClosure(pkgs, ['mssql'], 'backend')).toThrow(
+      /Seed dependency "mssql" not found/,
+    );
+  });
+});
+
+describe('installSlotFor', () => {
+  test('maps a root package to a top-level slot', () => {
+    expect(installSlotFor('node_modules/mssql')).toBe('mssql');
+  });
+
+  test('preserves nesting under a package', () => {
+    expect(installSlotFor('node_modules/mssql/node_modules/commander')).toBe(
+      'mssql/node_modules/commander',
+    );
+  });
+
+  test('flattens a workspace-prefixed package to a top-level slot', () => {
+    expect(installSlotFor('backend/node_modules/mssql')).toBe('mssql');
+  });
+
+  test('flattens a workspace-prefixed nested package while keeping its nesting', () => {
+    expect(installSlotFor('backend/node_modules/mssql/node_modules/commander')).toBe(
+      'mssql/node_modules/commander',
+    );
+  });
+});

--- a/backend/pack.sh
+++ b/backend/pack.sh
@@ -30,70 +30,56 @@ WORKSPACE_ROOT="../../.."
 FUNCTION_APP_PATH="backend/function-apps/$1"
 PACK_TEMP_DIR="/tmp/build/$1"
 
-# Define cleanup for temporary build directory
-cleanup_build_temp() {
-  if [[ -n "${BUILD_TEMP:-}" ]] && [[ "$BUILD_TEMP" == */npm-ci-* ]] && [[ -d "$BUILD_TEMP" ]]; then
-    echo "Cleaning up temporary build directory: $BUILD_TEMP"
-    rm -rf -- "$BUILD_TEMP"
-  fi
-}
-
-# Set trap to clean up on script exit (success or failure)
-trap cleanup_build_temp EXIT
-
 echo "Creating archive $PACK_TEMP_DIR/$FILE_NAME.zip"
 
-# Detect OS and build node_modules accordingly
+# Build the function app's production node_modules.
+#
+# Azure Function apps are deployed as a zip of the esbuild bundle (dist/) plus a node_modules/
+# holding only the dependencies esbuild leaves external (backend/esbuild-shared.mjs). The apps
+# are intentionally NOT npm workspaces and have no lockfile of their own (npm workspaces support
+# a single root lockfile only).
+#
+# We produce that node_modules from a normal, workspace-aware root install: every dependency the
+# app needs already exists there, correctly resolved at the locked version. build-function-app-
+# node-modules.mjs walks the production dependency graph from package-lock.json and copies just
+# the app's closure into the app directory, preserving the install layout. This is faithful to
+# the lockfile and independent of npm's (unstable) hoisting decisions — unlike the previous
+# approach, which ran a standalone `npm ci --workspaces=false` and broke whenever a dependency
+# was not hoisted to the top level of the root install.
 if [[ "$OSTYPE" == linux* ]]; then
-  # Running on Linux (GitHub Actions CI, or any Linux variant) - build dependencies directly
-  # Use root package-lock.json to match Dockerfile.build behavior
-  # Use npm ci for reproducible, lockfile-driven installs
-  # Use --workspaces=false to disable workspace linking and force local node_modules
-  # NOTE: Flags must match Dockerfile.build for consistency
+  # Running on Linux (GitHub Actions CI, or any Linux variant) - build dependencies directly.
   echo "Building dependencies on Linux (native)..."
 
-  # cd to workspace root to access package-lock.json
+  # cd to workspace root to access package-lock.json and node_modules
   cd "$WORKSPACE_ROOT" || exit
 
-  # Create unique temp build directory to avoid race conditions in concurrent builds
-  # Respects TMPDIR environment variable for custom temp directory locations
-  BUILD_TEMP=$(mktemp -d "${TMPDIR:-/tmp}/npm-ci-$1.XXXXXX")
+  # Ensure a lockfile-faithful root install exists. In CI this has already run; locally it makes
+  # the script self-contained. `npm ci` is reproducible and fails if the lockfile is out of sync.
+  if [[ ! -d node_modules ]]; then
+    echo "Root node_modules not found; running npm ci..."
+    npm ci
+  fi
 
-  # Copy package.json and root package-lock.json (mirror Dockerfile.build)
-  cp "$FUNCTION_APP_PATH/package.json" "$BUILD_TEMP/"
-  cp package-lock.json "$BUILD_TEMP/"
+  # Compute the app's production closure and copy it into the function app's node_modules.
+  node backend/build-function-app-node-modules.mjs "$1" "$FUNCTION_APP_PATH/node_modules"
 
-  # Merge root overrides into function app package.json so npm ci applies them
-  # npm only reads overrides from the root package.json it operates on
-  node -e "
-    const root = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
-    const app = JSON.parse(require('fs').readFileSync('$BUILD_TEMP/package.json', 'utf8'));
-    if (root.overrides) app.overrides = root.overrides;
-    require('fs').writeFileSync('$BUILD_TEMP/package.json', JSON.stringify(app, null, 2));
-  "
+  # Fail the pack if the assembled node_modules cannot load every runtime dependency.
+  node backend/verify-function-app-node-modules.mjs "$FUNCTION_APP_PATH"
 
-  # Run npm ci in temp directory with root lockfile
-  cd "$BUILD_TEMP" || exit
-  npm ci --production --ignore-scripts=false --workspaces=false
-
-  # Move node_modules to function app directory
-  cd - > /dev/null || exit
-  mv "$BUILD_TEMP/node_modules" "$FUNCTION_APP_PATH/"
-
-  # Return to function app directory (trap will clean up BUILD_TEMP on exit)
+  # Return to the function app directory.
   cd "$FUNCTION_APP_PATH" || exit
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  # Running on macOS - use Podman to build for Linux
+  # Running on macOS - use Podman to build inside Linux for parity with the deployment target.
   if ! command -v podman &> /dev/null; then
     echo "Error: Podman is required but not found. Please install it."
     exit 1
   fi
 
-  # Go to workspace root to access package-lock.json
+  # Go to workspace root to access the build context
   cd "$WORKSPACE_ROOT" || exit
   podman build -t "cams-$1-builder:latest" -f backend/Dockerfile.build --build-arg "FUNCTION_APP=$1" .
   CONTAINER_ID=$(podman create "cams-$1-builder:latest")
-  podman cp "$CONTAINER_ID:/build/node_modules" "$FUNCTION_APP_PATH/"
+  podman cp "$CONTAINER_ID:/build/output/node_modules" "$FUNCTION_APP_PATH/"
   podman rm "$CONTAINER_ID"
   # Return to function app directory
   cd "$FUNCTION_APP_PATH" || exit

--- a/backend/verify-function-app-node-modules.mjs
+++ b/backend/verify-function-app-node-modules.mjs
@@ -57,9 +57,23 @@ const appDeps = [
 
 // Extra deep-load probes for declared deps that lazily require a driver only when a specific
 // code path runs — a plain top-level require of the package would not surface a missing driver.
+//
+// These are INTERNAL module paths, not public entry points: requiring the file from inside the
+// package's own directory is what forces its lazy `require()` to execute AND lets that require
+// resolve the driver whether it is hoisted (node_modules/tedious) or nested
+// (mssql/node_modules/tedious) — the hoisting-independence this whole packaging approach exists
+// for. (Probing the driver as a top-level spec instead would falsely FAIL in the un-hoisted
+// layout, where it is not resolvable from the app root.) Because the path is internal, a major
+// internal restructure of the package (not a semver event) can move it.
+//   Last verified against: mssql@12.5.5 (tedious@19.x).
+//   If a probe below starts failing right after an mssql bump, re-check the path before assuming
+//   the driver is missing from the closure (the failure message also flags this).
 const DEEP_PROBES = {
   mssql: ['mssql/lib/tedious/connection-pool.js'], // forces mssql -> tedious lazy load
 };
+// Specs that are internal deep probes (vs. the app's public dependencies), for clearer
+// diagnostics when one fails.
+const DEEP_PROBE_SPECS = new Set(Object.values(DEEP_PROBES).flat());
 
 const PROBES = [];
 for (const dep of appDeps) {
@@ -72,6 +86,15 @@ const require = createRequire(path.join(appDir, 'verify-probe.cjs'));
 
 const nmDirReal = path.resolve(nmDir);
 
+// A deep probe targets an INTERNAL path of a package; if it fails to resolve, the likeliest
+// cause after a dependency bump is that the package moved the path, NOT that the driver is
+// absent from the closure. Surface that so a maintainer re-checks the probe path first.
+const driftHint = (spec) =>
+  DEEP_PROBE_SPECS.has(spec)
+    ? ' (internal deep-probe path — if this started failing after a dependency bump, verify the' +
+      ' path still exists in the package before assuming the closure is incomplete; see DEEP_PROBES)'
+    : '';
+
 let failures = 0;
 for (const spec of PROBES) {
   let resolved;
@@ -79,7 +102,7 @@ for (const spec of PROBES) {
     resolved = require.resolve(spec);
   } catch (e) {
     // Every probe is a declared app dependency (or its driver), so a resolve failure is real.
-    console.error(`  FAIL  ${spec} -> ${String(e.message).split('\n')[0]}`);
+    console.error(`  FAIL  ${spec} -> ${String(e.message).split('\n')[0]}${driftHint(spec)}`);
     failures++;
     continue;
   }
@@ -94,7 +117,7 @@ for (const spec of PROBES) {
     require(spec);
     console.log(`  ok    ${spec}`);
   } catch (e) {
-    console.error(`  FAIL  ${spec} -> ${String(e.message).split('\n')[0]}`);
+    console.error(`  FAIL  ${spec} -> ${String(e.message).split('\n')[0]}${driftHint(spec)}`);
     failures++;
   }
 }

--- a/backend/verify-function-app-node-modules.mjs
+++ b/backend/verify-function-app-node-modules.mjs
@@ -44,7 +44,16 @@ if (!existsSync(appPjPath)) {
   console.error(`No package.json found at ${appPjPath}.`);
   process.exit(1);
 }
-const appDeps = Object.keys(JSON.parse(readFileSync(appPjPath, 'utf8')).dependencies || {});
+const appPj = JSON.parse(readFileSync(appPjPath, 'utf8'));
+// Probe production dependencies AND peerDependencies: both must be loadable at runtime, so a
+// peer dep missing from the packaged tree is just as fatal as a missing regular dep.
+// optionalDependencies are deliberately NOT probed — they are legally absent (e.g. a
+// platform-specific package the closure builder correctly skips), so requiring them would
+// turn an expected absence into a false failure.
+const appDeps = [
+  ...Object.keys(appPj.dependencies || {}),
+  ...Object.keys(appPj.peerDependencies || {}),
+];
 
 // Extra deep-load probes for declared deps that lazily require a driver only when a specific
 // code path runs — a plain top-level require of the package would not surface a missing driver.

--- a/backend/verify-function-app-node-modules.mjs
+++ b/backend/verify-function-app-node-modules.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Verify a packaged function app's node_modules can actually load every dependency the
+// bundled code requires at runtime — a build-time gate against an incomplete closure.
+//
+// esbuild leaves a fixed set of dependencies EXTERNAL (backend/esbuild-shared.mjs); those,
+// plus everything they require transitively (including lazily-required submodules such as
+// mssql's tedious driver), must be present and resolvable in the packaged node_modules.
+// A package-count check is not enough — a subtly missed transitive dep can pass a count
+// check yet throw "Cannot find module" only when the relevant code path runs. So this
+// probe performs real require() calls from the perspective of the function app directory.
+//
+// The deployed zip contains ONLY the app's own node_modules (Azure has no ancestor
+// node_modules to fall back on). When packaging locally or in CI, however, ancestor
+// node_modules DO exist (backend/, repo root), so a require() could be satisfied from an
+// ancestor and mask a package missing from the app tree. To catch that, each top-level
+// external is required AND asserted to resolve from inside the app's own node_modules.
+//
+// USAGE
+//   node verify-function-app-node-modules.mjs <appDir>
+// where <appDir> contains the built node_modules (i.e. <appDir>/node_modules exists).
+
+import { createRequire } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const appDirArg = process.argv[2];
+if (!appDirArg) {
+  console.error('Usage: node verify-function-app-node-modules.mjs <appDir>');
+  process.exit(1);
+}
+// createRequire requires an absolute base path; callers may pass a relative appDir.
+const appDir = path.resolve(appDirArg);
+const nmDir = path.join(appDir, 'node_modules');
+if (!existsSync(nmDir)) {
+  console.error(`No node_modules found at ${nmDir}.`);
+  process.exit(1);
+}
+
+// Probe the app's own declared dependencies (its esbuild externals) — not a fixed union
+// across apps, which would flag a package legitimately absent from one app's closure.
+const appPjPath = path.join(appDir, 'package.json');
+if (!existsSync(appPjPath)) {
+  console.error(`No package.json found at ${appPjPath}.`);
+  process.exit(1);
+}
+const appDeps = Object.keys(JSON.parse(readFileSync(appPjPath, 'utf8')).dependencies || {});
+
+// Extra deep-load probes for declared deps that lazily require a driver only when a specific
+// code path runs — a plain top-level require of the package would not surface a missing driver.
+const DEEP_PROBES = {
+  mssql: ['mssql/lib/tedious/connection-pool.js'], // forces mssql -> tedious lazy load
+};
+
+const PROBES = [];
+for (const dep of appDeps) {
+  PROBES.push(dep);
+  if (DEEP_PROBES[dep]) PROBES.push(...DEEP_PROBES[dep]);
+}
+
+// Resolve as if from a module sitting in the function app directory.
+const require = createRequire(path.join(appDir, 'verify-probe.cjs'));
+
+const nmDirReal = path.resolve(nmDir);
+
+let failures = 0;
+for (const spec of PROBES) {
+  let resolved;
+  try {
+    resolved = require.resolve(spec);
+  } catch (e) {
+    // Every probe is a declared app dependency (or its driver), so a resolve failure is real.
+    console.error(`  FAIL  ${spec} -> ${String(e.message).split('\n')[0]}`);
+    failures++;
+    continue;
+  }
+  // The resolved file must live inside the app's own node_modules, not an ancestor's — a
+  // fall-through to an ancestor would pass here but fail in the ancestor-less deployed zip.
+  if (!path.resolve(resolved).startsWith(nmDirReal + path.sep)) {
+    console.error(`  FAIL  ${spec} -> resolved outside app node_modules: ${resolved}`);
+    failures++;
+    continue;
+  }
+  try {
+    require(spec);
+    console.log(`  ok    ${spec}`);
+  } catch (e) {
+    console.error(`  FAIL  ${spec} -> ${String(e.message).split('\n')[0]}`);
+    failures++;
+  }
+}
+
+if (failures) {
+  console.error(`\nnode_modules verification FAILED: ${failures} module(s) could not be loaded.`);
+  process.exit(1);
+}
+console.log('\nnode_modules verification passed: all runtime dependencies load.');


### PR DESCRIPTION
# Bug

A routine Renovate dependency bump (mssql) broke the backend `Package API` / `Package Data Flow` CI step with:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json are in sync.
npm error Missing: mssql@12.5.5 from lock file
npm error Missing: commander@11.1.0 from lock file
```

The failure was latent on `main`: `pack.sh` packaged each Azure Function app by copying the app's `package.json` plus the root lockfile into a temp dir and running `npm ci --workspaces=false`, treating the app as a standalone root project. That only worked when npm happened to hoist the app's externals to the top level of the root install. npm's hoisting is not stable across npm versions or install sequences, so the bump that un-hoisted mssql exposed the latent break.

# Purpose

Make Azure Function app packaging faithful to the lockfile and independent of npm's hoisting behavior, so dependency bumps can't silently break the deployment artifact.

# Major Changes

* Replaced the standalone `npm ci --workspaces=false` pack step with a workspace-aware approach: after a normal root `npm ci`, compute the app's production dependency closure from the `package-lock.json` graph and copy just that closure into the app's `node_modules`, preserving the install layout.
* Added `build-function-app-node-modules.mjs` — the lockfile-graph closure builder (resolves each dependency to its nearest install slot; fails loudly on an incomplete closure or a slot collision).
* Added `verify-function-app-node-modules.mjs` — a runtime load-probe that asserts each external (including the lazily-required `mssql` → `tedious` driver) resolves from the app's own `node_modules`, failing the pack on a gap.
* Rewired `pack.sh` and `Dockerfile.build` to use the new mechanism. The Linux-native and Podman build paths are retained; only the dependency-resolution step changed.
* Updated `TROUBLESHOOTING-AZURE-FUNCTIONS.md`.

# Testing/Validation

Implemented with TDD. `build-function-app-node-modules.test.ts` adds 12 tests that lock in the hoisting-independence property using synthetic lockfile fixtures — asserting an identical closure whether mssql is hoisted or un-hoisted.

Validated end-to-end against the `dev-728c0c` slot deployment:

* CI `Package API` / `Package Data Flow` steps pass — closure builds (328/329 packages) and the verifier confirms `mongodb`, `mssql`, and `mssql/lib/tedious/connection-pool.js` all load.
* API app: healthcheck returns `sqlDbReadStatus: true` and `cosmosDb{Read,Write,Delete}Status: true`; manual load-trustee / create-note / reload round-trip confirmed (corroborated by `trustees` / `trustee-notes` / `case-notes` requests succeeding in App Insights).
* Dataflows app: host boots cleanly from the new package, logs `Registered Dataflows` with all expected dataflows enabled, and shows zero module-load errors (`Cannot find module` / `ERR_DLOPEN` / native-binding) since deploy.

# Notes

* No `test/e2e` mssql bump is included on this branch by design. That bump alone does not reproduce the failure (it's npm-version-dependent hoisting), so committing it would prove nothing; the regression evidence lives in the unit test that asserts identical closure under both hoisting states.
* Once this merges to `main`, the Renovate PR (#2553) rebases on top and its pack step goes green.
* The function-app production closure is currently 100% pure JavaScript (no native binaries). The Linux-native/Podman apparatus is retained as a guard for any future native dependency.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Make Azure Function app packaging derive function app node_modules directly from the root workspace lockfile and verify runtime dependencies so deployments are independent of npm hoisting behavior.

Bug Fixes:
- Fix Azure Function app packaging failures caused by npm hoisting changes that left required dependencies missing from the packaged node_modules.

Enhancements:
- Introduce a lockfile-graph-based builder to assemble each function app’s production dependency closure into its own node_modules while preserving install layout.
- Add a verification step that load-tests each function app’s runtime dependencies to ensure they resolve from the app’s packaged node_modules.
- Align Linux and macOS/Podman packaging flows to share the new build and verification mechanism and keep their outputs consistent.

Documentation:
- Update Azure Functions troubleshooting documentation to describe the new closure-based packaging and verification flow, including expected zip contents.

Tests:
- Add unit tests for the lockfile-graph closure builder to guarantee hoisting-independent dependency resolution and slot mapping for function apps.