### PR TITLE
CAMS-768 Bulk-import notification suppression hardening

### DIFF
--- a/backend/lib/use-cases/dataflows/import-zoom-csv.test.ts
+++ b/backend/lib/use-cases/dataflows/import-zoom-csv.test.ts
@@ -1,9 +1,9 @@
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { parseZoomMatchedTsvFile, processZoomMatchedRow, importZoomCsv } from './import-zoom-csv';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
-import { MockNotificationGateway } from '../../adapters/gateways/notifications/mock-notification.gateway';
+import { MockNotificationGateway } from '../../testing/mock-gateways/mock-notification.gateway';
 import factory from '../../factory';
 import { ObjectStorageGateway } from '../gateways.types';
 import MockData from '@common/cams/test-utilities/mock-data';
@@ -415,20 +415,7 @@ describe('import-zoom-csv', () => {
       context.featureFlags['trustee-change-notification-enabled'] = true;
       MockNotificationGateway.getInstance().clear();
 
-      vi.spyOn(MockMongoRepository.prototype, 'findRecipientByKey').mockResolvedValue({
-        key: 'category:zoom-341',
-        recipientAddress: 'ustp-help@example.test',
-        displayName: 'USTP Help',
-      });
-      vi.spyOn(MockMongoRepository.prototype, 'getDefaultRecipient').mockResolvedValue({
-        key: 'default',
-        recipientAddress: 'default-oversight@example.test',
-        displayName: 'Default Oversight',
-      });
-    });
-
-    afterEach(() => {
-      MockNotificationGateway.getInstance().clear();
+      vi.spyOn(MockMongoRepository.prototype, 'findRecipientByRoutingKey').mockResolvedValue(null);
     });
 
     test('processZoomMatchedRow does not dispatch notifications when updating trustee zoom info', async () => {

--- a/backend/lib/use-cases/dataflows/import-zoom-csv.test.ts
+++ b/backend/lib/use-cases/dataflows/import-zoom-csv.test.ts
@@ -1,8 +1,9 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parseZoomMatchedTsvFile, processZoomMatchedRow, importZoomCsv } from './import-zoom-csv';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
+import { MockNotificationGateway } from '../../adapters/gateways/notifications/mock-notification.gateway';
 import factory from '../../factory';
 import { ObjectStorageGateway } from '../gateways.types';
 import MockData from '@common/cams/test-utilities/mock-data';
@@ -406,6 +407,56 @@ describe('import-zoom-csv', () => {
         'IMPORT-ZOOM-CSV',
         expect.stringContaining('Some ATS TRU_IDs not found in CAMS'),
       );
+    });
+  });
+
+  describe('notification suppression (CAMS-768 Slice 4)', () => {
+    beforeEach(() => {
+      context.featureFlags['trustee-change-notification-enabled'] = true;
+      MockNotificationGateway.getInstance().clear();
+
+      vi.spyOn(MockMongoRepository.prototype, 'findRecipientByKey').mockResolvedValue({
+        key: 'category:zoom-341',
+        recipientAddress: 'ustp-help@example.test',
+        displayName: 'USTP Help',
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'getDefaultRecipient').mockResolvedValue({
+        key: 'default',
+        recipientAddress: 'default-oversight@example.test',
+        displayName: 'Default Oversight',
+      });
+    });
+
+    afterEach(() => {
+      MockNotificationGateway.getInstance().clear();
+    });
+
+    test('processZoomMatchedRow does not dispatch notifications when updating trustee zoom info', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'findTrusteeByLegacyTruId').mockResolvedValue(
+        MOCK_TRUSTEE,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(MOCK_TRUSTEE);
+
+      const result = await processZoomMatchedRow(context, {
+        zoomName: 'John Doe',
+        zoomEmail: 'john.doe@example.com',
+        meetingId: '123456789',
+        passcode: 'abc123',
+        phone: '123-456-7890',
+        link: 'https://zoom.us/j/123456789',
+        outcome: 'matched',
+        strategy: 'email',
+        atsTruIds: '12345',
+        matchedNames: 'John Doe',
+        matchCount: '1',
+        similarity: '100.0',
+        activeStatus: 'YES',
+        statusCodes: 'PA,V',
+        ambiguousCandidates: '',
+      });
+
+      expect(result.outcome).toBe('matched');
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
     });
   });
 });

--- a/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
@@ -24,7 +24,7 @@ import { AtsTrusteeRecord, FailedAppointment } from '../../adapters/types/ats.ty
 import { TrusteeAppointmentInput } from '@common/cams/trustee-appointments';
 import { AcmsGateway, AtsGateway, ObjectStorageGateway } from '../../use-cases/gateways.types';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
-import { MockNotificationGateway } from '../../adapters/gateways/notifications/mock-notification.gateway';
+import { MockNotificationGateway } from '../../testing/mock-gateways/mock-notification.gateway';
 import { UstpOfficeDetails } from '@common/cams/offices';
 
 /**
@@ -1915,20 +1915,7 @@ describe('Migrate Trustees Use Case', () => {
       context.featureFlags['trustee-change-notification-enabled'] = true;
       MockNotificationGateway.getInstance().clear();
 
-      vi.spyOn(MockMongoRepository.prototype, 'findRecipientByKey').mockResolvedValue({
-        key: 'chapter:7',
-        recipientAddress: 'ch7-oversight@example.test',
-        displayName: 'CH7 Oversight',
-      });
-      vi.spyOn(MockMongoRepository.prototype, 'getDefaultRecipient').mockResolvedValue({
-        key: 'default',
-        recipientAddress: 'default-oversight@example.test',
-        displayName: 'Default Oversight',
-      });
-    });
-
-    afterEach(() => {
-      MockNotificationGateway.getInstance().clear();
+      vi.spyOn(MockMongoRepository.prototype, 'findRecipientByRoutingKey').mockResolvedValue(null);
     });
 
     test('upsertTrustee does not dispatch notifications when updating an existing trustee', async () => {

--- a/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.test.ts
@@ -24,6 +24,7 @@ import { AtsTrusteeRecord, FailedAppointment } from '../../adapters/types/ats.ty
 import { TrusteeAppointmentInput } from '@common/cams/trustee-appointments';
 import { AcmsGateway, AtsGateway, ObjectStorageGateway } from '../../use-cases/gateways.types';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
+import { MockNotificationGateway } from '../../adapters/gateways/notifications/mock-notification.gateway';
 import { UstpOfficeDetails } from '@common/cams/offices';
 
 /**
@@ -1906,6 +1907,105 @@ describe('Migrate Trustees Use Case', () => {
       );
       expect(ambiguousCall).toBeUndefined();
       expect(result.data?.ambiguousCount).toBe(0);
+    });
+  });
+
+  describe('notification suppression (CAMS-768 Slice 4)', () => {
+    beforeEach(() => {
+      context.featureFlags['trustee-change-notification-enabled'] = true;
+      MockNotificationGateway.getInstance().clear();
+
+      vi.spyOn(MockMongoRepository.prototype, 'findRecipientByKey').mockResolvedValue({
+        key: 'chapter:7',
+        recipientAddress: 'ch7-oversight@example.test',
+        displayName: 'CH7 Oversight',
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'getDefaultRecipient').mockResolvedValue({
+        key: 'default',
+        recipientAddress: 'default-oversight@example.test',
+        displayName: 'Default Oversight',
+      });
+    });
+
+    afterEach(() => {
+      MockNotificationGateway.getInstance().clear();
+    });
+
+    test('upsertTrustee does not dispatch notifications when updating an existing trustee', async () => {
+      const atsTrustee: AtsTrusteeRecord = {
+        ID: 1,
+        FIRST_NAME: 'John',
+        LAST_NAME: 'Doe',
+        STATE: 'NY',
+      };
+
+      const existingTrustee = {
+        id: 'existing-id',
+        trusteeId: 'trustee-123',
+        firstName: 'John',
+        lastName: 'Doe',
+        name: 'John Doe',
+        legacy: { truIds: ['1'] },
+        public: {
+          address: { address1: '', city: '', state: 'NY', zipCode: '', countryCode: 'US' as const },
+        },
+        updatedOn: '2023-01-01T00:00:00Z',
+        updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'findTrusteeByNameAndState').mockResolvedValue(
+        existingTrustee,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue({
+        ...existingTrustee,
+        name: 'John Doe',
+      });
+
+      const mergedData = wrapTrusteeForProcessing(atsTrustee);
+      await upsertTrustee(context, mergedData);
+
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
+    });
+
+    test('upsertTrustee does not dispatch notifications when creating a new trustee', async () => {
+      const atsTrustee: AtsTrusteeRecord = {
+        ID: 2,
+        FIRST_NAME: 'Jane',
+        LAST_NAME: 'Smith',
+        STATE: 'CA',
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'findTrusteeByNameAndState').mockResolvedValue(null);
+      vi.spyOn(MockMongoRepository.prototype, 'createTrustee').mockResolvedValue({
+        id: 'new-id',
+        trusteeId: 'trustee-456',
+        name: 'Jane Smith',
+      });
+
+      const mergedData = wrapTrusteeForProcessing(atsTrustee);
+      await upsertTrustee(context, mergedData);
+
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
+    });
+
+    test('createAppointments does not dispatch notifications', async () => {
+      const cleanAppointments: TrusteeAppointmentInput[] = [
+        {
+          chapter: '7',
+          appointmentType: 'panel',
+          courtId: '053N',
+          appointedDate: '2023-01-15',
+          status: 'active',
+          effectiveDate: '2023-01-15',
+        },
+      ];
+
+      vi.spyOn(MockMongoRepository.prototype, 'getTrusteeAppointments').mockResolvedValue([]);
+      vi.spyOn(MockMongoRepository.prototype, 'createAppointment').mockResolvedValue({});
+
+      await createAppointments(context, MOCK_TRUSTEE, cleanAppointments);
+
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
     });
   });
 });

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -1175,10 +1175,6 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       );
     });
 
-    afterEach(() => {
-      MockNotificationGateway.getInstance().clear();
-    });
-
     test('does not dispatch when feature flag is disabled', async () => {
       context.featureFlags['trustee-change-notification-enabled'] = false;
 
@@ -1481,10 +1477,6 @@ describe('TrusteeAppointmentsUseCase tests', () => {
           return null;
         },
       );
-    });
-
-    afterEach(() => {
-      MockNotificationGateway.getInstance().clear();
     });
 
     test('does not dispatch when feature flag is disabled', async () => {

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -1410,6 +1410,50 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       expect(recorded).toHaveLength(1);
       expect(recorded[0].to).toBe('ch7-oversight@example.test');
     });
+
+    test('does not dispatch notification when suppressNotifications is true', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const existingAppointment = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+      const updatedAppointment = {
+        ...existingAppointment,
+        status: 'voluntarily-suspended' as const,
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(existingAppointment);
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(
+        updatedAppointment,
+      );
+
+      const result = await trusteeAppointmentsUseCase.updateAppointment(
+        context,
+        trusteeId,
+        appointmentId,
+        {
+          chapter: '7',
+          appointmentType: 'panel',
+          courtId: '081',
+          divisionCode: '001',
+          appointedDate: '2024-01-15',
+          status: 'voluntarily-suspended',
+          effectiveDate: '2024-01-15',
+        },
+        { suppressNotifications: true },
+      );
+
+      expect(result).toEqual(updatedAppointment);
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
+    });
   });
 
   describe('createAppointment notification dispatch', () => {
@@ -1576,6 +1620,43 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       const recorded = MockNotificationGateway.getInstance().getRecorded();
       expect(recorded).toHaveLength(1);
       expect(recorded[0].to).toBe('ch-oversight@example.test');
+    });
+
+    test('does not dispatch notification when suppressNotifications is true', async () => {
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const mockCreatedAppointment = MockData.getTrusteeAppointment({
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createAppointment').mockResolvedValue(
+        mockCreatedAppointment,
+      );
+
+      const result = await trusteeAppointmentsUseCase.createAppointment(
+        context,
+        trusteeId,
+        {
+          chapter: '7',
+          appointmentType: 'panel',
+          courtId: '081',
+          divisionCode: '001',
+          appointedDate: '2024-01-15',
+          status: 'active',
+          effectiveDate: '2024-01-15',
+        },
+        { suppressNotifications: true },
+      );
+
+      expect(result).toEqual(mockCreatedAppointment);
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
     });
   });
 });

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -269,26 +269,13 @@ export class TrusteeAppointmentsUseCase {
         context.featureFlags['trustee-change-notification-enabled'] &&
         !options?.suppressNotifications
       ) {
-        try {
-          const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
-          const changeSet = buildAppointmentChangeSet({
-            trusteeId,
-            trusteeName,
-            before: undefined,
-            after: createdSnapshot,
-            courtNameResolver,
-          });
-          if (changeSet.fields.length > 0) {
-            const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
-            await notificationUseCase.notify(context, changeSet);
-          }
-        } catch (notificationError) {
-          context.logger.error(
-            MODULE_NAME,
-            'Failed to dispatch new appointment notification.',
-            notificationError,
-          );
-        }
+        await this.dispatchAppointmentNotification(context, {
+          trusteeId,
+          trusteeName,
+          before: undefined,
+          after: createdSnapshot,
+          courts,
+        });
       }
 
       context.logger.info(
@@ -356,27 +343,12 @@ export class TrusteeAppointmentsUseCase {
           context.featureFlags['trustee-change-notification-enabled'] &&
           !options?.suppressNotifications
         ) {
-          try {
-            const trustee = await this.trusteesRepository.read(trusteeId);
-            const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
-            const changeSet = buildAppointmentChangeSet({
-              trusteeId,
-              trusteeName: trustee.name,
-              before: beforeSnapshot,
-              after: afterSnapshot,
-              courtNameResolver,
-            });
-            if (changeSet.fields.length > 0) {
-              const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
-              await notificationUseCase.notify(context, changeSet);
-            }
-          } catch (notificationError) {
-            context.logger.error(
-              MODULE_NAME,
-              'Failed to dispatch appointment change notification.',
-              notificationError,
-            );
-          }
+          await this.dispatchAppointmentNotification(context, {
+            trusteeId,
+            before: beforeSnapshot,
+            after: afterSnapshot,
+            courts,
+          });
         }
       }
 
@@ -390,6 +362,36 @@ export class TrusteeAppointmentsUseCase {
           message: `Failed to update appointment ${appointmentId}.`,
         },
       });
+    }
+  }
+
+  private async dispatchAppointmentNotification(
+    context: ApplicationContext,
+    params: {
+      trusteeId: string;
+      trusteeName?: string;
+      before: AppointmentFieldSnapshot | undefined;
+      after: AppointmentFieldSnapshot;
+      courts: CourtDivisionDetails[];
+    },
+  ): Promise<void> {
+    try {
+      const trusteeName =
+        params.trusteeName ?? (await this.trusteesRepository.read(params.trusteeId)).name;
+      const courtNameResolver = (courtId: string) => this.findCourtDistrict(params.courts, courtId);
+      const changeSet = buildAppointmentChangeSet({
+        trusteeId: params.trusteeId,
+        trusteeName,
+        before: params.before,
+        after: params.after,
+        courtNameResolver,
+      });
+      if (changeSet.fields.length > 0) {
+        const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
+        await notificationUseCase.notify(context, changeSet);
+      }
+    } catch (error) {
+      context.logger.error(MODULE_NAME, 'Failed to dispatch appointment notification.', error);
     }
   }
 }

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -223,6 +223,7 @@ export class TrusteeAppointmentsUseCase {
     context: ApplicationContext,
     trusteeId: string,
     appointmentData: TrusteeAppointmentInput,
+    options?: { suppressNotifications?: boolean },
   ): Promise<TrusteeAppointment> {
     try {
       let trusteeName: string;
@@ -264,7 +265,10 @@ export class TrusteeAppointmentsUseCase {
 
       await this.trusteesRepository.createTrusteeHistory(history as Creatable<TrusteeHistory>);
 
-      if (context.featureFlags['trustee-change-notification-enabled']) {
+      if (
+        context.featureFlags['trustee-change-notification-enabled'] &&
+        !options?.suppressNotifications
+      ) {
         try {
           const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);
           const changeSet = buildAppointmentChangeSet({
@@ -308,6 +312,7 @@ export class TrusteeAppointmentsUseCase {
     trusteeId: string,
     appointmentId: string,
     appointmentData: TrusteeAppointmentInput,
+    options?: { suppressNotifications?: boolean },
   ): Promise<TrusteeAppointment> {
     try {
       // Normalize data (convert old format to new format if needed)
@@ -347,7 +352,10 @@ export class TrusteeAppointmentsUseCase {
 
         await this.trusteesRepository.createTrusteeHistory(history as Creatable<TrusteeHistory>);
 
-        if (context.featureFlags['trustee-change-notification-enabled']) {
+        if (
+          context.featureFlags['trustee-change-notification-enabled'] &&
+          !options?.suppressNotifications
+        ) {
           try {
             const trustee = await this.trusteesRepository.read(trusteeId);
             const courtNameResolver = (courtId: string) => this.findCourtDistrict(courts, courtId);

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -1848,5 +1848,35 @@ describe('TrusteesUseCase tests', () => {
       expect(recorded[0].html).toContain('Name');
       expect(recorded[0].html).toContain('Public Contact');
     });
+
+    test('does not dispatch notification when suppressNotifications is true', async () => {
+      const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+
+      const result = await trusteesUseCase.updateTrustee(
+        context,
+        trusteeId,
+        { name: 'Henry G. Green' },
+        { suppressNotifications: true },
+      );
+
+      expect(result).toEqual(updatedTrustee);
+      expect(MockNotificationGateway.getInstance().getRecorded()).toHaveLength(0);
+    });
+
+    test('still writes audit history when suppressNotifications is true', async () => {
+      const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+      const historySpy = vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory');
+
+      await trusteesUseCase.updateTrustee(
+        context,
+        trusteeId,
+        { name: 'Henry G. Green' },
+        { suppressNotifications: true },
+      );
+
+      expect(historySpy).toHaveBeenCalled();
+    });
   });
 });

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -417,25 +417,7 @@ export class TrusteesUseCase {
         !options?.suppressNotifications &&
         changeSet.fields.length > 0
       ) {
-        try {
-          changeSet.primaryChapter = await this.resolvePrimaryChapter(trusteeId);
-          const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
-          await notificationUseCase.notify(context, changeSet);
-        } catch (originalError) {
-          context.logger.error(
-            MODULE_NAME,
-            'Failed to dispatch trustee change notification.',
-            originalError,
-          );
-          const trace = context.observability.startTrace(context.invocationId);
-          context.observability.completeTrace(trace, 'Trustee Change Notification', {
-            success: false,
-            properties: {},
-            measurements: {},
-          });
-          // Intentional: do not rethrow — notification failure must not fail
-          // the save (per CAMS-768 Slice 1 Decision 5: failure isolation).
-        }
+        await this.dispatchChangeNotification(context, changeSet, trusteeId);
       }
 
       return updatedTrustee;
@@ -648,6 +630,30 @@ export class TrusteesUseCase {
     });
 
     return sorted[0].chapter;
+  }
+
+  private async dispatchChangeNotification(
+    context: ApplicationContext,
+    changeSet: TrusteeChangeSet,
+    trusteeId: string,
+  ): Promise<void> {
+    try {
+      changeSet.primaryChapter = await this.resolvePrimaryChapter(trusteeId);
+      const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
+      await notificationUseCase.notify(context, changeSet);
+    } catch (originalError) {
+      context.logger.error(
+        MODULE_NAME,
+        'Failed to dispatch trustee change notification.',
+        originalError,
+      );
+      const trace = context.observability.startTrace(context.invocationId);
+      context.observability.completeTrace(trace, 'Trustee Change Notification', {
+        success: false,
+        properties: {},
+        measurements: {},
+      });
+    }
   }
 
   private buildBankNameMap(

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -362,6 +362,7 @@ export class TrusteesUseCase {
     context: ApplicationContext,
     trusteeId: string,
     trustee: Partial<TrusteeInput>,
+    options?: { suppressNotifications?: boolean },
   ): Promise<Trustee> {
     try {
       const existingTrustee = await this.trusteesRepository.read(trusteeId);
@@ -413,6 +414,7 @@ export class TrusteesUseCase {
 
       if (
         context.featureFlags['trustee-change-notification-enabled'] &&
+        !options?.suppressNotifications &&
         changeSet.fields.length > 0
       ) {
         try {


### PR DESCRIPTION
# Purpose

Ensure migration and dataflow imports cannot flood oversight mailboxes with notifications. Only human-initiated saves through the use-case layer dispatch notifications — proven by tests.

# Major Changes

* Added `suppressNotifications` option to `TrusteesUseCase.updateTrustee`, `TrusteeAppointmentsUseCase.createAppointment`, and `TrusteeAppointmentsUseCase.updateAppointment` — provides an explicit opt-out for any future caller that needs use-case logic without the notification side-effect
* Added hardening tests proving `migrate-trustees.upsertTrustee()` and `createAppointments()` do NOT dispatch notifications even with the feature flag enabled
* Added hardening test proving `import-zoom-csv.processZoomMatchedRow()` does NOT dispatch notifications

# Testing/Validation

Implemented using TDD. 8 new tests verify:
- `suppressNotifications: true` suppresses dispatch on all three use-case methods while preserving audit history
- Migration functions (create and update paths) bypass notification hooks entirely
- Zoom CSV import bypasses notification hooks entirely

All 2996 backend tests pass. TypeScript compiles clean. ESLint clean.

# Notes

The CAMS architecture already prevents migration/dataflow notifications because those code paths call repositories directly, bypassing the use-case layer where notification hooks live. This slice hardens that boundary with explicit tests (regression protection if someone refactors a migration to use the use-case layer) and provides the `suppressNotifications` flag for future callers that legitimately need use-case validation without the notification side-effect.

No changes to migration or dataflow production code. No changes to the notification use case, template, or gateway.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce trustee change notification infrastructure with routing, templates, and audit-driven change sets, while ensuring migrations and dataflow imports do not emit notifications and core save operations can explicitly suppress them.

New Features:
- Add trustee change notification use case, HTML/plaintext template, and notification gateway/routing abstractions to support oversight emails for trustee profile and appointment changes.
- Emit structured trustee change sets from trustee and appointment use cases, including primary chapter resolution and appointment-specific subjects, to drive notification content.
- Expose a suppressNotifications option on trustee and appointment use-case methods to allow callers to opt out of notification dispatch while retaining audit history.

Bug Fixes:
- Correct upcoming key date quarter-end alignment to use December 31 as the Q4 boundary instead of rolling into the next year.

Enhancements:
- Extend trustee and appointment use cases to build richer audit history change sets for names, contacts, software, banks, Zoom info, and appointment details.
- Improve validation of trustee appointment division codes to require at least one non-empty division value in either divisionCode or divisionCodes.
- Export the trustees use-case module name for reuse in logging and tracing.
- Seed notification routing configuration via database scripts, including chapter-based and zoom-341 categories, and add corresponding Mongo repository.
- Add feature flag coverage for trustee change notifications in test environments.
- Update mock Mongo repository to support notification routing, and add a process-wide notification gateway singleton with mock and no-op implementations.
- Add comprehensive tests around notification routing, template compilation, gateway behavior, trustee change notification dispatch, change set generation, and notification suppression for migrations and Zoom imports.

Build:
- Wire notification routing repository and notification gateway into the backend factory for both mock and real environments.
- Add undici as a dev dependency and override to the project dependency manifest.

Tests:
- Add extensive unit tests for trustee change notification template rendering, notification routing repository behavior, mock notification gateway, trustee and appointment change notification flows, change set emission, primary chapter resolution, division code validation, and notification suppression in migration and Zoom CSV imports.

Chores:
- Introduce a knip configuration file stub and supporting snapshot artifacts for notification template tests.