### PR TITLE
CAMS-789 Display case number and trustee name in browser tab

### DIFF
--- a/user-interface/src/case-detail/CaseDetailScreen.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.test.tsx
@@ -89,6 +89,15 @@ describe('Case Detail screen tests', () => {
     await TestingUtilities.waitForDocumentBody();
   }
 
+  test('should set document title with case number', async () => {
+    await renderWithRoutes(defaultTestCaseDetail);
+    await waitFor(() => {
+      expect(document.title).toBe(
+        `Case ${getCaseNumber(caseId)} | U.S. Trustee Program - Case Management System (CAMS)`,
+      );
+    });
+  });
+
   test('should render CaseDetailHeader', async () => {
     const headerSpy = vi.spyOn(detailHeader, 'default');
 

--- a/user-interface/src/case-detail/CaseDetailScreen.test.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.test.tsx
@@ -89,12 +89,10 @@ describe('Case Detail screen tests', () => {
     await TestingUtilities.waitForDocumentBody();
   }
 
-  test('should set document title with case number', async () => {
+  test('should set browser tab title to the case number', async () => {
     await renderWithRoutes(defaultTestCaseDetail);
     await waitFor(() => {
-      expect(document.title).toBe(
-        `Case ${getCaseNumber(caseId)} | U.S. Trustee Program - Case Management System (CAMS)`,
-      );
+      expect(document.title).toContain(`Case ${getCaseNumber(caseId)}`);
     });
   });
 

--- a/user-interface/src/case-detail/CaseDetailScreen.tsx
+++ b/user-interface/src/case-detail/CaseDetailScreen.tsx
@@ -13,7 +13,7 @@ import {
   InputRef,
 } from '@/lib/type-declarations/input-fields';
 import CaseDetailAuditHistory from './panels/CaseDetailAuditHistory';
-import { CaseDetail, CaseDocket, CaseDocketEntry } from '@common/cams/cases';
+import { CaseDetail, CaseDocket, CaseDocketEntry, getCaseNumber } from '@common/cams/cases';
 import CaseDetailAssociatedCases from './panels/CaseDetailAssociatedCases';
 import { LoadingSpinner } from '@/lib/components/LoadingSpinner';
 import { EventCaseReference } from '@common/cams/events';
@@ -407,7 +407,7 @@ export default function CaseDetailScreen(props: Readonly<CaseDetailProps>) {
 
   return (
     <MainContent className="record-detail" data-testid="case-detail">
-      <DocumentTitle name="Case Detail" />
+      <DocumentTitle name={`Case ${getCaseNumber(caseId)}`} />
       {isLoading && (
         <>
           <CaseDetailHeader isLoading={isLoading} caseId={caseId} />

--- a/user-interface/src/lib/components/cams/DocumentTitle/DocumentTitle.test.tsx
+++ b/user-interface/src/lib/components/cams/DocumentTitle/DocumentTitle.test.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
-import { describe } from 'vitest';
 import DocumentTitle from './DocumentTitle';
 
 describe('DocumentTitle', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    document.title = '';
   });
 
   test('sets document.title on mount', () => {

--- a/user-interface/src/lib/components/cams/DocumentTitle/DocumentTitle.test.tsx
+++ b/user-interface/src/lib/components/cams/DocumentTitle/DocumentTitle.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import { describe } from 'vitest';
+import DocumentTitle from './DocumentTitle';
+
+describe('DocumentTitle', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('sets document.title on mount', () => {
+    render(<DocumentTitle name="Test Page" />);
+    expect(document.title).toBe('Test Page | U.S. Trustee Program - Case Management System (CAMS)');
+  });
+
+  test('updates document.title when name prop changes', () => {
+    const { rerender } = render(<DocumentTitle name="First" />);
+    expect(document.title).toBe('First | U.S. Trustee Program - Case Management System (CAMS)');
+
+    rerender(<DocumentTitle name="Second" />);
+    expect(document.title).toBe('Second | U.S. Trustee Program - Case Management System (CAMS)');
+  });
+});

--- a/user-interface/src/lib/components/cams/DocumentTitle/DocumentTitle.tsx
+++ b/user-interface/src/lib/components/cams/DocumentTitle/DocumentTitle.tsx
@@ -11,5 +11,5 @@ export default function DocumentTitle(props: DocumentTitleProps) {
     document.title = `${name} | U.S. Trustee Program - Case Management System (CAMS)`;
   }, [name]);
 
-  return <></>;
+  return null;
 }

--- a/user-interface/src/lib/components/cams/DocumentTitle/DocumentTitle.tsx
+++ b/user-interface/src/lib/components/cams/DocumentTitle/DocumentTitle.tsx
@@ -9,7 +9,7 @@ export default function DocumentTitle(props: DocumentTitleProps) {
 
   useEffect(() => {
     document.title = `${name} | U.S. Trustee Program - Case Management System (CAMS)`;
-  }, []);
+  }, [name]);
 
   return <></>;
 }

--- a/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
@@ -103,28 +103,34 @@ describe('TrusteeDetailScreen', () => {
     vi.restoreAllMocks();
   });
 
-  test('should set document title to generic label while loading', async () => {
+  test('should set browser tab title to generic label while loading', async () => {
     vi.spyOn(Api2, 'getTrustee').mockImplementation(() => new Promise(() => {}));
 
     renderWithRouter();
 
     await waitFor(() => {
-      expect(document.title).toBe(
-        'Trustee Detail | U.S. Trustee Program - Case Management System (CAMS)',
-      );
+      expect(document.title).toContain('Trustee Detail');
     });
   });
 
-  test('should set document title to trustee name after loading', async () => {
+  test('should set browser tab title to trustee name after loading', async () => {
     vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
     vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
 
     renderWithRouter();
 
     await waitFor(() => {
-      expect(document.title).toBe(
-        'John Doe | U.S. Trustee Program - Case Management System (CAMS)',
-      );
+      expect(document.title).toContain(mockTrustee.name);
+    });
+  });
+
+  test('should set browser tab title to generic label when trustee not found', async () => {
+    vi.spyOn(Api2, 'getTrustee').mockRejectedValue(new Error('Not found'));
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(document.title).toContain('Trustee Detail');
     });
   });
 

--- a/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.test.tsx
@@ -84,6 +84,7 @@ describe('TrusteeDetailScreen', () => {
   };
 
   beforeEach(() => {
+    document.title = '';
     TestingUtilities.spyOnGlobalAlert();
 
     mockUseParams.mockReturnValue({ trusteeId: '123' });
@@ -100,6 +101,31 @@ describe('TrusteeDetailScreen', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  test('should set document title to generic label while loading', async () => {
+    vi.spyOn(Api2, 'getTrustee').mockImplementation(() => new Promise(() => {}));
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(document.title).toBe(
+        'Trustee Detail | U.S. Trustee Program - Case Management System (CAMS)',
+      );
+    });
+  });
+
+  test('should set document title to trustee name after loading', async () => {
+    vi.spyOn(Api2, 'getTrustee').mockResolvedValue({ data: mockTrustee });
+    vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: mockCourts });
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(document.title).toBe(
+        'John Doe | U.S. Trustee Program - Case Management System (CAMS)',
+      );
+    });
   });
 
   test('should display loading spinner while fetching data', async () => {

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -338,7 +338,7 @@ export default function TrusteeDetailScreen() {
 
   return (
     <MainContent className="record-detail" data-testid="record-detail">
-      <DocumentTitle name="Trustee Detail" />
+      <DocumentTitle name={trustee.name} />
 
       <Routes>
         {routeConfigs.map(({ path, subHeading, content, disabled }) => (

--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -338,7 +338,7 @@ export default function TrusteeDetailScreen() {
 
   return (
     <MainContent className="record-detail" data-testid="record-detail">
-      <DocumentTitle name={trustee.name} />
+      <DocumentTitle name={trustee.name ?? 'Trustee Detail'} />
 
       <Routes>
         {routeConfigs.map(({ path, subHeading, content, disabled }) => (


### PR DESCRIPTION
# Bug

`DocumentTitle` used an empty `useEffect` dependency array (`[]`), so `document.title` was only set on initial mount and never updated when the `name` prop changed. This caused every page to show a generic label (e.g. "Case Detail") regardless of which case or trustee was loaded.

# Purpose

When analysts and attorneys have multiple CAMS tabs open, all tabs show identical generic labels making it impossible to identify the right tab at a glance. This change makes the Case Detail and Trustee Detail tabs show the specific case number or trustee name.

# Major Changes

* Fixed `DocumentTitle` component: changed `useEffect` dependency array from `[]` to `[name]` so the title updates reactively when props change
* `CaseDetailScreen` now passes the case number derived from the URL param immediately — no API response required, so the tab is correct even before the page finishes loading
* `TrusteeDetailScreen` passes the trustee's full name once loaded; generic label shown during load and on the not-found path
* Added unit tests for `DocumentTitle` (new test file), `CaseDetailScreen`, and `TrusteeDetailScreen`

# Testing/Validation

* Unit tests written for all changed components (3210 tests passing across all workspaces)
* `DocumentTitle` tests verify both mount behavior and reactive updates on prop change
* Screen tests verify the correct value is present in `document.title` for loading, loaded, and not-found states
* Accessibility tests pass

# Notes

The `DocumentTitle` fix is safe for all existing callers — every other usage passes a static string literal, so adding `name` to the dependency array has no behavioral effect on those pages (a static string never changes between renders).

The case number is available immediately from `getCaseNumber(caseId)` using the URL param, so `CaseDetailScreen` never needs a loading state for the tab title.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Update browser tab titles so case and trustee detail pages show specific case numbers or trustee names, backed by a reactive DocumentTitle component and new tests verifying title behavior in key states.

New Features:
- Display the specific case number in the Case Detail browser tab title.
- Display the trustee’s full name in the Trustee Detail browser tab title after data load.

Bug Fixes:
- Ensure the DocumentTitle component updates document.title whenever the name prop changes instead of only on initial mount.

Enhancements:
- Use the case number derived from the URL to set the Case Detail tab title immediately without waiting for API responses.
- Set a generic Trustee Detail tab title during loading and when the trustee record is not found to maintain a meaningful tab label.

Tests:
- Add unit tests for DocumentTitle to cover initial mount and reactive updates when the name prop changes.
- Add CaseDetailScreen tests to verify the browser tab title includes the case number.
- Add TrusteeDetailScreen tests to verify the browser tab title behavior across loading, loaded, and not-found states.