### PR TITLE
Stop Renovate from bumping Node in all Dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -61,10 +61,9 @@
       "enabled": false
     },
     {
-      "description": "Disable Node.js Docker image updates in build Dockerfiles - version pinned to match .nvmrc",
+      "description": "Disable Node.js Docker image updates in all Dockerfiles - version pinned to match .nvmrc and Azure DevOps runners",
       "matchManagers": ["dockerfile"],
       "matchPackageNames": ["node"],
-      "matchFileNames": ["backend/Dockerfile.build", ".github/docker/Dockerfile.build-and-test"],
       "enabled": false
     },
     {


### PR DESCRIPTION
# Bug

Renovate opened #2580 (`renovate/node-24.x`) bumping `test/e2e/Dockerfile.deps` from `node:22.22.2` to `node:24.15.0`. Node must stay pinned to `.nvmrc`/Azure DevOps runner version, so this update should never have been proposed. The existing dockerfile/node disable-rule was scoped via `matchFileNames` to only `backend/Dockerfile.build` and `.github/docker/Dockerfile.build-and-test`, leaving `test/e2e/Dockerfile.deps` (and any other Dockerfile) uncovered.

# Purpose

Ensure Renovate never bumps the Node base image in any Dockerfile, keeping all Dockerfiles aligned with `.nvmrc` and the Azure DevOps runners.

# Major Changes

* Removed the `matchFileNames` restriction from the existing "Disable Node.js Docker image updates" rule so it applies to every `dockerfile`-manager `node` dependency, and updated its description accordingly.

# Testing/Validation

* `renovate-config-validator renovate.json` → "Config validated successfully".
* `renovate --platform=local --dry-run=lookup` confirms behavior: all `docker`-datasource `node` records — including `test/e2e/Dockerfile.deps` — now report `updates: []` with `skipReason: "disabled"`.

# Notes

The Playwright `customManager` is unrelated and untouched: it tracks the `mcr.microsoft.com/playwright` base image (not a `node:` image) against the `@playwright/test` npm version, so this rule neither covers nor conflicts with it.

After this merges, #2580 should stop being regenerated. The pre-existing `fileMatch` → `managerFilePatterns` deprecation warning from the validator is in the Playwright manager and is unrelated to this change.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhancements:
- Broaden the existing rule that disables Node.js Docker image updates so it applies to all Dockerfiles managed by Renovate, not just specific build Dockerfiles.