### PR TITLE
Add factory.getObservability seam for telemetry

### DIFF
--- a/backend/function-apps/azure/application-context-creator.test.ts
+++ b/backend/function-apps/azure/application-context-creator.test.ts
@@ -62,6 +62,27 @@ describe('Application Context Creator', () => {
       );
     });
 
+    test('should resolve observability via the factory singleton when none is injected', async () => {
+      vi.resetModules();
+      const FreshContextCreator = (await import('./application-context-creator')).default;
+      const freshFactory = (await import('../../lib/factory')).default;
+      const { NoOpObservability } = await import('../../lib/adapters/services/observability');
+
+      const invocationContext = createMockAzureFunctionContext();
+      const request = createMockAzureFunctionRequest();
+
+      const context = await FreshContextCreator.getApplicationContext({
+        invocationContext,
+        request,
+      });
+
+      // DATABASE_MOCK is true in the test environment, so the no-op resolves
+      // (applicationinsights is never required) and the instance is the one
+      // and only process-wide singleton the factory hands out.
+      expect(context.observability).toBeInstanceOf(NoOpObservability);
+      expect(context.observability).toBe(freshFactory.getObservability());
+    });
+
     test('should scrub unicode characters', async () => {
       const unicode = 'Hello World 你好 with emoji 🚀';
       const scrubbed = 'Hello World  with emoji ';

--- a/backend/function-apps/azure/application-context-creator.ts
+++ b/backend/function-apps/azure/application-context-creator.ts
@@ -9,7 +9,6 @@ import { UnauthorizedError } from '../../lib/common-errors/unauthorized-error';
 import factory from '../../lib/factory';
 import { sanitizeDeep } from '../../lib/use-cases/validations';
 import { ObservabilityGateway } from '../../lib/use-cases/gateways.types';
-import { AppInsightsObservability } from '../../lib/adapters/services/observability';
 
 const MODULE_NAME = 'APPLICATION-CONTEXT-CREATOR';
 
@@ -57,7 +56,7 @@ async function getApplicationContext<B = unknown>(
     config,
     featureFlags,
     logger: contextLogger,
-    observability: observability ?? new AppInsightsObservability(contextLogger),
+    observability: observability ?? factory.getObservability(contextLogger),
     invocationId: invocationContext.invocationId,
     request: request ? await azureToCamsHttpRequest<B>(request) : undefined,
     session: undefined,

--- a/backend/function-apps/dataflows/downstream/acms-cams-transition.test.ts
+++ b/backend/function-apps/dataflows/downstream/acms-cams-transition.test.ts
@@ -360,6 +360,7 @@ describe('sync health metrics', () => {
       expect.arrayContaining([
         expect.objectContaining({ name: expect.stringContaining('acms_cmmap') }),
       ]),
+      mockLogger,
     );
   });
 
@@ -379,6 +380,7 @@ describe('sync health metrics', () => {
       expect.arrayContaining([
         expect.objectContaining({ name: 'acms_cmmap_sync_rows_merged', value: 42 }),
       ]),
+      mockLogger,
     );
   });
 });

--- a/backend/function-apps/dataflows/import/sync-cases.ts
+++ b/backend/function-apps/dataflows/import/sync-cases.ts
@@ -15,7 +15,7 @@ import { buildQueueError } from '../../../lib/use-cases/dataflows/queue-types';
 import { FIX_QUEUE_NAME } from '../migrations/division-change-cleanup';
 import { CaseSyncEvent } from '@common/cams/dataflow-events';
 import { STORAGE_QUEUE_CONNECTION } from '../../../lib/storage-queues';
-import { AppInsightsObservability } from '../../../lib/adapters/services/observability';
+import factory from '../../../lib/factory';
 import { completeDataflowTrace } from '../../../lib/use-cases/dataflows/dataflow-telemetry';
 import { handleRateLimitRetry } from '../dataflows-rate-limit';
 import { getCamsError } from '../../../lib/common-errors/error-utilities';
@@ -65,7 +65,7 @@ const TIMER_TRIGGER = buildFunctionName(MODULE_NAME, 'timerTrigger');
  */
 async function handleStart(startMessage: StartMessage, invocationContext: InvocationContext) {
   const logger = ContextCreator.getLogger(invocationContext);
-  const observability = new AppInsightsObservability(logger);
+  const observability = factory.getObservability(logger);
   const trace = observability.startTrace(invocationContext.invocationId);
   try {
     const context = await ContextCreator.getApplicationContext({

--- a/backend/function-apps/dataflows/import/sync-trustee-appointments.ts
+++ b/backend/function-apps/dataflows/import/sync-trustee-appointments.ts
@@ -12,7 +12,7 @@ import { buildQueueError } from '../../../lib/use-cases/dataflows/queue-types';
 import { TrusteeAppointmentSyncEvent } from '@common/cams/dataflow-events';
 import { TrusteeAppointmentsSyncState } from '../../../lib/use-cases/gateways.types';
 import { STORAGE_QUEUE_CONNECTION } from '../../../lib/storage-queues';
-import { AppInsightsObservability } from '../../../lib/adapters/services/observability';
+import factory from '../../../lib/factory';
 import { completeDataflowTrace } from '../../../lib/use-cases/dataflows/dataflow-telemetry';
 import { handleRateLimitRetry } from '../dataflows-rate-limit';
 import { getCamsError } from '../../../lib/common-errors/error-utilities';
@@ -77,7 +77,7 @@ async function handleStart(
   invocationContext: InvocationContext,
 ) {
   const logger = ContextCreator.getLogger(invocationContext);
-  const observability = new AppInsightsObservability(logger);
+  const observability = factory.getObservability(logger);
   const trace = observability.startTrace(invocationContext.invocationId);
   try {
     const context = await ContextCreator.getApplicationContext({
@@ -292,7 +292,7 @@ async function handlePagePoison(
 
 async function timerTrigger(_timer: Timer, invocationContext: InvocationContext): Promise<void> {
   const logger = ContextCreator.getLogger(invocationContext);
-  const observability = new AppInsightsObservability(logger);
+  const observability = factory.getObservability(logger);
   const trace = observability.startTrace(invocationContext.invocationId);
   try {
     invocationContext.extraOutputs.set(START, {});

--- a/backend/function-apps/dataflows/migrations/migrate-consolidations.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-consolidations.ts
@@ -10,7 +10,7 @@ import {
 import AcmsOrdersController from '../../../lib/controllers/acms-orders/acms-orders.controller';
 import { getCamsError } from '../../../lib/common-errors/error-utilities';
 import { STORAGE_QUEUE_CONNECTION } from '../../../lib/storage-queues';
-import { AppInsightsObservability } from '../../../lib/adapters/services/observability';
+import factory from '../../../lib/factory';
 import { completeDataflowTrace } from '../../../lib/use-cases/dataflows/dataflow-telemetry';
 
 const MODULE_NAME = 'MIGRATE-CONSOLIDATIONS';
@@ -44,7 +44,7 @@ const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
  */
 async function handleStart(bounds: AcmsBounds, invocationContext: InvocationContext) {
   const logger = ApplicationContextCreator.getLogger(invocationContext);
-  const observability = new AppInsightsObservability(logger);
+  const observability = factory.getObservability(logger);
   const trace = observability.startTrace(invocationContext.invocationId);
   let totalQueued = 0;
   for (const chapter of bounds.chapters) {
@@ -80,7 +80,7 @@ async function handleStart(bounds: AcmsBounds, invocationContext: InvocationCont
  */
 async function handlePage(page: AcmsEtlQueueItem[], invocationContext: InvocationContext) {
   const logger = ApplicationContextCreator.getLogger(invocationContext);
-  const observability = new AppInsightsObservability(logger);
+  const observability = factory.getObservability(logger);
   const trace = observability.startTrace(invocationContext.invocationId);
   logger.debug(MODULE_NAME, `Processing page of ${page.length} migrations.`);
   for (const event of page) {

--- a/backend/function-apps/dataflows/migrations/resync-remaining-cases.ts
+++ b/backend/function-apps/dataflows/migrations/resync-remaining-cases.ts
@@ -13,7 +13,7 @@ import { STORAGE_QUEUE_CONNECTION } from '../../../lib/storage-queues';
 import { buildQueueError } from '../../../lib/use-cases/dataflows/queue-types';
 import { filterToExtendedAscii } from '@common/cams/sanitization';
 import { LoggerImpl } from '../../../lib/adapters/services/logger.service';
-import { AppInsightsObservability } from '../../../lib/adapters/services/observability';
+import factory from '../../../lib/factory';
 import { completeDataflowTrace } from '../../../lib/use-cases/dataflows/dataflow-telemetry';
 import { FIX_QUEUE_NAME } from './division-change-cleanup';
 
@@ -306,7 +306,7 @@ function routeErrorForInitialAttempt(
 
 async function handleError(event: CaseSyncEvent, invocationContext: InvocationContext) {
   const logger = ApplicationContextCreator.getLogger(invocationContext);
-  const observability = new AppInsightsObservability(logger);
+  const observability = factory.getObservability(logger);
   const trace = observability.startTrace(invocationContext.invocationId);
   const abandoned = isNotFoundError(event.error);
   routeErrorForInitialAttempt(event, invocationContext, logger);

--- a/backend/lib/adapters/services/observability.test.ts
+++ b/backend/lib/adapters/services/observability.test.ts
@@ -134,6 +134,60 @@ describe('AppInsightsObservability', () => {
       );
     });
 
+    test('should log the client-unavailable diagnostic with the call-time logger over the cached one', () => {
+      const cachedLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as unknown as LoggerImpl;
+      const callTimeLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as unknown as LoggerImpl;
+      const nullClientFactory = vi.fn(() => null);
+      const gatewayWithCachedLogger = new AppInsightsObservability(cachedLogger, nullClientFactory);
+      const trace = gatewayWithCachedLogger.startTrace(TEST_INVOCATION_ID);
+      const completion: TraceCompletion = { success: false, properties: {}, measurements: {} };
+
+      gatewayWithCachedLogger.completeTrace(
+        trace,
+        'TestEvent',
+        completion,
+        undefined,
+        callTimeLogger,
+      );
+
+      expect(vi.mocked(callTimeLogger.error)).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('App Insights client unavailable'),
+      );
+      expect(vi.mocked(cachedLogger.error)).not.toHaveBeenCalled();
+      expect(nullClientFactory).toHaveBeenCalledWith(callTimeLogger);
+    });
+
+    test('should fall back to the cached logger when no call-time logger is provided', () => {
+      const cachedLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as unknown as LoggerImpl;
+      const nullClientFactory = vi.fn(() => null);
+      const gatewayWithCachedLogger = new AppInsightsObservability(cachedLogger, nullClientFactory);
+      const trace = gatewayWithCachedLogger.startTrace(TEST_INVOCATION_ID);
+      const completion: TraceCompletion = { success: false, properties: {}, measurements: {} };
+
+      gatewayWithCachedLogger.completeTrace(trace, 'TestEvent', completion);
+
+      expect(vi.mocked(cachedLogger.error)).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('App Insights client unavailable'),
+      );
+    });
+
     test('should not include error property when not provided', () => {
       const gatewayWithLogger = new AppInsightsObservability(mockLogger, mockClientFactory);
       const trace = gatewayWithLogger.startTrace(TEST_INVOCATION_ID);

--- a/backend/lib/adapters/services/observability.ts
+++ b/backend/lib/adapters/services/observability.ts
@@ -73,9 +73,39 @@ function getOrInitializeAppInsightsClient(logger?: LoggerImpl): TelemetryClient 
   }
 }
 
+/**
+ * Builds a trace. Trace creation is SDK-independent — it records only the
+ * invocation identity and a start timestamp — so it is shared by every
+ * ObservabilityGateway implementation.
+ */
+function startTrace(invocationId: string): ObservabilityTrace {
+  return {
+    invocationId,
+    instanceId: process.env.WEBSITE_INSTANCE_ID ?? 'local',
+    startTime: Date.now(),
+  };
+}
+
+/**
+ * NoOpObservability
+ *
+ * A trace recorder that produces traces but emits no telemetry. Used in
+ * environments without Application Insights instrumentation (local development
+ * and unit tests), where loading the heavyweight `applicationinsights` SDK is
+ * both unnecessary and costly. Honors the ObservabilityGateway contract so
+ * handlers can start and complete traces uniformly regardless of environment.
+ */
+export class NoOpObservability implements ObservabilityGateway {
+  startTrace = startTrace;
+
+  completeTrace(): void {}
+}
+
 export class AppInsightsObservability implements ObservabilityGateway {
   private readonly MODULE_NAME = 'APP-INSIGHTS-OBSERVABILITY';
   private readonly clientFactory: AppInsightsClientFactory;
+
+  startTrace = startTrace;
 
   constructor(
     private readonly logger?: LoggerImpl,
@@ -84,20 +114,17 @@ export class AppInsightsObservability implements ObservabilityGateway {
     this.clientFactory = clientFactory ?? getOrInitializeAppInsightsClient;
   }
 
-  startTrace(invocationId: string): ObservabilityTrace {
-    return {
-      invocationId,
-      instanceId: process.env.WEBSITE_INSTANCE_ID ?? 'local',
-      startTime: Date.now(),
-    };
-  }
-
   completeTrace(
     trace: ObservabilityTrace,
     eventName: string,
     completion: TraceCompletion,
     metrics?: { name: string; value: number }[],
+    logger?: LoggerImpl,
   ): void {
+    // Prefer the per-invocation logger passed at call time. This gateway is a
+    // process-wide singleton, so the constructor-cached logger belongs to the
+    // first invocation and would mislabel diagnostics in a warm worker.
+    const activeLogger = logger ?? this.logger;
     const durationMs = Date.now() - trace.startTime;
 
     const properties: Record<string, string> = {
@@ -116,10 +143,10 @@ export class AppInsightsObservability implements ObservabilityGateway {
       ...completion.measurements,
     };
 
-    const client = this.clientFactory(this.logger);
+    const client = this.clientFactory(activeLogger);
 
     if (!client) {
-      this.logger?.error(
+      activeLogger?.error(
         this.MODULE_NAME,
         `CRITICAL: Telemetry not sent for ${eventName} - App Insights client unavailable (business reporting impacted)`,
       );

--- a/backend/lib/factory.test.ts
+++ b/backend/lib/factory.test.ts
@@ -1,4 +1,4 @@
-import { vi, beforeEach, describe, test, expect } from 'vitest';
+import { vi, beforeEach, afterEach, describe, test, expect } from 'vitest';
 import { ApplicationContext } from './adapters/types/basic';
 import { createMockApplicationContext } from './testing/testing-utilities';
 
@@ -391,12 +391,17 @@ describe('Factory getObservability', () => {
     import('./adapters/services/observability').AppInsightsObservability
   >;
   let NoOpObservability: Constructor<import('./adapters/services/observability').NoOpObservability>;
+  const originalDatabaseMock = process.env.DATABASE_MOCK;
 
   beforeEach(async () => {
     vi.resetModules();
     factory = (await import('./factory')).default;
     ({ AppInsightsObservability, NoOpObservability } =
       await import('./adapters/services/observability'));
+  });
+
+  afterEach(() => {
+    process.env.DATABASE_MOCK = originalDatabaseMock;
   });
 
   test('returns an ObservabilityGateway with startTrace and completeTrace', () => {

--- a/backend/lib/factory.test.ts
+++ b/backend/lib/factory.test.ts
@@ -384,3 +384,44 @@ describe('Factory mock implementations (DATABASE_MOCK=true)', () => {
     });
   });
 });
+
+describe('Factory getObservability', () => {
+  let factory: Factory;
+  let AppInsightsObservability: Constructor<
+    import('./adapters/services/observability').AppInsightsObservability
+  >;
+  let NoOpObservability: Constructor<import('./adapters/services/observability').NoOpObservability>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    factory = (await import('./factory')).default;
+    ({ AppInsightsObservability, NoOpObservability } =
+      await import('./adapters/services/observability'));
+  });
+
+  test('returns an ObservabilityGateway with startTrace and completeTrace', () => {
+    const observability = factory.getObservability();
+    expect(typeof observability.startTrace).toBe('function');
+    expect(typeof observability.completeTrace).toBe('function');
+  });
+
+  test('returns the same instance on repeated calls (process singleton)', () => {
+    expect(factory.getObservability()).toBe(factory.getObservability());
+  });
+
+  test('accepts an optional logger without an application context', async () => {
+    const { LoggerImpl } = await import('./adapters/services/logger.service');
+    const logger = new LoggerImpl('invocation-id');
+    expect(factory.getObservability(logger)).toBeDefined();
+  });
+
+  test('resolves the no-op implementation when DATABASE_MOCK is true', () => {
+    process.env.DATABASE_MOCK = 'true';
+    expect(factory.getObservability()).toBeInstanceOf(NoOpObservability);
+  });
+
+  test('resolves the real AppInsights implementation when DATABASE_MOCK is false', () => {
+    process.env.DATABASE_MOCK = 'false';
+    expect(factory.getObservability()).toBeInstanceOf(AppInsightsObservability);
+  });
+});

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -598,9 +598,9 @@ const getApiToDataflowsGateway = (context: ApplicationContext): ApiToDataflowsGa
 /**
  * getObservability
  *
- * The single sanctioned construction point for the ObservabilityGateway, and the
- * one place that enforces the process-wide-singleton constraint: a running
- * process must never see two different observability instances.
+ * The single sanctioned construction point for the ObservabilityGateway. Every
+ * factory consumer in a process shares this one instance; the standalone
+ * express/BDD dev harness is never deployed and constructs its own.
  *
  * Takes an optional logger rather than an ApplicationContext: some dataflow
  * handlers must start a trace before (or independently of) context creation so a

--- a/backend/lib/factory.ts
+++ b/backend/lib/factory.ts
@@ -97,6 +97,7 @@ import {
   NotificationGateway,
   NotificationRoutingRepository,
   ObjectStorageGateway,
+  ObservabilityGateway,
   TrusteeMatchVerificationRepository,
   TrusteeUpcomingKeyDatesRepository,
 } from './use-cases/gateways.types';
@@ -106,6 +107,8 @@ import { NotificationRoutingMongoRepository } from './adapters/gateways/mongo/no
 import { MockNotificationGateway } from './testing/mock-gateways/mock-notification.gateway';
 import { AcsNotificationGateway } from './adapters/gateways/notifications/acs-notification.gateway';
 import { EmailClient } from '@azure/communication-email';
+import { AppInsightsObservability, NoOpObservability } from './adapters/services/observability';
+import { LoggerImpl } from './adapters/services/logger.service';
 
 let casesGateway: CasesInterface;
 let ordersGateway: OrdersGateway;
@@ -115,6 +118,7 @@ let acmsGateway: AcmsGateway;
 let atsGateway: AtsGateway;
 let idpApiGateway: UserGroupGateway & Initializer<UserGroupGatewayConfig | ApplicationContext>;
 let notificationGateway: NotificationGateway | undefined;
+let observabilityGateway: ObservabilityGateway;
 
 let orderSyncStateRepo: RuntimeStateRepository<OrderSyncState>;
 let casesSyncStateRepo: RuntimeStateRepository<CasesSyncState>;
@@ -591,6 +595,28 @@ const getApiToDataflowsGateway = (context: ApplicationContext): ApiToDataflowsGa
   return new ApiToDataflowsGatewayImpl(context);
 };
 
+/**
+ * getObservability
+ *
+ * The single sanctioned construction point for the ObservabilityGateway, and the
+ * one place that enforces the process-wide-singleton constraint: a running
+ * process must never see two different observability instances.
+ *
+ * Takes an optional logger rather than an ApplicationContext: some dataflow
+ * handlers must start a trace before (or independently of) context creation so a
+ * trace survives a failed context build. The logger wires call-time diagnostics
+ * into the real implementation without forcing a fake context across the fence.
+ */
+const getObservability = (logger?: LoggerImpl): ObservabilityGateway => {
+  if (!observabilityGateway) {
+    observabilityGateway =
+      process.env.DATABASE_MOCK?.toLowerCase() === 'true'
+        ? new NoOpObservability()
+        : new AppInsightsObservability(logger);
+  }
+  return observabilityGateway;
+};
+
 const getTrusteeProfessionalIdsRepository = (
   context: ApplicationContext,
 ): TrusteeProfessionalIdsRepository => {
@@ -649,6 +675,7 @@ const factory = {
   resetNotificationGateway,
   getUserGroupsRepository,
   getApiToDataflowsGateway,
+  getObservability,
 };
 
 export default factory;

--- a/backend/lib/use-cases/cases/case-management.test.ts
+++ b/backend/lib/use-cases/cases/case-management.test.ts
@@ -694,6 +694,7 @@ describe('Case management tests', () => {
             expect.objectContaining({ name: 'SearchResultCount', value: 1 }),
             expect.objectContaining({ name: 'SearchTotalCount', value: 1 }),
           ]),
+          applicationContext.logger,
         );
       });
 
@@ -728,6 +729,7 @@ describe('Case management tests', () => {
             }),
           }),
           expect.anything(),
+          ctx.logger,
         );
       });
 
@@ -749,6 +751,7 @@ describe('Case management tests', () => {
             error: expect.stringContaining('test error'),
           }),
           expect.anything(),
+          applicationContext.logger,
         );
       });
 
@@ -773,6 +776,7 @@ describe('Case management tests', () => {
             }),
           }),
           expect.anything(),
+          applicationContext.logger,
         );
       });
 
@@ -812,6 +816,7 @@ describe('Case management tests', () => {
             }),
           }),
           expect.anything(),
+          ctx.logger,
         );
       });
     });

--- a/backend/lib/use-cases/cases/case-management.ts
+++ b/backend/lib/use-cases/cases/case-management.ts
@@ -133,6 +133,7 @@ export default class CaseManagement {
         { name: 'SearchResultCount', value: resultCount },
         { name: 'SearchTotalCount', value: totalCount },
       ],
+      context.logger,
     );
   }
 

--- a/backend/lib/use-cases/dataflows/dataflow-telemetry.test.ts
+++ b/backend/lib/use-cases/dataflows/dataflow-telemetry.test.ts
@@ -57,6 +57,7 @@ describe('completeDataflowTrace', () => {
         { name: 'DataflowDocumentsWritten', value: 5 },
         { name: 'DataflowDocumentsFailed', value: 2 },
       ]),
+      mockLogger,
     );
 
     const metricsArg = (mockObservability.completeTrace as ReturnType<typeof vi.fn>).mock

--- a/backend/lib/use-cases/dataflows/dataflow-telemetry.ts
+++ b/backend/lib/use-cases/dataflows/dataflow-telemetry.ts
@@ -63,5 +63,6 @@ export function completeDataflowTrace(
       error: result.error,
     },
     metrics,
+    logger,
   );
 }

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -1,4 +1,5 @@
 import { ApplicationContext } from '../adapters/types/basic';
+import { LoggerImpl } from '../adapters/services/logger.service';
 import { AtsTrusteeRecord, TrusteeAppointmentsResult } from '../adapters/types/ats.types';
 import { DbTableFieldSpec, QueryResults } from '../adapters/types/database';
 import {
@@ -728,6 +729,7 @@ export interface ObservabilityGateway {
     eventName: string,
     completion: TraceCompletion,
     metrics?: { name: string; value: number }[],
+    logger?: LoggerImpl,
   ): void;
 }
 

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.test.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.test.ts
@@ -188,6 +188,7 @@ describe('TrusteeMatchVerificationUseCase', () => {
           }),
         }),
         [{ name: 'TrusteeVerificationResolutionMs', value: expect.any(Number) }],
+        context.logger,
       );
     });
 
@@ -201,6 +202,7 @@ describe('TrusteeMatchVerificationUseCase', () => {
           properties: expect.objectContaining({ wasPreselectedConfirmed: 'false' }),
         }),
         expect.anything(),
+        context.logger,
       );
     });
 
@@ -215,6 +217,8 @@ describe('TrusteeMatchVerificationUseCase', () => {
         expect.anything(),
         'TrusteeMatchVerificationResolved',
         expect.objectContaining({ success: false, properties: { action: 'approve' } }),
+        undefined,
+        context.logger,
       );
     });
 
@@ -313,6 +317,7 @@ describe('TrusteeMatchVerificationUseCase', () => {
           }),
         }),
         [{ name: 'TrusteeVerificationResolutionMs', value: expect.any(Number) }],
+        context.logger,
       );
     });
 
@@ -325,6 +330,8 @@ describe('TrusteeMatchVerificationUseCase', () => {
         expect.anything(),
         'TrusteeMatchVerificationResolved',
         expect.objectContaining({ success: false, properties: { action: 'reject' } }),
+        undefined,
+        context.logger,
       );
     });
 

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
@@ -105,13 +105,20 @@ export class TrusteeMatchVerificationUseCase {
           },
         },
         [{ name: 'TrusteeVerificationResolutionMs', value: resolutionMs }],
+        context.logger,
       );
     } catch (originalError) {
-      context.observability.completeTrace(trace, 'TrusteeMatchVerificationResolved', {
-        success: false,
-        properties: { action: 'reject' },
-        measurements: {},
-      });
+      context.observability.completeTrace(
+        trace,
+        'TrusteeMatchVerificationResolved',
+        {
+          success: false,
+          properties: { action: 'reject' },
+          measurements: {},
+        },
+        undefined,
+        context.logger,
+      );
       throw getCamsError(originalError, MODULE_NAME);
     }
   }
@@ -213,13 +220,20 @@ export class TrusteeMatchVerificationUseCase {
           },
         },
         [{ name: 'TrusteeVerificationResolutionMs', value: resolutionMs }],
+        context.logger,
       );
     } catch (originalError) {
-      context.observability.completeTrace(trace, 'TrusteeMatchVerificationResolved', {
-        success: false,
-        properties: { action: 'approve' },
-        measurements: {},
-      });
+      context.observability.completeTrace(
+        trace,
+        'TrusteeMatchVerificationResolved',
+        {
+          success: false,
+          properties: { action: 'approve' },
+          measurements: {},
+        },
+        undefined,
+        context.logger,
+      );
       throw getCamsError(originalError, MODULE_NAME);
     }
   }

--- a/backend/lib/use-cases/trustees/trustee-search.use-case.test.ts
+++ b/backend/lib/use-cases/trustees/trustee-search.use-case.test.ts
@@ -278,6 +278,8 @@ describe('TrusteeSearchUseCase', () => {
           totalResultCount: expect.any(Number),
         }),
       }),
+      undefined,
+      context.logger,
     );
   });
 
@@ -298,6 +300,8 @@ describe('TrusteeSearchUseCase', () => {
       expect.any(Object),
       'TrusteeManualSearchPerformed',
       expect.objectContaining({ success: false }),
+      undefined,
+      context.logger,
     );
   });
 });

--- a/backend/lib/use-cases/trustees/trustee-search.use-case.ts
+++ b/backend/lib/use-cases/trustees/trustee-search.use-case.ts
@@ -46,27 +46,39 @@ export class TrusteeSearchUseCase {
         });
       }
 
-      context.observability.completeTrace(trace, 'TrusteeManualSearchPerformed', {
-        success: true,
-        properties: {
-          searchQuery: name,
-          courtIdFilter: courtId ?? 'none',
+      context.observability.completeTrace(
+        trace,
+        'TrusteeManualSearchPerformed',
+        {
+          success: true,
+          properties: {
+            searchQuery: name,
+            courtIdFilter: courtId ?? 'none',
+          },
+          measurements: {
+            totalResultCount: results.length,
+          },
         },
-        measurements: {
-          totalResultCount: results.length,
-        },
-      });
+        undefined,
+        context.logger,
+      );
 
       return results;
     } catch (originalError) {
-      context.observability.completeTrace(trace, 'TrusteeManualSearchPerformed', {
-        success: false,
-        properties: {
-          searchQuery: name,
-          courtIdFilter: courtId ?? 'none',
+      context.observability.completeTrace(
+        trace,
+        'TrusteeManualSearchPerformed',
+        {
+          success: false,
+          properties: {
+            searchQuery: name,
+            courtIdFilter: courtId ?? 'none',
+          },
+          measurements: {},
         },
-        measurements: {},
-      });
+        undefined,
+        context.logger,
+      );
       throw getCamsError(originalError, MODULE_NAME);
     }
   }

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -591,6 +591,7 @@ describe('TrusteesUseCase tests', () => {
       const historyCreateSpy = vi
         .spyOn(MockMongoRepository.prototype, 'createTrusteeHistory')
         .mockResolvedValue();
+      const completeTraceSpy = vi.spyOn(context.observability, 'completeTrace');
 
       await trusteesUseCase.updateTrustee(context, trusteeId, updateData);
       expect(updateTrusteeSpy).toHaveBeenCalledWith(trusteeId, updatedTrustee, updatedBy);
@@ -607,6 +608,13 @@ describe('TrusteesUseCase tests', () => {
           updatedBy,
           updatedOn: expect.any(String),
         }),
+      );
+      expect(completeTraceSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'Trustee Name Edited',
+        expect.objectContaining({ success: true }),
+        undefined,
+        context.logger,
       );
       expect(historyCreateSpy).not.toHaveBeenCalledWith(
         expect.objectContaining({ updatedBy: context.session.user }),

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -504,11 +504,17 @@ export class TrusteesUseCase {
       });
       const trace = context.observability.startTrace(context.invocationId);
       const isMigrated = !!(after.legacy?.truIds && after.legacy.truIds.length > 0);
-      context.observability.completeTrace(trace, 'Trustee Name Edited', {
-        success: true,
-        properties: { isMigrated: String(isMigrated) },
-        measurements: {},
-      });
+      context.observability.completeTrace(
+        trace,
+        'Trustee Name Edited',
+        {
+          success: true,
+          properties: { isMigrated: String(isMigrated) },
+          measurements: {},
+        },
+        undefined,
+        context.logger,
+      );
     }
 
     if (!deepEqual(before.public, after.public)) {


### PR DESCRIPTION
# Purpose

A scheduled constrained-test report flagged `sync-trustee-appointments`'s `handleStart` unit test as an outlier (~840ms vs 1-4ms for peers). Investigation showed the cost was a lazy `require('applicationinsights')` (~410ms cold) triggered because five dataflow handlers - and the shared Azure context creator - constructed `AppInsightsObservability` directly instead of resolving it through a dependency seam. Under `DATABASE_MOCK` that SDK load leaked into test runtime, and in production every context held a distinct gateway instance rather than a shared one.

This is the OeA dependency-seam fix for that smell. (The separate staging/prod dataflow *runtime* timeouts - non-sargable DXTR query and serial Cosmos loop - are not addressed here.)

# Major Changes

- Add `factory.getObservability(logger?)` as the single sanctioned construction point for `ObservabilityGateway`, backed by a process-wide singleton.
- Add a production `NoOpObservability` (resolved under `DATABASE_MOCK`) so tests and local dev never load the App Insights SDK; the test-only `mockObservability` stays on its own side of the test/prod fence.
- Route the 5 dataflow handlers and the shared `function-apps/azure/application-context-creator.ts` default through the factory instead of `new AppInsightsObservability(...)`.
- Thread a per-invocation `logger` through `completeTrace` (dataflow path + 8 API use-case call sites) so warm-worker diagnostics attribute to the current invocation rather than the first request that built the singleton.

# Testing/Validation

- Full backend suite green via canonical `npm test`: **217 files, 2991 tests, 0 failures**.
- ESLint: 0 errors on all changed files.
- `sync-trustee-appointments` test file: **~932ms -> ~46ms** (SDK no longer loads under test), which also de-noises the constrained-test-report rankings.
- Telemetry correctness verified against deployed Bicep configs: no deployed environment sets `DATABASE_MOCK`, so staging/prod resolve the real `AppInsightsObservability`; event correlation rides `trace.invocationId`, unaffected by the singleton.

# Notes

- Reviewed via a two-turn adversarial multi-agent pass (architect, SRE, test-quality, pragmatic). No correctness findings survived; two follow-up review nits (doc-comment scope + test env restore) are in the second commit.
- Deferred follow-up: replace `completeTrace`'s two trailing optional positional params (`metrics?`, `logger?`) with an options object to remove `undefined` placeholders at call sites.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
