### PR TITLE
CAMS-768 Add user attribution and profile link to notifications

### DIFF
--- a/backend/lib/use-cases/notifications/templates/__snapshots__/trustee-change-template.test.ts.snap
+++ b/backend/lib/use-cases/notifications/templates/__snapshots__/trustee-change-template.test.ts.snap
@@ -70,6 +70,8 @@ exports[`compileTrusteeChangeTemplate > snapshot > matches the rendered HTML for
                         </td>
                     </tr>
 
+
+
                 </table>
             </td>
         </tr>

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
@@ -376,4 +376,106 @@ describe('compileTrusteeChangeTemplate', () => {
       expect(result.html).toMatchSnapshot();
     });
   });
+
+  describe('author and profile link section', () => {
+    const baseChangeSet: TrusteeChangeSet = {
+      trusteeId: 'trustee-1',
+      trusteeName: 'Henry Green',
+      fields: [
+        {
+          label: 'Name',
+          before: 'Henry Green',
+          after: 'Henry G. Green',
+          category: 'profile',
+          section: 'appointment',
+        },
+      ],
+    };
+
+    test('renders author name and email in the footer when author is provided', () => {
+      const result = compileTrusteeChangeTemplate({
+        ...baseChangeSet,
+        author: { name: 'Alex Rivera', email: 'alex@ustp.test' },
+        changedAt: '2026-06-26T14:30:00.000Z',
+      });
+
+      expect(result.html).toContain(
+        'Changed by Alex Rivera (alex@ustp.test) on 2026-06-26T14:30:00.000Z',
+      );
+    });
+
+    test('renders author name without email when email is undefined', () => {
+      const result = compileTrusteeChangeTemplate({
+        ...baseChangeSet,
+        author: { name: 'Alex Rivera' },
+        changedAt: '2026-06-26T14:30:00.000Z',
+      });
+
+      expect(result.html).toContain('Changed by Alex Rivera on 2026-06-26T14:30:00.000Z');
+      expect(result.html).not.toContain('(');
+    });
+
+    test('renders profile link when profileLink is provided', () => {
+      const result = compileTrusteeChangeTemplate({
+        ...baseChangeSet,
+        author: { name: 'Alex Rivera', email: 'alex@ustp.test' },
+        changedAt: '2026-06-26T14:30:00.000Z',
+        profileLink: 'https://cams.ustp.gov/trustees/trustee-1',
+      });
+
+      expect(result.html).toContain('href="https://cams.ustp.gov/trustees/trustee-1"');
+      expect(result.html).toContain('View Trustee Profile in CAMS');
+    });
+
+    test('omits profile link paragraph when profileLink is undefined', () => {
+      const result = compileTrusteeChangeTemplate({
+        ...baseChangeSet,
+        author: { name: 'Alex Rivera', email: 'alex@ustp.test' },
+        changedAt: '2026-06-26T14:30:00.000Z',
+      });
+
+      expect(result.html).toContain('Changed by Alex Rivera');
+      expect(result.html).not.toContain('View Trustee Profile');
+    });
+
+    test('omits entire author section when author is undefined', () => {
+      const result = compileTrusteeChangeTemplate(baseChangeSet);
+
+      expect(result.html).not.toContain('Changed by');
+      expect(result.html).not.toContain('View Trustee Profile');
+    });
+
+    test('escapes HTML in author name and email', () => {
+      const result = compileTrusteeChangeTemplate({
+        ...baseChangeSet,
+        author: { name: '<script>alert(1)</script>', email: 'x"@y.com' },
+        changedAt: '2026-06-26T14:30:00.000Z',
+      });
+
+      expect(result.html).toContain('&lt;script&gt;');
+      expect(result.html).toContain('&quot;');
+      expect(result.html).not.toContain('<script>alert');
+    });
+
+    test('plaintext includes author and link when both are provided', () => {
+      const result = compileTrusteeChangeTemplate({
+        ...baseChangeSet,
+        author: { name: 'Alex Rivera', email: 'alex@ustp.test' },
+        changedAt: '2026-06-26T14:30:00.000Z',
+        profileLink: 'https://cams.ustp.gov/trustees/trustee-1',
+      });
+
+      expect(result.text).toContain(
+        'Changed by Alex Rivera (alex@ustp.test) on 2026-06-26T14:30:00.000Z',
+      );
+      expect(result.text).toContain('View profile: https://cams.ustp.gov/trustees/trustee-1');
+    });
+
+    test('plaintext omits author line when author is undefined', () => {
+      const result = compileTrusteeChangeTemplate(baseChangeSet);
+
+      expect(result.text).not.toContain('Changed by');
+      expect(result.text).not.toContain('View profile');
+    });
+  });
 });

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
@@ -92,6 +92,15 @@ function buildPlaintext(changeSet: TrusteeChangeSet): string {
     }
   }
 
+  if (changeSet.author) {
+    const emailPart = changeSet.author.email ? ` (${changeSet.author.email})` : '';
+    const timePart = changeSet.changedAt ? ` on ${changeSet.changedAt}` : '';
+    lines.push('', `Changed by ${changeSet.author.name}${emailPart}${timePart}`);
+    if (changeSet.profileLink) {
+      lines.push(`View profile: ${changeSet.profileLink}`);
+    }
+  }
+
   return lines.join('\n');
 }
 
@@ -105,6 +114,32 @@ function stripTrailingWhitespace(html: string): string {
 function renderSection(sectionHtml: string, rows: string): string {
   if (!rows) return '';
   return sectionHtml;
+}
+
+function renderAuthorSection(sectionHtml: string, changeSet: TrusteeChangeSet): string {
+  if (!changeSet.author) return '';
+
+  const authorName = escapeHtml(changeSet.author.name);
+  const authorEmailDisplay = changeSet.author.email
+    ? ` (${escapeHtml(changeSet.author.email)})`
+    : '';
+  const timestamp = changeSet.changedAt ? escapeHtml(changeSet.changedAt) : '';
+
+  let rendered = sectionHtml
+    .replace('{{author_name}}', authorName)
+    .replace('{{author_email_display}}', authorEmailDisplay)
+    .replace('{{timestamp}}', timestamp);
+
+  if (!changeSet.profileLink) {
+    rendered = rendered.replace(
+      /<p style="margin: 0; font-size: 13px;"><a href="{{profile_link}}"[^<]*<\/a><\/p>/,
+      '',
+    );
+  } else {
+    rendered = rendered.replace('{{profile_link}}', escapeHtml(changeSet.profileLink));
+  }
+
+  return rendered;
 }
 
 export function compileTrusteeChangeTemplate(changeSet: TrusteeChangeSet): CompiledTemplate {
@@ -125,6 +160,9 @@ export function compileTrusteeChangeTemplate(changeSet: TrusteeChangeSet): Compi
     .replace(
       /<!-- 341 Meeting Information Section -->[\s\S]*?{{meeting_info_rows}}[\s\S]*?<\/td>\s*<\/tr>/,
       (match) => renderSection(match.replace('{{meeting_info_rows}}', meetingRows), meetingRows),
+    )
+    .replace(/<!-- Author & Link Section -->[\s\S]*?<\/td>\s*<\/tr>/, (match) =>
+      renderAuthorSection(match, changeSet),
     );
 
   const rawSubject =

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
@@ -116,30 +116,22 @@ function renderSection(sectionHtml: string, rows: string): string {
   return sectionHtml;
 }
 
-function renderAuthorSection(sectionHtml: string, changeSet: TrusteeChangeSet): string {
+function buildAuthorSection(changeSet: TrusteeChangeSet): string {
   if (!changeSet.author) return '';
 
-  const authorName = escapeHtml(changeSet.author.name);
-  const authorEmailDisplay = changeSet.author.email
-    ? ` (${escapeHtml(changeSet.author.email)})`
+  const name = escapeHtml(changeSet.author.name);
+  const emailDisplay = changeSet.author.email ? ` (${escapeHtml(changeSet.author.email)})` : '';
+  const timestamp = changeSet.changedAt ? ` on ${escapeHtml(changeSet.changedAt)}` : '';
+
+  const profileLinkHtml = changeSet.profileLink
+    ? `\n                            <p style="margin: 0; font-size: 13px;"><a href="${escapeHtml(changeSet.profileLink)}" style="color: #005ea2;">View Trustee Profile in CAMS</a></p>`
     : '';
-  const timestamp = changeSet.changedAt ? escapeHtml(changeSet.changedAt) : '';
 
-  let rendered = sectionHtml
-    .replace('{{author_name}}', authorName)
-    .replace('{{author_email_display}}', authorEmailDisplay)
-    .replace('{{timestamp}}', timestamp);
-
-  if (!changeSet.profileLink) {
-    rendered = rendered.replace(
-      /<p style="margin: 0; font-size: 13px;"><a href="{{profile_link}}"[^<]*<\/a><\/p>/,
-      '',
-    );
-  } else {
-    rendered = rendered.replace('{{profile_link}}', escapeHtml(changeSet.profileLink));
-  }
-
-  return rendered;
+  return `<tr>
+                        <td style="padding-top: 20px; border-top: 1px solid #cccccc;">
+                            <p style="margin: 0 0 8px 0; font-size: 13px; color: #333333;">Changed by ${name}${emailDisplay}${timestamp}</p>${profileLinkHtml}
+                        </td>
+                    </tr>`;
 }
 
 export function compileTrusteeChangeTemplate(changeSet: TrusteeChangeSet): CompiledTemplate {
@@ -161,9 +153,7 @@ export function compileTrusteeChangeTemplate(changeSet: TrusteeChangeSet): Compi
       /<!-- 341 Meeting Information Section -->[\s\S]*?{{meeting_info_rows}}[\s\S]*?<\/td>\s*<\/tr>/,
       (match) => renderSection(match.replace('{{meeting_info_rows}}', meetingRows), meetingRows),
     )
-    .replace(/<!-- Author & Link Section -->[\s\S]*?<\/td>\s*<\/tr>/, (match) =>
-      renderAuthorSection(match, changeSet),
-    );
+    .replace('{{author_section}}', buildAuthorSection(changeSet));
 
   const rawSubject =
     changeSet.subjectOverride ?? `Trustee Information Changed: ${changeSet.trusteeName}`;

--- a/backend/lib/use-cases/notifications/templates/trustee-change.template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change.template.ts
@@ -17,9 +17,13 @@
  *                                 Information section, or empty string if no
  *                                 meeting-section fields changed
  *
- * Slice 4 will introduce additional placeholders (editor name, profile link,
- * timestamp). The grammar is intentionally simple — no logic, no loops; the
- * compiler handles all conditional rendering.
+ *   {{author_name}}              — escaped editing user's display name
+ *   {{author_email_display}}     — " (email)" with parens, or empty string
+ *   {{timestamp}}                — ISO 8601 UTC timestamp of the change
+ *   {{profile_link}}             — full URL to the trustee profile page
+ *
+ * The grammar is intentionally simple — no logic, no loops; the compiler
+ * handles all conditional rendering (omitting sections when data is absent).
  *
  * Ported from the prototype at commit 11ea9cc25
  * (backend/trustee-change-notification.html).
@@ -75,6 +79,14 @@ export const TRUSTEE_CHANGE_TEMPLATE = `<!DOCTYPE html>
                                 </tr>
                                 {{meeting_info_rows}}
                             </table>
+                        </td>
+                    </tr>
+
+                    <!-- Author & Link Section -->
+                    <tr>
+                        <td style="padding-top: 20px; border-top: 1px solid #cccccc;">
+                            <p style="margin: 0 0 8px 0; font-size: 13px; color: #333333;">Changed by {{author_name}}{{author_email_display}} on {{timestamp}}</p>
+                            <p style="margin: 0; font-size: 13px;"><a href="{{profile_link}}" style="color: #005ea2;">View Trustee Profile in CAMS</a></p>
                         </td>
                     </tr>
 

--- a/backend/lib/use-cases/notifications/templates/trustee-change.template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change.template.ts
@@ -82,13 +82,7 @@ export const TRUSTEE_CHANGE_TEMPLATE = `<!DOCTYPE html>
                         </td>
                     </tr>
 
-                    <!-- Author & Link Section -->
-                    <tr>
-                        <td style="padding-top: 20px; border-top: 1px solid #cccccc;">
-                            <p style="margin: 0 0 8px 0; font-size: 13px; color: #333333;">Changed by {{author_name}}{{author_email_display}} on {{timestamp}}</p>
-                            <p style="margin: 0; font-size: 13px;"><a href="{{profile_link}}" style="color: #005ea2;">View Trustee Profile in CAMS</a></p>
-                        </td>
-                    </tr>
+                    {{author_section}}
 
                 </table>
             </td>

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.test.ts
@@ -1407,6 +1407,56 @@ describe('TrusteeAppointmentsUseCase tests', () => {
       expect(recorded[0].to).toBe('ch7-oversight@example.test');
     });
 
+    test('notification includes author info and profile link', async () => {
+      process.env.CAMS_FRONTEND_URL = 'https://cams.ustp.gov';
+      context.session.user = {
+        ...context.session.user,
+        name: 'Alex Rivera',
+        email: 'alex@ustp.test',
+      };
+
+      const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
+      const existingAppointment = MockData.getTrusteeAppointment({
+        id: appointmentId,
+        trusteeId,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCodes: ['001'],
+        appointedDate: '2024-01-15',
+        status: 'active',
+        effectiveDate: '2024-01-15',
+      });
+      const updatedAppointment = {
+        ...existingAppointment,
+        status: 'voluntarily-suspended' as const,
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(existingAppointment);
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValueOnce(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'updateAppointment').mockResolvedValue(
+        updatedAppointment,
+      );
+
+      await trusteeAppointmentsUseCase.updateAppointment(context, trusteeId, appointmentId, {
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: '081',
+        divisionCode: '001',
+        appointedDate: '2024-01-15',
+        status: 'voluntarily-suspended',
+        effectiveDate: '2024-01-15',
+      });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].html).toContain('Alex Rivera');
+      expect(recorded[0].html).toContain('alex@ustp.test');
+      expect(recorded[0].html).toContain(`https://cams.ustp.gov/trustees/${trusteeId}`);
+
+      delete process.env.CAMS_FRONTEND_URL;
+    });
+
     test('does not dispatch notification when suppressNotifications is true', async () => {
       const mockTrustee = MockData.getTrustee({ trusteeId, name: 'Henry Green' });
       const existingAppointment = MockData.getTrusteeAppointment({

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -393,7 +393,7 @@ export class TrusteeAppointmentsUseCase {
         };
         changeSet.changedAt = DateHelper.getCurrentIsoTimestamp();
         const frontendUrl = process.env.CAMS_FRONTEND_URL?.replace(/\/+$/, '');
-        if (frontendUrl) {
+        if (frontendUrl && /^https?:\/\//i.test(frontendUrl)) {
           changeSet.profileLink = `${frontendUrl}/trustees/${params.trusteeId}`;
         }
         const notificationUseCase = new TrusteeChangeNotificationUseCase(context);

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -387,6 +387,15 @@ export class TrusteeAppointmentsUseCase {
         courtNameResolver,
       });
       if (changeSet.fields.length > 0) {
+        changeSet.author = {
+          name: context.session.user.name,
+          email: context.session.user.email,
+        };
+        changeSet.changedAt = DateHelper.getCurrentIsoTimestamp();
+        const frontendUrl = process.env.CAMS_FRONTEND_URL;
+        if (frontendUrl) {
+          changeSet.profileLink = `${frontendUrl}/trustees/${params.trusteeId}`;
+        }
         const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
         await notificationUseCase.notify(context, changeSet);
       }

--- a/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
+++ b/backend/lib/use-cases/trustee-appointments/trustee-appointments.ts
@@ -392,7 +392,7 @@ export class TrusteeAppointmentsUseCase {
           email: context.session.user.email,
         };
         changeSet.changedAt = DateHelper.getCurrentIsoTimestamp();
-        const frontendUrl = process.env.CAMS_FRONTEND_URL;
+        const frontendUrl = process.env.CAMS_FRONTEND_URL?.replace(/\/+$/, '');
         if (frontendUrl) {
           changeSet.profileLink = `${frontendUrl}/trustees/${params.trusteeId}`;
         }

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -1849,6 +1849,52 @@ describe('TrusteesUseCase tests', () => {
       expect(recorded[0].html).toContain('Public Contact');
     });
 
+    test('notification body includes author name and email from session user', async () => {
+      context.session.user = {
+        ...context.session.user,
+        name: 'Alex Rivera',
+        email: 'alex@ustp.test',
+      };
+
+      const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+
+      await trusteesUseCase.updateTrustee(context, trusteeId, { name: 'Henry G. Green' });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].html).toContain('Alex Rivera');
+      expect(recorded[0].html).toContain('alex@ustp.test');
+    });
+
+    test('notification body includes profile link when CAMS_FRONTEND_URL is set', async () => {
+      process.env.CAMS_FRONTEND_URL = 'https://cams.ustp.gov';
+
+      const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+
+      await trusteesUseCase.updateTrustee(context, trusteeId, { name: 'Henry G. Green' });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].html).toContain(`https://cams.ustp.gov/trustees/${trusteeId}`);
+
+      delete process.env.CAMS_FRONTEND_URL;
+    });
+
+    test('notification body omits profile link when CAMS_FRONTEND_URL is not set', async () => {
+      delete process.env.CAMS_FRONTEND_URL;
+
+      const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+
+      await trusteesUseCase.updateTrustee(context, trusteeId, { name: 'Henry G. Green' });
+
+      const recorded = MockNotificationGateway.getInstance().getRecorded();
+      expect(recorded).toHaveLength(1);
+      expect(recorded[0].html).not.toContain('View Trustee Profile');
+    });
+
     test('does not dispatch notification when suppressNotifications is true', async () => {
       const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
       vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -646,7 +646,7 @@ export class TrusteesUseCase {
       };
       changeSet.changedAt = DateHelper.getCurrentIsoTimestamp();
       const frontendUrl = process.env.CAMS_FRONTEND_URL?.replace(/\/+$/, '');
-      if (frontendUrl) {
+      if (frontendUrl && /^https?:\/\//i.test(frontendUrl)) {
         changeSet.profileLink = `${frontendUrl}/trustees/${trusteeId}`;
       }
       const notificationUseCase = new TrusteeChangeNotificationUseCase(context);

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -645,7 +645,7 @@ export class TrusteesUseCase {
         email: context.session.user.email,
       };
       changeSet.changedAt = DateHelper.getCurrentIsoTimestamp();
-      const frontendUrl = process.env.CAMS_FRONTEND_URL;
+      const frontendUrl = process.env.CAMS_FRONTEND_URL?.replace(/\/+$/, '');
       if (frontendUrl) {
         changeSet.profileLink = `${frontendUrl}/trustees/${trusteeId}`;
       }

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -54,6 +54,7 @@ import { Address, ContactInformation, PhoneNumber } from '@common/cams/contact';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 import { TrusteeChangeField, TrusteeChangeSet } from '@common/cams/notifications';
 import { TrusteeChangeNotificationUseCase } from '../notifications/trustee-change-notification';
+import DateHelper from '@common/date-helper';
 
 export const MODULE_NAME = 'TRUSTEES-USE-CASE';
 
@@ -639,6 +640,15 @@ export class TrusteesUseCase {
   ): Promise<void> {
     try {
       changeSet.primaryChapter = await this.resolvePrimaryChapter(trusteeId);
+      changeSet.author = {
+        name: context.session.user.name,
+        email: context.session.user.email,
+      };
+      changeSet.changedAt = DateHelper.getCurrentIsoTimestamp();
+      const frontendUrl = process.env.CAMS_FRONTEND_URL;
+      if (frontendUrl) {
+        changeSet.profileLink = `${frontendUrl}/trustees/${trusteeId}`;
+      }
       const notificationUseCase = new TrusteeChangeNotificationUseCase(context);
       await notificationUseCase.notify(context, changeSet);
     } catch (originalError) {

--- a/common/src/cams/notifications.ts
+++ b/common/src/cams/notifications.ts
@@ -94,4 +94,10 @@ export type TrusteeChangeSet = {
   primaryChapter?: AppointmentChapterType;
   /** When set, overrides the default subject line. Used by appointment notifications. */
   subjectOverride?: string;
+  /** The user who made the change. */
+  author?: { name: string; email?: string };
+  /** ISO 8601 UTC timestamp of when the change was saved. */
+  changedAt?: string;
+  /** Full URL to the trustee profile page in CAMS. Omitted if frontend URL is not configured. */
+  profileLink?: string;
 };


### PR DESCRIPTION
# Purpose

Enable notification recipients to see WHO made a trustee change and click through to the trustee profile in CAMS, eliminating the need to manually cross-reference audit logs.

# Major Changes

* Extended `TrusteeChangeSet` type with optional `author`, `changedAt`, and `profileLink` fields
* Added a conditional footer section to the HTML email template showing author name/email, timestamp, and a "View Trustee Profile in CAMS" deep link
* Wired author metadata population into both `dispatchChangeNotification` (profile saves) and `dispatchAppointmentNotification` (appointment saves) from `context.session.user`
* Profile link constructed from `CAMS_FRONTEND_URL` environment variable — gracefully omitted when unset

# Testing/Validation

Implemented using TDD. 12 new tests across 3 files:
- 8 template compiler tests (author rendering, link rendering, conditional omission, XSS escaping, plaintext output)
- 3 trustees dispatch tests (author in body, profile link present/absent based on env var)
- 1 appointments dispatch test (author + link in appointment notification)

All 3029 backend tests pass. TypeScript compiles clean. ESLint clean.

# Notes

- Template footer is completely omitted when `author` is undefined — backward compatible with all existing tests from slices 1-4 (they don't set author)
- Timestamp is ISO 8601 UTC (no timezone conversion) per design decision — USTP staff are in multiple time zones
- `CAMS_FRONTEND_URL` must be configured in Azure App Service per environment. Unset = no link (safe default)
- The link color `#005ea2` matches USWDS primary blue for consistency with CAMS UI

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add author attribution and trustee profile deep links to trustee change notification emails and wire population of this metadata from the current session into trustee and appointment update flows.

Enhancements:
- Extend trustee change notification templates and compiler to render an optional author/timestamp footer and trustee profile link in both HTML and plaintext outputs.
- Populate trustee change sets with author identity, change timestamp, and CAMS-based profile URL when dispatching trustee and appointment notifications, falling back gracefully when the frontend URL is not configured.

Tests:
- Add tests covering author/footer rendering, profile link presence/omission, HTML escaping, and plaintext output for trustee change notifications.
- Add tests ensuring trustee and appointment notifications include author details and profile links when available and omit links when CAMS_FRONTEND_URL is unset.