### PR TITLE
CAMS-764 Remove redundant font-size declarations in TrusteeMatchVerificationAccordion

### DIFF
--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.scss
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.scss
@@ -9,7 +9,6 @@
   p.problem-statement,
   p.resolved-statement {
     margin: 1.5rem 0;
-    font-size: 1rem;
     line-height: 1.25;
     .new-tab-link {
       vertical-align: top;
@@ -17,7 +16,6 @@
   }
 
   p.other-matches-subtext {
-    font-size: 1rem;
     margin: 1.5rem 0;
   }
 
@@ -32,7 +30,6 @@
 
     .trustee-data-header {
       font-weight: bold;
-      font-size: 0.875rem;
 
       .trustee-data-cell {
         padding: 0.5rem 0.5rem 0.5rem 0;


### PR DESCRIPTION
# Purpose

Eliminate redundant CSS that overrides design system defaults with identical values, reducing noise and making the stylesheet easier to maintain.

# Major Changes

* Removed three explicit `font-size` declarations from `TrusteeMatchVerificationAccordion.scss` that duplicated the design system defaults:
  * `font-size: 1rem` on `.problem-statement` and `.resolved-statement` paragraphs
  * `font-size: 1rem` on `.other-matches-subtext`
  * `font-size: 0.875rem` on `.trustee-data-header`

# Testing/Validation

All 3201 unit tests pass. Accessibility tests pass. Visual appearance is unchanged — the removed values matched the inherited defaults exactly.

# Notes

These declarations were identified as redundant because they set the same values the design system already applies by default. Removing them has no visible effect but reduces the risk of future confusion about whether these sizes are intentional overrides.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enhancements:
- Simplify TrusteeMatchVerificationAccordion.scss by relying on design system default font sizes instead of explicit overrides.