### PR TITLE
CAMS-768: Make email sender domain configurable

### DIFF
--- a/ops/cloud-deployment/lib/email/acs-email.bicep
+++ b/ops/cloud-deployment/lib/email/acs-email.bicep
@@ -11,6 +11,9 @@ param kvAppConfigResourceGroupName string = resourceGroup().name
 
 param tags object = {}
 
+@description('Custom domain FQDN (e.g. notifications.example.gov). Leave empty to use Azure-managed domain.')
+param customDomain string = ''
+
 var emailServiceName = '${stackName}-email'
 var communicationServiceName = '${stackName}-comms'
 
@@ -20,6 +23,7 @@ module emailService 'email-communication-services.bicep' = {
     emailServiceName: emailServiceName
     location: location
     tags: tags
+    customDomain: customDomain
   }
 }
 

--- a/ops/cloud-deployment/lib/email/email-communication-services.bicep
+++ b/ops/cloud-deployment/lib/email/email-communication-services.bicep
@@ -11,6 +11,9 @@ param dataLocation string = 'usgov'
 
 param tags object = {}
 
+@description('Custom domain FQDN (e.g. notifications.example.gov). Leave empty to use Azure-managed domain.')
+param customDomain string = ''
+
 resource emailService 'Microsoft.Communication/emailServices@2023-04-01' = {
   name: emailServiceName
   location: location
@@ -20,7 +23,7 @@ resource emailService 'Microsoft.Communication/emailServices@2023-04-01' = {
   }
 }
 
-resource azureManagedDomain 'Microsoft.Communication/emailServices/domains@2023-04-01' = {
+resource azureManagedDomain 'Microsoft.Communication/emailServices/domains@2023-04-01' = if (empty(customDomain)) {
   parent: emailService
   name: 'AzureManagedDomain'
   location: location
@@ -30,6 +33,16 @@ resource azureManagedDomain 'Microsoft.Communication/emailServices/domains@2023-
   }
 }
 
+resource customerManagedDomain 'Microsoft.Communication/emailServices/domains@2023-04-01' = if (!empty(customDomain)) {
+  parent: emailService
+  name: !empty(customDomain) ? customDomain : 'placeholder'
+  location: location
+  properties: {
+    domainManagement: 'CustomerManaged'
+    userEngagementTracking: 'Disabled'
+  }
+}
+
 output emailServiceId string = emailService.id
-output domainResourceId string = azureManagedDomain.id
-output senderAddress string = 'DoNotReply@${azureManagedDomain.properties.mailFromSenderDomain}'
+output domainResourceId string = empty(customDomain) ? azureManagedDomain.id : customerManagedDomain.id
+output senderAddress string = empty(customDomain) ? 'DoNotReply@${azureManagedDomain.properties.mailFromSenderDomain}' : 'DoNotReply@${customDomain}'

--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -125,6 +125,9 @@ param e2eSqlDatabaseName string = 'CAMS_E2E'
 @description('Comma delimited list of data flow names to enable.')
 param enabledDataflows string = ''
 
+@description('Custom domain FQDN for sending email. Leave empty to use Azure-managed subdomain.')
+param customDomain string = ''
+
 @description('Name of the blob container used for migration and operational artifacts.')
 param objectContainerName string = 'migration-files'
 
@@ -242,6 +245,7 @@ module acsEmail './lib/email/acs-email.bicep' = {
     stackName: stackName
     kvAppConfigName: kvAppConfigName
     kvAppConfigResourceGroupName: kvAppConfigResourceGroupName
+    customDomain: customDomain
     tags: {
       app: 'cams'
       component: 'email'

--- a/ops/scripts/pipeline/azure-deploy.sh
+++ b/ops/scripts/pipeline/azure-deploy.sh
@@ -21,7 +21,7 @@ requiredUSTPParams=("--enabledDataflows" "--mssqlRequestTimeout" "--isUstpDeploy
 requiredFlexionParams=("--enabledDataflows" "--mssqlRequestTimeout" "--resource-group" "--file" "--stackName" "--slotName" "--gitSha" "--networkResourceGroupName" "--kvAppConfigName" "--kvAppConfigResourceGroupName" "--virtualNetworkName" "--analyticsResourceGroupName" "--idKeyvaultAppConfiguration" "--cosmosDatabaseName" "--deployVnet" "--ustpIssueCollectorHash" "--createAlerts" "--deployAppInsights" "--loginProvider" "--loginProviderConfig" "--sqlServerName" "--sqlServerResourceGroupName" "--sqlServerIdentityName" "--actionGroupName" "--oktaUrl" "--e2eDatabaseName" "--e2eSqlDatabaseName")
 
 # shellcheck disable=SC2034 # REASON: to have a reference for all possible parameters
-allParams=("--enabledDataflows" "--mssqlRequestTimeout" "--isUstpDeployment" "--resource-group" "--file" "--stackName" "--slotName" "--gitSha" "--networkResourceGroupName" "--virtualNetworkName" "--analyticsWorkspaceId" "--idKeyvaultAppConfiguration" "--kvAppConfigName" "--cosmosDatabaseName" "--deployVnet" "--ustpIssueCollectorHash" "--createAlerts" "--deployAppInsights" "--apiFunctionPlanName" "--dataflowsFunctionPlanName" "--webappPlanType" "--loginProvider" "--loginProviderConfig" "--sqlServerName" "--sqlServerResourceGroupName" "--sqlServerIdentityResourceGroupName" "--sqlServerIdentityName"  "--actionGroupName" "--oktaUrl" "--location" "--webappSubnetName" "--apiFunctionSubnetName" "--privateEndpointSubnetName" "--webappSubnetAddressPrefix" "--apiFunctionSubnetAddressPrefix" "--dataflowsSubnetName" "--dataflowsSubnetAddressPrefix" "--vnetAddressPrefix" "--linkVnetIds" "--privateDnsZoneName" "--privateDnsZoneResourceGroup" "--privateDnsZoneSubscriptionId" "--analyticsResourceGroupName" "--kvAppConfigResourceGroupName" "--deployDns" "--e2eDatabaseName" "--e2eSqlDatabaseName")
+allParams=("--enabledDataflows" "--mssqlRequestTimeout" "--isUstpDeployment" "--resource-group" "--file" "--stackName" "--slotName" "--gitSha" "--networkResourceGroupName" "--virtualNetworkName" "--analyticsWorkspaceId" "--idKeyvaultAppConfiguration" "--kvAppConfigName" "--cosmosDatabaseName" "--deployVnet" "--ustpIssueCollectorHash" "--createAlerts" "--deployAppInsights" "--apiFunctionPlanName" "--dataflowsFunctionPlanName" "--webappPlanType" "--loginProvider" "--loginProviderConfig" "--sqlServerName" "--sqlServerResourceGroupName" "--sqlServerIdentityResourceGroupName" "--sqlServerIdentityName"  "--actionGroupName" "--oktaUrl" "--location" "--webappSubnetName" "--apiFunctionSubnetName" "--privateEndpointSubnetName" "--webappSubnetAddressPrefix" "--apiFunctionSubnetAddressPrefix" "--dataflowsSubnetName" "--dataflowsSubnetAddressPrefix" "--vnetAddressPrefix" "--linkVnetIds" "--privateDnsZoneName" "--privateDnsZoneResourceGroup" "--privateDnsZoneSubscriptionId" "--analyticsResourceGroupName" "--kvAppConfigResourceGroupName" "--deployDns" "--e2eDatabaseName" "--e2eSqlDatabaseName" "--customDomain")
 
 
 function az_vnet_exists_func() {
@@ -372,6 +372,13 @@ while [[ $# -gt 0 ]]; do
         inputParams+=("${1}")
         e2eSqlDatabaseName="e2eSqlDatabaseName=${2}"
         deployment_parameters="${deployment_parameters} ${e2eSqlDatabaseName}"
+        shift 2
+        ;;
+
+    --customDomain)
+        inputParams+=("${1}")
+        custom_domain_param="customDomain=${2}"
+        deployment_parameters="${deployment_parameters} ${custom_domain_param}"
         shift 2
         ;;
 


### PR DESCRIPTION
# Purpose

Production must send email from the client's own domain rather than an Azure-managed subdomain. This change makes the email sender domain configurable per environment so that staging continues using the Azure-managed domain while production can be configured to use a custom domain.

Part of CAMS-768.

# Major Changes

- `ops/cloud-deployment/lib/email/email-communication-services.bicep` — adds optional `customDomain string = ''` parameter; when empty the existing `AzureManaged` domain resource deploys unchanged; when set to a FQDN a `CustomerManaged` domain resource is provisioned instead and outputs are wired accordingly
- `ops/cloud-deployment/lib/email/acs-email.bicep` — threads `customDomain` param through to the child module
- `ops/cloud-deployment/main.bicep` — adds `customDomain` param (default empty) and passes it to the `acsEmail` module
- `ops/scripts/pipeline/azure-deploy.sh` — adds `--customDomain` to `allParams` and the arg parser case block (optional, not added to required arrays)

Note: the ADO pipeline template change (`deploy-main-bicep.yaml`) that passes `ACS_EMAIL_CUSTOM_DOMAIN` from the variable group is a separate PR in the `.ado-mirror` repo.

# Testing/Validation

- [ ] Run `az deployment group what-if` with `customDomain=''` — confirm no change to existing `AzureManagedDomain` resource
- [ ] Run `az deployment group what-if` with `customDomain='notifications.example.gov'` — confirm a `CustomerManaged` domain resource is planned and `AzureManagedDomain` is not
- [ ] Confirm `ACS-EMAIL-SENDER-ADDRESS` Key Vault secret reflects `DoNotReply@notifications.example.gov` when custom domain is set
- [ ] Confirm existing staging deployment succeeds with no `customDomain` parameter passed

# Notes

When production is ready to use a custom domain:
1. Add `ACS_EMAIL_CUSTOM_DOMAIN` (empty) to `CAMS-STG` variable group
2. Add `ACS_EMAIL_CUSTOM_DOMAIN` (subdomain FQDN) to `CAMS-PRD` variable group
3. After first deployment, retrieve the generated TXT and CNAME DNS records from Azure and provide to the DNS admin
4. Once DNS records are in place, trigger domain verification via `az communication email domain initiate-verification`

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application