### PR TITLE
CAMS-790 Remove no-trustees empty message

### DIFF
--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.test.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.test.tsx
@@ -309,7 +309,7 @@ describe('CaseDetailTrusteePanel', () => {
       expect(screen.getByText('Past Trustee One')).toBeInTheDocument();
     });
 
-    test('renders empty message when flag is on and history is empty', () => {
+    test('does not render past trustees section when flag is on and history is empty', () => {
       mockUseFeatureFlags.mockReturnValue({
         [TRUSTEE_APPOINTMENT_HISTORY_ENABLED]: true,
       });
@@ -324,8 +324,9 @@ describe('CaseDetailTrusteePanel', () => {
 
       renderPanel();
 
-      expect(screen.getByTestId('past-trustees-empty')).toBeInTheDocument();
-      expect(screen.getByText('No past trustees for this case.')).toBeInTheDocument();
+      expect(screen.queryByTestId('past-trustees-empty')).not.toBeInTheDocument();
+      expect(screen.queryByText('No past trustees for this case.')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('past-trustees-section')).not.toBeInTheDocument();
     });
 
     test('does not render section when flag is off', () => {

--- a/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.tsx
+++ b/user-interface/src/case-detail/panels/CaseDetailTrusteePanel.tsx
@@ -37,11 +37,7 @@ interface PastTrusteesSectionProps {
 
 function PastTrusteesSection({ history }: Readonly<PastTrusteesSectionProps>) {
   if (history.length === 0) {
-    return (
-      <div data-testid="past-trustees-empty" className="past-trustees-empty">
-        No past trustees for this case.
-      </div>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
# Bug

The message "No past trustees for this case." was displayed on the Trustee tab even when there were no past trustees to show. The empty-state message adds no value and the section should simply be absent when there is no past trustee history.

# Purpose

Prevent confusing empty-state text from appearing on the Trustee tab when there is no past trustee history to display.

# Major Changes

* `PastTrusteesSection` now returns `null` when the history array is empty instead of rendering an empty-state message div
* Updated the corresponding test to assert the section is absent (not present with a message) when history is empty

# Testing/Validation

Existing unit tests updated to reflect correct behavior. All 23 tests in `CaseDetailTrusteePanel.test.tsx` pass. Accessibility tests pass.

# Notes

The fix is a one-line change in `PastTrusteesSection`. The feature flag guard (`historyEnabled && trusteeId`) and all other rendering paths are unchanged. The past trustees table continues to render correctly when history is non-empty.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove the past trustees empty-state message so the section is hidden when there is no trustee history.

Bug Fixes:
- Stop rendering an empty past trustees message on the Trustee tab when there is no trustee history to display.

Tests:
- Update trustee panel tests to assert the past trustees section and empty-state message are not rendered when history is empty.