### PR TITLE
Stop Renovate from auto-bumping npm overrides

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -127,6 +127,11 @@
       "groupName": "bicep resource definitions",
       "groupSlug": "bicep-resources",
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Do not auto-update npm overrides — they are deliberate security/compatibility pins (e.g. protobufjs held at 7.x, @opentelemetry/exporter-prometheus kept in lockstep with sdk-node). Bumping them desyncs from the packages that pin them exactly and breaks lockfile resolution. Change override values by hand.",
+      "matchDepTypes": ["overrides"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
# Bug

The all-minor-patch Renovate PR (#2571) repeatedly failed `Build / backend` with `applicationinsights -> Cannot find module '@opentelemetry/exporter-prometheus'`. Root cause: Renovate was bumping the root `package.json` `overrides` as if they were ordinary dependencies. Bumping `@opentelemetry/exporter-prometheus` (0.218.0 → 0.219.0) put it out of lockstep with `@opentelemetry/sdk-node@0.218.0`, which depends on it at an **exact** version. npm could not satisfy both, so it pruned `exporter-prometheus` and the `protobufjs` subtree from the lockfile, breaking the function-app pack verifier. Renovate force-rebases and re-applies the same bump, so the breakage recurs until Renovate stops touching overrides.

# Purpose

Prevent Renovate from auto-updating npm `overrides`, which are deliberate security/compatibility pins, so they stop desyncing from the packages that pin them exactly and breaking lockfile resolution.

# Major Changes

* Added a `packageRules` entry matching `matchDepTypes: ["overrides"]` with `enabled: false`, placed last so it wins over the broad non-major grouping rule.

# Testing/Validation

* `renovate-config-validator renovate.json` → "Config validated successfully".
* `renovate --platform=local --dry-run=lookup` confirms behavior: every `overrides`-typed dependency (15 of them, including `@opentelemetry/exporter-prometheus` and `protobufjs`) now reports `updates: []` with `skipReason: "disabled"`, while ~104 normal dependencies (e.g. `@types/node`, `eslint`) still receive update proposals — so the rule does not over-disable.

# Notes

Override values are now changed by hand only. This is intentional: the overrides exist to constrain the tree (e.g. `protobufjs` held at 7.x to avoid the protobufjs@8 / OpenTelemetry CVE cluster documented in the adjacent applicationinsights rule; `@opentelemetry/exporter-prometheus` kept in lockstep with `sdk-node`'s exact pin). Auto-bumping them defeats their purpose.

After this merges, #2571 should regenerate on Renovate's next run without the override bumps and reconcile cleanly. The pre-existing `fileMatch` → `managerFilePatterns` deprecation surfaced by the validator is unrelated and left out of scope.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Disable Renovate updates for npm overrides to prevent lockfile breakages caused by desynchronised pinned dependencies.

Enhancements:
- Add a Renovate package rule that disables updates for dependencies declared under the npm overrides section, keeping them manually controlled pins.

Chores:
- Adjust dependency management configuration so Renovate no longer proposes version bumps for security/compatibility override pins.