### PR TITLE
CAMS-787 Fix appointment status filter leaking wrong-status rows

### DIFF
--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -421,6 +421,30 @@ describe('TrusteesUseCase tests', () => {
       );
     });
 
+    test('should filter appointments by status when a trustee has mixed-status appointments', async () => {
+      const trustee = MockData.getTrustee({ trusteeId: 'mixed-1' });
+      const activeAppt = MockData.getTrusteeAppointment({ trusteeId: 'mixed-1', status: 'active' });
+      const removedAppt = MockData.getTrusteeAppointment({
+        trusteeId: 'mixed-1',
+        status: 'removed',
+      });
+
+      vi.spyOn(MockMongoRepository.prototype, 'getTrusteeIdsByStatuses').mockResolvedValue([
+        'mixed-1',
+      ]);
+      vi.spyOn(MockMongoRepository.prototype, 'listTrustees').mockResolvedValue([trustee]);
+      vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
+        activeAppt,
+        removedAppt,
+      ]);
+
+      const result = await trusteesUseCase.listTrustees(context, { status: 'active' });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].appointments).toHaveLength(1);
+      expect(result[0].appointments[0].status).toBe('active');
+    });
+
     test('should return all trustees when status is all', async () => {
       const trustee1 = MockData.getTrustee({ trusteeId: 't1' });
       const trustee2 = MockData.getTrustee({ trusteeId: 't2' });

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -272,7 +272,12 @@ export class TrusteesUseCase {
       const allAppointments =
         await this.trusteeAppointmentsRepository.getAppointmentsByTrusteeIds(trusteeIds);
 
-      const enrichedAppointments = allAppointments.map((appt) => ({
+      const statusFilteredAppointments =
+        statusStatuses === null
+          ? allAppointments
+          : allAppointments.filter((appt) => statusStatuses.includes(appt.status));
+
+      const enrichedAppointments = statusFilteredAppointments.map((appt) => ({
         ...appt,
         courtName: this.findCourtName(courts, appt.courtId),
         courtDivisionName: this.findCourtDivisionName(courts, appt.divisionCode),

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -250,13 +250,13 @@ export class TrusteesUseCase {
   ): Promise<TrusteeListItem[]> {
     try {
       const status = predicate?.status;
-      const statusStatuses = this.getStatusFilterValues(status);
+      const requestedStatuses = this.getStatusFilterValues(status);
 
       const [allTrustees, courts, filteredTrusteeIds] = await Promise.all([
         this.trusteesRepository.listTrustees(),
         this.courtsUseCase.getCourts(context),
-        statusStatuses
-          ? this.trusteeAppointmentsRepository.getTrusteeIdsByStatuses(statusStatuses)
+        requestedStatuses
+          ? this.trusteeAppointmentsRepository.getTrusteeIdsByStatuses(requestedStatuses)
           : Promise.resolve(null),
       ]);
 
@@ -272,12 +272,12 @@ export class TrusteesUseCase {
       const allAppointments =
         await this.trusteeAppointmentsRepository.getAppointmentsByTrusteeIds(trusteeIds);
 
-      const statusFilteredAppointments =
-        statusStatuses === null
+      const filteredAppointmentsByStatus =
+        requestedStatuses === null
           ? allAppointments
-          : allAppointments.filter((appt) => statusStatuses.includes(appt.status));
+          : allAppointments.filter((appt) => requestedStatuses.includes(appt.status));
 
-      const enrichedAppointments = statusFilteredAppointments.map((appt) => ({
+      const enrichedAppointments = filteredAppointmentsByStatus.map((appt) => ({
         ...appt,
         courtName: this.findCourtName(courts, appt.courtId),
         courtDivisionName: this.findCourtDivisionName(courts, appt.divisionCode),


### PR DESCRIPTION
# Bug

When filtering the trustee list by status (e.g. Active), appointments with a mismatched status were still appearing in the results. A trustee who had both an active appointment and a removed appointment would show both rows — the removed one should have been excluded.

# Purpose

Ensure the appointment status filter is applied consistently so the API response only contains appointments matching the requested status.

# Major Changes

* After fetching all appointments for filtered trustee IDs, apply the same status predicate to the appointments themselves before enriching and grouping
* Added a regression test covering a trustee with mixed-status appointments filtered to active

# Testing/Validation

Implemented using TDD. New unit test covers the exact bug scenario: a trustee with one active and one removed appointment filtered to `status=active` — only the active appointment should be returned. All 54 tests in `trustees.test.ts` pass.

# Notes

The bug was a two-step mismatch: `getTrusteeIdsByStatuses` correctly narrowed which trustees to include, but `getAppointmentsByTrusteeIds` fetched all appointments for those trustees without any status filter. The fix adds a filter between those two steps using the already-computed `statusStatuses` array — no new logic required.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Ensure trustee appointment status filters are applied consistently so only appointments matching the requested status are returned.

Bug Fixes:
- Fix trustee listing to exclude appointments whose status does not match the requested filter when trustees have mixed-status appointments.

Tests:
- Add a regression test covering trustees with both active and removed appointments to verify only active appointments are returned when filtering by active status.