### PR TITLE
CAMS-794 Fix null address2 in ATS trustee import

### DIFF
--- a/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.test.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.test.ts
@@ -298,6 +298,23 @@ describe('ATS Mappings', () => {
       });
     });
 
+    test('should normalize a null STREET1 (SQL NULL) to undefined address2', () => {
+      const atsTrustee: AtsTrusteeRecord = {
+        ID: 123,
+        FIRST_NAME: 'John',
+        LAST_NAME: 'Doe',
+        STREET: '123 Main St',
+        STREET1: null as unknown as string,
+        CITY: 'New York',
+        STATE: 'NY',
+        ZIP: '10001',
+      };
+
+      const result = transformTrusteeRecord(atsTrustee);
+
+      expect(result.public.address.address2).toBeUndefined();
+    });
+
     test('should handle minimal trustee record', () => {
       const atsTrustee: AtsTrusteeRecord = {
         ID: 456,
@@ -490,6 +507,24 @@ describe('ATS Mappings', () => {
 
       expect(result.internal).toBeDefined();
       expect(result.internal?.address.address2).toBe('Suite 200');
+    });
+
+    test('should normalize a null STREET1_A2 (SQL NULL) to undefined internal address2', () => {
+      const atsTrustee: AtsTrusteeRecord = {
+        ID: 123,
+        FIRST_NAME: 'John',
+        LAST_NAME: 'Doe',
+        STREET_A2: '456 Internal St',
+        STREET1_A2: null as unknown as string,
+        CITY_A2: 'Albany',
+        STATE_A2: 'NY',
+        ZIP_A2: '12207',
+      };
+
+      const result = transformTrusteeRecord(atsTrustee);
+
+      expect(result.internal).toBeDefined();
+      expect(result.internal?.address.address2).toBeUndefined();
     });
 
     test('should add internal contact with ZIP+4', () => {

--- a/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.ts
@@ -270,7 +270,7 @@ export function transformTrusteeRecord(
   const publicContact: ContactInformation = {
     address: {
       address1: primaryStreet || '',
-      address2: primaryStreet1,
+      address2: primaryStreet1 || undefined,
       city: primaryCity || '',
       state: primaryState || '',
       zipCode: formatZipCode(primaryZip, primaryZipPlus) || '',
@@ -311,7 +311,7 @@ export function transformTrusteeRecord(
     const internalContact: ContactInformation = {
       address: {
         address1: secondaryStreet || '',
-        address2: secondaryStreet1,
+        address2: secondaryStreet1 || undefined,
         city: secondaryCity || '',
         state: secondaryState || '',
         zipCode: formatZipCode(secondaryZip, secondaryZipPlus) || '',


### PR DESCRIPTION
# Problem

Staging trustee records show "Value is null" and refuse to submit when editing a trustee whose Address Line 2 is blank. Root cause: the ATS-to-CAMS migration mapped `STREET1`/`STREET1_A2` directly to `address2` with no null-coalescing, unlike the sibling `address1`/`city`/`state`/`zipCode` fields on the same object. SQL `NULL` columns surface as JS `null` via the `mssql` driver, so any trustee imported with no secondary address line got `address2` persisted as literal `null` instead of being omitted.

# Solution

`transformTrusteeRecord` in `ats-mappings.ts` now normalizes `STREET1`/`STREET1_A2` with the same `|| undefined` fallback pattern already used by `address1`/`city`/`state`/`zipCode`, for both the public and internal contact address blocks. This stops the ATS import pipeline from writing `null` into `address2` on future migrations.

# Testing/Validation

Implemented using TDD. Added two regression tests simulating a SQL `NULL` `STREET1`/`STREET1_A2` (`null as unknown as string`) and asserting `address2` resolves to `undefined`, not `null`. Confirmed red without the fix (assertions failed with "expected null to be undefined"), green with it. Full validation suite passed: lint, typecheck (backend/common/root), all unit tests across common/backend/user-interface workspaces (3128+ backend tests), backend coverage, npm audit (no high/critical), knip.

# Other Changes

This fix only prevents new `null` values on future ATS re-imports — it does not backfill existing `null` address2/address3/companyName values already in staging/prod data. Per team decision, staging will be re-migrated cleanly rather than backfilled, so no data-migration script is included in this PR.

A companion fix on a separate branch (`fix-cams-794-address-line-2-required`) makes the shared validators (`common/src/cams/trustees-validators.ts`) tolerate `null` for `address2`/`address3`/`companyName`, so records with pre-existing `null` values remain editable in the meantime — that PR is being tracked separately.

`address3` has no source column in the ATS trustee table today, so it isn't affected by this import path; `companyName` was already guarded correctly (`if (atsTrustee.COMPANY) {...}`).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application