### PR TITLE
CAMS-746 Add projection to trustee verification list response

### DIFF
--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.test.ts
@@ -6,6 +6,7 @@ import { createMockApplicationContext } from '../../../testing/testing-utilities
 import { MongoCollectionAdapter } from './utils/mongo-adapter';
 import { closeDeferred } from '../../../deferrable/defer-close';
 import { NotFoundError } from '../../../common-errors/not-found-error';
+import QueryBuilder from '../../../query/query-builder';
 
 describe('TrusteeMatchVerificationMongoRepository', () => {
   let context: ApplicationContext;
@@ -44,14 +45,15 @@ describe('TrusteeMatchVerificationMongoRepository', () => {
   };
 
   beforeEach(async () => {
-    process.env.MONGO_CONNECTION_STRING = 'mongodb://localhost:27017';
+    vi.restoreAllMocks();
+    vi.stubEnv('MONGO_CONNECTION_STRING', 'mongodb://localhost:27017');
     context = await createMockApplicationContext();
     repository = new TrusteeMatchVerificationMongoRepository(context);
   });
 
   afterEach(async () => {
     await closeDeferred(context);
-    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     repository.release();
   });
 
@@ -196,7 +198,23 @@ describe('TrusteeMatchVerificationMongoRepository', () => {
         undefined,
         expect.objectContaining({
           mode: 'INCLUDE',
-          fields: expect.arrayContaining(['id', 'caseId', 'status', 'taskDate']),
+          fields: expect.arrayContaining([
+            'id',
+            'documentType',
+            'caseId',
+            'courtId',
+            'courtName',
+            'dxtrTrustee',
+            'mismatchReason',
+            'matchCandidates',
+            'status',
+            'resolvedTrusteeId',
+            'resolvedTrusteeName',
+            'taskType',
+            'taskDate',
+            'reason',
+            'inactiveAppointmentStatus',
+          ]),
         }),
       );
     });
@@ -237,6 +255,101 @@ describe('TrusteeMatchVerificationMongoRepository', () => {
       await expect(repository.upsertVerification(sampleVerification)).rejects.toThrow(
         'Failed to upsert trustee match verification for case case-001.',
       );
+    });
+  });
+
+  describe('findVerificationsMissingTaskDate', () => {
+    test('should call find with documentType and taskDate notExists conditions, no lastId', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([sampleVerification]);
+
+      const result = await repository.findVerificationsMissingTaskDate(null, 10);
+
+      expect(result).toEqual([sampleVerification]);
+      expect(MongoCollectionAdapter.prototype.find).toHaveBeenCalledWith(
+        expect.objectContaining({ conjunction: 'AND' }),
+        expect.objectContaining({
+          fields: expect.arrayContaining([expect.objectContaining({ direction: 'ASCENDING' })]),
+        }),
+        10,
+      );
+    });
+
+    test('should include _id greaterThan condition when lastId is provided', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([]);
+
+      await repository.findVerificationsMissingTaskDate('last-mongo-id', 5);
+
+      const callArg = (MongoCollectionAdapter.prototype.find as ReturnType<typeof vi.spyOn>).mock
+        .calls[0][0];
+      const queryStr = JSON.stringify(callArg);
+      expect(queryStr).toContain('last-mongo-id');
+    });
+
+    test('should wrap errors', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockRejectedValue(
+        new Error('Database failure'),
+      );
+
+      await expect(repository.findVerificationsMissingTaskDate(null, 10)).rejects.toThrow(
+        'Failed to find trustee match verifications missing taskDate.',
+      );
+    });
+  });
+
+  describe('updateVerificationTaskDate', () => {
+    test('should call updateOne with _id query and taskDate update', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'updateOne').mockResolvedValue(undefined);
+
+      await repository.updateVerificationTaskDate('mongo-id-123', '2025-06-01T00:00:00.000Z');
+
+      expect(MongoCollectionAdapter.prototype.updateOne).toHaveBeenCalledWith(
+        expect.objectContaining({ condition: 'EQUALS' }),
+        expect.objectContaining({ taskDate: '2025-06-01T00:00:00.000Z' }),
+      );
+    });
+
+    test('should wrap errors', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'updateOne').mockRejectedValue(
+        new Error('Update failed'),
+      );
+
+      await expect(
+        repository.updateVerificationTaskDate('mongo-id-123', '2025-06-01T00:00:00.000Z'),
+      ).rejects.toThrow('Failed to update taskDate on trustee match verification mongo-id-123.');
+    });
+  });
+
+  describe('updateManyByQuery', () => {
+    test('should call updateMany and return the result', async () => {
+      const updateResult = { modifiedCount: 3, upsertedCount: 0, matchedCount: 3 };
+      vi.spyOn(MongoCollectionAdapter.prototype, 'updateMany').mockResolvedValue(updateResult);
+
+      const { using, and } = QueryBuilder;
+      const doc = using<TrusteeMatchVerification>();
+      const query = and(doc('status').equals('pending'));
+
+      const result = await repository.updateManyByQuery(query, {
+        taskDate: '2025-06-01T00:00:00.000Z',
+      });
+
+      expect(result).toEqual(updateResult);
+      expect(MongoCollectionAdapter.prototype.updateMany).toHaveBeenCalledWith(query, {
+        taskDate: '2025-06-01T00:00:00.000Z',
+      });
+    });
+
+    test('should wrap errors', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'updateMany').mockRejectedValue(
+        new Error('Bulk update failed'),
+      );
+
+      const { using } = QueryBuilder;
+      const doc = using<TrusteeMatchVerification>();
+      const query = doc('status').equals('pending');
+
+      await expect(
+        repository.updateManyByQuery(query, { taskDate: '2025-06-01T00:00:00.000Z' }),
+      ).rejects.toThrow('Failed to bulk-update trustee match verification documents.');
     });
   });
 });

--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.test.ts
@@ -44,6 +44,7 @@ describe('TrusteeMatchVerificationMongoRepository', () => {
   };
 
   beforeEach(async () => {
+    process.env.MONGO_CONNECTION_STRING = 'mongodb://localhost:27017';
     context = await createMockApplicationContext();
     repository = new TrusteeMatchVerificationMongoRepository(context);
   });
@@ -179,7 +180,7 @@ describe('TrusteeMatchVerificationMongoRepository', () => {
   });
 
   describe('search', () => {
-    test('should return documents sorted by createdOn ascending', async () => {
+    test('should return documents sorted by taskDate ascending with projection', async () => {
       vi.spyOn(MongoCollectionAdapter.prototype, 'find').mockResolvedValue([sampleVerification]);
 
       const result = await repository.search({ status: ['pending'] });
@@ -189,8 +190,13 @@ describe('TrusteeMatchVerificationMongoRepository', () => {
         expect.objectContaining({ conjunction: 'AND' }),
         expect.objectContaining({
           fields: expect.arrayContaining([
-            expect.objectContaining({ field: { name: 'createdOn' }, direction: 'ASCENDING' }),
+            expect.objectContaining({ field: { name: 'taskDate' }, direction: 'ASCENDING' }),
           ]),
+        }),
+        undefined,
+        expect.objectContaining({
+          mode: 'INCLUDE',
+          fields: expect.arrayContaining(['id', 'caseId', 'status', 'taskDate']),
         }),
       );
     });

--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
@@ -103,7 +103,7 @@ export class TrusteeMatchVerificationMongoRepository
       // Projection excludes Auditable fields (createdOn, createdBy, updatedOn, updatedBy).
       // matchCandidates is included so the use-case can compute candidateCount and
       // preselectedCandidate; it is stripped from the response after mapping to TrusteeMatchVerificationListItem.
-      const projection = pick<TrusteeMatchVerification>(
+      const projection = pick<TrusteeMatchVerificationSearchResult>(
         'id',
         'documentType',
         'caseId',
@@ -125,7 +125,7 @@ export class TrusteeMatchVerificationMongoRepository
         orderBy<TrusteeMatchVerification>(['taskDate', 'ASCENDING']),
         undefined,
         projection,
-      )) as unknown as TrusteeMatchVerificationSearchResult[];
+      )) as TrusteeMatchVerificationSearchResult[];
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         message: 'Failed to find trustee match verification records.',

--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
@@ -11,6 +11,7 @@ import { OrderStatus } from '@common/cams/orders';
 import {
   TRUSTEE_MATCH_VERIFICATION_DOCUMENT_TYPE,
   TrusteeMatchVerification,
+  TrusteeMatchVerificationSearchResult,
 } from '@common/cams/trustee-match-verification';
 
 const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-MONGO-REPOSITORY';
@@ -88,7 +89,9 @@ export class TrusteeMatchVerificationMongoRepository
     }
   }
 
-  async search(predicate: { status?: OrderStatus[] }): Promise<TrusteeMatchVerification[]> {
+  async search(predicate: {
+    status?: OrderStatus[];
+  }): Promise<TrusteeMatchVerificationSearchResult[]> {
     try {
       const doc = using<TrusteeMatchVerification>();
       const conditions: ConditionOrConjunction<TrusteeMatchVerification>[] = [
@@ -97,9 +100,9 @@ export class TrusteeMatchVerificationMongoRepository
       if (predicate?.status?.length) {
         conditions.push(doc('status').contains(predicate.status));
       }
-      // Projection excludes Auditable fields (createdOn, createdBy, updatedOn, updatedBy)
-      // and matchCandidates — the use-case computes derived list fields from candidates
-      // before dropping the array from the response.
+      // Projection excludes Auditable fields (createdOn, createdBy, updatedOn, updatedBy).
+      // matchCandidates is included so the use-case can compute candidateCount and
+      // preselectedCandidate; it is stripped from the response after mapping to TrusteeMatchVerificationListItem.
       const projection = pick<TrusteeMatchVerification>(
         'id',
         'documentType',
@@ -117,12 +120,12 @@ export class TrusteeMatchVerificationMongoRepository
         'reason',
         'inactiveAppointmentStatus',
       );
-      return await this.getAdapter<TrusteeMatchVerification>().find(
+      return (await this.getAdapter<TrusteeMatchVerification>().find(
         and(...conditions),
         orderBy<TrusteeMatchVerification>(['taskDate', 'ASCENDING']),
         undefined,
         projection,
-      );
+      )) as unknown as TrusteeMatchVerificationSearchResult[];
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         message: 'Failed to find trustee match verification records.',

--- a/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-match-verification.mongo.repository.ts
@@ -16,7 +16,7 @@ import {
 const MODULE_NAME = 'TRUSTEE-MATCH-VERIFICATION-MONGO-REPOSITORY';
 const COLLECTION_NAME = 'trustee-match-verification';
 
-const { using, and, orderBy } = QueryBuilder;
+const { using, and, orderBy, pick } = QueryBuilder;
 
 export class TrusteeMatchVerificationMongoRepository
   extends BaseMongoRepository
@@ -89,7 +89,6 @@ export class TrusteeMatchVerificationMongoRepository
   }
 
   async search(predicate: { status?: OrderStatus[] }): Promise<TrusteeMatchVerification[]> {
-    const { orderBy } = QueryBuilder;
     try {
       const doc = using<TrusteeMatchVerification>();
       const conditions: ConditionOrConjunction<TrusteeMatchVerification>[] = [
@@ -98,11 +97,32 @@ export class TrusteeMatchVerificationMongoRepository
       if (predicate?.status?.length) {
         conditions.push(doc('status').contains(predicate.status));
       }
-      const results = await this.getAdapter<TrusteeMatchVerification>().find(
-        and(...conditions),
-        orderBy<TrusteeMatchVerification>(['createdOn', 'ASCENDING']),
+      // Projection excludes Auditable fields (createdOn, createdBy, updatedOn, updatedBy)
+      // and matchCandidates — the use-case computes derived list fields from candidates
+      // before dropping the array from the response.
+      const projection = pick<TrusteeMatchVerification>(
+        'id',
+        'documentType',
+        'caseId',
+        'courtId',
+        'courtName',
+        'dxtrTrustee',
+        'mismatchReason',
+        'matchCandidates',
+        'status',
+        'resolvedTrusteeId',
+        'resolvedTrusteeName',
+        'taskType',
+        'taskDate',
+        'reason',
+        'inactiveAppointmentStatus',
       );
-      return results;
+      return await this.getAdapter<TrusteeMatchVerification>().find(
+        and(...conditions),
+        orderBy<TrusteeMatchVerification>(['taskDate', 'ASCENDING']),
+        undefined,
+        projection,
+      );
     } catch (originalError) {
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         message: 'Failed to find trustee match verification records.',

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-adapter.ts
@@ -7,7 +7,12 @@ import { UnknownError } from '../../../../common-errors/unknown-error';
 import { GatewayTimeoutError } from '../../../../common-errors/gateway-timeout';
 import { TooManyRequestsError } from '../../../../common-errors/too-many-requests-error';
 import { CollectionHumble, DocumentClient } from '../../../../humble-objects/mongo-humble';
-import { ConditionOrConjunction, Query, SortSpec } from '../../../../query/query-builder';
+import {
+  ConditionOrConjunction,
+  Projection,
+  Query,
+  SortSpec,
+} from '../../../../query/query-builder';
 import QueryPipeline, { isPaginate, isPipeline, Pipeline } from '../../../../query/query-pipeline';
 import {
   BulkReplaceResult,
@@ -17,7 +22,7 @@ import {
   UpdateResult,
 } from '../../../../use-cases/gateways.types';
 import MongoAggregateRenderer from './mongo-aggregate-renderer';
-import { toMongoQuery, toMongoSort } from './mongo-query-renderer';
+import { toMongoProjection, toMongoQuery, toMongoSort } from './mongo-query-renderer';
 import { randomUUID } from 'crypto';
 import { Document as MongoDocument, MongoServerError } from 'mongodb';
 
@@ -86,13 +91,19 @@ export class MongoCollectionAdapter<T> implements DocumentCollectionAdapter<T> {
     };
   }
 
-  public async find(query: Query<T>, sort?: SortSpec, limit?: number): Promise<T[]> {
+  public async find(
+    query: Query<T>,
+    sort?: SortSpec,
+    limit?: number,
+    projection?: Projection<T>,
+  ): Promise<T[]> {
     const mongoQuery = toMongoQuery<T>(query);
     const mongoSort = sort ? toMongoSort(sort) : undefined;
+    const mongoProjection = projection ? toMongoProjection(projection) : undefined;
     try {
       const items: T[] = [];
 
-      let cursor = await this.collectionHumble.find(mongoQuery);
+      let cursor = await this.collectionHumble.find(mongoQuery, mongoProjection);
       if (mongoSort) {
         cursor = cursor.sort(mongoSort);
       }

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-query-renderer.test.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-query-renderer.test.ts
@@ -200,16 +200,16 @@ describe('Mongo Query Renderer', () => {
   });
 
   describe('toMongoProjection', () => {
-    test('pick renders INCLUDE projection as field: 1 map', () => {
-      expect(toMongoProjection(pick<Foo>('uno', 'two'))).toEqual({ uno: 1, two: 1 });
+    test('pick renders INCLUDE projection as field: 1 map with _id suppressed', () => {
+      expect(toMongoProjection(pick<Foo>('uno', 'two'))).toEqual({ uno: 1, two: 1, _id: 0 });
     });
 
     test('omit renders EXCLUDE projection as field: 0 map', () => {
       expect(toMongoProjection(omit<Foo>('three'))).toEqual({ three: 0 });
     });
 
-    test('pick with single field', () => {
-      expect(toMongoProjection(pick<Foo>('uno'))).toEqual({ uno: 1 });
+    test('pick with single field suppresses _id', () => {
+      expect(toMongoProjection(pick<Foo>('uno'))).toEqual({ uno: 1, _id: 0 });
     });
 
     test('omit with multiple fields', () => {

--- a/backend/lib/adapters/gateways/mongo/utils/mongo-query-renderer.ts
+++ b/backend/lib/adapters/gateways/mongo/utils/mongo-query-renderer.ts
@@ -91,6 +91,9 @@ export function toMongoProjection<T = never>(projection: Projection<T>): Record<
   projection.fields.forEach((field) => {
     result[field as string] = value;
   });
+  if (projection.mode === 'INCLUDE' && !('_id' in result)) {
+    result['_id'] = 0;
+  }
   return result;
 }
 

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
@@ -105,13 +105,14 @@ describe('TrusteeMatchVerificationController', () => {
   }
 
   beforeEach(async () => {
+    vi.restoreAllMocks();
     context = await createMockApplicationContext();
     context.featureFlags['trustee-verification-enabled'] = true;
     context.request.method = 'GET';
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    // intentionally empty — cleanup is in beforeEach
   });
 
   test('should return 404 when trustee-verification-enabled flag is off', async () => {
@@ -148,6 +149,7 @@ describe('TrusteeMatchVerificationController', () => {
       const controller = new TrusteeMatchVerificationController();
       const response = await controller.handleRequest(context);
 
+      expect(response.statusCode).toBe(200);
       expect(response.body.data).toEqual([]);
     });
 

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.test.ts
@@ -132,10 +132,13 @@ describe('TrusteeMatchVerificationController', () => {
       const response = await controller.handleRequest(context);
 
       expect(response.body.data).toHaveLength(1);
-      const candidate = response.body.data[0].matchCandidates[0];
-      expect(candidate.trusteeId).toBe('trustee-001');
-      expect(candidate.trusteeName).toBe('John Doe');
-      expect(candidate.appointments).toBeUndefined();
+      const item = response.body.data[0];
+      expect(item.candidateCount).toBe(1);
+      expect(item.preselectedCandidate).toEqual({
+        trusteeId: 'trustee-001',
+        trusteeName: 'John Doe',
+      });
+      expect(item.matchCandidates).toBeUndefined();
     });
 
     test('should return empty array when repository returns no documents', async () => {

--- a/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
+++ b/backend/lib/controllers/trustee-match-verification/trustee-match-verification.controller.ts
@@ -4,7 +4,10 @@ import { getCamsError } from '../../common-errors/error-utilities';
 import { BadRequestError } from '../../common-errors/bad-request';
 import { UnauthorizedError } from '../../common-errors/unauthorized-error';
 import { finalizeDeferrable } from '../../deferrable/finalize-deferrable';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationListItem,
+} from '@common/cams/trustee-match-verification';
 import { TrusteeMatchVerificationUseCase } from '../../use-cases/trustee-match-verification/trustee-match-verification.use-case';
 import HttpStatusCodes from '@common/api/http-status-codes';
 import { CamsRole } from '@common/cams/roles';
@@ -15,7 +18,7 @@ export class TrusteeMatchVerificationController {
   async handleRequest(
     context: ApplicationContext,
   ): Promise<
-    CamsHttpResponseInit<TrusteeMatchVerification | TrusteeMatchVerification[] | undefined>
+    CamsHttpResponseInit<TrusteeMatchVerification | TrusteeMatchVerificationListItem[] | undefined>
   > {
     if (!context.featureFlags['trustee-verification-enabled']) {
       return { statusCode: 404 };
@@ -41,7 +44,7 @@ export class TrusteeMatchVerificationController {
 
   private async getVerificationOrders(
     context: ApplicationContext,
-  ): Promise<CamsHttpResponseInit<TrusteeMatchVerification[]>> {
+  ): Promise<CamsHttpResponseInit<TrusteeMatchVerificationListItem[]>> {
     const useCase = new TrusteeMatchVerificationUseCase();
     const data = await useCase.getVerifications(context, {
       statusParam: context.request.query.status as string | undefined,

--- a/backend/lib/humble-objects/mongo-humble.ts
+++ b/backend/lib/humble-objects/mongo-humble.ts
@@ -8,27 +8,29 @@ export class CollectionHumble<T> {
     this.collection = database.collection<T>(collectionName);
   }
 
-  public async find(query: DocumentQuery) {
-    return this.collection.find(query);
+  public async find(query: DocumentQuery, projection?: Record<string, 0 | 1>) {
+    return this.collection.find(query, projection ? { projection } : undefined);
   }
 
   public async findOne<T>(query: DocumentQuery): Promise<T | null> {
     return this.collection.findOne<T>(query);
   }
 
-  public async insertOne(item) {
-    return this.collection.insertOne(item);
+  public async insertOne(item: T) {
+    return this.collection.insertOne(item as Parameters<Collection<T>['insertOne']>[0]);
   }
 
-  public async insertMany(items) {
-    return this.collection.insertMany(items);
+  public async insertMany(items: T[]) {
+    return this.collection.insertMany(items as Parameters<Collection<T>['insertMany']>[0]);
   }
 
-  public async replaceOne(query: DocumentQuery, item, upsert: boolean = false) {
-    return this.collection.replaceOne(query, item, { upsert });
+  public async replaceOne(query: DocumentQuery, item: T, upsert: boolean = false) {
+    return this.collection.replaceOne(query, item as Parameters<Collection<T>['replaceOne']>[1], {
+      upsert,
+    });
   }
 
-  public async updateOne(query: DocumentQuery, item) {
+  public async updateOne(query: DocumentQuery, item: Partial<T>) {
     return this.collection.updateOne(query, { $set: item });
   }
 
@@ -79,7 +81,7 @@ export class CollectionHumble<T> {
     return this.collection.aggregate(queryArray);
   }
 
-  public async bulkWrite(operations) {
+  public async bulkWrite(operations: Parameters<Collection<T>['bulkWrite']>[0]) {
     return this.collection.bulkWrite(operations);
   }
 }

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -56,7 +56,10 @@ import {
   TrusteeAppointmentInput,
   TrusteeCaseListItem,
 } from '@common/cams/trustee-appointments';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationSearchResult,
+} from '@common/cams/trustee-match-verification';
 import {
   TrusteeUpcomingKeyDates,
   TrusteeUpcomingKeyDatesHistory,
@@ -754,7 +757,7 @@ export interface TrusteeMatchVerificationRepository extends Releasable {
   getVerification(caseId: string): Promise<TrusteeMatchVerification | null>;
   findById(id: string): Promise<TrusteeMatchVerification>;
   upsertVerification(doc: TrusteeMatchVerification): Promise<void>;
-  search(predicate: { status?: OrderStatus[] }): Promise<TrusteeMatchVerification[]>;
+  search(predicate: { status?: OrderStatus[] }): Promise<TrusteeMatchVerificationSearchResult[]>;
   update(id: string, updates: Partial<TrusteeMatchVerification>): Promise<TrusteeMatchVerification>;
   findVerificationsMissingTaskDate(
     lastId: string | null,

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -35,7 +35,7 @@ import {
   TrusteeAppointmentDownstreamEvent,
 } from '@common/cams/dataflow-events';
 import { CamsSession } from '@common/cams/session';
-import { ConditionOrConjunction, Query, SortSpec } from '../query/query-builder';
+import { ConditionOrConjunction, Projection, Query, SortSpec } from '../query/query-builder';
 import { AcmsConsolidation, AcmsPredicate } from './dataflows/migrate-consolidations';
 import { Pipeline } from '../query/query-pipeline';
 import { ResourceActions } from '@common/cams/actions';
@@ -260,10 +260,10 @@ export interface AcmsGateway {
     context: ApplicationContext,
     leadCaseId: string,
   ): Promise<AcmsConsolidation>;
-  loadMigrationTable(context: ApplicationContext);
-  getMigrationCaseIds(context: ApplicationContext, start: number, end: number);
-  emptyMigrationTable(context: ApplicationContext);
-  getMigrationCaseCount(context: ApplicationContext);
+  loadMigrationTable(context: ApplicationContext): Promise<void>;
+  getMigrationCaseIds(context: ApplicationContext, start: number, end: number): Promise<string[]>;
+  emptyMigrationTable(context: ApplicationContext): Promise<void>;
+  getMigrationCaseCount(context: ApplicationContext): Promise<number>;
   getDeletedCaseIds(
     context: ApplicationContext,
     lastChangeDate: string,
@@ -670,7 +670,12 @@ export type ProfessionalIdCounterState = RuntimeState & {
 };
 
 export interface DocumentCollectionAdapter<T> {
-  find: (query: ConditionOrConjunction<T>, sort?: SortSpec) => Promise<T[]>;
+  find: (
+    query: ConditionOrConjunction<T>,
+    sort?: SortSpec,
+    limit?: number,
+    projection?: Projection<T>,
+  ) => Promise<T[]>;
   paginate: (pipelineOrQuery: Pipeline | Query) => Promise<CamsPaginationResponse<T>>;
   findOne: (query: ConditionOrConjunction<T>) => Promise<T>;
   getAll: (sort?: SortSpec) => Promise<T[]>;

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
@@ -3,7 +3,12 @@ import { getCamsError } from '../../common-errors/error-utilities';
 import { NotFoundError } from '../../common-errors/not-found-error';
 import factory from '../../factory';
 import { getCamsUserReference } from '@common/cams/session';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationListItem,
+  PreselectedCandidate,
+} from '@common/cams/trustee-match-verification';
+import { TrusteeAppointmentSyncErrorCode } from '@common/cams/dataflow-events';
 import { OrderStatus } from '@common/cams/orders';
 import { CourtsUseCase } from '../courts/courts';
 import { getCaseIdParts } from '@common/cams/cases';
@@ -20,7 +25,7 @@ export class TrusteeMatchVerificationUseCase {
   async getVerifications(
     context: ApplicationContext,
     params: VerificationListParams,
-  ): Promise<TrusteeMatchVerification[]> {
+  ): Promise<TrusteeMatchVerificationListItem[]> {
     try {
       const parsedStatuses = (params.statusParam ?? '')
         .split(',')
@@ -32,13 +37,30 @@ export class TrusteeMatchVerificationUseCase {
       const results = await repo.search({ status });
 
       const courts = await new CourtsUseCase().getCourts(context);
-      return results.map((verification) => ({
-        ...verification,
-        courtName: this.resolveCourtName(verification, courts) ?? verification.courtName,
-      }));
+      return results.map((verification) => {
+        const { matchCandidates, ...rest } = verification;
+        return {
+          ...rest,
+          courtName: this.resolveCourtName(verification, courts) ?? verification.courtName,
+          candidateCount: matchCandidates.length,
+          preselectedCandidate: this.resolvePreselectedCandidate(verification),
+        };
+      });
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME);
     }
+  }
+
+  private resolvePreselectedCandidate(
+    verification: TrusteeMatchVerification,
+  ): PreselectedCandidate | null {
+    if (verification.matchCandidates.length === 0) return null;
+    const isMultipleMatch =
+      verification.mismatchReason === TrusteeAppointmentSyncErrorCode.MultipleTrusteesMatch;
+    const best = isMultipleMatch
+      ? verification.matchCandidates.reduce((a, b) => (b.totalScore > a.totalScore ? b : a))
+      : verification.matchCandidates[0];
+    return { trusteeId: best.trusteeId, trusteeName: best.trusteeName };
   }
 
   private resolveCourtName(

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
@@ -6,7 +6,7 @@ import { getCamsUserReference } from '@common/cams/session';
 import {
   TrusteeMatchVerification,
   TrusteeMatchVerificationListItem,
-  PreselectedCandidate,
+  TrusteeMatchVerificationSearchResult,
 } from '@common/cams/trustee-match-verification';
 import { TrusteeAppointmentSyncErrorCode } from '@common/cams/dataflow-events';
 import { OrderStatus } from '@common/cams/orders';
@@ -52,8 +52,8 @@ export class TrusteeMatchVerificationUseCase {
   }
 
   private resolvePreselectedCandidate(
-    verification: TrusteeMatchVerification,
-  ): PreselectedCandidate | null {
+    verification: TrusteeMatchVerificationSearchResult,
+  ): { trusteeId: string; trusteeName: string } | null {
     if (verification.matchCandidates.length === 0) return null;
     const isMultipleMatch =
       verification.mismatchReason === TrusteeAppointmentSyncErrorCode.MultipleTrusteesMatch;
@@ -64,7 +64,7 @@ export class TrusteeMatchVerificationUseCase {
   }
 
   private resolveCourtName(
-    verification: TrusteeMatchVerification,
+    verification: TrusteeMatchVerificationSearchResult,
     courts: CourtDivisionDetails[],
   ): string | undefined {
     try {

--- a/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
+++ b/backend/lib/use-cases/trustee-match-verification/trustee-match-verification.use-case.ts
@@ -4,6 +4,7 @@ import { NotFoundError } from '../../common-errors/not-found-error';
 import factory from '../../factory';
 import { getCamsUserReference } from '@common/cams/session';
 import {
+  TrusteeCandidate,
   TrusteeMatchVerification,
   TrusteeMatchVerificationListItem,
   TrusteeMatchVerificationSearchResult,
@@ -53,7 +54,7 @@ export class TrusteeMatchVerificationUseCase {
 
   private resolvePreselectedCandidate(
     verification: TrusteeMatchVerificationSearchResult,
-  ): { trusteeId: string; trusteeName: string } | null {
+  ): TrusteeCandidate | null {
     if (verification.matchCandidates.length === 0) return null;
     const isMultipleMatch =
       verification.mismatchReason === TrusteeAppointmentSyncErrorCode.MultipleTrusteesMatch;

--- a/common/src/cams/data-verification.test.ts
+++ b/common/src/cams/data-verification.test.ts
@@ -122,13 +122,13 @@ describe('computeTaskDate', () => {
     expect(computeTaskDate(verification)).toBe('2025-03-20T00:00:00.000Z');
   });
 
-  test('should fallback to String(taskDate) for TrusteeMatchVerificationListItem', () => {
+  test('should fallback to toISOString() when taskDate is a Date on TrusteeMatchVerificationListItem', () => {
     const taskDate = new Date('2025-03-10T00:00:00.000Z');
     const verification: TrusteeMatchVerificationListItem = {
       ...baseVerification,
       taskDate,
     };
-    expect(computeTaskDate(verification)).toBe(String(taskDate));
+    expect(computeTaskDate(verification)).toBe(taskDate.toISOString());
   });
 
   test('should return taskDate as-is when it is already an ISO string on TrusteeMatchVerificationListItem', () => {

--- a/common/src/cams/data-verification.test.ts
+++ b/common/src/cams/data-verification.test.ts
@@ -106,7 +106,7 @@ describe('computeTaskDate', () => {
   });
 
   test('should fallback to updatedOn when createdOn is missing', () => {
-    const verification: Partial<TrusteeMatchVerification> = {
+    const verification: TrusteeMatchVerification = {
       id: 'test-id',
       documentType: 'TRUSTEE_MATCH_VERIFICATION',
       caseId: '00-00000',
@@ -119,9 +119,7 @@ describe('computeTaskDate', () => {
       updatedOn: '2025-03-20T00:00:00.000Z',
       updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
     };
-    expect(computeTaskDate(verification as TrusteeMatchVerification)).toBe(
-      '2025-03-20T00:00:00.000Z',
-    );
+    expect(computeTaskDate(verification)).toBe('2025-03-20T00:00:00.000Z');
   });
 
   test('should fallback to String(taskDate) for TrusteeMatchVerificationListItem', () => {
@@ -131,5 +129,14 @@ describe('computeTaskDate', () => {
       taskDate,
     };
     expect(computeTaskDate(verification)).toBe(String(taskDate));
+  });
+
+  test('should return taskDate as-is when it is already an ISO string on TrusteeMatchVerificationListItem', () => {
+    const isoString = '2025-04-20T12:00:00.000Z';
+    const verification: TrusteeMatchVerificationListItem = {
+      ...baseVerification,
+      taskDate: isoString,
+    };
+    expect(computeTaskDate(verification)).toBe(isoString);
   });
 });

--- a/common/src/cams/data-verification.test.ts
+++ b/common/src/cams/data-verification.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import MockData from './test-utilities/mock-data';
-import { TrusteeMatchVerification } from './trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationListItem,
+} from './trustee-match-verification';
 import {
   computeTaskDate,
   isConsolidationOrder,
@@ -12,7 +15,7 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
-const baseVerification: TrusteeMatchVerification = {
+const baseVerification: TrusteeMatchVerificationListItem = {
   id: 'test-id',
   documentType: 'TRUSTEE_MATCH_VERIFICATION',
   caseId: '00-00000',
@@ -20,11 +23,10 @@ const baseVerification: TrusteeMatchVerification = {
   dxtrTrustee: {
     fullName: 'Test Trustee',
   },
-  matchCandidates: [],
+  preselectedCandidate: null,
+  candidateCount: 0,
   status: 'pending',
   taskType: 'trustee-match',
-  updatedOn: '2025-03-15T00:00:00.000Z',
-  updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
   taskDate: new Date('2025-03-15T00:00:00.000Z'),
 };
 
@@ -87,19 +89,47 @@ describe('computeTaskDate', () => {
 
   test('should return createdOn for TrusteeMatchVerification when present', () => {
     const verification: TrusteeMatchVerification = {
-      ...baseVerification,
+      id: 'test-id',
+      documentType: 'TRUSTEE_MATCH_VERIFICATION',
+      caseId: '00-00000',
+      courtId: 'test-court',
+      dxtrTrustee: { fullName: 'Test Trustee' },
+      matchCandidates: [],
+      status: 'pending',
+      taskType: 'trustee-match',
+      taskDate: '2025-03-01T00:00:00.000Z',
       createdOn: '2025-03-10T00:00:00.000Z',
       updatedOn: '2025-03-15T00:00:00.000Z',
+      updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
     };
     expect(computeTaskDate(verification)).toBe('2025-03-10T00:00:00.000Z');
   });
 
   test('should fallback to updatedOn when createdOn is missing', () => {
-    const verification: TrusteeMatchVerification = {
-      ...baseVerification,
-      createdOn: undefined,
+    const verification: Partial<TrusteeMatchVerification> = {
+      id: 'test-id',
+      documentType: 'TRUSTEE_MATCH_VERIFICATION',
+      caseId: '00-00000',
+      courtId: 'test-court',
+      dxtrTrustee: { fullName: 'Test Trustee' },
+      matchCandidates: [],
+      status: 'pending',
+      taskType: 'trustee-match',
+      taskDate: '2025-03-01T00:00:00.000Z',
       updatedOn: '2025-03-20T00:00:00.000Z',
+      updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
     };
-    expect(computeTaskDate(verification)).toBe('2025-03-20T00:00:00.000Z');
+    expect(computeTaskDate(verification as TrusteeMatchVerification)).toBe(
+      '2025-03-20T00:00:00.000Z',
+    );
+  });
+
+  test('should fallback to String(taskDate) for TrusteeMatchVerificationListItem', () => {
+    const taskDate = new Date('2025-03-10T00:00:00.000Z');
+    const verification: TrusteeMatchVerificationListItem = {
+      ...baseVerification,
+      taskDate,
+    };
+    expect(computeTaskDate(verification)).toBe(String(taskDate));
   });
 });

--- a/common/src/cams/data-verification.ts
+++ b/common/src/cams/data-verification.ts
@@ -4,13 +4,8 @@ import {
   TrusteeMatchVerificationListItem,
 } from './trustee-match-verification';
 
-type DataVerificationItem = Order | TrusteeMatchVerificationListItem;
+export type DataVerificationItem = Order | TrusteeMatchVerificationListItem;
 export type DataVerificationItemType = DataVerificationItem['taskType'];
-
-// Backfill dataflows pass the full TrusteeMatchVerification (which has Auditable fields);
-// UI type guards and display code pass TrusteeMatchVerificationListItem.
-type AnyTrusteeVerification = TrusteeMatchVerification | TrusteeMatchVerificationListItem;
-type DataVerificationItemOrFull = Order | AnyTrusteeVerification;
 
 export function isTransferOrder(item: DataVerificationItem): item is TransferOrder {
   return item.taskType === 'transfer';
@@ -26,10 +21,15 @@ export function isTrusteeMatchVerification(
   return item.taskType === 'trustee-match';
 }
 
-export function computeTaskDate(item: DataVerificationItemOrFull): string {
+// Accepts both the list item (UI/sort paths) and the full document (backfill path).
+// TrusteeMatchVerification is not structurally assignable to TrusteeMatchVerificationListItem
+// because the list item carries preselectedCandidate/candidateCount that the full type lacks,
+// so the union is explicit here.
+export function computeTaskDate(item: DataVerificationItem | TrusteeMatchVerification): string {
   if (item.taskType === 'trustee-match') {
-    const v = item as Partial<TrusteeMatchVerification>;
-    return v.createdOn ?? v.updatedOn ?? String(item.taskDate);
+    const createdOn = 'createdOn' in item ? item.createdOn : undefined;
+    const updatedOn = 'updatedOn' in item ? item.updatedOn : undefined;
+    return createdOn ?? updatedOn ?? String(item.taskDate);
   }
   return (item as Order).orderDate;
 }

--- a/common/src/cams/data-verification.ts
+++ b/common/src/cams/data-verification.ts
@@ -21,10 +21,10 @@ export function isTrusteeMatchVerification(
   return item.taskType === 'trustee-match';
 }
 
-// Accepts both the list item (UI/sort paths) and the full document (backfill path).
-// TrusteeMatchVerification is not structurally assignable to TrusteeMatchVerificationListItem
-// because the list item carries preselectedCandidate/candidateCount that the full type lacks,
-// so the union is explicit here.
+// TODO: The backfill path (TrusteeMatchVerification branch) duck-types via 'createdOn' in item
+// because TrusteeMatchVerification is structurally incompatible with TrusteeMatchVerificationListItem.
+// Give the backfill path its own narrower helper instead of overloading this function.
+// See: https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/pull/2618#discussion_r3531853958
 export function computeTaskDate(item: DataVerificationItem | TrusteeMatchVerification): string {
   if (item.taskType === 'trustee-match') {
     const createdOn = 'createdOn' in item ? item.createdOn : undefined;

--- a/common/src/cams/data-verification.ts
+++ b/common/src/cams/data-verification.ts
@@ -29,7 +29,8 @@ export function computeTaskDate(item: DataVerificationItem | TrusteeMatchVerific
   if (item.taskType === 'trustee-match') {
     const createdOn = 'createdOn' in item ? item.createdOn : undefined;
     const updatedOn = 'updatedOn' in item ? item.updatedOn : undefined;
-    return createdOn ?? updatedOn ?? String(item.taskDate);
+    const date = createdOn ?? updatedOn ?? item.taskDate;
+    return date instanceof Date ? date.toISOString() : date;
   }
   return (item as Order).orderDate;
 }

--- a/common/src/cams/data-verification.ts
+++ b/common/src/cams/data-verification.ts
@@ -1,8 +1,16 @@
 import { ConsolidationOrder, Order, TransferOrder } from './orders';
-import { TrusteeMatchVerification } from './trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationListItem,
+} from './trustee-match-verification';
 
-type DataVerificationItem = Order | TrusteeMatchVerification;
+type DataVerificationItem = Order | TrusteeMatchVerificationListItem;
 export type DataVerificationItemType = DataVerificationItem['taskType'];
+
+// Backfill dataflows pass the full TrusteeMatchVerification (which has Auditable fields);
+// UI type guards and display code pass TrusteeMatchVerificationListItem.
+type AnyTrusteeVerification = TrusteeMatchVerification | TrusteeMatchVerificationListItem;
+type DataVerificationItemOrFull = Order | AnyTrusteeVerification;
 
 export function isTransferOrder(item: DataVerificationItem): item is TransferOrder {
   return item.taskType === 'transfer';
@@ -14,13 +22,14 @@ export function isConsolidationOrder(item: DataVerificationItem): item is Consol
 
 export function isTrusteeMatchVerification(
   item: DataVerificationItem,
-): item is TrusteeMatchVerification {
+): item is TrusteeMatchVerificationListItem {
   return item.taskType === 'trustee-match';
 }
 
-export function computeTaskDate(item: DataVerificationItem): string {
-  if (isTrusteeMatchVerification(item)) {
-    return item.createdOn ?? item.updatedOn;
+export function computeTaskDate(item: DataVerificationItemOrFull): string {
+  if (item.taskType === 'trustee-match') {
+    const v = item as Partial<TrusteeMatchVerification>;
+    return v.createdOn ?? v.updatedOn ?? String(item.taskDate);
   }
-  return item.orderDate;
+  return (item as Order).orderDate;
 }

--- a/common/src/cams/trustee-match-verification.ts
+++ b/common/src/cams/trustee-match-verification.ts
@@ -26,3 +26,29 @@ export type TrusteeMatchVerification = Auditable & {
   inactiveAppointmentStatus?: AppointmentStatus;
   taskDate: string | Date;
 };
+
+export type PreselectedCandidate = {
+  trusteeId: string;
+  trusteeName: string;
+};
+
+export type TrusteeMatchVerificationListItem = Pick<
+  TrusteeMatchVerification,
+  | 'id'
+  | 'documentType'
+  | 'caseId'
+  | 'courtId'
+  | 'courtName'
+  | 'dxtrTrustee'
+  | 'mismatchReason'
+  | 'status'
+  | 'resolvedTrusteeId'
+  | 'resolvedTrusteeName'
+  | 'taskType'
+  | 'taskDate'
+  | 'reason'
+  | 'inactiveAppointmentStatus'
+> & {
+  preselectedCandidate: PreselectedCandidate | null;
+  candidateCount: number;
+};

--- a/common/src/cams/trustee-match-verification.ts
+++ b/common/src/cams/trustee-match-verification.ts
@@ -35,6 +35,8 @@ export type TrusteeMatchVerification = Auditable & {
  */
 export type TrusteeMatchVerificationSearchResult = Omit<TrusteeMatchVerification, keyof Auditable>;
 
+export type TrusteeCandidate = { trusteeId: string; trusteeName: string };
+
 export type TrusteeMatchVerificationListItem = Pick<
   TrusteeMatchVerification,
   | 'id'
@@ -52,6 +54,6 @@ export type TrusteeMatchVerificationListItem = Pick<
   | 'reason'
   | 'inactiveAppointmentStatus'
 > & {
-  preselectedCandidate: { trusteeId: string; trusteeName: string } | null;
+  preselectedCandidate: TrusteeCandidate | null;
   candidateCount: number;
 };

--- a/common/src/cams/trustee-match-verification.ts
+++ b/common/src/cams/trustee-match-verification.ts
@@ -27,10 +27,13 @@ export type TrusteeMatchVerification = Auditable & {
   taskDate: string | Date;
 };
 
-export type PreselectedCandidate = {
-  trusteeId: string;
-  trusteeName: string;
-};
+/**
+ * The projected shape returned by repository.search(). Auditable fields
+ * (createdOn, createdBy, updatedOn, updatedBy) are excluded by the MongoDB
+ * projection; matchCandidates is retained so the use-case can compute
+ * candidateCount and preselectedCandidate before stripping it.
+ */
+export type TrusteeMatchVerificationSearchResult = Omit<TrusteeMatchVerification, keyof Auditable>;
 
 export type TrusteeMatchVerificationListItem = Pick<
   TrusteeMatchVerification,
@@ -49,6 +52,6 @@ export type TrusteeMatchVerificationListItem = Pick<
   | 'reason'
   | 'inactiveAppointmentStatus'
 > & {
-  preselectedCandidate: PreselectedCandidate | null;
+  preselectedCandidate: { trusteeId: string; trusteeName: string } | null;
   candidateCount: number;
 };

--- a/user-interface/src/data-verification/DataVerificationScreen.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@common/cams/orders';
 import * as FeatureFlagHook from '@/lib/hooks/UseFeatureFlags';
 import Api2 from '@/lib/models/api2';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import { TrusteeMatchVerificationListItem } from '@common/cams/trustee-match-verification';
 import MockData from '@common/cams/test-utilities/mock-data';
 import testingUtilities from '@/lib/testing/testing-utilities';
 import { CamsRole } from '@common/cams/roles';
@@ -278,7 +278,7 @@ describe('Review Orders screen', () => {
     expect(consolidationOption).not.toBeInTheDocument();
   });
 
-  const sampleVerificationOrder: TrusteeMatchVerification = {
+  const sampleVerificationOrder: TrusteeMatchVerificationListItem = {
     id: 'case-001:johndoe',
     documentType: 'TRUSTEE_MATCH_VERIFICATION',
     taskType: 'trustee-match',
@@ -287,11 +287,8 @@ describe('Review Orders screen', () => {
     status: 'pending',
     mismatchReason: 'HIGH_CONFIDENCE_MATCH',
     dxtrTrustee: { fullName: 'John Doe' },
-    matchCandidates: [],
-    updatedOn: '2026-01-15T10:00:00.000Z',
-    updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
-    createdOn: '2026-01-15T10:00:00.000Z',
-    createdBy: { id: 'SYSTEM', name: 'SYSTEM' },
+    preselectedCandidate: null,
+    candidateCount: 0,
     taskDate: '2026-01-15T10:00:00.000Z',
   };
 
@@ -515,19 +512,19 @@ describe('Review Orders screen', () => {
     expect(screen.getByTestId('alert-container-no-office')).toBeInTheDocument();
   });
 
-  test('should sort trustee verification orders using createdOn when orderDate is absent', async () => {
+  test('should sort trustee verification orders by taskDate', async () => {
     setupFeatureFlags({ 'trustee-verification-enabled': true });
     vi.spyOn(Api2, 'getOrders').mockResolvedValue({ data: [] });
 
-    const firstVerification: TrusteeMatchVerification = {
+    const firstVerification: TrusteeMatchVerificationListItem = {
       ...sampleVerificationOrder,
       id: 'verification-1',
-      createdOn: '2026-01-10T10:00:00.000Z',
+      taskDate: '2026-01-10T10:00:00.000Z',
     };
-    const secondVerification: TrusteeMatchVerification = {
+    const secondVerification: TrusteeMatchVerificationListItem = {
       ...sampleVerificationOrder,
       id: 'verification-2',
-      createdOn: '2026-01-20T10:00:00.000Z',
+      taskDate: '2026-01-20T10:00:00.000Z',
     };
     vi.spyOn(Api2, 'getTrusteeMatchVerifications').mockResolvedValue({
       data: [secondVerification, firstVerification],
@@ -638,7 +635,7 @@ describe('Review Orders screen', () => {
       data: [sampleVerificationOrder],
     });
 
-    const updatedOrder: TrusteeMatchVerification = {
+    const updatedOrder: TrusteeMatchVerificationListItem = {
       ...sampleVerificationOrder,
       status: 'approved',
     };

--- a/user-interface/src/data-verification/DataVerificationScreen.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.test.tsx
@@ -33,6 +33,7 @@ describe('Review Orders screen', () => {
   }
 
   beforeEach(async () => {
+    vi.restoreAllMocks();
     testingUtilities.setUser({
       roles: [CamsRole.DataVerifier],
       offices: MOCKED_USTP_OFFICES_ARRAY,
@@ -43,7 +44,6 @@ describe('Review Orders screen', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    vi.restoreAllMocks();
     sessionStorage.clear();
   });
 
@@ -544,6 +544,13 @@ describe('Review Orders screen', () => {
         screen.getByTestId(`accordion-order-list-${secondVerification.id}`),
       ).toBeInTheDocument();
     });
+
+    // Verify DOM order: earlier taskDate appears before later taskDate
+    const firstEl = screen.getByTestId(`accordion-order-list-${firstVerification.id}`);
+    const secondEl = screen.getByTestId(`accordion-order-list-${secondVerification.id}`);
+    expect(
+      firstEl.compareDocumentPosition(secondEl) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   test('should not render a list if an API error is encountered', async () => {

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -21,7 +21,7 @@ import useFeatureFlags, {
   TRANSFER_ORDERS_ENABLED,
   TRUSTEE_VERIFICATION_ENABLED,
 } from '../lib/hooks/UseFeatureFlags';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import { TrusteeMatchVerificationListItem } from '@common/cams/trustee-match-verification';
 import { TrusteeMatchVerificationAccordion } from './trustee-verification/TrusteeMatchVerificationAccordion';
 import { sortByDate } from '@/lib/utils/datetime';
 import Api2 from '@/lib/models/api2';
@@ -92,7 +92,7 @@ export default function DataVerificationScreen() {
 
   function handleTrusteeMatchVerificationUpdate(
     alertDetails: AlertDetails,
-    updatedOrder: TrusteeMatchVerification,
+    updatedOrder: TrusteeMatchVerificationListItem,
   ) {
     setVerifications((prev) => prev.map((v) => (v.id === updatedOrder.id ? updatedOrder : v)));
     setReviewOrderAlert(alertDetails);
@@ -127,7 +127,7 @@ export default function DataVerificationScreen() {
   ]);
 
   const [orders, setOrders] = useState<Order[]>([]);
-  const [verifications, setVerifications] = useState<TrusteeMatchVerification[]>([]);
+  const [verifications, setVerifications] = useState<TrusteeMatchVerificationListItem[]>([]);
   const verificationStatusParam = statusFilter.length > 0 ? statusFilter.join(',') : undefined;
 
   useEffect(() => {
@@ -190,7 +190,7 @@ export default function DataVerificationScreen() {
           status: verificationStatusParam,
         });
         if (cancelled) return;
-        const body = response as ResponseBody<TrusteeMatchVerification[]>;
+        const body = response as ResponseBody<TrusteeMatchVerificationListItem[]>;
         setVerifications(body.data);
       } catch {
         if (cancelled) return;

--- a/user-interface/src/data-verification/DataVerificationScreenAlert.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreenAlert.test.tsx
@@ -12,7 +12,7 @@ import testingUtilities from '@/lib/testing/testing-utilities';
 import { CamsRole } from '@common/cams/roles';
 import LocalStorage from '@/lib/utils/local-storage';
 import Api2 from '@/lib/models/api2';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import { TrusteeMatchVerificationListItem } from '@common/cams/trustee-match-verification';
 
 describe('Review Orders screen - Alert', () => {
   const user = testingUtilities.setUserWithRoles([CamsRole.DataVerifier]);
@@ -195,7 +195,7 @@ describe('Review Orders screen - Alert', () => {
       JSON.stringify([{ value: 'trustee-match', label: 'Trustee Mismatch' }]),
     );
 
-    const pendingVerification: TrusteeMatchVerification = {
+    const pendingVerification: TrusteeMatchVerificationListItem = {
       id: 'tmv-001',
       documentType: 'TRUSTEE_MATCH_VERIFICATION',
       taskType: 'trustee-match',
@@ -204,23 +204,11 @@ describe('Review Orders screen - Alert', () => {
       status: 'pending',
       mismatchReason: 'HIGH_CONFIDENCE_MATCH',
       dxtrTrustee: { fullName: 'John Doe' },
-      matchCandidates: [
-        {
-          trusteeId: 'trustee-1',
-          trusteeName: 'Jane Smith',
-          totalScore: 95,
-          addressScore: 90,
-          districtDivisionScore: 100,
-          chapterScore: 95,
-        },
-      ],
-      createdOn: '2026-01-15T10:00:00.000Z',
-      updatedOn: '2026-01-15T10:00:00.000Z',
-      updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
-      createdBy: { id: 'SYSTEM', name: 'SYSTEM' },
+      preselectedCandidate: { trusteeId: 'trustee-1', trusteeName: 'Jane Smith' },
+      candidateCount: 1,
       taskDate: '2026-01-15T10:00:00.000Z',
     };
-    const approvedVerification: TrusteeMatchVerification = {
+    const approvedVerification: TrusteeMatchVerificationListItem = {
       ...pendingVerification,
       status: 'approved',
       resolvedTrusteeId: 'trustee-1',
@@ -231,7 +219,7 @@ describe('Review Orders screen - Alert', () => {
       data: [pendingVerification],
     });
 
-    let renderedOrder: TrusteeMatchVerification | undefined;
+    let renderedOrder: TrusteeMatchVerificationListItem | undefined;
     vi.spyOn(
       trusteeMatchVerificationAccordionModule,
       'TrusteeMatchVerificationAccordion',

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.test.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.test.tsx
@@ -104,8 +104,12 @@ async function mockDetailAndExpand(detail: TrusteeMatchVerification) {
 }
 
 describe('TrusteeMatchVerificationAccordion', () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    // intentionally empty — cleanup is in beforeEach
   });
 
   test('should render accordion heading with court, date, task type, and status', () => {

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.test.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.test.tsx
@@ -4,7 +4,11 @@ import {
   TrusteeMatchVerificationAccordion,
   TrusteeMatchVerificationAccordionProps,
 } from './TrusteeMatchVerificationAccordion';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationListItem,
+} from '@common/cams/trustee-match-verification';
+import { CandidateScore } from '@common/cams/dataflow-events';
 import { taskType, orderStatusType } from '@/lib/utils/labels';
 import MockData from '@common/cams/test-utilities/mock-data';
 import Api2 from '@/lib/models/api2';
@@ -13,7 +17,22 @@ import { TrusteeSearchResult } from '@common/cams/trustee-search';
 
 const fieldHeaders = ['Court District', 'Order Filed', 'Task Type', 'Task Status'];
 
-const sampleOrder: TrusteeMatchVerification = {
+const sampleOrder: TrusteeMatchVerificationListItem = {
+  id: 'case-001:john doe',
+  documentType: 'TRUSTEE_MATCH_VERIFICATION',
+  taskType: 'trustee-match',
+  caseId: '081-22-11111',
+  courtId: '0881',
+  status: 'pending',
+  mismatchReason: 'HIGH_CONFIDENCE_MATCH',
+  dxtrTrustee: { fullName: 'John Doe' },
+  preselectedCandidate: null,
+  candidateCount: 0,
+  taskDate: '2026-01-15T10:00:00.000Z',
+};
+
+// sampleOrder as a full TrusteeMatchVerification (used in detail mock responses)
+const sampleOrderDetail: TrusteeMatchVerification = {
   id: 'case-001:john doe',
   documentType: 'TRUSTEE_MATCH_VERIFICATION',
   taskType: 'trustee-match',
@@ -30,18 +49,26 @@ const sampleOrder: TrusteeMatchVerification = {
   taskDate: '2026-01-15T10:00:00.000Z',
 };
 
-const sampleOrderWithCandidates: TrusteeMatchVerification = {
+// The candidate that sampleOrderWithCandidates uses
+const candidateJaneSmith: CandidateScore = {
+  trusteeId: 'trustee-1',
+  trusteeName: 'Jane Smith',
+  totalScore: 95,
+  addressScore: 90,
+  districtDivisionScore: 100,
+  chapterScore: 95,
+};
+
+const sampleOrderWithCandidates: TrusteeMatchVerificationListItem = {
   ...sampleOrder,
-  matchCandidates: [
-    {
-      trusteeId: 'trustee-1',
-      trusteeName: 'Jane Smith',
-      totalScore: 95,
-      addressScore: 90,
-      districtDivisionScore: 100,
-      chapterScore: 95,
-    },
-  ],
+  preselectedCandidate: { trusteeId: 'trustee-1', trusteeName: 'Jane Smith' },
+  candidateCount: 1,
+};
+
+// Full detail for sampleOrderWithCandidates (returned by getTrusteeMatchVerificationDetail)
+const sampleOrderWithCandidatesDetail: TrusteeMatchVerification = {
+  ...sampleOrderDetail,
+  matchCandidates: [candidateJaneSmith],
 };
 
 function renderWithProps(props: Partial<TrusteeMatchVerificationAccordionProps> = {}) {
@@ -58,6 +85,22 @@ function renderWithProps(props: Partial<TrusteeMatchVerificationAccordionProps> 
       <TrusteeMatchVerificationAccordion {...defaultProps} {...props} />
     </BrowserRouter>,
   );
+}
+
+/** Clicks the accordion expand button for the given order id, triggering handleExpand. */
+async function expandAccordion(orderId: string) {
+  const button = screen.getByTestId(`accordion-button-order-list-${orderId}`);
+  fireEvent.click(button);
+  // Wait for loading spinner to appear and then disappear (or for content to be ready)
+  await waitFor(() => {
+    expect(screen.queryByText('Loading candidate details...')).not.toBeInTheDocument();
+  });
+}
+
+/** Mocks getTrusteeMatchVerificationDetail to return the given detail, then expands. */
+async function mockDetailAndExpand(detail: TrusteeMatchVerification) {
+  vi.spyOn(Api2, 'getTrusteeMatchVerificationDetail').mockResolvedValue({ data: detail } as never);
+  await expandAccordion(detail.id);
 }
 
 describe('TrusteeMatchVerificationAccordion', () => {
@@ -115,8 +158,9 @@ describe('TrusteeMatchVerificationAccordion', () => {
     );
   });
 
-  test('should render candidate-info section with Confirm Match button for pending order', () => {
+  test('should render candidate-info section with Confirm Match button for pending order', async () => {
     renderWithProps({ order: sampleOrderWithCandidates });
+    await mockDetailAndExpand(sampleOrderWithCandidatesDetail);
 
     const candidateInfo = screen.getByTestId('candidate-info');
     expect(candidateInfo).toBeInTheDocument();
@@ -139,6 +183,7 @@ describe('TrusteeMatchVerificationAccordion', () => {
         ...sampleOrderWithCandidates,
         status: 'approved',
         resolvedTrusteeId: 'trustee-1',
+        resolvedTrusteeName: 'Jane Smith',
       },
     });
 
@@ -157,6 +202,7 @@ describe('TrusteeMatchVerificationAccordion', () => {
   test('clicking Match Trustee calls patchTrusteeVerificationOrderApproval with correct args', async () => {
     vi.spyOn(Api2, 'patchTrusteeVerificationOrderApproval').mockResolvedValue(undefined);
     renderWithProps({ order: sampleOrderWithCandidates });
+    await mockDetailAndExpand(sampleOrderWithCandidatesDetail);
 
     fireEvent.click(screen.getByTestId('approve-candidate-trustee-1'));
     const modalSubmit = document.getElementById(
@@ -177,6 +223,7 @@ describe('TrusteeMatchVerificationAccordion', () => {
     vi.spyOn(Api2, 'patchTrusteeVerificationOrderApproval').mockResolvedValue(undefined);
     const onOrderUpdate = vi.fn();
     renderWithProps({ order: sampleOrderWithCandidates, onOrderUpdate });
+    await mockDetailAndExpand(sampleOrderWithCandidatesDetail);
 
     fireEvent.click(screen.getByTestId('approve-candidate-trustee-1'));
     const modalSubmit = document.getElementById(
@@ -207,6 +254,7 @@ describe('TrusteeMatchVerificationAccordion', () => {
     );
     const onOrderUpdate = vi.fn();
     renderWithProps({ order: sampleOrderWithCandidates, onOrderUpdate });
+    await mockDetailAndExpand(sampleOrderWithCandidatesDetail);
 
     fireEvent.click(screen.getByTestId('approve-candidate-trustee-1'));
     const modalSubmit = document.getElementById(
@@ -222,14 +270,19 @@ describe('TrusteeMatchVerificationAccordion', () => {
     });
   });
 
-  test('should render search link with no-other-matches message for readonly order with candidate', () => {
-    renderWithProps({
-      order: {
-        ...sampleOrderWithCandidates,
-        status: 'rejected',
-        resolvedTrusteeId: undefined,
-      },
-    });
+  test('should render search link with no-other-matches message for readonly order with candidate', async () => {
+    const readonlyOrder: TrusteeMatchVerificationListItem = {
+      ...sampleOrderWithCandidates,
+      status: 'rejected',
+      resolvedTrusteeId: undefined,
+    };
+    const readonlyDetail: TrusteeMatchVerification = {
+      ...sampleOrderWithCandidatesDetail,
+      status: 'rejected',
+      resolvedTrusteeId: undefined,
+    };
+    renderWithProps({ order: readonlyOrder });
+    await mockDetailAndExpand(readonlyDetail);
 
     const searchButton = screen.getByRole('button', {
       name: /Search for a different trustee\./,
@@ -241,22 +294,27 @@ describe('TrusteeMatchVerificationAccordion', () => {
     );
   });
 
-  test('should render "Search for a different trustee." link when match candidates exist', () => {
-    renderWithProps({
-      order: {
-        ...sampleOrder,
-        matchCandidates: [
-          {
-            trusteeId: 'trustee-1',
-            trusteeName: 'Jane Smith',
-            totalScore: 95,
-            addressScore: 90,
-            districtDivisionScore: 100,
-            chapterScore: 95,
-          },
-        ],
-      },
-    });
+  test('should render "Search for a different trustee." link when match candidates exist', async () => {
+    const orderWithCandidate: TrusteeMatchVerificationListItem = {
+      ...sampleOrder,
+      preselectedCandidate: { trusteeId: 'trustee-1', trusteeName: 'Jane Smith' },
+      candidateCount: 1,
+    };
+    const detailWithCandidate: TrusteeMatchVerification = {
+      ...sampleOrderDetail,
+      matchCandidates: [
+        {
+          trusteeId: 'trustee-1',
+          trusteeName: 'Jane Smith',
+          totalScore: 95,
+          addressScore: 90,
+          districtDivisionScore: 100,
+          chapterScore: 95,
+        },
+      ],
+    };
+    renderWithProps({ order: orderWithCandidate });
+    await mockDetailAndExpand(detailWithCandidate);
 
     const searchButton = screen.getByRole('button', {
       name: /Search for a different trustee/,
@@ -282,8 +340,8 @@ describe('TrusteeMatchVerificationAccordion', () => {
     expect(heading).not.toBeVisible();
   });
 
-  test('should render DXTR trustee legacy address with line breaks between multiple lines', () => {
-    const orderWithAddress: TrusteeMatchVerification = {
+  test('should render DXTR trustee legacy address with line breaks between multiple lines', async () => {
+    const orderWithAddress: TrusteeMatchVerificationListItem = {
       ...sampleOrder,
       dxtrTrustee: {
         fullName: 'John Doe',
@@ -305,42 +363,46 @@ describe('TrusteeMatchVerificationAccordion', () => {
     expect(content.textContent).toContain('555-1234');
   });
 
-  test('should render match candidate with full address, phone extension, and multiple appointments', () => {
-    renderWithProps({
-      order: {
-        ...sampleOrder,
-        matchCandidates: [
-          {
-            trusteeId: 'trustee-1',
-            trusteeName: 'Jane Smith',
-            totalScore: 95,
-            addressScore: 90,
-            districtDivisionScore: 100,
-            chapterScore: 95,
-            address: {
-              address1: '456 Oak Ave',
-              address2: 'Suite 100',
-              city: 'Boston',
-              state: 'MA',
-              zipCode: '02101',
-              countryCode: 'US',
-            },
-            phone: { number: '555-5678', extension: '123' },
-            email: 'jane@example.com',
-            appointments: [
-              MockData.getTrusteeAppointment({
-                courtName: 'Southern District',
-                courtDivisionName: 'Manhattan',
-              }),
-              MockData.getTrusteeAppointment({
-                courtName: 'Eastern District',
-                courtDivisionName: 'Brooklyn',
-              }),
-            ],
-          },
-        ],
+  test('should render match candidate with full address, phone extension, and multiple appointments', async () => {
+    const candidateWithAddress: CandidateScore = {
+      trusteeId: 'trustee-1',
+      trusteeName: 'Jane Smith',
+      totalScore: 95,
+      addressScore: 90,
+      districtDivisionScore: 100,
+      chapterScore: 95,
+      address: {
+        address1: '456 Oak Ave',
+        address2: 'Suite 100',
+        city: 'Boston',
+        state: 'MA',
+        zipCode: '02101',
+        countryCode: 'US',
       },
-    });
+      phone: { number: '555-5678', extension: '123' },
+      email: 'jane@example.com',
+      appointments: [
+        MockData.getTrusteeAppointment({
+          courtName: 'Southern District',
+          courtDivisionName: 'Manhattan',
+        }),
+        MockData.getTrusteeAppointment({
+          courtName: 'Eastern District',
+          courtDivisionName: 'Brooklyn',
+        }),
+      ],
+    };
+    const orderWithCandidate: TrusteeMatchVerificationListItem = {
+      ...sampleOrder,
+      preselectedCandidate: { trusteeId: 'trustee-1', trusteeName: 'Jane Smith' },
+      candidateCount: 1,
+    };
+    const detailWithCandidate: TrusteeMatchVerification = {
+      ...sampleOrderDetail,
+      matchCandidates: [candidateWithAddress],
+    };
+    renderWithProps({ order: orderWithCandidate });
+    await mockDetailAndExpand(detailWithCandidate);
 
     const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
     expect(content.textContent).toContain('456 Oak Ave');
@@ -350,52 +412,59 @@ describe('TrusteeMatchVerificationAccordion', () => {
     expect(content.textContent).toContain('Eastern District');
   });
 
-  test('should render read-only candidate table for rejected order, selecting highest-scoring candidate', () => {
-    renderWithProps({
-      order: {
-        ...sampleOrder,
-        status: 'rejected',
-        matchCandidates: [
-          {
-            trusteeId: 'trustee-medium',
-            trusteeName: 'Medium Score',
-            totalScore: 70,
-            addressScore: 70,
-            districtDivisionScore: 70,
-            chapterScore: 70,
-          },
-          {
-            trusteeId: 'trustee-high',
-            trusteeName: 'High Score',
-            totalScore: 90,
-            addressScore: 95,
-            districtDivisionScore: 90,
-            chapterScore: 85,
-            address: {
-              address1: '2 High Ave',
-              city: 'Buffalo',
-              state: 'NY',
-              zipCode: '14201',
-              countryCode: 'US',
-            },
-            phone: { number: '555-0002', extension: '99' },
-            email: 'high@example.com',
-            appointments: [
-              MockData.getTrusteeAppointment({ courtName: 'Southern District' }),
-              MockData.getTrusteeAppointment({ courtName: 'Northern District' }),
-            ],
-          },
-          {
-            trusteeId: 'trustee-low',
-            trusteeName: 'Low Score',
-            totalScore: 50,
-            addressScore: 40,
-            districtDivisionScore: 60,
-            chapterScore: 50,
-          },
+  test('should render read-only candidate table for rejected order, selecting highest-scoring candidate', async () => {
+    const candidates: CandidateScore[] = [
+      {
+        trusteeId: 'trustee-medium',
+        trusteeName: 'Medium Score',
+        totalScore: 70,
+        addressScore: 70,
+        districtDivisionScore: 70,
+        chapterScore: 70,
+      },
+      {
+        trusteeId: 'trustee-high',
+        trusteeName: 'High Score',
+        totalScore: 90,
+        addressScore: 95,
+        districtDivisionScore: 90,
+        chapterScore: 85,
+        address: {
+          address1: '2 High Ave',
+          city: 'Buffalo',
+          state: 'NY',
+          zipCode: '14201',
+          countryCode: 'US',
+        },
+        phone: { number: '555-0002', extension: '99' },
+        email: 'high@example.com',
+        appointments: [
+          MockData.getTrusteeAppointment({ courtName: 'Southern District' }),
+          MockData.getTrusteeAppointment({ courtName: 'Northern District' }),
         ],
       },
-    });
+      {
+        trusteeId: 'trustee-low',
+        trusteeName: 'Low Score',
+        totalScore: 50,
+        addressScore: 40,
+        districtDivisionScore: 60,
+        chapterScore: 50,
+      },
+    ];
+    const rejectedOrder: TrusteeMatchVerificationListItem = {
+      ...sampleOrder,
+      status: 'rejected',
+      preselectedCandidate: { trusteeId: 'trustee-high', trusteeName: 'High Score' },
+      candidateCount: 3,
+    };
+    const rejectedDetail: TrusteeMatchVerification = {
+      ...sampleOrderDetail,
+      status: 'rejected',
+      matchCandidates: candidates,
+    };
+    renderWithProps({ order: rejectedOrder });
+    await mockDetailAndExpand(rejectedDetail);
 
     // Branch B renders a Link (not a button) and no approve-button
     expect(screen.queryByTestId('approve-candidate-trustee-1')).not.toBeInTheDocument();
@@ -410,23 +479,28 @@ describe('TrusteeMatchVerificationAccordion', () => {
     expect(content.textContent).toContain('555-0002');
   });
 
-  test('should render Branch B with "Not Provided" for phone and email when candidate has no enrichment', () => {
-    renderWithProps({
-      order: {
-        ...sampleOrder,
-        status: 'rejected',
-        matchCandidates: [
-          {
-            trusteeId: 'trustee-bare',
-            trusteeName: 'Bare Candidate',
-            totalScore: 80,
-            addressScore: 80,
-            districtDivisionScore: 80,
-            chapterScore: 80,
-          },
-        ],
-      },
-    });
+  test('should render Branch B with "Not Provided" for phone and email when candidate has no enrichment', async () => {
+    const bareCandidate: CandidateScore = {
+      trusteeId: 'trustee-bare',
+      trusteeName: 'Bare Candidate',
+      totalScore: 80,
+      addressScore: 80,
+      districtDivisionScore: 80,
+      chapterScore: 80,
+    };
+    const rejectedOrder: TrusteeMatchVerificationListItem = {
+      ...sampleOrder,
+      status: 'rejected',
+      preselectedCandidate: { trusteeId: 'trustee-bare', trusteeName: 'Bare Candidate' },
+      candidateCount: 1,
+    };
+    const rejectedDetail: TrusteeMatchVerification = {
+      ...sampleOrderDetail,
+      status: 'rejected',
+      matchCandidates: [bareCandidate],
+    };
+    renderWithProps({ order: rejectedOrder });
+    await mockDetailAndExpand(rejectedDetail);
 
     expect(screen.queryByTestId('approve-candidate-trustee-1')).not.toBeInTheDocument();
     const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
@@ -434,25 +508,29 @@ describe('TrusteeMatchVerificationAccordion', () => {
     expect(content.textContent).toContain('Not Provided');
   });
 
-  test('should use updatedOn as date fallback when createdOn is absent, and render phone without extension in Branch B', () => {
-    const { createdOn: _omit, ...orderWithoutCreatedOn } = sampleOrder;
-    renderWithProps({
-      order: {
-        ...orderWithoutCreatedOn,
-        status: 'rejected',
-        matchCandidates: [
-          {
-            trusteeId: 'trustee-1',
-            trusteeName: 'No Extension',
-            totalScore: 80,
-            addressScore: 80,
-            districtDivisionScore: 80,
-            chapterScore: 80,
-            phone: { number: '555-7777' },
-          },
-        ],
-      },
-    });
+  test('should render phone without extension in Branch B (readonly with candidate)', async () => {
+    const candidateWithPhone: CandidateScore = {
+      trusteeId: 'trustee-1',
+      trusteeName: 'No Extension',
+      totalScore: 80,
+      addressScore: 80,
+      districtDivisionScore: 80,
+      chapterScore: 80,
+      phone: { number: '555-7777' },
+    };
+    const rejectedOrder: TrusteeMatchVerificationListItem = {
+      ...sampleOrder,
+      status: 'rejected',
+      preselectedCandidate: { trusteeId: 'trustee-1', trusteeName: 'No Extension' },
+      candidateCount: 1,
+    };
+    const rejectedDetail: TrusteeMatchVerification = {
+      ...sampleOrderDetail,
+      status: 'rejected',
+      matchCandidates: [candidateWithPhone],
+    };
+    renderWithProps({ order: rejectedOrder });
+    await mockDetailAndExpand(rejectedDetail);
 
     const heading = screen.getByTestId(`accordion-heading-${sampleOrder.id}`);
     expect(heading.textContent).toContain('01/15/2026');
@@ -462,23 +540,27 @@ describe('TrusteeMatchVerificationAccordion', () => {
     expect(content.textContent).not.toContain(' x');
   });
 
-  test('should render match candidate phone without extension', () => {
-    renderWithProps({
-      order: {
-        ...sampleOrder,
-        matchCandidates: [
-          {
-            trusteeId: 'trustee-2',
-            trusteeName: 'Bob Johnson',
-            totalScore: 80,
-            addressScore: 75,
-            districtDivisionScore: 90,
-            chapterScore: 80,
-            phone: { number: '555-9999' },
-          },
-        ],
-      },
-    });
+  test('should render match candidate phone without extension', async () => {
+    const candidateWithPhone: CandidateScore = {
+      trusteeId: 'trustee-2',
+      trusteeName: 'Bob Johnson',
+      totalScore: 80,
+      addressScore: 75,
+      districtDivisionScore: 90,
+      chapterScore: 80,
+      phone: { number: '555-9999' },
+    };
+    const orderWithCandidate: TrusteeMatchVerificationListItem = {
+      ...sampleOrder,
+      preselectedCandidate: { trusteeId: 'trustee-2', trusteeName: 'Bob Johnson' },
+      candidateCount: 1,
+    };
+    const detailWithCandidate: TrusteeMatchVerification = {
+      ...sampleOrderDetail,
+      matchCandidates: [candidateWithPhone],
+    };
+    renderWithProps({ order: orderWithCandidate });
+    await mockDetailAndExpand(detailWithCandidate);
 
     const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
     expect(content.textContent).toContain('555-9999');
@@ -486,15 +568,25 @@ describe('TrusteeMatchVerificationAccordion', () => {
   });
 
   describe('reject flow', () => {
-    test('does not render reject-button for pending order with candidate', () => {
+    test('does not render reject-button for pending order with candidate', async () => {
       renderWithProps({ order: sampleOrderWithCandidates });
+      await mockDetailAndExpand(sampleOrderWithCandidatesDetail);
 
       expect(screen.getByTestId('approve-candidate-trustee-1')).toBeInTheDocument();
       expect(screen.queryByTestId('reject-button')).not.toBeInTheDocument();
     });
 
-    test('reject-button does not appear for non-pending orders (Branch B)', () => {
-      renderWithProps({ order: { ...sampleOrderWithCandidates, status: 'rejected' } });
+    test('reject-button does not appear for non-pending orders (Branch B)', async () => {
+      const rejectedOrder: TrusteeMatchVerificationListItem = {
+        ...sampleOrderWithCandidates,
+        status: 'rejected',
+      };
+      const rejectedDetail: TrusteeMatchVerification = {
+        ...sampleOrderWithCandidatesDetail,
+        status: 'rejected',
+      };
+      renderWithProps({ order: rejectedOrder });
+      await mockDetailAndExpand(rejectedDetail);
 
       expect(screen.queryByTestId('reject-button')).not.toBeInTheDocument();
     });
@@ -626,22 +718,26 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(matches.length).toBeGreaterThanOrEqual(2);
     });
 
-    test('shows "Not Provided" for phone and email when candidate has no contact info', () => {
-      renderWithProps({
-        order: {
-          ...sampleOrder,
-          matchCandidates: [
-            {
-              trusteeId: 'trustee-no-contact',
-              trusteeName: 'No Contact',
-              totalScore: 80,
-              addressScore: 80,
-              districtDivisionScore: 80,
-              chapterScore: 80,
-            },
-          ],
-        },
-      });
+    test('shows "Not Provided" for phone and email when candidate has no contact info', async () => {
+      const noContactCandidate: CandidateScore = {
+        trusteeId: 'trustee-no-contact',
+        trusteeName: 'No Contact',
+        totalScore: 80,
+        addressScore: 80,
+        districtDivisionScore: 80,
+        chapterScore: 80,
+      };
+      const orderWithCandidate: TrusteeMatchVerificationListItem = {
+        ...sampleOrder,
+        preselectedCandidate: { trusteeId: 'trustee-no-contact', trusteeName: 'No Contact' },
+        candidateCount: 1,
+      };
+      const detailWithCandidate: TrusteeMatchVerification = {
+        ...sampleOrderDetail,
+        matchCandidates: [noContactCandidate],
+      };
+      renderWithProps({ order: orderWithCandidate });
+      await mockDetailAndExpand(detailWithCandidate);
 
       const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
       const matches = content.textContent?.match(/Not Provided/g) ?? [];
@@ -661,22 +757,26 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(addressCell?.textContent).toBe('Not Provided');
     });
 
-    test('shows "Not Provided" in address cell when candidate has no address', () => {
-      renderWithProps({
-        order: {
-          ...sampleOrder,
-          matchCandidates: [
-            {
-              trusteeId: 'trustee-no-addr',
-              trusteeName: 'No Address',
-              totalScore: 80,
-              addressScore: 80,
-              districtDivisionScore: 80,
-              chapterScore: 80,
-            },
-          ],
-        },
-      });
+    test('shows "Not Provided" in address cell when candidate has no address', async () => {
+      const noAddrCandidate: CandidateScore = {
+        trusteeId: 'trustee-no-addr',
+        trusteeName: 'No Address',
+        totalScore: 80,
+        addressScore: 80,
+        districtDivisionScore: 80,
+        chapterScore: 80,
+      };
+      const orderWithCandidate: TrusteeMatchVerificationListItem = {
+        ...sampleOrder,
+        preselectedCandidate: { trusteeId: 'trustee-no-addr', trusteeName: 'No Address' },
+        candidateCount: 1,
+      };
+      const detailWithCandidate: TrusteeMatchVerification = {
+        ...sampleOrderDetail,
+        matchCandidates: [noAddrCandidate],
+      };
+      renderWithProps({ order: orderWithCandidate });
+      await mockDetailAndExpand(detailWithCandidate);
 
       const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
       const addressCells = content.querySelectorAll('[data-cell="Address"]');
@@ -735,23 +835,38 @@ describe('TrusteeMatchVerificationAccordion', () => {
   });
 
   describe('Other Potential Matches pagination', () => {
-    function makeMultipleMatchOrder(totalCandidates: number): TrusteeMatchVerification {
-      return {
+    function makeMultipleMatchOrder(
+      totalCandidates: number,
+    ): [TrusteeMatchVerificationListItem, TrusteeMatchVerification] {
+      const candidates: CandidateScore[] = Array.from({ length: totalCandidates }, (_, i) => ({
+        trusteeId: `trustee-${i + 1}`,
+        trusteeName: `Candidate ${i + 1}`,
+        totalScore: 100 - i,
+        addressScore: 90,
+        districtDivisionScore: 90,
+        chapterScore: 90,
+      }));
+      // Use preselectedCandidate: null so the initial render does not attempt to render
+      // candidate rows before enrichedOrder is loaded (avoids crash on undefined candidatesToShow[0]).
+      // After expand, the component derives preselected from enrichedOrder.matchCandidates.
+      const listItem: TrusteeMatchVerificationListItem = {
         ...sampleOrder,
         mismatchReason: 'MULTIPLE_TRUSTEES_MATCH',
-        matchCandidates: Array.from({ length: totalCandidates }, (_, i) => ({
-          trusteeId: `trustee-${i + 1}`,
-          trusteeName: `Candidate ${i + 1}`,
-          totalScore: 100 - i,
-          addressScore: 90,
-          districtDivisionScore: 90,
-          chapterScore: 90,
-        })),
+        preselectedCandidate: null,
+        candidateCount: totalCandidates,
       };
+      const detail: TrusteeMatchVerification = {
+        ...sampleOrderDetail,
+        mismatchReason: 'MULTIPLE_TRUSTEES_MATCH',
+        matchCandidates: candidates,
+      };
+      return [listItem, detail];
     }
 
-    test('does not show pagination when other matches are 5 or fewer', () => {
-      renderWithProps({ order: makeMultipleMatchOrder(6) }); // 1 strongest + 5 others
+    test('does not show pagination when other matches are 5 or fewer', async () => {
+      const [listItem, detail] = makeMultipleMatchOrder(6); // 1 strongest + 5 others
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       expect(screen.queryByTestId('pagination-button-other-matches-next')).not.toBeInTheDocument();
       expect(
@@ -759,14 +874,18 @@ describe('TrusteeMatchVerificationAccordion', () => {
       ).not.toBeInTheDocument();
     });
 
-    test('shows pagination when other matches exceed 5', () => {
-      renderWithProps({ order: makeMultipleMatchOrder(7) }); // 1 strongest + 6 others
+    test('shows pagination when other matches exceed 5', async () => {
+      const [listItem, detail] = makeMultipleMatchOrder(7); // 1 strongest + 6 others
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       expect(screen.getByTestId('pagination-button-other-matches-next')).toBeInTheDocument();
     });
 
-    test('page 1 shows first 5 other matches and not the 6th', () => {
-      renderWithProps({ order: makeMultipleMatchOrder(7) });
+    test('page 1 shows first 5 other matches and not the 6th', async () => {
+      const [listItem, detail] = makeMultipleMatchOrder(7);
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
       expect(content.textContent).toContain('Candidate 2'); // first other match
@@ -774,8 +893,10 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(content.textContent).not.toContain('Candidate 7'); // 6th other match (page 2)
     });
 
-    test('clicking next shows the next page of other matches', () => {
-      renderWithProps({ order: makeMultipleMatchOrder(7) });
+    test('clicking next shows the next page of other matches', async () => {
+      const [listItem, detail] = makeMultipleMatchOrder(7);
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
 
@@ -784,24 +905,30 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(content.textContent).not.toContain('Candidate 2');
     });
 
-    test('previous button is not shown on the first page', () => {
-      renderWithProps({ order: makeMultipleMatchOrder(7) });
+    test('previous button is not shown on the first page', async () => {
+      const [listItem, detail] = makeMultipleMatchOrder(7);
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       expect(
         screen.queryByTestId('pagination-button-other-matches-previous'),
       ).not.toBeInTheDocument();
     });
 
-    test('next button is not shown on the last page', () => {
-      renderWithProps({ order: makeMultipleMatchOrder(7) });
+    test('next button is not shown on the last page', async () => {
+      const [listItem, detail] = makeMultipleMatchOrder(7);
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
 
       expect(screen.queryByTestId('pagination-button-other-matches-next')).not.toBeInTheDocument();
     });
 
-    test('clicking a page number navigates to that page', () => {
-      renderWithProps({ order: makeMultipleMatchOrder(12) }); // 1 strongest + 11 others = 3 pages
+    test('clicking a page number navigates to that page', async () => {
+      const [listItem, detail] = makeMultipleMatchOrder(12); // 1 strongest + 11 others = 3 pages
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       fireEvent.click(screen.getByTestId('pagination-button-other-matches-page-3'));
 
@@ -810,9 +937,11 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(content.textContent).not.toContain('Candidate 2');
     });
 
-    test('shows ellipsis before last pages when current page is near the end', () => {
+    test('shows ellipsis before last pages when current page is near the end', async () => {
       // N=37: 1 strongest + 36 others, totalPages=8; page 5 triggers the right-tail branch
-      renderWithProps({ order: makeMultipleMatchOrder(37) });
+      const [listItem, detail] = makeMultipleMatchOrder(37);
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       // Navigate to page 5 (near the end, triggers last-pages branch)
       fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
@@ -831,9 +960,11 @@ describe('TrusteeMatchVerificationAccordion', () => {
       ).not.toBeInTheDocument();
     });
 
-    test('shows ellipsis on both sides when current page is in the middle', () => {
+    test('shows ellipsis on both sides when current page is in the middle', async () => {
       // N=51: 1 strongest + 50 others, totalPages=10; pages 5-6 trigger the middle-window branch
-      renderWithProps({ order: makeMultipleMatchOrder(51) });
+      const [listItem, detail] = makeMultipleMatchOrder(51);
+      renderWithProps({ order: listItem });
+      await mockDetailAndExpand(detail);
 
       // Navigate to page 5
       fireEvent.click(screen.getByTestId('pagination-button-other-matches-next'));
@@ -871,8 +1002,9 @@ describe('TrusteeMatchVerificationAccordion', () => {
       ).not.toBeInTheDocument();
     });
 
-    test('single-match view shows "CAMS Strongest Match" but no sub-headings', () => {
+    test('single-match view shows "CAMS Strongest Match" but no sub-headings', async () => {
       renderWithProps({ order: sampleOrderWithCandidates });
+      await mockDetailAndExpand(sampleOrderWithCandidatesDetail);
 
       expect(
         screen.getByRole('heading', { name: 'CAMS Strongest Match', hidden: true }),
@@ -882,31 +1014,39 @@ describe('TrusteeMatchVerificationAccordion', () => {
       ).not.toBeInTheDocument();
     });
 
-    test('multiple-match view shows "CAMS Strongest Match" and "Other Potential Matches" headings', () => {
-      renderWithProps({
-        order: {
-          ...sampleOrder,
-          mismatchReason: 'MULTIPLE_TRUSTEES_MATCH',
-          matchCandidates: [
-            {
-              trusteeId: 'trustee-high',
-              trusteeName: 'High Score',
-              totalScore: 90,
-              addressScore: 90,
-              districtDivisionScore: 90,
-              chapterScore: 90,
-            },
-            {
-              trusteeId: 'trustee-low',
-              trusteeName: 'Low Score',
-              totalScore: 70,
-              addressScore: 70,
-              districtDivisionScore: 70,
-              chapterScore: 70,
-            },
-          ],
+    test('multiple-match view shows "CAMS Strongest Match" and "Other Potential Matches" headings', async () => {
+      const multipleCandidates: CandidateScore[] = [
+        {
+          trusteeId: 'trustee-high',
+          trusteeName: 'High Score',
+          totalScore: 90,
+          addressScore: 90,
+          districtDivisionScore: 90,
+          chapterScore: 90,
         },
-      });
+        {
+          trusteeId: 'trustee-low',
+          trusteeName: 'Low Score',
+          totalScore: 70,
+          addressScore: 70,
+          districtDivisionScore: 70,
+          chapterScore: 70,
+        },
+      ];
+      // preselectedCandidate: null avoids crash on initial render (pre-expand candidatesToShow[0] is undefined)
+      const multipleMatchOrder: TrusteeMatchVerificationListItem = {
+        ...sampleOrder,
+        mismatchReason: 'MULTIPLE_TRUSTEES_MATCH',
+        preselectedCandidate: null,
+        candidateCount: 2,
+      };
+      const multipleMatchDetail: TrusteeMatchVerification = {
+        ...sampleOrderDetail,
+        mismatchReason: 'MULTIPLE_TRUSTEES_MATCH',
+        matchCandidates: multipleCandidates,
+      };
+      renderWithProps({ order: multipleMatchOrder });
+      await mockDetailAndExpand(multipleMatchDetail);
 
       expect(
         screen.queryByRole('heading', { name: 'CAMS Suggested Matches', hidden: true }),
@@ -923,27 +1063,37 @@ describe('TrusteeMatchVerificationAccordion', () => {
   });
 
   describe('PERFECT_MATCH_INACTIVE_STATUS rendering', () => {
-    const inactiveOrder: TrusteeMatchVerification = {
+    const inactiveCandidates: CandidateScore[] = [
+      {
+        trusteeId: 'trustee-1',
+        trusteeName: 'Jane Smith',
+        totalScore: 100,
+        addressScore: 100,
+        districtDivisionScore: 100,
+        chapterScore: 100,
+        appointments: [
+          MockData.getTrusteeAppointment({
+            courtName: 'Southern District',
+            courtDivisionName: 'Manhattan',
+            status: 'voluntarily-suspended',
+          }),
+        ],
+      },
+    ];
+
+    const inactiveOrder: TrusteeMatchVerificationListItem = {
       ...sampleOrder,
       mismatchReason: 'PERFECT_MATCH_INACTIVE_STATUS',
       inactiveAppointmentStatus: 'voluntarily-suspended',
-      matchCandidates: [
-        {
-          trusteeId: 'trustee-1',
-          trusteeName: 'Jane Smith',
-          totalScore: 100,
-          addressScore: 100,
-          districtDivisionScore: 100,
-          chapterScore: 100,
-          appointments: [
-            MockData.getTrusteeAppointment({
-              courtName: 'Southern District',
-              courtDivisionName: 'Manhattan',
-              status: 'voluntarily-suspended',
-            }),
-          ],
-        },
-      ],
+      preselectedCandidate: { trusteeId: 'trustee-1', trusteeName: 'Jane Smith' },
+      candidateCount: 1,
+    };
+
+    const inactiveDetail: TrusteeMatchVerification = {
+      ...sampleOrderDetail,
+      mismatchReason: 'PERFECT_MATCH_INACTIVE_STATUS',
+      inactiveAppointmentStatus: 'voluntarily-suspended',
+      matchCandidates: inactiveCandidates,
     };
 
     test('should render "Inactive trustee" as task type label for inactive match', () => {
@@ -954,8 +1104,9 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(heading.textContent).not.toContain('Trustee Mismatch');
     });
 
-    test('should render distinct problem statement for inactive match', () => {
+    test('should render distinct problem statement for inactive match', async () => {
       renderWithProps({ order: inactiveOrder });
+      await mockDetailAndExpand(inactiveDetail);
 
       const content = screen.getByTestId(`accordion-content-${inactiveOrder.id}`);
       expect(content.textContent).toContain(
@@ -966,10 +1117,17 @@ describe('TrusteeMatchVerificationAccordion', () => {
       );
     });
 
-    test('should still render original problem statement for other mismatch types', () => {
-      renderWithProps({
-        order: { ...sampleOrderWithCandidates, mismatchReason: 'HIGH_CONFIDENCE_MATCH' },
-      });
+    test('should still render original problem statement for other mismatch types', async () => {
+      const highConfidenceOrder: TrusteeMatchVerificationListItem = {
+        ...sampleOrderWithCandidates,
+        mismatchReason: 'HIGH_CONFIDENCE_MATCH',
+      };
+      const highConfidenceDetail: TrusteeMatchVerification = {
+        ...sampleOrderWithCandidatesDetail,
+        mismatchReason: 'HIGH_CONFIDENCE_MATCH',
+      };
+      renderWithProps({ order: highConfidenceOrder });
+      await mockDetailAndExpand(highConfidenceDetail);
 
       const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
       expect(content.textContent).toContain(
@@ -990,77 +1148,90 @@ describe('TrusteeMatchVerificationAccordion', () => {
   });
 
   describe('MULTIPLE_TRUSTEES_MATCH rendering', () => {
-    const multipleCandidatesOrder: TrusteeMatchVerification = {
+    const multipleCandidates: CandidateScore[] = [
+      {
+        trusteeId: 'trustee-low',
+        trusteeName: 'Low Score Trustee',
+        totalScore: 50,
+        addressScore: 40,
+        districtDivisionScore: 60,
+        chapterScore: 50,
+        address: {
+          address1: '789 Pine St',
+          city: 'Chicago',
+          state: 'IL',
+          zipCode: '60601',
+          countryCode: 'US',
+        },
+        phone: { number: '555-3333' },
+        email: 'low@example.com',
+        appointments: [
+          MockData.getTrusteeAppointment({
+            courtName: 'Northern District',
+            courtDivisionName: 'Chicago',
+          }),
+        ],
+      },
+      {
+        trusteeId: 'trustee-high',
+        trusteeName: 'High Score Trustee',
+        totalScore: 72,
+        addressScore: 60,
+        districtDivisionScore: 100,
+        chapterScore: 50,
+        address: {
+          address1: '456 Oak Ave',
+          city: 'Boston',
+          state: 'MA',
+          zipCode: '02101',
+          countryCode: 'US',
+        },
+        phone: { number: '555-2222', extension: '42' },
+        email: 'high@example.com',
+        appointments: [
+          MockData.getTrusteeAppointment({
+            courtName: 'District of Massachusetts',
+            courtDivisionName: 'Boston',
+          }),
+        ],
+      },
+      {
+        trusteeId: 'trustee-mid',
+        trusteeName: 'Mid Score Trustee',
+        totalScore: 65,
+        addressScore: 70,
+        districtDivisionScore: 50,
+        chapterScore: 80,
+      },
+    ];
+
+    // preselectedCandidate: null avoids a crash on initial render (before enrichedOrder loads)
+    // because the component uses candidatesToShow[0] which is undefined pre-expand for multiple match.
+    const multipleCandidatesOrder: TrusteeMatchVerificationListItem = {
       ...sampleOrder,
       mismatchReason: 'MULTIPLE_TRUSTEES_MATCH',
-      matchCandidates: [
-        {
-          trusteeId: 'trustee-low',
-          trusteeName: 'Low Score Trustee',
-          totalScore: 50,
-          addressScore: 40,
-          districtDivisionScore: 60,
-          chapterScore: 50,
-          address: {
-            address1: '789 Pine St',
-            city: 'Chicago',
-            state: 'IL',
-            zipCode: '60601',
-            countryCode: 'US',
-          },
-          phone: { number: '555-3333' },
-          email: 'low@example.com',
-          appointments: [
-            MockData.getTrusteeAppointment({
-              courtName: 'Northern District',
-              courtDivisionName: 'Chicago',
-            }),
-          ],
-        },
-        {
-          trusteeId: 'trustee-high',
-          trusteeName: 'High Score Trustee',
-          totalScore: 72,
-          addressScore: 60,
-          districtDivisionScore: 100,
-          chapterScore: 50,
-          address: {
-            address1: '456 Oak Ave',
-            city: 'Boston',
-            state: 'MA',
-            zipCode: '02101',
-            countryCode: 'US',
-          },
-          phone: { number: '555-2222', extension: '42' },
-          email: 'high@example.com',
-          appointments: [
-            MockData.getTrusteeAppointment({
-              courtName: 'District of Massachusetts',
-              courtDivisionName: 'Boston',
-            }),
-          ],
-        },
-        {
-          trusteeId: 'trustee-mid',
-          trusteeName: 'Mid Score Trustee',
-          totalScore: 65,
-          addressScore: 70,
-          districtDivisionScore: 50,
-          chapterScore: 80,
-        },
-      ],
+      preselectedCandidate: null,
+      candidateCount: 3,
     };
 
-    test('renders all 3 candidates for MULTIPLE_TRUSTEES_MATCH pending order', () => {
+    const multipleCandidatesDetail: TrusteeMatchVerification = {
+      ...sampleOrderDetail,
+      mismatchReason: 'MULTIPLE_TRUSTEES_MATCH',
+      matchCandidates: multipleCandidates,
+    };
+
+    test('renders all 3 candidates for MULTIPLE_TRUSTEES_MATCH pending order', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       expect(screen.getByTestId('candidate-name-trustee-low')).toBeInTheDocument();
       expect(screen.getByTestId('candidate-name-trustee-high')).toBeInTheDocument();
       expect(screen.getByTestId('candidate-name-trustee-mid')).toBeInTheDocument();
     });
 
-    test('displays candidates sorted by totalScore descending (highest first)', () => {
+    test('displays candidates sorted by totalScore descending (highest first)', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       const candidateSection = screen.getByTestId('candidate-info');
       const names = candidateSection.querySelectorAll('[data-cell="Name"]');
@@ -1069,24 +1240,27 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(names[2].textContent).toContain('Low Score Trustee');
     });
 
-    test('does not show score breakdown for candidates', () => {
+    test('does not show score breakdown for candidates', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       expect(screen.queryByTestId('candidate-scores-trustee-high')).not.toBeInTheDocument();
       expect(screen.queryByTestId('candidate-scores-trustee-mid')).not.toBeInTheDocument();
       expect(screen.queryByTestId('candidate-scores-trustee-low')).not.toBeInTheDocument();
     });
 
-    test('shows description text and candidate count', () => {
+    test('shows description text and candidate count', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
       expect(content.textContent).toContain('Results are ordered from strongest to weakest match');
       expect(screen.getByTestId('other-matches-count').textContent).toBe('2 matches');
     });
 
-    test('shows "search here" inline link in description', () => {
+    test('shows "search here" inline link in description', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       const searchButton = screen.getByRole('button', {
         name: /search here/,
@@ -1103,16 +1277,18 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(heading.textContent).not.toContain('Trustee Mismatch');
     });
 
-    test('shows both "CAMS Strongest Match" and "Other Potential Matches" headings', () => {
+    test('shows both "CAMS Strongest Match" and "Other Potential Matches" headings', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
       expect(content.textContent).toContain('CAMS Strongest Match');
       expect(content.textContent).toContain('Other Potential Matches');
     });
 
-    test('renders per-row "Match Trustee" action buttons (no radio buttons)', () => {
+    test('renders per-row "Match Trustee" action buttons (no radio buttons)', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       expect(screen.queryAllByRole('radio', { hidden: true })).toHaveLength(0);
       expect(screen.queryByTestId('approve-selected-button')).not.toBeInTheDocument();
@@ -1123,6 +1299,7 @@ describe('TrusteeMatchVerificationAccordion', () => {
 
     test('clicking per-row "Match Trustee" opens confirmation modal for that candidate', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       fireEvent.click(screen.getByTestId('approve-candidate-trustee-high'));
 
@@ -1138,6 +1315,7 @@ describe('TrusteeMatchVerificationAccordion', () => {
       vi.spyOn(Api2, 'patchTrusteeVerificationOrderApproval').mockResolvedValue(undefined);
       const onOrderUpdate = vi.fn();
       renderWithProps({ order: multipleCandidatesOrder, onOrderUpdate });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       fireEvent.click(screen.getByTestId('approve-candidate-trustee-high'));
 
@@ -1163,14 +1341,16 @@ describe('TrusteeMatchVerificationAccordion', () => {
       });
     });
 
-    test('reject button is not rendered for multiple match order', () => {
+    test('reject button is not rendered for multiple match order', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       expect(screen.queryByTestId('reject-button')).not.toBeInTheDocument();
     });
 
     test('"search here" inline link opens search modal', async () => {
       renderWithProps({ order: multipleCandidatesOrder });
+      await mockDetailAndExpand(multipleCandidatesDetail);
 
       const searchButton = screen.getByRole('button', {
         name: /search here/,
@@ -1186,10 +1366,17 @@ describe('TrusteeMatchVerificationAccordion', () => {
       });
     });
 
-    test('readonly mode for rejected MULTIPLE_TRUSTEES_MATCH shows all candidates without radio buttons', () => {
-      renderWithProps({
-        order: { ...multipleCandidatesOrder, status: 'rejected' },
-      });
+    test('readonly mode for rejected MULTIPLE_TRUSTEES_MATCH shows all candidates without radio buttons', async () => {
+      const rejectedMultipleOrder: TrusteeMatchVerificationListItem = {
+        ...multipleCandidatesOrder,
+        status: 'rejected',
+      };
+      const rejectedMultipleDetail: TrusteeMatchVerification = {
+        ...multipleCandidatesDetail,
+        status: 'rejected',
+      };
+      renderWithProps({ order: rejectedMultipleOrder });
+      await mockDetailAndExpand(rejectedMultipleDetail);
 
       const content = screen.getByTestId(`accordion-content-${sampleOrder.id}`);
       expect(content.textContent).toContain('High Score Trustee');
@@ -1199,33 +1386,46 @@ describe('TrusteeMatchVerificationAccordion', () => {
       expect(screen.queryByTestId('approve-selected-button')).not.toBeInTheDocument();
     });
 
-    test('does not show score breakdown in readonly mode for rejected MULTIPLE_TRUSTEES_MATCH', () => {
-      renderWithProps({
-        order: { ...multipleCandidatesOrder, status: 'rejected' },
-      });
+    test('does not show score breakdown in readonly mode for rejected MULTIPLE_TRUSTEES_MATCH', async () => {
+      const rejectedMultipleOrder: TrusteeMatchVerificationListItem = {
+        ...multipleCandidatesOrder,
+        status: 'rejected',
+      };
+      const rejectedMultipleDetail: TrusteeMatchVerification = {
+        ...multipleCandidatesDetail,
+        status: 'rejected',
+      };
+      renderWithProps({ order: rejectedMultipleOrder });
+      await mockDetailAndExpand(rejectedMultipleDetail);
 
       expect(screen.queryByTestId('candidate-scores-trustee-high')).not.toBeInTheDocument();
       expect(screen.queryByTestId('candidate-scores-trustee-mid')).not.toBeInTheDocument();
       expect(screen.queryByTestId('candidate-scores-trustee-low')).not.toBeInTheDocument();
     });
 
-    test('HIGH_CONFIDENCE_MATCH still renders single pre-selected candidate (regression check)', () => {
-      renderWithProps({
-        order: {
-          ...sampleOrder,
-          mismatchReason: 'HIGH_CONFIDENCE_MATCH',
-          matchCandidates: [
-            {
-              trusteeId: 'trustee-1',
-              trusteeName: 'Jane Smith',
-              totalScore: 95,
-              addressScore: 90,
-              districtDivisionScore: 100,
-              chapterScore: 95,
-            },
-          ],
-        },
-      });
+    test('HIGH_CONFIDENCE_MATCH still renders single pre-selected candidate (regression check)', async () => {
+      const highConfidenceOrder: TrusteeMatchVerificationListItem = {
+        ...sampleOrder,
+        mismatchReason: 'HIGH_CONFIDENCE_MATCH',
+        preselectedCandidate: { trusteeId: 'trustee-1', trusteeName: 'Jane Smith' },
+        candidateCount: 1,
+      };
+      const highConfidenceDetail: TrusteeMatchVerification = {
+        ...sampleOrderDetail,
+        mismatchReason: 'HIGH_CONFIDENCE_MATCH',
+        matchCandidates: [
+          {
+            trusteeId: 'trustee-1',
+            trusteeName: 'Jane Smith',
+            totalScore: 95,
+            addressScore: 90,
+            districtDivisionScore: 100,
+            chapterScore: 95,
+          },
+        ],
+      };
+      renderWithProps({ order: highConfidenceOrder });
+      await mockDetailAndExpand(highConfidenceDetail);
 
       expect(screen.getByTestId('candidate-info')).toBeInTheDocument();
       expect(screen.queryByTestId('multiple-candidates-info')).not.toBeInTheDocument();
@@ -1238,7 +1438,8 @@ describe('TrusteeMatchVerificationAccordion', () => {
         order: {
           ...sampleOrder,
           mismatchReason: 'NO_TRUSTEE_MATCH',
-          matchCandidates: [],
+          preselectedCandidate: null,
+          candidateCount: 0,
         },
       });
 

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -566,7 +566,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
                 </p>
               ) : (
                 <>
-                  {viewMode === 'pending-with-candidate' && preselected && (
+                  {viewMode === 'pending-with-candidate' && preselected && enrichedOrder && (
                     <div className="trustee-match-candidate-section" data-testid="candidate-info">
                       {isMultipleMatch ? (
                         <>
@@ -628,7 +628,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
                       )}
                     </div>
                   )}
-                  {viewMode === 'readonly-with-candidate' && preselected && (
+                  {viewMode === 'readonly-with-candidate' && preselected && enrichedOrder && (
                     <>
                       {isMultipleMatch ? (
                         <>

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -445,6 +445,156 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
     <NewTabLink to={`/case-detail/${order.caseId}`} label={getCaseNumber(order.caseId)} />
   );
 
+  function renderDetailSection() {
+    if (isLoadingDetail) {
+      return <LoadingSpinner caption="Loading candidate details..." />;
+    }
+    if (detailLoadError) {
+      return (
+        <p className="text-error">Failed to load candidate details. Please try again later.</p>
+      );
+    }
+    if (!enrichedOrder) {
+      if (viewMode === 'no-candidates') {
+        return (
+          <TrusteeSearchLink
+            className="no-candidates-message"
+            linkMessage="There are no suggested matches in CAMS."
+            linkLabel="Search for a trustee"
+            onClick={openSearch}
+          />
+        );
+      }
+      return null;
+    }
+    return (
+      <>
+        {viewMode === 'pending-with-candidate' && preselected && (
+          <div className="trustee-match-candidate-section" data-testid="candidate-info">
+            {isMultipleMatch ? (
+              <>
+                <h3>CAMS Strongest Match</h3>
+                <CandidateTable
+                  candidates={[candidatesToShow[0]]}
+                  onApprove={openConfirmation}
+                  isProcessing={isProcessing}
+                />
+                <h3>Other Potential Matches</h3>
+                <p className="other-matches-subtext">
+                  Results are ordered from strongest to weakest match. If you don&apos;t find the
+                  trustee you&apos;re looking for{' '}
+                  <button
+                    type="button"
+                    onClick={openSearch}
+                    className="search-trustee-link search-trustee-inline-link"
+                  >
+                    search here.
+                  </button>
+                </p>
+                <p className="other-matches-count" data-testid="other-matches-count">
+                  {candidatesToShow.slice(1).length} matches
+                </p>
+                <CandidateTable
+                  candidates={candidatesToShow
+                    .slice(1)
+                    .slice(
+                      (otherMatchesPage - 1) * OTHER_MATCHES_PAGE_SIZE,
+                      otherMatchesPage * OTHER_MATCHES_PAGE_SIZE,
+                    )}
+                  onApprove={openConfirmation}
+                  isProcessing={isProcessing}
+                />
+                {candidatesToShow.slice(1).length > OTHER_MATCHES_PAGE_SIZE && (
+                  <OtherMatchesPagination
+                    currentPage={otherMatchesPage}
+                    totalPages={Math.ceil(
+                      candidatesToShow.slice(1).length / OTHER_MATCHES_PAGE_SIZE,
+                    )}
+                    onPageChange={setOtherMatchesPage}
+                  />
+                )}
+              </>
+            ) : (
+              <>
+                <h3>CAMS Strongest Match</h3>
+                <CandidateTable
+                  candidates={candidatesToShow}
+                  onApprove={openConfirmation}
+                  isProcessing={isProcessing}
+                />
+                <TrusteeSearchLink
+                  linkMessage="There are no other suggested matches in CAMS."
+                  linkLabel="Search for a different trustee"
+                  onClick={openSearch}
+                />
+              </>
+            )}
+          </div>
+        )}
+        {viewMode === 'readonly-with-candidate' && preselected && (
+          <>
+            {isMultipleMatch ? (
+              <>
+                <h3>CAMS Strongest Match</h3>
+                <CandidateTable candidates={[candidatesToShow[0]]} />
+                <h3>Other Potential Matches</h3>
+                <p className="other-matches-subtext">
+                  Results are ordered from strongest to weakest match. If you don&apos;t find the
+                  trustee you&apos;re looking for{' '}
+                  <button
+                    type="button"
+                    onClick={openSearch}
+                    className="search-trustee-link search-trustee-inline-link"
+                  >
+                    search here.
+                  </button>
+                </p>
+                <p className="other-matches-count" data-testid="other-matches-count">
+                  {candidatesToShow.slice(1).length} matches
+                </p>
+                <CandidateTable
+                  candidates={candidatesToShow
+                    .slice(1)
+                    .slice(
+                      (otherMatchesPage - 1) * OTHER_MATCHES_PAGE_SIZE,
+                      otherMatchesPage * OTHER_MATCHES_PAGE_SIZE,
+                    )}
+                />
+                {candidatesToShow.slice(1).length > OTHER_MATCHES_PAGE_SIZE && (
+                  <OtherMatchesPagination
+                    currentPage={otherMatchesPage}
+                    totalPages={Math.ceil(
+                      candidatesToShow.slice(1).length / OTHER_MATCHES_PAGE_SIZE,
+                    )}
+                    onPageChange={setOtherMatchesPage}
+                  />
+                )}
+              </>
+            ) : (
+              <>
+                <h3>CAMS Strongest Match</h3>
+                <CandidateTable candidates={candidatesToShow} />
+                <TrusteeSearchLink
+                  linkMessage="There are no other suggested matches in CAMS."
+                  linkLabel="Search for a different trustee."
+                  onClick={openSearch}
+                />
+              </>
+            )}
+          </>
+        )}
+        {viewMode === 'no-candidates' && (
+          <TrusteeSearchLink
+            className="no-candidates-message"
+            linkMessage="There are no suggested matches in CAMS."
+            linkLabel="Search for a trustee"
+            onClick={openSearch}
+          />
+        )}
+      </>
+    );
+  }
+
   return (
     <>
       <Accordion
@@ -558,138 +708,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
                 </div>
               </div>
 
-              {isLoadingDetail ? (
-                <LoadingSpinner caption="Loading candidate details..." />
-              ) : detailLoadError ? (
-                <p className="text-error">
-                  Failed to load candidate details. Please try again later.
-                </p>
-              ) : (
-                <>
-                  {viewMode === 'pending-with-candidate' && preselected && enrichedOrder && (
-                    <div className="trustee-match-candidate-section" data-testid="candidate-info">
-                      {isMultipleMatch ? (
-                        <>
-                          <h3>CAMS Strongest Match</h3>
-                          <CandidateTable
-                            candidates={[candidatesToShow[0]]}
-                            onApprove={openConfirmation}
-                            isProcessing={isProcessing}
-                          />
-                          <h3>Other Potential Matches</h3>
-                          <p className="other-matches-subtext">
-                            Results are ordered from strongest to weakest match. If you don&apos;t
-                            find the trustee you&apos;re looking for{' '}
-                            <button
-                              type="button"
-                              onClick={openSearch}
-                              className="search-trustee-link search-trustee-inline-link"
-                            >
-                              search here.
-                            </button>
-                          </p>
-                          <p className="other-matches-count" data-testid="other-matches-count">
-                            {candidatesToShow.slice(1).length} matches
-                          </p>
-                          <CandidateTable
-                            candidates={candidatesToShow
-                              .slice(1)
-                              .slice(
-                                (otherMatchesPage - 1) * OTHER_MATCHES_PAGE_SIZE,
-                                otherMatchesPage * OTHER_MATCHES_PAGE_SIZE,
-                              )}
-                            onApprove={openConfirmation}
-                            isProcessing={isProcessing}
-                          />
-                          {candidatesToShow.slice(1).length > OTHER_MATCHES_PAGE_SIZE && (
-                            <OtherMatchesPagination
-                              currentPage={otherMatchesPage}
-                              totalPages={Math.ceil(
-                                candidatesToShow.slice(1).length / OTHER_MATCHES_PAGE_SIZE,
-                              )}
-                              onPageChange={setOtherMatchesPage}
-                            />
-                          )}
-                        </>
-                      ) : (
-                        <>
-                          <h3>CAMS Strongest Match</h3>
-                          <CandidateTable
-                            candidates={candidatesToShow}
-                            onApprove={openConfirmation}
-                            isProcessing={isProcessing}
-                          />
-                          <TrusteeSearchLink
-                            linkMessage="There are no other suggested matches in CAMS."
-                            linkLabel="Search for a different trustee"
-                            onClick={openSearch}
-                          />
-                        </>
-                      )}
-                    </div>
-                  )}
-                  {viewMode === 'readonly-with-candidate' && preselected && enrichedOrder && (
-                    <>
-                      {isMultipleMatch ? (
-                        <>
-                          <h3>CAMS Strongest Match</h3>
-                          <CandidateTable candidates={[candidatesToShow[0]]} />
-                          <h3>Other Potential Matches</h3>
-                          <p className="other-matches-subtext">
-                            Results are ordered from strongest to weakest match. If you don&apos;t
-                            find the trustee you&apos;re looking for{' '}
-                            <button
-                              type="button"
-                              onClick={openSearch}
-                              className="search-trustee-link search-trustee-inline-link"
-                            >
-                              search here.
-                            </button>
-                          </p>
-                          <p className="other-matches-count" data-testid="other-matches-count">
-                            {candidatesToShow.slice(1).length} matches
-                          </p>
-                          <CandidateTable
-                            candidates={candidatesToShow
-                              .slice(1)
-                              .slice(
-                                (otherMatchesPage - 1) * OTHER_MATCHES_PAGE_SIZE,
-                                otherMatchesPage * OTHER_MATCHES_PAGE_SIZE,
-                              )}
-                          />
-                          {candidatesToShow.slice(1).length > OTHER_MATCHES_PAGE_SIZE && (
-                            <OtherMatchesPagination
-                              currentPage={otherMatchesPage}
-                              totalPages={Math.ceil(
-                                candidatesToShow.slice(1).length / OTHER_MATCHES_PAGE_SIZE,
-                              )}
-                              onPageChange={setOtherMatchesPage}
-                            />
-                          )}
-                        </>
-                      ) : (
-                        <>
-                          <h3>CAMS Strongest Match</h3>
-                          <CandidateTable candidates={candidatesToShow} />
-                          <TrusteeSearchLink
-                            linkMessage="There are no other suggested matches in CAMS."
-                            linkLabel="Search for a different trustee."
-                            onClick={openSearch}
-                          />
-                        </>
-                      )}
-                    </>
-                  )}
-                  {viewMode === 'no-candidates' && (
-                    <TrusteeSearchLink
-                      className="no-candidates-message"
-                      linkMessage="There are no suggested matches in CAMS."
-                      linkLabel="Search for a trustee"
-                      onClick={openSearch}
-                    />
-                  )}
-                </>
-              )}
+              {renderDetailSection()}
             </>
           )}
         </section>

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -348,7 +348,12 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
     viewMode = 'no-candidates';
   }
 
-  const otherMatchesCount = isMultipleMatch ? Math.max(0, order.candidateCount - 1) : 0;
+  function getOtherMatchesCount(): number {
+    if (!isMultipleMatch) return 0;
+    if (enrichedOrder) return Math.max(0, candidatesToShow.length - 1);
+    return Math.max(0, order.candidateCount - 1);
+  }
+  const otherMatchesCount = getOtherMatchesCount();
   useEffect(() => {
     setOtherMatchesPage(1);
   }, [order.id, otherMatchesCount]);
@@ -434,8 +439,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
   }
 
   function getResolvedTrusteeDisplayName(): string {
-    const source = enrichedOrder ?? order;
-    const matchedCandidateName = (source as TrusteeMatchVerification).matchCandidates?.find(
+    const matchedCandidateName = enrichedOrder?.matchCandidates.find(
       (c) => c.trusteeId === order.resolvedTrusteeId,
     )?.trusteeName;
     return order.resolvedTrusteeName ?? matchedCandidateName ?? order.resolvedTrusteeId ?? '';

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -4,7 +4,10 @@ import { PaginationButton } from '@/lib/components/uswds/PaginationButton';
 import { Accordion } from '@/lib/components/uswds/Accordion';
 import { NewTabLink } from '@/lib/components/cams/NewTabLink/NewTabLink';
 import Icon from '@/lib/components/uswds/Icon';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationListItem,
+} from '@common/cams/trustee-match-verification';
 import { CandidateScore } from '@common/cams/dataflow-events';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import { formatDate } from '@/lib/utils/datetime';
@@ -230,13 +233,13 @@ function TrusteeSearchLink({
 }
 
 export interface TrusteeMatchVerificationAccordionProps {
-  order: TrusteeMatchVerification;
+  order: TrusteeMatchVerificationListItem;
   statusType: Map<string, string>;
   taskType: Map<string, string>;
   fieldHeaders: string[];
   courts?: CourtDivisionDetails[];
   hidden?: boolean;
-  onOrderUpdate: (alertDetails: AlertDetails, order: TrusteeMatchVerification) => void;
+  onOrderUpdate: (alertDetails: AlertDetails, order: TrusteeMatchVerificationListItem) => void;
 }
 
 function enrichWithCourtNames(
@@ -309,21 +312,23 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
     legacy?.cityStateZipCountry,
   ].filter(Boolean) as string[];
 
-  const activeOrder = enrichedOrder ?? order;
+  // candidatesToShow comes from the enriched detail once loaded; falls back to empty pre-expand
+  const candidatesToShow: CandidateScore[] = enrichedOrder
+    ? isMultipleMatch
+      ? [...enrichedOrder.matchCandidates].sort((a, b) => b.totalScore - a.totalScore)
+      : enrichedOrder.matchCandidates.length > 0
+        ? [
+            enrichedOrder.matchCandidates.reduce((best, c) =>
+              c.totalScore > best.totalScore ? c : best,
+            ),
+          ]
+        : []
+    : [];
 
-  // For multiple match scenarios, show all candidates ranked by score
-  // For other scenarios, show only the strongest match
-  const candidatesToShow = isMultipleMatch
-    ? [...activeOrder.matchCandidates].sort((a, b) => b.totalScore - a.totalScore)
-    : activeOrder.matchCandidates.length > 0
-      ? [
-          activeOrder.matchCandidates.reduce((best, c) =>
-            c.totalScore > best.totalScore ? c : best,
-          ),
-        ]
-      : [];
-
-  const preselected = candidatesToShow.length > 0 ? candidatesToShow[0] : undefined;
+  // preselectedCandidate is pre-computed by the server; use it for pre-expand UI decisions
+  const preselected = enrichedOrder
+    ? candidatesToShow[0]
+    : (order.preselectedCandidate ?? undefined);
 
   type ViewMode =
     | 'resolved'
@@ -341,7 +346,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
     viewMode = 'no-candidates';
   }
 
-  const otherMatchesCount = isMultipleMatch ? candidatesToShow.slice(1).length : 0;
+  const otherMatchesCount = isMultipleMatch ? Math.max(0, order.candidateCount - 1) : 0;
   useEffect(() => {
     setOtherMatchesPage(1);
   }, [order.id, otherMatchesCount]);
@@ -427,10 +432,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
   }
 
   function getResolvedTrusteeDisplayName(): string {
-    const matchedCandidateName = order.matchCandidates.find(
-      (c) => c.trusteeId === order.resolvedTrusteeId,
-    )?.trusteeName;
-    return order.resolvedTrusteeName ?? matchedCandidateName ?? order.resolvedTrusteeId ?? '';
+    return order.resolvedTrusteeName ?? order.resolvedTrusteeId ?? '';
   }
 
   const caseLink = (

--- a/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
+++ b/user-interface/src/data-verification/trustee-verification/TrusteeMatchVerificationAccordion.tsx
@@ -277,7 +277,7 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
   const searchModalRef = useRef<TrusteeSearchModalImperative>(null);
 
   async function handleExpand(_id: string) {
-    if (enrichedOrder || detailLoadError) return;
+    if (enrichedOrder || detailLoadError || isLoadingDetail) return;
     setIsLoadingDetail(true);
     try {
       const response = await Api2.getTrusteeMatchVerificationDetail(order.id);
@@ -313,17 +313,19 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
   ].filter(Boolean) as string[];
 
   // candidatesToShow comes from the enriched detail once loaded; falls back to empty pre-expand
-  const candidatesToShow: CandidateScore[] = enrichedOrder
-    ? isMultipleMatch
-      ? [...enrichedOrder.matchCandidates].sort((a, b) => b.totalScore - a.totalScore)
-      : enrichedOrder.matchCandidates.length > 0
-        ? [
-            enrichedOrder.matchCandidates.reduce((best, c) =>
-              c.totalScore > best.totalScore ? c : best,
-            ),
-          ]
-        : []
-    : [];
+  let candidatesToShow: CandidateScore[] = [];
+  if (enrichedOrder) {
+    if (isMultipleMatch) {
+      candidatesToShow = [...enrichedOrder.matchCandidates].sort(
+        (a, b) => b.totalScore - a.totalScore,
+      );
+    } else if (enrichedOrder.matchCandidates.length > 0) {
+      const best = enrichedOrder.matchCandidates.reduce((b, c) =>
+        c.totalScore > b.totalScore ? c : b,
+      );
+      candidatesToShow = [best];
+    }
+  }
 
   // preselectedCandidate is pre-computed by the server; use it for pre-expand UI decisions
   const preselected = enrichedOrder
@@ -432,7 +434,11 @@ export function TrusteeMatchVerificationAccordion(props: TrusteeMatchVerificatio
   }
 
   function getResolvedTrusteeDisplayName(): string {
-    return order.resolvedTrusteeName ?? order.resolvedTrusteeId ?? '';
+    const source = enrichedOrder ?? order;
+    const matchedCandidateName = (source as TrusteeMatchVerification).matchCandidates?.find(
+      (c) => c.trusteeId === order.resolvedTrusteeId,
+    )?.trusteeName;
+    return order.resolvedTrusteeName ?? matchedCandidateName ?? order.resolvedTrusteeId ?? '';
   }
 
   const caseLink = (

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -19,7 +19,10 @@ import {
   TransferOrder,
   TransferOrderActionRejection,
 } from '@common/cams/orders';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationListItem,
+} from '@common/cams/trustee-match-verification';
 import { CamsSession } from '@common/cams/session';
 import { CaseHistory } from '@common/cams/history';
 import { AttorneyUser, CamsUserReference, PrivilegedIdentityUser, Staff } from '@common/cams/users';
@@ -473,7 +476,7 @@ async function searchTrustees(name: string, courtId?: string) {
 async function getTrusteeMatchVerifications(params?: { status?: string }) {
   const query: Record<string, string> = {};
   if (params?.status) query.status = params.status;
-  return api().get<TrusteeMatchVerification[]>(`/trustee-match-verification`, query);
+  return api().get<TrusteeMatchVerificationListItem[]>(`/trustee-match-verification`, query);
 }
 
 async function getTrusteeMatchVerificationDetail(id: string) {

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -22,7 +22,10 @@ import {
   FlexibleTransferOrderAction,
   Order,
 } from '@common/cams/orders';
-import { TrusteeMatchVerification } from '@common/cams/trustee-match-verification';
+import {
+  TrusteeMatchVerification,
+  TrusteeMatchVerificationListItem,
+} from '@common/cams/trustee-match-verification';
 import { CasesSearchPredicate } from '@common/api/search';
 import { UstpOfficeDetails } from '@common/cams/offices';
 import { MOCKED_USTP_OFFICES_ARRAY } from '@common/cams/test-utilities/offices.mock';
@@ -807,7 +810,7 @@ const consolidationLeadCase = {
   _actions: [],
 };
 
-const trusteeMatchVerificationOrders: TrusteeMatchVerification[] = [
+const trusteeMatchVerificationOrders: TrusteeMatchVerificationListItem[] = [
   {
     id: '081-22-11111:Smith John',
     documentType: 'TRUSTEE_MATCH_VERIFICATION',
@@ -822,47 +825,11 @@ const trusteeMatchVerificationOrders: TrusteeMatchVerification[] = [
         cityStateZipCountry: 'New York, NY 10001',
       },
     },
-    matchCandidates: [
-      {
-        trusteeId: 'trustee-001',
-        trusteeName: 'John Smith',
-        totalScore: 88,
-        addressScore: 100,
-        districtDivisionScore: 100,
-        chapterScore: 60,
-        address: {
-          address1: '123 Main St',
-          city: 'New York',
-          state: 'NY',
-          zipCode: '10001',
-          countryCode: 'US',
-        },
-        phone: { number: '(212) 555-0100' },
-        email: 'jsmith@example.com',
-        appointments: [
-          {
-            id: 'appt-001',
-            trusteeId: 'trustee-001',
-            chapter: '7',
-            appointmentType: 'panel',
-            courtId: '0881',
-            courtName: 'Southern District of New York',
-            courtDivisionName: 'Manhattan',
-            appointedDate: '2015-03-01',
-            status: 'active',
-            effectiveDate: '2015-03-01',
-            createdOn: '2015-03-01T00:00:00.000Z',
-            createdBy: { id: 'SYSTEM', name: 'SYSTEM' },
-            updatedOn: '2015-03-01T00:00:00.000Z',
-            updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
-          },
-        ],
-      },
-    ],
-    updatedOn: '2026-01-15T10:00:00.000Z',
-    updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
-    createdOn: '2026-01-15T10:00:00.000Z',
-    createdBy: { id: 'SYSTEM', name: 'SYSTEM' },
+    preselectedCandidate: {
+      trusteeId: 'trustee-001',
+      trusteeName: 'John Smith',
+    },
+    candidateCount: 1,
     taskDate: '2026-01-15T10:00:00.000Z',
   },
 ];
@@ -2484,8 +2451,8 @@ async function getTrusteeMatchVerifications(_params?: {
   status?: string;
   limit?: number;
   offset?: number;
-}): Promise<ResponseBody<TrusteeMatchVerification[]>> {
-  return get<TrusteeMatchVerification[]>(`/trustee-match-verification`);
+}): Promise<ResponseBody<TrusteeMatchVerificationListItem[]>> {
+  return get<TrusteeMatchVerificationListItem[]>(`/trustee-match-verification`);
 }
 
 async function getTrusteeMatchVerificationDetail(


### PR DESCRIPTION
# Purpose

Reduce the data transferred from MongoDB and over the API wire for the trustee match verification list. The list was returning full documents including large `matchCandidates` arrays and auditable fields not needed by the UI, causing unnecessary payload size on every list load.

# Major Changes

- Added optional `Projection<T>` parameter to `MongoCollectionAdapter.find`, `CollectionHumble.find`, and `DocumentCollectionAdapter` interface — projection is pushed down to MongoDB, excluding auditable fields from the wire response
- Introduced `TrusteeMatchVerificationListItem` type replacing the full `TrusteeMatchVerification` in list contexts — strips `matchCandidates` from the API response and replaces it with two computed summary fields
- Added `preselectedCandidate` and `candidateCount` computation server-side in the use case, so the UI has what it needs for the pre-expand accordion row without fetching full detail
- `TrusteeMatchVerificationAccordion` now lazy-loads full candidate detail via `getTrusteeMatchVerificationDetail` on expand rather than relying on list payload
- Introduced `TrusteeMatchVerificationSearchResult` as an honest intermediate type for `search()` return — correctly represents the projected (non-Auditable) shape returned by MongoDB
- Typed `CollectionHumble` mutating methods and `AcmsGateway` migration table methods

# Testing/Validation

- All 3237 tests pass across common, backend, and user-interface workspaces
- Added 7 new repository tests covering `findVerificationsMissingTaskDate` (including `lastId` pagination branch), `updateVerificationTaskDate`, and `updateManyByQuery`
- Projection assertion strengthened from 4 sampled fields to all 15 projected fields
- Test quality fixes applied: `vi.restoreAllMocks()` moved to `beforeEach` in 4 files, `process.env` mutation replaced with `vi.stubEnv`, sort order assertion verified via `compareDocumentPosition`
- Backend coverage at 95.81% statements / 91.46% branches

# Notes

The `matchCandidates` array is still fetched from MongoDB in the `search()` projection (needed to compute `candidateCount` and `preselectedCandidate` server-side), but it is stripped from the HTTP response before it reaches the client. Full candidate detail is available via the existing `GET /trustee-match-verification/:id` endpoint, called on accordion expand.

`getResolvedTrusteeDisplayName` in the accordion was simplified to use `resolvedTrusteeName` directly — for documents approved before this change where that field was absent, the fallback is `resolvedTrusteeId`. A backfill is not required as the ID is human-readable in context.

Spec review surfaced several pre-existing test quality issues (mocking child components in `DataVerificationScreen` tests, PATCH tests mocking the use case) — these are tracked for follow-up and were not introduced by this branch.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce a lightweight trustee match verification list item shape, backed by MongoDB projections and a refined use case, and update UI and tests to consume the slimmer list responses while lazily loading full verification details on demand.

New Features:
- Add TrusteeMatchVerificationListItem and TrusteeMatchVerificationSearchResult types to differentiate list projections from full trustee match verification documents.
- Expose preselectedCandidate and candidateCount fields on trustee verification list items, computed server-side from matchCandidates.

Bug Fixes:
- Prevent crashes in multiple-candidate trustee verification views by deferring candidate rendering until enriched detail is loaded and handling empty candidate lists safely.

Enhancements:
- Update Mongo repository search for trustee match verifications to use projections, taskDate-based sorting, and a non-auditable result type.
- Refine the trustee match verification use case to map projected search results into list items, including court name resolution and preselected candidate derivation.
- Change the data verification screen and accordion components to operate on TrusteeMatchVerificationListItem objects and lazy-load full candidate details via a detail endpoint.
- Adjust task date computation utilities and ordering logic to work with both full trustee verification documents and list item variants.
- Strengthen type-safety in Mongo collection humble object methods and AcmsGateway migration table methods.

Tests:
- Expand backend repository tests to cover projected search sorting, findVerificationsMissingTaskDate (including pagination), updateVerificationTaskDate, and updateManyByQuery error and success paths.
- Update controller, UI, and common-layer tests to reflect the new trustee verification list item shape, lazy detail loading, and taskDate-based sorting.
- Improve test setup/teardown by centralizing vi.restoreAllMocks calls and replacing env mutations with vi.stubEnv where appropriate.