### PR TITLE
CAMS-765 Fix inactive software/bank display

### DIFF
--- a/user-interface/src/trustees/TrusteeDetailScreen.tsx
+++ b/user-interface/src/trustees/TrusteeDetailScreen.tsx
@@ -118,7 +118,7 @@ export default function TrusteeDetailScreen() {
     };
 
     fetchSoftwareOptions();
-  }, []);
+  }, [location.pathname]);
 
   useEffect(() => {
     if (!trusteeId) return;
@@ -177,7 +177,6 @@ export default function TrusteeDetailScreen() {
               onEditOtherInformation={openEditOtherInformation}
               onEditZoomInfo={openEditZoomInfo}
               showSoftwareBankInfo={showSoftwareBankInfo}
-              softwareOptions={softwareOptions}
               softwareProfiles={softwareProfiles}
             />
           </div>

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.test.tsx
@@ -481,4 +481,31 @@ describe('TrusteeOtherInfoForm', () => {
     });
     expect(screen.getByTestId('button-submit-button')).toBeDisabled();
   });
+
+  test('clears software and bank state when the assigned software is inactive', () => {
+    render(
+      <TrusteeOtherInfoForm
+        trusteeId={TEST_TRUSTEE_ID}
+        softwareId="sw-inactive"
+        banks={['bank-fifth-third']}
+        softwareOptions={mockSoftwareOptions}
+        softwareProfiles={mockSoftwareProfiles}
+      />,
+    );
+
+    // Software field should be blank — inactive software is not in softwareOptions
+    const softwareInput = document.querySelector(
+      '#trustee-software-combo-box-input',
+    ) as HTMLInputElement;
+    expect(softwareInput).toHaveValue('');
+
+    // Bank field should be disabled because softwareId is cleared
+    const bankInput = document.querySelector(
+      '#trustee-banks-0-combo-box-input',
+    ) as HTMLInputElement;
+    expect(bankInput).toBeDisabled();
+
+    // Save should be disabled
+    expect(screen.getByTestId('button-submit-button')).toBeDisabled();
+  });
 });

--- a/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
+++ b/user-interface/src/trustees/forms/TrusteeOtherInfoForm.tsx
@@ -21,10 +21,19 @@ function TrusteeOtherInfoForm(props: Readonly<TrusteeOtherInfoFormProps>) {
   const { trusteeId, softwareOptions, softwareProfiles } = props;
   const initialBanks = props.banks?.filter((b) => b.trim() !== '') ?? [];
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [banks, setBanks] = useState<string[]>(
-    initialBanks.length > 0 ? initialBanks : props.softwareId ? [''] : [],
+  const isActiveSoftware = softwareOptions.some((opt) => opt.value === props.softwareId);
+
+  function getInitialBankState(): string[] {
+    if (!isActiveSoftware) return [];
+    if (initialBanks.length > 0) return initialBanks;
+    if (props.softwareId) return [''];
+    return [];
+  }
+
+  const [banks, setBanks] = useState<string[]>(getInitialBankState);
+  const [softwareId, setSoftwareId] = useState<string>(
+    isActiveSoftware ? (props.softwareId ?? '') : '',
   );
-  const [softwareId, setSoftwareId] = useState<string>(props.softwareId ?? '');
 
   const navigate = useCamsNavigator();
 

--- a/user-interface/src/trustees/panels/OtherInformationCard.tsx
+++ b/user-interface/src/trustees/panels/OtherInformationCard.tsx
@@ -1,13 +1,11 @@
 import './OtherInformationCard.scss';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import { IconLabel } from '@/lib/components/cams/IconLabel/IconLabel';
-import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 interface OtherInformationCardProps {
   banks?: string[];
   softwareId?: string;
-  softwareOptions: ComboOption[];
   softwareProfiles: BankruptcySoftwareProfile[];
   onEdit: () => void;
 }
@@ -15,12 +13,11 @@ interface OtherInformationCardProps {
 export default function OtherInformationCard({
   banks,
   softwareId,
-  softwareOptions,
   softwareProfiles,
   onEdit,
 }: Readonly<OtherInformationCardProps>) {
   const softwareName = softwareId
-    ? (softwareOptions.find((opt) => opt.value === softwareId)?.label ?? 'Unknown software')
+    ? (softwareProfiles.find((p) => p.id === softwareId)?.name ?? 'Unknown software')
     : undefined;
 
   const selectedSoftware = softwareProfiles.find((p) => p.id === softwareId);

--- a/user-interface/src/trustees/panels/OtherInformationCard.tsx
+++ b/user-interface/src/trustees/panels/OtherInformationCard.tsx
@@ -16,11 +16,8 @@ export default function OtherInformationCard({
   softwareProfiles,
   onEdit,
 }: Readonly<OtherInformationCardProps>) {
-  const softwareName = softwareId
-    ? (softwareProfiles.find((p) => p.id === softwareId)?.name ?? 'Unknown software')
-    : undefined;
-
   const selectedSoftware = softwareProfiles.find((p) => p.id === softwareId);
+  const softwareName = softwareId ? (selectedSoftware?.name ?? 'Unknown software') : undefined;
   const bankNameMap = new Map(
     selectedSoftware?.associatedBanks?.map((b) => [b.bankId, b.bankName]) ?? [],
   );

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.test.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.test.tsx
@@ -58,7 +58,6 @@ function renderWithProps(props?: Partial<TrusteeDetailProfileProps>) {
     onEditZoomInfo: onEditZoomInfo,
     onAddAssistant: mockOnAddAssistant,
     onEditAssistant: mockOnEditAssistant,
-    softwareOptions: [],
     softwareProfiles: [],
   };
 
@@ -368,7 +367,16 @@ describe('TrusteeDetailProfile', () => {
 
     renderWithProps({
       trustee: trusteeWithSoftware,
-      softwareOptions: [{ value: 'sw-bestcase', label: 'BestCase Trustee Software v2.1' }],
+      softwareProfiles: [
+        {
+          id: 'sw-bestcase',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'BestCase Trustee Software v2.1',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: SYSTEM_USER_REFERENCE,
+        },
+      ],
     });
 
     expect(screen.getByTestId('trustee-software')).toHaveTextContent(

--- a/user-interface/src/trustees/panels/TrusteeDetailProfile.tsx
+++ b/user-interface/src/trustees/panels/TrusteeDetailProfile.tsx
@@ -7,7 +7,6 @@ import MeetingOfCreditorsInfoCard from './MeetingOfCreditorsInfoCard';
 import OtherInformationCard from './OtherInformationCard';
 import ContactInformationCard from './ContactInformationCard';
 import TrusteeAssistantCard from './TrusteeAssistantCard';
-import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
 export interface TrusteeDetailProfileProps {
@@ -19,7 +18,6 @@ export interface TrusteeDetailProfileProps {
   onEditOtherInformation: () => void;
   onEditZoomInfo: () => void;
   showSoftwareBankInfo?: boolean;
-  softwareOptions: ComboOption[];
   softwareProfiles: BankruptcySoftwareProfile[];
 }
 
@@ -32,7 +30,6 @@ export default function TrusteeDetailProfile({
   onEditOtherInformation,
   onEditZoomInfo,
   showSoftwareBankInfo = true,
-  softwareOptions,
   softwareProfiles,
 }: Readonly<TrusteeDetailProfileProps>) {
   return (
@@ -92,7 +89,6 @@ export default function TrusteeDetailProfile({
               <OtherInformationCard
                 banks={trustee.banks}
                 softwareId={trustee.softwareId}
-                softwareOptions={softwareOptions}
                 softwareProfiles={softwareProfiles}
                 onEdit={onEditOtherInformation}
               />


### PR DESCRIPTION

# Purpose

Re-fetch software profiles on each route change so the edit form always reflects current active/inactive state rather than stale data from the initial page load.

Clear softwareId and banks initial state in TrusteeOtherInfoForm when the assigned software is no longer active, preventing the form from opening with a blank software field but an enabled bank dropdown.

Fix OtherInformationCard to resolve the software name from softwareProfiles (all profiles) instead of softwareOptions (active only), so inactive software still displays its name rather than 'Unknown software'. Remove the now-unused softwareOptions prop from OtherInformationCard and TrusteeDetailProfile.

Jira ticket: CAMS-765

# Testing/Validation

Enumerate on steps to validate that this feature is working.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Ensure trustee software and bank information stays in sync with active/inactive software status and correctly displays software names, including inactive ones.

Bug Fixes:
- Clear initial software and bank selections in TrusteeOtherInfoForm when the assigned software is no longer active so banks cannot be edited without an active software.
- Re-fetch software options on each trustee detail route change so the edit form reflects current software activation state instead of stale data.
- Resolve software names in OtherInformationCard from all software profiles so inactive software still displays its name rather than appearing as unknown.

Enhancements:
- Simplify TrusteeDetailProfile and OtherInformationCard props by removing the now-unneeded softwareOptions dependency.

Tests:
- Add a TrusteeOtherInfoForm test verifying software and bank state are cleared and disabled when the assigned software is inactive.
- Update TrusteeDetailProfile tests to use softwareProfiles for software name resolution instead of softwareOptions.