### PR TITLE
CAMS-765 Reject inactive banks in trustee update

### DIFF
--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -1268,6 +1268,135 @@ describe('TrusteesUseCase tests', () => {
       );
     });
 
+    test('should succeed when clearing both softwareId and banks', async () => {
+      const softwareId = 'sw-axos';
+      const baseSoftwareProfile = {
+        id: softwareId,
+        documentType: 'BANKRUPTCY_SOFTWARE' as const,
+        name: 'Axos',
+        status: 'active' as const,
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const trusteeWithSoftwareAndBanks = MockData.getTrustee({
+        softwareId,
+        banks: ['bank-active'],
+      });
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(
+        trusteeWithSoftwareAndBanks,
+      );
+      // resolveSoftwareName is called for the old softwareId during audit history recording
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+        ...baseSoftwareProfile,
+        associatedBanks: [],
+      });
+      const updatedTrustee = { ...trusteeWithSoftwareAndBanks };
+      delete updatedTrustee.softwareId;
+      delete updatedTrustee.banks;
+      const updateTrusteeSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'updateTrustee')
+        .mockResolvedValue(updatedTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+
+      const result = await trusteesUseCase.updateTrustee(context, trusteeId, {
+        softwareId: null,
+        banks: null,
+      });
+
+      expect(updateTrusteeSpy).toHaveBeenCalled();
+      expect(result.softwareId).toBeUndefined();
+      expect(result.banks).toBeUndefined();
+    });
+
+    describe('bank status validation (CAMS-765)', () => {
+      const softwareId = 'sw-axos';
+      const baseSoftwareProfile = {
+        id: softwareId,
+        documentType: 'BANKRUPTCY_SOFTWARE' as const,
+        name: 'Axos',
+        status: 'active' as const,
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const activeBanks = [
+        { bankId: 'bank-active', bankName: 'Active Bank', status: 'active' as const },
+        { bankId: 'bank-inactive', bankName: 'Inactive Bank', status: 'inactive' as const },
+      ];
+
+      let trusteeWithSoftware: ReturnType<typeof MockData.getTrustee>;
+
+      beforeEach(() => {
+        trusteeWithSoftware = MockData.getTrustee({ softwareId });
+        vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(trusteeWithSoftware);
+      });
+
+      test('should throw BadRequestError and NOT call updateTrustee when bank status is inactive', async () => {
+        vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+          ...baseSoftwareProfile,
+          associatedBanks: activeBanks,
+        });
+        const updateTrusteeSpy = vi.spyOn(MockMongoRepository.prototype, 'updateTrustee');
+
+        await expect(
+          trusteesUseCase.updateTrustee(context, trusteeId, { banks: ['bank-inactive'] }),
+        ).rejects.toThrow(BadRequestError);
+
+        expect(updateTrusteeSpy).not.toHaveBeenCalled();
+      });
+
+      test('should throw BadRequestError when bank id is not in associatedBanks at all', async () => {
+        vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+          ...baseSoftwareProfile,
+          associatedBanks: [
+            { bankId: 'bank-active', bankName: 'Active Bank', status: 'active' as const },
+          ],
+        });
+
+        await expect(
+          trusteesUseCase.updateTrustee(context, trusteeId, { banks: ['bank-unknown'] }),
+        ).rejects.toThrow(BadRequestError);
+      });
+
+      test('should throw BadRequestError listing all invalid bank IDs when multiple are supplied', async () => {
+        vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+          ...baseSoftwareProfile,
+          associatedBanks: activeBanks,
+        });
+
+        const error = await trusteesUseCase
+          .updateTrustee(context, trusteeId, {
+            banks: ['bank-inactive', 'bank-unknown'],
+          })
+          .catch((e) => e);
+        expect(error).toBeInstanceOf(BadRequestError);
+        expect(error.message).toContain('bank-inactive');
+        expect(error.message).toContain('bank-unknown');
+      });
+
+      test('should succeed and call updateTrustee when bank is active and associated', async () => {
+        vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue({
+          ...baseSoftwareProfile,
+          associatedBanks: activeBanks,
+        });
+        const updatedTrustee = { ...trusteeWithSoftware, banks: ['bank-active'] };
+        const updateTrusteeSpy = vi
+          .spyOn(MockMongoRepository.prototype, 'updateTrustee')
+          .mockResolvedValue(updatedTrustee);
+        vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+
+        const result = await trusteesUseCase.updateTrustee(context, trusteeId, {
+          banks: ['bank-active'],
+        });
+
+        expect(updateTrusteeSpy).toHaveBeenCalledWith(
+          trusteeId,
+          expect.objectContaining({ banks: ['bank-active'] }),
+          expect.anything(),
+        );
+        expect(result.banks).toEqual(['bank-active']);
+      });
+    });
+
     describe('zoomInfoValidation', () => {
       test('should update trustee with valid zoomInfo', async () => {
         const updatedBy = getCamsUserReference(context.session.user);

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -467,7 +467,7 @@ export class TrusteesUseCase {
 
     if (banks && banks.length > 0) {
       const validBankIds = new Set(
-        software.associatedBanks?.filter((b) => b.status === 'active').map((b) => b.bankId) ?? [],
+        (software.associatedBanks ?? []).filter((b) => b.status === 'active').map((b) => b.bankId),
       );
       const invalidBanks = banks.filter((id) => !validBankIds.has(id));
       if (invalidBanks.length > 0) {

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -466,11 +466,13 @@ export class TrusteesUseCase {
     }
 
     if (banks && banks.length > 0) {
-      const validBankIds = new Set(software.associatedBanks?.map((b) => b.bankId) ?? []);
+      const validBankIds = new Set(
+        software.associatedBanks?.filter((b) => b.status === 'active').map((b) => b.bankId) ?? [],
+      );
       const invalidBanks = banks.filter((id) => !validBankIds.has(id));
       if (invalidBanks.length > 0) {
         throw new BadRequestError(MODULE_NAME, {
-          message: `Banks [${invalidBanks.join(', ')}] are not associated with the selected software.`,
+          message: `Banks [${invalidBanks.join(', ')}] are not active and associated with the selected software.`,
         });
       }
     }

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
@@ -401,17 +401,13 @@ describe('TrusteeOtherInfoForm', () => {
     );
 
     // Select an active bank from the dropdown
-    const expandButton = document.querySelector('#trustee-banks-0-expand') as HTMLButtonElement;
-    await userEvent.click(expandButton);
+    await userEvent.click(screen.getByTestId('button-trustee-banks-0-expand'));
 
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
 
-    const fifthThirdOption = document.querySelector(
-      '[data-value="bank-fifth-third"]',
-    ) as HTMLLIElement;
-    await userEvent.click(fifthThirdOption);
+    await userEvent.click(screen.getByRole('option', { name: /Fifth Third Bank/ }));
 
     // Save button should now be enabled
     await waitFor(() => {
@@ -449,18 +445,17 @@ describe('TrusteeOtherInfoForm', () => {
     );
 
     // Open the bank ComboBox dropdown
-    const expandButton = document.querySelector('#trustee-banks-0-expand') as HTMLButtonElement;
-    await userEvent.click(expandButton);
+    await userEvent.click(screen.getByTestId('button-trustee-banks-0-expand'));
 
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
 
     // Active banks should be visible
-    expect(document.querySelector('[data-value="bank-fifth-third"]')).toBeInTheDocument();
-    expect(document.querySelector('[data-value="bank-key"]')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Fifth Third Bank/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Key Bank/ })).toBeInTheDocument();
     // Inactive bank should NOT be visible
-    expect(document.querySelector('[data-value="bank-inactive"]')).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Inactive Bank/ })).not.toBeInTheDocument();
   });
 
   test('disables bank and save when software is cleared', async () => {

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
@@ -374,6 +374,70 @@ describe('TrusteeOtherInfoForm', () => {
     },
   );
 
+  test('disables Save when only an inactive bank is in state', async () => {
+    render(
+      <TrusteeOtherInfoForm
+        trusteeId={TEST_TRUSTEE_ID}
+        softwareId="sw-axos"
+        banks={['bank-inactive']}
+        softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
+      />,
+    );
+
+    // 'bank-inactive' is not in availableBanks, so Save must be disabled
+    expect(screen.getByTestId('button-submit-button')).toBeDisabled();
+  });
+
+  test('enables Save when user replaces an inactive bank selection with an active one', async () => {
+    render(
+      <TrusteeOtherInfoForm
+        trusteeId={TEST_TRUSTEE_ID}
+        softwareId="sw-axos"
+        banks={['bank-inactive']}
+        softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
+      />,
+    );
+
+    // Select an active bank from the dropdown
+    const expandButton = document.querySelector('#trustee-banks-0-expand') as HTMLButtonElement;
+    await userEvent.click(expandButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    const fifthThirdOption = document.querySelector(
+      '[data-value="bank-fifth-third"]',
+    ) as HTMLLIElement;
+    await userEvent.click(fifthThirdOption);
+
+    // Save button should now be enabled
+    await waitFor(() => {
+      expect(screen.getByTestId('button-submit-button')).not.toBeDisabled();
+    });
+  });
+
+  test('Save is enabled when an active associated bank is already assigned', async () => {
+    render(
+      <TrusteeOtherInfoForm
+        trusteeId={TEST_TRUSTEE_ID}
+        softwareId="sw-axos"
+        banks={['bank-fifth-third']}
+        softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
+      />,
+    );
+
+    // Active bank pre-populated — Save should be enabled immediately
+    await waitFor(() => {
+      const input = document.querySelector('#trustee-banks-0-combo-box-input') as HTMLInputElement;
+      expect(input).toHaveValue('Fifth Third Bank');
+      expect(screen.getByTestId('button-submit-button')).not.toBeDisabled();
+    });
+  });
+
   test('filters inactive banks from dropdown options', async () => {
     render(
       <TrusteeOtherInfoForm

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
@@ -5,7 +5,7 @@ import ComboBox, { ComboOption } from '@/lib/components/combobox/ComboBox';
 import Api2 from '@/lib/models/api2';
 import useCamsNavigator from '@/lib/hooks/UseCamsNavigator';
 import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 type TrusteeOtherInfoFormProps = {
@@ -89,8 +89,12 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
     navigate.navigateTo(`/trustees/${trusteeId}`);
   }
 
+  const activeBankIds = useMemo(
+    () => new Set(availableBanks.map((opt) => opt.value)),
+    [availableBanks],
+  );
   const bankDisabled = !softwareId;
-  const hasBankSelected = banks.some((b) => availableBanks.some((opt) => opt.value === b));
+  const hasBankSelected = banks.some((b) => activeBankIds.has(b));
   const saveDisabled = isSubmitting || !softwareId || !hasBankSelected;
 
   return (

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
@@ -90,7 +90,7 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
   }
 
   const bankDisabled = !softwareId;
-  const hasBankSelected = banks.some((b) => b.trim() !== '');
+  const hasBankSelected = banks.some((b) => availableBanks.some((opt) => opt.value === b));
   const saveDisabled = isSubmitting || !softwareId || !hasBankSelected;
 
   return (


### PR DESCRIPTION
# Bug

When a bank assigned to a trustee is later inactivated, the trustee profile's Software and Bank edit form shows the bank field blank (inactive banks are filtered from the dropdown), yet the Save button remains enabled and the backend accepts the stale bank id. Bank is a required field and must not be saveable while blank/inactive.

# Purpose

Enforce that only active, associated banks are accepted on the trustee interactive update path — both at the API layer and at the form layer — so an inactivated bank can never be persisted through the UI.

# Major Changes

- **Backend (`trustees.ts`):** `loadAndValidateSoftware` now builds `validBankIds` from active-only associations (`status === 'active'`), causing any inactive or unassociated bank id to be rejected with `BadRequestError`
- **Frontend (`TrusteeOtherInfoForm.tsx`):** `hasBankSelected` guard now validates bank state against the active-only `availableBanks` list rather than any non-empty string, keeping Save disabled when only a stale inactive bank id lingers in form state

Migration/import write paths are intentionally out of scope.

# Testing/Validation

Implemented using TDD. Tests written first (RED), minimal production change applied (GREEN), then refined via adversarial two-turn review (REFACTOR).

- Backend: 5 new unit tests covering inactive bank rejection, unassociated bank rejection, active bank acceptance, multiple-invalid-bank error message content, and clearing software+banks together
- Frontend: 3 new unit tests covering Save disabled with inactive bank in state, Save enabled after selecting an active bank, and regression guard for active bank already assigned
- Full test suite: 3220 passed, 3 skipped (226 test files)
- Backend coverage: 95.72% statements, 91.25% branches

# Notes

The backend change is a one-line filter addition inside `loadAndValidateSoftware` — the early-exit path (clearing both software and banks together) is unaffected. The frontend change is a single-line guard replacement — submit-time `filteredBanks` filtering is left as-is since it handles multi-bank edge cases independently.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enforce that trustee updates only accept active, associated banks and ensure the trustee form UI reflects this constraint so inactive or stale bank selections cannot be saved.

Bug Fixes:
- Prevent inactive or unassociated banks from being persisted on trustee updates by validating bank IDs against active software-associated banks.
- Keep the trustee Software and Bank form Save button disabled when only inactive or unavailable banks are present in form state, avoiding submission with a blank or stale bank selection.

Tests:
- Add backend unit tests covering clearing software and banks together, rejecting inactive or unassociated banks, error messaging for multiple invalid bank IDs, and accepting valid active banks.
- Add frontend tests to verify Save is disabled with only inactive banks, becomes enabled after selecting an active bank, and remains enabled when an active associated bank is already assigned.