### PR TITLE
CAMS-777 Make TrusteeCaseList table responsive on mobile

### DIFF
--- a/user-interface/src/trustees/panels/TrusteeCaseList.scss
+++ b/user-interface/src/trustees/panels/TrusteeCaseList.scss
@@ -1,5 +1,5 @@
 @use 'styles/abstracts/device-screens' as device-screens;
-@use 'styles/abstracts/colors' as colors;
+@use '@/lib/components/cams/CamsTable/cams-table-mixins' as cams-table;
 
 .trustee-case-list-heading {
   line-height: 1;
@@ -8,6 +8,11 @@
 
 .trustee-case-list-count {
   font-weight: bold;
+  padding-left: 1rem;
+
+  @media screen and (min-width: #{device-screens.$tablet-screen-small + 1}) {
+    padding-left: 0;
+  }
 }
 
 .usa-alert-container.inline-alert.case-list-alert {
@@ -18,96 +23,31 @@
   }
 }
 
-.trustee-case-list-grid {
-  overflow-x: auto;
-}
-
-// Mobile default — stacked with inline labels
-.trustee-case-list-header {
-  display: none;
-  padding: 0 1rem 0.5rem 1rem;
-}
-
-.trustee-case-list-row {
-  font-size: 1rem;
-  line-height: 1.625rem;
-  display: block;
-  border-bottom: 1px solid colors.$ink;
-  padding: 0.625rem 1rem;
-  margin-bottom: 0.25rem;
-}
-
-.trustee-case-list-cell {
-  padding: 0;
-  word-wrap: break-word;
-}
-
-.trustee-case-list-cell[data-cell] {
-  display: block;
-  width: 100%;
-  padding: 0.25rem 0.375rem 0.25rem 0;
-  white-space: normal;
-
-  &::before {
-    content: attr(data-cell) ': ';
-    display: inline;
-    font-weight: 700;
-    white-space: nowrap;
-  }
-}
-
-// Tablet — row layout
-@media screen and (min-width: #{device-screens.$tablet-screen-small + 1}) {
-  .trustee-case-list-header {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    font-weight: bold;
-    font-size: 1rem;
-    line-height: 1.5rem;
-    border-bottom: 1px solid colors.$ink;
-    padding-bottom: 0.5rem;
+.trustee-case-list-table.cams-table--responsive {
+  @media screen and (max-width: #{device-screens.$tablet-screen-small}) {
+    @include cams-table.cams-table-stacked;
   }
 
-  .trustee-case-list-row {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    padding: 0.5rem 0;
-    margin-bottom: 0;
-  }
+  @media screen and (min-width: #{device-screens.$tablet-screen-small + 1}) {
+    @include cams-table.cams-table-flex-row;
 
-  .trustee-case-list-cell[data-cell] {
-    display: block;
-    width: auto;
-    padding: 0;
-    white-space: normal;
-
-    &::before {
-      display: none;
+    .col-case-number {
+      flex: 2 1 0;
     }
-  }
 
-  .col-case-number {
-    flex: 2 1 0;
-    min-width: 0;
-  }
+    .col-case-title {
+      flex: 3 1 0;
+    }
 
-  .col-case-title {
-    flex: 3 1 0;
-    min-width: 0;
-  }
+    .col-chapter {
+      flex: 1 1 0;
+      max-width: 90px;
+    }
 
-  .col-chapter {
-    flex: 1 1 0;
-    min-width: 0;
-    max-width: 90px;
-  }
-
-  .col-date-filed,
-  .col-appt-date {
-    flex: 1.5 1 0;
-    min-width: 0;
-    max-width: 130px;
+    .col-date-filed,
+    .col-appt-date {
+      flex: 1.5 1 0;
+      max-width: 130px;
+    }
   }
 }

--- a/user-interface/src/trustees/panels/TrusteeCaseList.scss
+++ b/user-interface/src/trustees/panels/TrusteeCaseList.scss
@@ -1,15 +1,113 @@
+@use 'styles/abstracts/device-screens' as device-screens;
+@use 'styles/abstracts/colors' as colors;
+
 .trustee-case-list-heading {
   line-height: 1;
   margin-bottom: 1rem;
 }
+
 .trustee-case-list-count {
   font-weight: bold;
 }
 
 .usa-alert-container.inline-alert.case-list-alert {
-  margin-left: unset;;
+  margin-left: unset;
   .usa-alert__body {
     padding-top: 1rem;
     padding-bottom: 1rem;
+  }
+}
+
+.trustee-case-list-grid {
+  overflow-x: auto;
+}
+
+// Mobile default — stacked with inline labels
+.trustee-case-list-header {
+  display: none;
+  padding: 0 1rem 0.5rem 1rem;
+}
+
+.trustee-case-list-row {
+  font-size: 1rem;
+  line-height: 1.625rem;
+  display: block;
+  border-bottom: 1px solid colors.$ink;
+  padding: 0.625rem 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.trustee-case-list-cell {
+  padding: 0;
+  word-wrap: break-word;
+}
+
+.trustee-case-list-cell[data-cell] {
+  display: block;
+  width: 100%;
+  padding: 0.25rem 0.375rem 0.25rem 0;
+  white-space: normal;
+
+  &::before {
+    content: attr(data-cell) ': ';
+    display: inline;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+}
+
+// Tablet — row layout
+@media screen and (min-width: #{device-screens.$tablet-screen-small + 1}) {
+  .trustee-case-list-header {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    font-weight: bold;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    border-bottom: 1px solid colors.$ink;
+    padding-bottom: 0.5rem;
+  }
+
+  .trustee-case-list-row {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    padding: 0.5rem 0;
+    margin-bottom: 0;
+  }
+
+  .trustee-case-list-cell[data-cell] {
+    display: block;
+    width: auto;
+    padding: 0;
+    white-space: normal;
+
+    &::before {
+      display: none;
+    }
+  }
+
+  .col-case-number {
+    flex: 2 1 0;
+    min-width: 0;
+  }
+
+  .col-case-title {
+    flex: 3 1 0;
+    min-width: 0;
+  }
+
+  .col-chapter {
+    flex: 1 1 0;
+    min-width: 0;
+    max-width: 90px;
+  }
+
+  .col-date-filed,
+  .col-appt-date {
+    flex: 1.5 1 0;
+    min-width: 0;
+    max-width: 130px;
   }
 }

--- a/user-interface/src/trustees/panels/TrusteeCaseList.tsx
+++ b/user-interface/src/trustees/panels/TrusteeCaseList.tsx
@@ -106,37 +106,76 @@ export default function TrusteeCaseList({
           <p className="trustee-case-list-count" aria-live="polite" aria-atomic="true">
             {totalCount} {totalCount === 1 ? 'Case' : 'Cases'}
           </p>
-          <table
-            className="usa-table usa-table--borderless"
+          <div
+            className="trustee-case-list-grid"
+            role="table"
             data-testid="trustee-case-list-table"
             aria-label="Case list for trustee"
             aria-live="off"
             aria-atomic="false"
           >
-            <thead>
-              <tr>
-                <th scope="col">Case Number (Division)</th>
-                <th scope="col">Case Title</th>
-                <th scope="col">Chapter</th>
-                <th scope="col">Case Filed</th>
-                <th scope="col">Appt. Date</th>
-              </tr>
-            </thead>
-            <tbody>
+            <div role="rowgroup">
+              <div className="trustee-case-list-header" role="row">
+                <div role="columnheader" className="trustee-case-list-cell col-case-number">
+                  Case Number (Division)
+                </div>
+                <div role="columnheader" className="trustee-case-list-cell col-case-title">
+                  Case Title
+                </div>
+                <div role="columnheader" className="trustee-case-list-cell col-chapter">
+                  Chapter
+                </div>
+                <div role="columnheader" className="trustee-case-list-cell col-date-filed">
+                  Case Filed
+                </div>
+                <div role="columnheader" className="trustee-case-list-cell col-appt-date">
+                  Appt. Date
+                </div>
+              </div>
+            </div>
+            <div role="rowgroup">
               {cases.map((item) => (
-                <tr key={item.caseId}>
-                  <td>
+                <div key={item.caseId} className="trustee-case-list-row" role="row">
+                  <div
+                    role="cell"
+                    className="trustee-case-list-cell col-case-number"
+                    data-cell="Case Number (Division)"
+                  >
                     <CaseNumber caseId={item.caseId} openLinkIn="new-window" />
                     {item.courtDivisionName && ` (${item.courtDivisionName})`}
-                  </td>
-                  <td>{item.caseTitle}</td>
-                  <td>{item.chapter}</td>
-                  <td>{formatDate(item.dateFiled)}</td>
-                  <td>{item.appointedDate ? formatDate(item.appointedDate) : ''}</td>
-                </tr>
+                  </div>
+                  <div
+                    role="cell"
+                    className="trustee-case-list-cell col-case-title"
+                    data-cell="Case Title"
+                  >
+                    {item.caseTitle}
+                  </div>
+                  <div
+                    role="cell"
+                    className="trustee-case-list-cell col-chapter"
+                    data-cell="Chapter"
+                  >
+                    {item.chapter}
+                  </div>
+                  <div
+                    role="cell"
+                    className="trustee-case-list-cell col-date-filed"
+                    data-cell="Case Filed"
+                  >
+                    {formatDate(item.dateFiled)}
+                  </div>
+                  <div
+                    role="cell"
+                    className="trustee-case-list-cell col-appt-date"
+                    data-cell="Appt. Date"
+                  >
+                    {item.appointedDate ? formatDate(item.appointedDate) : ''}
+                  </div>
+                </div>
               ))}
-            </tbody>
-          </table>
+            </div>
+          </div>
           {pagination && pagination.totalPages && pagination.totalPages > 1 && (
             <div aria-live="off" aria-atomic="false">
               <Pagination<PaginationPredicate>

--- a/user-interface/src/trustees/panels/TrusteeCaseList.tsx
+++ b/user-interface/src/trustees/panels/TrusteeCaseList.tsx
@@ -15,6 +15,14 @@ import {
 } from '@common/api/search';
 import TrusteeCaseListFilter from './filters/TrusteeCaseListFilter';
 import { TrusteeCaseListFilterValue } from './filters/trusteeCaseListFilter.types';
+import {
+  CamsTable,
+  CamsTableBody,
+  CamsTableCell,
+  CamsTableHeader,
+  CamsTableHeaderCell,
+  CamsTableRow,
+} from '@/lib/components/cams/CamsTable';
 
 type PaginationPredicate = { limit: number; offset: number };
 
@@ -106,76 +114,43 @@ export default function TrusteeCaseList({
           <p className="trustee-case-list-count" aria-live="polite" aria-atomic="true">
             {totalCount} {totalCount === 1 ? 'Case' : 'Cases'}
           </p>
-          <div
-            className="trustee-case-list-grid"
-            role="table"
+          <CamsTable
+            className="trustee-case-list-table"
             data-testid="trustee-case-list-table"
             aria-label="Case list for trustee"
-            aria-live="off"
-            aria-atomic="false"
           >
-            <div role="rowgroup">
-              <div className="trustee-case-list-header" role="row">
-                <div role="columnheader" className="trustee-case-list-cell col-case-number">
-                  Case Number (Division)
-                </div>
-                <div role="columnheader" className="trustee-case-list-cell col-case-title">
-                  Case Title
-                </div>
-                <div role="columnheader" className="trustee-case-list-cell col-chapter">
-                  Chapter
-                </div>
-                <div role="columnheader" className="trustee-case-list-cell col-date-filed">
-                  Case Filed
-                </div>
-                <div role="columnheader" className="trustee-case-list-cell col-appt-date">
-                  Appt. Date
-                </div>
-              </div>
-            </div>
-            <div role="rowgroup">
+            <CamsTableHeader>
+              <CamsTableHeaderCell className="col-case-number">
+                Case Number (Division)
+              </CamsTableHeaderCell>
+              <CamsTableHeaderCell className="col-case-title">Case Title</CamsTableHeaderCell>
+              <CamsTableHeaderCell className="col-chapter">Chapter</CamsTableHeaderCell>
+              <CamsTableHeaderCell className="col-date-filed">Case Filed</CamsTableHeaderCell>
+              <CamsTableHeaderCell className="col-appt-date">Appt. Date</CamsTableHeaderCell>
+            </CamsTableHeader>
+            <CamsTableBody>
               {cases.map((item) => (
-                <div key={item.caseId} className="trustee-case-list-row" role="row">
-                  <div
-                    role="cell"
-                    className="trustee-case-list-cell col-case-number"
-                    data-cell="Case Number (Division)"
-                  >
+                <CamsTableRow key={item.caseId}>
+                  <CamsTableCell className="col-case-number" data-cell="Case Number (Division)">
                     <CaseNumber caseId={item.caseId} openLinkIn="new-window" />
                     {item.courtDivisionName && ` (${item.courtDivisionName})`}
-                  </div>
-                  <div
-                    role="cell"
-                    className="trustee-case-list-cell col-case-title"
-                    data-cell="Case Title"
-                  >
+                  </CamsTableCell>
+                  <CamsTableCell className="col-case-title" data-cell="Case Title">
                     {item.caseTitle}
-                  </div>
-                  <div
-                    role="cell"
-                    className="trustee-case-list-cell col-chapter"
-                    data-cell="Chapter"
-                  >
+                  </CamsTableCell>
+                  <CamsTableCell className="col-chapter" data-cell="Chapter">
                     {item.chapter}
-                  </div>
-                  <div
-                    role="cell"
-                    className="trustee-case-list-cell col-date-filed"
-                    data-cell="Case Filed"
-                  >
+                  </CamsTableCell>
+                  <CamsTableCell className="col-date-filed" data-cell="Case Filed">
                     {formatDate(item.dateFiled)}
-                  </div>
-                  <div
-                    role="cell"
-                    className="trustee-case-list-cell col-appt-date"
-                    data-cell="Appt. Date"
-                  >
+                  </CamsTableCell>
+                  <CamsTableCell className="col-appt-date" data-cell="Appt. Date">
                     {item.appointedDate ? formatDate(item.appointedDate) : ''}
-                  </div>
-                </div>
+                  </CamsTableCell>
+                </CamsTableRow>
               ))}
-            </div>
-          </div>
+            </CamsTableBody>
+          </CamsTable>
           {pagination && pagination.totalPages && pagination.totalPages > 1 && (
             <div aria-live="off" aria-atomic="false">
               <Pagination<PaginationPredicate>


### PR DESCRIPTION
# Bug

The Trustee Case List table did not adapt to mobile viewports. Columns shrank until content was inaccessible, with no horizontal scroll available — blocking trustees from viewing case information on small screens.

# Purpose

Make the trustee case list readable on mobile by adopting the same responsive table pattern used elsewhere in the application.

# Major Changes

* Replaced the plain `<table>` element with the `CamsTable` component family (`CamsTable`, `CamsTableHeader`, `CamsTableHeaderCell`, `CamsTableBody`, `CamsTableRow`, `CamsTableCell`)
* Overrode `CamsTable`'s default 640px breakpoint to 880px via the `cams-table-stacked` / `cams-table-flex-row` mixins, matching the breakpoint used by `TrusteesList`
* Added `data-cell` labels on each cell so mobile stacked view renders inline column labels
* Added `padding-left: 1rem` on the case count at mobile widths, removed at wide breakpoint
* Custom column width proportions (case number, title, chapter, dates) scoped to `.trustee-case-list-table`

# Testing/Validation

All 21 existing unit tests pass unchanged — ARIA roles (`role="table"`, `role="cell"`, `role="columnheader"`) are preserved by the `CamsTable` component so no test updates were needed. Full test suite (3201 tests), typecheck, lint, coverage, and a11y checks all pass.

Manual verification with the `trustee-case-list` seed scenario (`npm run seed:local -- --scenario=trustee-case-list`) confirmed the table stacks correctly below 880px and displays columns above it.

# Notes

`CamsTable` uses `tablet-screen-extra-small` (640px) as its default flex-row breakpoint. The case list panel lives inside the right-side pane of the trustee detail screen, where available width is more constrained — so the breakpoint was overridden to match `TrusteesList` (880px) using the provided mixins rather than duplicating the pattern by hand.

`TrusteesList` itself does not use `CamsTable` because it has multi-row trustee groups (one row per appointment) that don't fit the component's row model. `TrusteeCaseList` is a straightforward one-row-per-case table and is a clean fit.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve the TrusteeCaseList panel by adopting the shared responsive CamsTable layout and mobile-friendly styling so trustees can reliably view case information on smaller screens.

Bug Fixes:
- Make the trustee case list table responsive and readable on mobile viewports using the shared CamsTable responsive pattern.

Enhancements:
- Refactor TrusteeCaseList to use the CamsTable component family with labeled cells and scoped column width proportions for better layout consistency.
- Adjust trustee case count styling so spacing adapts between mobile and larger breakpoints.