### PR TITLE
CAMS-780 Gate BanksController behind trustee-software-bank-display flag

### DIFF
--- a/backend/lib/controllers/banks/banks.controller.test.ts
+++ b/backend/lib/controllers/banks/banks.controller.test.ts
@@ -5,6 +5,7 @@ import { BanksController } from './banks.controller';
 import { BanksUseCase } from '../../use-cases/banks/banks';
 import { CamsRole } from '@common/cams/roles';
 import { BankProfile } from '@common/cams/banks';
+import HttpStatusCodes from '@common/api/http-status-codes';
 
 vi.mock('../../use-cases/banks/banks');
 
@@ -37,6 +38,7 @@ describe('BanksController', () => {
   beforeEach(async () => {
     context = await createMockApplicationContext();
     context.session.user.roles = [CamsRole.SuperUser];
+    context.featureFlags['trustee-software-bank-display'] = true;
     controller = new BanksController(context);
   });
 
@@ -45,6 +47,18 @@ describe('BanksController', () => {
   });
 
   describe('handleRequest', () => {
+    test('should throw ForbiddenError when trustee-software-bank-display flag is off', async () => {
+      context.featureFlags['trustee-software-bank-display'] = false;
+      context.request.method = 'GET';
+
+      await expect(controller.handleRequest(context)).rejects.toThrow(
+        expect.objectContaining({
+          status: HttpStatusCodes.FORBIDDEN,
+          message: 'Banks feature is not enabled.',
+        }),
+      );
+    });
+
     test('should route GET to handleGet', async () => {
       context.request.method = 'GET';
       vi.spyOn(BanksUseCase.prototype, 'getBanks').mockResolvedValue(mockBanks);

--- a/backend/lib/controllers/banks/banks.controller.ts
+++ b/backend/lib/controllers/banks/banks.controller.ts
@@ -9,6 +9,7 @@ import HttpStatusCodes from '@common/api/http-status-codes';
 import { CamsController } from '../controller';
 
 const MODULE_NAME = 'BANKS-CONTROLLER';
+const NOT_ENABLED = 'Banks feature is not enabled.';
 
 export class BanksController implements CamsController {
   private readonly useCase: BanksUseCase;
@@ -22,6 +23,10 @@ export class BanksController implements CamsController {
   ): Promise<
     CamsHttpResponseInit | CamsHttpResponseInit<BankProfile> | CamsHttpResponseInit<BankProfile[]>
   > {
+    if (!context.featureFlags['trustee-software-bank-display']) {
+      throw new ForbiddenError(MODULE_NAME, { message: NOT_ENABLED });
+    }
+
     const { method } = context.request;
     const { bankId } = context.request.params;
 


### PR DESCRIPTION
# Purpose

Enforce the same `trustee-software-bank-display` flag gate on the backend that Slice 1 added to the frontend. Without this, a caller who knows the API URL can still reach Banks endpoints even when the flag is off.

# Major Changes

* `BanksController.handleRequest` now throws `403 Forbidden` with the message "Banks feature is not enabled." when `context.featureFlags['trustee-software-bank-display']` is falsy — matching the pattern from `PrivilegedIdentityAdminController`
* Added a new test asserting the 403 response for the flag-off case
* Set `context.featureFlags['trustee-software-bank-display'] = true` in `beforeEach` so existing routing tests are unaffected

# Testing/Validation

Implemented using TDD. 23 tests pass in `banks.controller.test.ts`. All 217 backend test files pass with no regressions. TypeScript, lint, and knip clean.

# Notes

This PR targets the Slice 1 branch (`CAMS-780-privileged-identity-feature-flag`) and should be merged there, not directly to `main`. It will reach `main` when the Slice 1 PR merges.

The flag check sits at the top of `handleRequest` before the role check — same order as `PrivilegedIdentityAdminController`. The `handleGet`, `handleGetOne`, `handlePut`, and `handlePost` methods are intentionally not gated individually since `handleRequest` is the sole entry point from the function app.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Gate BanksController requests behind the trustee-software-bank-display feature flag to align backend access with the frontend.

Enhancements:
- Add a feature-flag check in BanksController.handleRequest that forbids access when trustee-software-bank-display is disabled.

Tests:
- Extend banks.controller.test.ts to cover the forbidden response when the trustee-software-bank-display flag is off and default the flag to on for existing routing tests.