### PR TITLE
CAMS-768 Fix email formatting, notify multiple chapters

### DIFF
--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
@@ -9,7 +9,7 @@ function buildChangeSet(
     trusteeId: 'trustee-1',
     trusteeName: 'Henry Green',
     fields,
-    primaryChapter: '7',
+    chapters: ['7'],
     ...overrides,
   };
 }

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
@@ -22,8 +22,7 @@ describe('compileTrusteeChangeTemplate', () => {
           [
             {
               label: 'Public Email',
-              before: 'a@b.test',
-              after: 'c@d.test',
+              comparisons: [{ before: 'a@b.test', after: 'c@d.test' }],
               category: 'profile',
               section: 'appointment',
             },
@@ -40,8 +39,7 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Public Email',
-            before: 'a@b.test',
-            after: 'c@d.test',
+            comparisons: [{ before: 'a@b.test', after: 'c@d.test' }],
             category: 'profile',
             section: 'appointment',
           },
@@ -57,8 +55,7 @@ describe('compileTrusteeChangeTemplate', () => {
           [
             {
               label: 'Chapter',
-              before: '7',
-              after: '11 Subchapter V',
+              comparisons: [{ before: '7', after: '11 Subchapter V' }],
               category: 'profile',
               section: 'appointment',
             },
@@ -76,8 +73,7 @@ describe('compileTrusteeChangeTemplate', () => {
           [
             {
               label: 'Chapter',
-              before: '7',
-              after: '11',
+              comparisons: [{ before: '7', after: '11' }],
               category: 'profile',
               section: 'appointment',
             },
@@ -98,22 +94,19 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Name',
-            before: 'Henry Green',
-            after: 'Henry G. Green',
+            comparisons: [{ before: 'Henry Green', after: 'Henry G. Green' }],
             category: 'profile',
             section: 'appointment',
           },
           {
             label: 'Public Email',
-            before: 'a@b.test',
-            after: 'c@d.test',
+            comparisons: [{ before: 'a@b.test', after: 'c@d.test' }],
             category: 'profile',
             section: 'appointment',
           },
           {
             label: 'Software',
-            before: 'OldSoft',
-            after: 'NewSoft',
+            comparisons: [{ before: 'OldSoft', after: 'NewSoft' }],
             category: 'profile',
             section: 'appointment',
           },
@@ -132,8 +125,9 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Division(s)',
-            before: 'Manhattan, Queens',
-            after: 'Brooklyn, Queens, Staten Island',
+            comparisons: [
+              { before: 'Manhattan, Queens', after: 'Brooklyn, Queens, Staten Island' },
+            ],
             category: 'profile',
             section: 'appointment',
             stackValues: true,
@@ -149,13 +143,12 @@ describe('compileTrusteeChangeTemplate', () => {
       );
     });
 
-    test('renders a single-item stackValues field without key:value shape as plain escaped text', () => {
+    test('renders a single-item stackValues field without propertyName as plain escaped text', () => {
       const result = compileTrusteeChangeTemplate(
         buildChangeSet([
           {
             label: 'Division(s)',
-            before: 'Manhattan',
-            after: 'Brooklyn',
+            comparisons: [{ before: 'Manhattan', after: 'Brooklyn' }],
             category: 'profile',
             section: 'appointment',
             stackValues: true,
@@ -168,16 +161,20 @@ describe('compileTrusteeChangeTemplate', () => {
       expect(result.html).toContain('Brooklyn');
     });
 
-    test('renders a single-item stackValues field with key:value shape with a bold label', () => {
+    test('renders a comparison with propertyName as a bold label', () => {
       const result = compileTrusteeChangeTemplate(
         buildChangeSet([
           {
             label: 'Public Contact',
-            before: 'Website: https://old.example.com',
-            after: 'Website: https://new.example.com',
+            comparisons: [
+              {
+                propertyName: 'Website',
+                before: 'https://old.example.com',
+                after: 'https://new.example.com',
+              },
+            ],
             category: 'profile',
             section: 'appointment',
-            stackValues: true,
           },
         ]),
       );
@@ -186,13 +183,35 @@ describe('compileTrusteeChangeTemplate', () => {
       expect(result.html).toContain('<strong>Website:</strong> https://new.example.com');
     });
 
+    test('renders multiple comparisons in a single row when they share a label', () => {
+      const result = compileTrusteeChangeTemplate(
+        buildChangeSet([
+          {
+            label: 'Public Contact',
+            comparisons: [
+              { propertyName: 'Email', before: 'old@example.com', after: 'new@example.com' },
+              { propertyName: 'Website', before: 'https://old.com', after: 'https://new.com' },
+            ],
+            category: 'profile',
+            section: 'appointment',
+          },
+        ]),
+      );
+
+      const rowCount = (result.html.match(/class="change-row"/g) ?? []).length;
+      expect(rowCount).toBe(1);
+      expect(result.html).toContain('<strong>Email:</strong> old@example.com');
+      expect(result.html).toContain('<strong>Email:</strong> new@example.com');
+      expect(result.html).toContain('<strong>Website:</strong> https://old.com');
+      expect(result.html).toContain('<strong>Website:</strong> https://new.com');
+    });
+
     test('escapes HTML special characters in field values', () => {
       const result = compileTrusteeChangeTemplate(
         buildChangeSet([
           {
             label: 'Public Email',
-            before: '',
-            after: '<script>alert(1)</script>',
+            comparisons: [{ before: '', after: '<script>alert(1)</script>' }],
             category: 'profile',
             section: 'appointment',
           },
@@ -209,8 +228,7 @@ describe('compileTrusteeChangeTemplate', () => {
           [
             {
               label: 'Public Email',
-              before: '',
-              after: 'x@y.test',
+              comparisons: [{ before: '', after: 'x@y.test' }],
               category: 'profile',
               section: 'appointment',
             },
@@ -228,8 +246,7 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Zoom Link',
-            before: 'https://zoom.us/old',
-            after: 'https://zoom.us/new',
+            comparisons: [{ before: 'https://zoom.us/old', after: 'https://zoom.us/new' }],
             category: 'zoom-341',
             section: 'meeting',
           },
@@ -247,8 +264,7 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Public Email',
-            before: 'old@example.test',
-            after: 'new@example.test',
+            comparisons: [{ before: 'old@example.test', after: 'new@example.test' }],
             category: 'profile',
             section: 'appointment',
           },
@@ -270,8 +286,7 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Name',
-            before: 'Henry Green',
-            after: 'Henry G. Green',
+            comparisons: [{ before: 'Henry Green', after: 'Henry G. Green' }],
             category: 'profile',
             section: 'appointment',
           },
@@ -286,8 +301,7 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Zoom Link',
-            before: 'https://zoom.us/old',
-            after: 'https://zoom.us/new',
+            comparisons: [{ before: 'https://zoom.us/old', after: 'https://zoom.us/new' }],
             category: 'zoom-341',
             section: 'meeting',
           },
@@ -304,15 +318,13 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Name',
-            before: 'Henry Green',
-            after: 'Henry G. Green',
+            comparisons: [{ before: 'Henry Green', after: 'Henry G. Green' }],
             category: 'profile',
             section: 'appointment',
           },
           {
             label: 'Zoom Link',
-            before: 'https://zoom.us/old',
-            after: 'https://zoom.us/new',
+            comparisons: [{ before: 'https://zoom.us/old', after: 'https://zoom.us/new' }],
             category: 'zoom-341',
             section: 'meeting',
           },
@@ -330,8 +342,9 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Division(s)',
-            before: 'Manhattan, Queens',
-            after: 'Brooklyn, Queens, Staten Island',
+            comparisons: [
+              { before: 'Manhattan, Queens', after: 'Brooklyn, Queens, Staten Island' },
+            ],
             category: 'profile',
             section: 'appointment',
             stackValues: true,
@@ -349,8 +362,7 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Division(s)',
-            before: 'Manhattan',
-            after: 'Brooklyn',
+            comparisons: [{ before: 'Manhattan', after: 'Brooklyn' }],
             category: 'profile',
             section: 'appointment',
             stackValues: true,
@@ -360,6 +372,29 @@ describe('compileTrusteeChangeTemplate', () => {
 
       expect(result.text).toContain('Division(s): Manhattan -> Brooklyn');
     });
+
+    test('renders propertyName in plaintext as PropertyName: value', () => {
+      const result = compileTrusteeChangeTemplate(
+        buildChangeSet([
+          {
+            label: 'Public Contact',
+            comparisons: [
+              { propertyName: 'Email', before: 'old@example.test', after: 'new@example.test' },
+              { propertyName: 'Website', before: 'https://old.com', after: 'https://new.com' },
+            ],
+            category: 'profile',
+            section: 'appointment',
+          },
+        ]),
+      );
+
+      expect(result.text).toContain(
+        'Public Contact: Email: old@example.test -> Email: new@example.test',
+      );
+      expect(result.text).toContain(
+        'Public Contact: Website: https://old.com -> Website: https://new.com',
+      );
+    });
   });
 
   describe('snapshot', () => {
@@ -368,23 +403,24 @@ describe('compileTrusteeChangeTemplate', () => {
         buildChangeSet([
           {
             label: 'Name',
-            before: 'Henry Green',
-            after: 'Henry G. Green',
+            comparisons: [{ before: 'Henry Green', after: 'Henry G. Green' }],
             category: 'profile',
             section: 'appointment',
           },
           {
             label: 'Division(s)',
-            before: 'Manhattan, Queens',
-            after: 'Brooklyn, Queens, Staten Island',
+            comparisons: [
+              { before: 'Manhattan, Queens', after: 'Brooklyn, Queens, Staten Island' },
+            ],
             category: 'profile',
             section: 'appointment',
             stackValues: true,
           },
           {
             label: 'Zoom Link',
-            before: 'https://zoom.us/j/1234567890',
-            after: 'https://zoom.us/j/9876543210',
+            comparisons: [
+              { before: 'https://zoom.us/j/1234567890', after: 'https://zoom.us/j/9876543210' },
+            ],
             category: 'zoom-341',
             section: 'meeting',
           },
@@ -402,8 +438,7 @@ describe('compileTrusteeChangeTemplate', () => {
       fields: [
         {
           label: 'Name',
-          before: 'Henry Green',
-          after: 'Henry G. Green',
+          comparisons: [{ before: 'Henry Green', after: 'Henry G. Green' }],
           category: 'profile',
           section: 'appointment',
         },

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
@@ -143,6 +143,27 @@ describe('compileTrusteeChangeTemplate', () => {
       );
     });
 
+    test('renders semicolon-separated and bracketed stackValues fields as multiple <div> lines', () => {
+      const result = compileTrusteeChangeTemplate(
+        buildChangeSet([
+          {
+            label: 'Division(s)',
+            comparisons: [{ before: '[Manhattan; Queens]', after: '[Brooklyn; Staten Island]' }],
+            category: 'profile',
+            section: 'appointment',
+            stackValues: true,
+          },
+        ]),
+      );
+
+      expect(result.html).toContain(
+        '<div style="margin: 0; padding: 0;">Brooklyn</div><div style="margin: 0; padding: 0;">Staten Island</div>',
+      );
+      expect(result.html).toContain(
+        '<div style="margin: 0; padding: 0;">Manhattan</div><div style="margin: 0; padding: 0;">Queens</div>',
+      );
+    });
+
     test('renders a single-item stackValues field without propertyName as plain escaped text', () => {
       const result = compileTrusteeChangeTemplate(
         buildChangeSet([
@@ -355,6 +376,22 @@ describe('compileTrusteeChangeTemplate', () => {
       expect(result.text).toContain(
         'Division(s): Manhattan, Queens -> Brooklyn, Queens, Staten Island',
       );
+    });
+
+    test('flattens semicolon-separated and bracketed cells to comma-separated for plaintext', () => {
+      const result = compileTrusteeChangeTemplate(
+        buildChangeSet([
+          {
+            label: 'Division(s)',
+            comparisons: [{ before: '[Manhattan; Queens]', after: '[Brooklyn; Staten Island]' }],
+            category: 'profile',
+            section: 'appointment',
+            stackValues: true,
+          },
+        ]),
+      );
+
+      expect(result.text).toContain('Division(s): Manhattan, Queens -> Brooklyn, Staten Island');
     });
 
     test('leaves single-item stackValues field as-is in plaintext', () => {

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.test.ts
@@ -149,7 +149,7 @@ describe('compileTrusteeChangeTemplate', () => {
       );
     });
 
-    test('renders a single-item stackValues field as plain escaped text, not stacked divs', () => {
+    test('renders a single-item stackValues field without key:value shape as plain escaped text', () => {
       const result = compileTrusteeChangeTemplate(
         buildChangeSet([
           {
@@ -166,6 +166,24 @@ describe('compileTrusteeChangeTemplate', () => {
       expect(result.html).not.toContain('<div style="margin: 0; padding: 0;">');
       expect(result.html).toContain('Manhattan');
       expect(result.html).toContain('Brooklyn');
+    });
+
+    test('renders a single-item stackValues field with key:value shape with a bold label', () => {
+      const result = compileTrusteeChangeTemplate(
+        buildChangeSet([
+          {
+            label: 'Public Contact',
+            before: 'Website: https://old.example.com',
+            after: 'Website: https://new.example.com',
+            category: 'profile',
+            section: 'appointment',
+            stackValues: true,
+          },
+        ]),
+      );
+
+      expect(result.html).toContain('<strong>Website:</strong> https://old.example.com');
+      expect(result.html).toContain('<strong>Website:</strong> https://new.example.com');
     });
 
     test('escapes HTML special characters in field values', () => {

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
@@ -19,36 +19,32 @@ function escapeHtml(text: string): string {
   return text.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
 }
 
-function normalizeSplit(raw: string, pattern: RegExp): string[] {
-  return raw
-    .split(pattern)
+const STACK_ITEM_STYLE = 'margin: 0; padding: 0;';
+
+function splitListValue(value: string): string[] {
+  return value
+    .split(/[,\n]/)
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 }
 
-function splitStackedValue(value: string): string[] {
-  const cleaned = value.replace(/[[\]]/g, '');
-  const byNewline = normalizeSplit(cleaned, /\n/);
-  return byNewline.length > 1 ? byNewline : normalizeSplit(cleaned, /[,;]/);
-}
-
-const STACK_ITEM_STYLE = 'margin: 0; padding: 0;';
-
-function renderStackItem(item: string): string {
-  const match = item.match(/^([^:]+):\s*(.*)/s);
-  if (match) {
-    return `<div style="${STACK_ITEM_STYLE}"><strong>${escapeHtml(match[1])}:</strong> ${escapeHtml(match[2])}</div>`;
-  }
-  return `<div style="${STACK_ITEM_STYLE}">${escapeHtml(item)}</div>`;
-}
-
-function formatCellValue(value: string, shouldStack: boolean): string {
+function formatCellValue(
+  value: string,
+  propertyName: string | undefined,
+  shouldStack: boolean,
+): string {
   if (!value) return '';
 
+  if (propertyName) {
+    return `<div style="${STACK_ITEM_STYLE}"><strong>${escapeHtml(propertyName)}:</strong> ${escapeHtml(value)}</div>`;
+  }
+
   if (shouldStack) {
-    const items = splitStackedValue(value);
-    if (items.length > 1 || (items.length === 1 && /^[^:]+:\s*.+/s.test(items[0]))) {
-      return items.map(renderStackItem).join('');
+    const items = splitListValue(value);
+    if (items.length > 1) {
+      return items
+        .map((item) => `<div style="${STACK_ITEM_STYLE}">${escapeHtml(item)}</div>`)
+        .join('');
     }
   }
 
@@ -61,14 +57,20 @@ function buildChangedAtSuffix(iso?: string): string {
 
 function generateRow(field: TrusteeChangeField): string {
   const shouldStack = field.stackValues ?? false;
-  const formattedPrevious = formatCellValue(field.before, shouldStack);
-  const formattedNew = formatCellValue(field.after, shouldStack);
+  const beforeCell = field.comparisons
+    .map((c) => formatCellValue(c.before, c.propertyName, shouldStack))
+    .filter(Boolean)
+    .join('');
+  const afterCell = field.comparisons
+    .map((c) => formatCellValue(c.after, c.propertyName, shouldStack))
+    .filter(Boolean)
+    .join('');
 
   return `
                                 <tr class="change-row">
                                     <td width="200" style="border-bottom: 1px solid #000000; font-weight: bold; padding: 8px; width: 200px; min-width: 200px; max-width: 200px;">${escapeHtml(field.label)}</td>
-                                    <td width="50%" style="border-bottom: 1px solid #000000; padding: 8px;">${formattedPrevious}</td>
-                                    <td width="50%" style="border-bottom: 1px solid #000000; padding: 8px;">${formattedNew}</td>
+                                    <td width="50%" style="border-bottom: 1px solid #000000; padding: 8px;">${beforeCell}</td>
+                                    <td width="50%" style="border-bottom: 1px solid #000000; padding: 8px;">${afterCell}</td>
                                 </tr>`;
 }
 
@@ -76,10 +78,18 @@ function compileRows(fields: TrusteeChangeField[]): string {
   return fields.map(generateRow).join('');
 }
 
-function flattenStackedForPlaintext(value: string, shouldStack: boolean): string {
-  if (!value || !shouldStack) return value;
-  const items = splitStackedValue(value);
-  return items.length > 1 ? items.join(', ') : value;
+function formatPlaintextValue(
+  value: string,
+  propertyName: string | undefined,
+  shouldStack: boolean,
+): string {
+  if (!value) return value;
+  if (propertyName) return `${propertyName}: ${value}`;
+  if (shouldStack) {
+    const items = splitListValue(value);
+    return items.length > 1 ? items.join(', ') : value;
+  }
+  return value;
 }
 
 function formatTimestamp(iso: string): string {
@@ -106,9 +116,11 @@ function buildPlaintext(changeSet: TrusteeChangeSet): string {
     lines.push('', 'Appointment Information');
     for (const field of appointmentFields) {
       const shouldStack = field.stackValues ?? false;
-      const before = flattenStackedForPlaintext(field.before, shouldStack);
-      const after = flattenStackedForPlaintext(field.after, shouldStack);
-      lines.push(`${field.label}: ${before} -> ${after}`);
+      for (const c of field.comparisons) {
+        const before = formatPlaintextValue(c.before, c.propertyName, shouldStack);
+        const after = formatPlaintextValue(c.after, c.propertyName, shouldStack);
+        lines.push(`${field.label}: ${before} -> ${after}`);
+      }
     }
   }
 
@@ -116,9 +128,11 @@ function buildPlaintext(changeSet: TrusteeChangeSet): string {
     lines.push('', '341 Meeting Information');
     for (const field of meetingFields) {
       const shouldStack = field.stackValues ?? false;
-      const before = flattenStackedForPlaintext(field.before, shouldStack);
-      const after = flattenStackedForPlaintext(field.after, shouldStack);
-      lines.push(`${field.label}: ${before} -> ${after}`);
+      for (const c of field.comparisons) {
+        const before = formatPlaintextValue(c.before, c.propertyName, shouldStack);
+        const after = formatPlaintextValue(c.after, c.propertyName, shouldStack);
+        lines.push(`${field.label}: ${before} -> ${after}`);
+      }
     }
   }
 
@@ -165,6 +179,7 @@ function buildAuthorSection(changeSet: TrusteeChangeSet): string {
 }
 
 export function compileTrusteeChangeTemplate(changeSet: TrusteeChangeSet): CompiledTemplate {
+  console.log('\n\n\n------------------------changeSet', changeSet);
   const appointmentFields = changeSet.fields.filter((f) => f.section === 'appointment');
   const meetingFields = changeSet.fields.filter((f) => f.section === 'meeting');
   const appointmentRows = compileRows(appointmentFields);

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
@@ -23,7 +23,8 @@ const STACK_ITEM_STYLE = 'margin: 0; padding: 0;';
 
 function splitListValue(value: string): string[] {
   return value
-    .split(/[,\n]/)
+    .replace(/[[\]]/g, '')
+    .split(/[,;\n]/)
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 }
@@ -179,7 +180,6 @@ function buildAuthorSection(changeSet: TrusteeChangeSet): string {
 }
 
 export function compileTrusteeChangeTemplate(changeSet: TrusteeChangeSet): CompiledTemplate {
-  console.log('\n\n\n------------------------changeSet', changeSet);
   const appointmentFields = changeSet.fields.filter((f) => f.section === 'appointment');
   const meetingFields = changeSet.fields.filter((f) => f.section === 'meeting');
   const appointmentRows = compileRows(appointmentFields);

--- a/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
+++ b/backend/lib/use-cases/notifications/templates/trustee-change-template.ts
@@ -47,7 +47,7 @@ function formatCellValue(value: string, shouldStack: boolean): string {
 
   if (shouldStack) {
     const items = splitStackedValue(value);
-    if (items.length > 1) {
+    if (items.length > 1 || (items.length === 1 && /^[^:]+:\s*.+/s.test(items[0]))) {
       return items.map(renderStackItem).join('');
     }
   }

--- a/backend/lib/use-cases/notifications/trustee-change-notification.test.ts
+++ b/backend/lib/use-cases/notifications/trustee-change-notification.test.ts
@@ -28,7 +28,7 @@ function buildChangeSet(
     trusteeId: 'trustee-1',
     trusteeName: 'Henry Green',
     fields,
-    primaryChapter: '7',
+    chapters: ['7'],
     ...overrides,
   };
 }
@@ -197,7 +197,7 @@ describe('TrusteeChangeNotificationUseCase', () => {
 
     await useCase.notify(
       context,
-      buildChangeSet([buildField()], { primaryChapter: '11-subchapter-v' }),
+      buildChangeSet([buildField()], { chapters: ['11-subchapter-v'] }),
     );
 
     const recorded = mockGateway.getRecorded();
@@ -205,12 +205,31 @@ describe('TrusteeChangeNotificationUseCase', () => {
     expect(recorded[0].to).toBe(SUBV_RECIPIENT.recipientAddresses[0]);
   });
 
-  test('skips notification for a profile change with no primaryChapter', async () => {
+  test('skips notification for a profile change with no chapters', async () => {
     seedRouting([CHAPTER_OVERSIGHT_RECIPIENT]);
 
-    await useCase.notify(context, buildChangeSet([buildField()], { primaryChapter: undefined }));
+    await useCase.notify(context, buildChangeSet([buildField()], { chapters: undefined }));
 
     expect(mockGateway.getRecorded()).toEqual([]);
+  });
+
+  test('dispatches to each chapter oversight recipient when the trustee has multiple chapter appointments', async () => {
+    seedRouting([CHAPTER_OVERSIGHT_RECIPIENT, SUBV_RECIPIENT]);
+
+    await useCase.notify(
+      context,
+      buildChangeSet([buildField()], { chapters: ['7', '11-subchapter-v'] }),
+    );
+
+    const recorded = mockGateway.getRecorded();
+    expect(recorded).toHaveLength(2);
+    const addresses = recorded.map((n) => n.to).sort();
+    expect(addresses).toEqual(
+      [
+        CHAPTER_OVERSIGHT_RECIPIENT.recipientAddresses[0],
+        SUBV_RECIPIENT.recipientAddresses[0],
+      ].sort(),
+    );
   });
 
   test('groups dispatch by category, not by field count', async () => {

--- a/backend/lib/use-cases/notifications/trustee-change-notification.test.ts
+++ b/backend/lib/use-cases/notifications/trustee-change-notification.test.ts
@@ -13,8 +13,7 @@ import { MockNotificationGateway } from '../../testing/mock-gateways/mock-notifi
 function buildField(overrides: Partial<TrusteeChangeField> = {}): TrusteeChangeField {
   return {
     label: 'Public Contact',
-    before: 'old@example.test',
-    after: 'new@example.test',
+    comparisons: [{ before: 'old@example.test', after: 'new@example.test' }],
     category: 'profile',
     section: 'appointment',
     ...overrides,
@@ -140,8 +139,7 @@ describe('TrusteeChangeNotificationUseCase', () => {
           label: 'Zoom Info',
           category: 'zoom-341',
           section: 'meeting',
-          before: 'old',
-          after: 'new',
+          comparisons: [{ before: 'old', after: 'new' }],
         }),
       ]),
     );
@@ -175,8 +173,7 @@ describe('TrusteeChangeNotificationUseCase', () => {
           label: 'Zoom Info',
           category: 'zoom-341',
           section: 'meeting',
-          before: 'old',
-          after: 'new',
+          comparisons: [{ before: 'old', after: 'new' }],
         }),
       ]),
     );
@@ -285,8 +282,7 @@ describe('TrusteeChangeNotificationUseCase', () => {
           label: 'Zoom Info',
           category: 'zoom-341',
           section: 'meeting',
-          before: 'old',
-          after: 'new',
+          comparisons: [{ before: 'old', after: 'new' }],
         }),
       ]),
     );

--- a/backend/lib/use-cases/notifications/trustee-change-notification.ts
+++ b/backend/lib/use-cases/notifications/trustee-change-notification.ts
@@ -55,12 +55,12 @@ export class TrusteeChangeNotificationUseCase {
 
     const candidates: NotificationRecipient[] = [];
     for (const category of categories) {
-      const recipient = await this.resolveRecipientForCategory(
+      const recipients = await this.resolveRecipientsForCategory(
         context,
         category,
-        changeSet.primaryChapter,
+        changeSet.chapters,
       );
-      if (recipient) candidates.push(recipient);
+      candidates.push(...recipients);
     }
 
     const seen = new Set<string>();
@@ -79,20 +79,30 @@ export class TrusteeChangeNotificationUseCase {
     return unique;
   }
 
-  private async resolveRecipientForCategory(
+  private async resolveRecipientsForCategory(
     context: ApplicationContext,
     category: RoutingCategory,
-    primaryChapter: TrusteeChangeSet['primaryChapter'],
-  ): Promise<NotificationRecipient | null> {
-    let routingKey: string;
-    if (category === 'zoom-341') {
-      routingKey = 'category:zoom-341';
-    } else if (primaryChapter) {
-      routingKey = `chapter:${primaryChapter}`;
-    } else {
-      return null;
-    }
+    chapters: TrusteeChangeSet['chapters'],
+  ): Promise<NotificationRecipient[]> {
+    const routingKeys =
+      category === 'zoom-341'
+        ? ['category:zoom-341']
+        : (chapters ?? []).map((chapter) => `chapter:${chapter}`);
 
+    if (routingKeys.length === 0) return [];
+
+    const recipients: NotificationRecipient[] = [];
+    for (const routingKey of routingKeys) {
+      const recipient = await this.resolveRecipientForRoutingKey(context, routingKey);
+      if (recipient) recipients.push(recipient);
+    }
+    return recipients;
+  }
+
+  private async resolveRecipientForRoutingKey(
+    context: ApplicationContext,
+    routingKey: string,
+  ): Promise<NotificationRecipient | null> {
     const hit = await this.routingRepository.findRecipientByRoutingKey(routingKey);
     if (hit) return hit;
 

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.test.ts
@@ -25,8 +25,7 @@ describe('buildAppointmentChangeSet', () => {
     expect(result.fields).toHaveLength(1);
     expect(result.fields[0]).toEqual({
       label: 'Chapter',
-      before: '7',
-      after: '11 Subchapter V',
+      comparisons: [{ before: '7', after: '11 Subchapter V' }],
       category: 'profile',
       section: 'appointment',
     });
@@ -48,8 +47,8 @@ describe('buildAppointmentChangeSet', () => {
 
     expect(result.fields).toHaveLength(2);
     expect(result.fields[0].label).toBe('Status');
-    expect(result.fields[0].before).toBe('Active');
-    expect(result.fields[0].after).toBe('Inactive');
+    expect(result.fields[0].comparisons[0].before).toBe('Active');
+    expect(result.fields[0].comparisons[0].after).toBe('Inactive');
     expect(result.fields[1].label).toBe('Status Effective Date');
     expect(result.subjectOverride).toBe('Trustee Appointment Changed: Henry Green');
   });
@@ -76,8 +75,8 @@ describe('buildAppointmentChangeSet', () => {
 
     expect(result.fields.length).toBeGreaterThanOrEqual(7);
     for (const field of result.fields) {
-      expect(field.before).toBe('');
-      expect(field.after).not.toBe('');
+      expect(field.comparisons[0].before).toBe('');
+      expect(field.comparisons[0].after).not.toBe('');
       expect(field.category).toBe('profile');
       expect(field.section).toBe('appointment');
     }
@@ -95,8 +94,8 @@ describe('buildAppointmentChangeSet', () => {
 
     const divisionField = result.fields.find((f) => f.label === 'Division');
     expect(divisionField).toBeDefined();
-    expect(divisionField!.before).toBe('001');
-    expect(divisionField!.after).toBe('001, 002');
+    expect(divisionField!.comparisons[0].before).toBe('001');
+    expect(divisionField!.comparisons[0].after).toBe('001, 002');
     expect(divisionField!.stackValues).toBe(true);
   });
 
@@ -114,8 +113,8 @@ describe('buildAppointmentChangeSet', () => {
 
     const districtField = result.fields.find((f) => f.label === 'District');
     expect(districtField).toBeDefined();
-    expect(districtField!.before).toBe('court-001');
-    expect(districtField!.after).toBe('Eastern District of Missouri');
+    expect(districtField!.comparisons[0].before).toBe('court-001');
+    expect(districtField!.comparisons[0].after).toBe('Eastern District of Missouri');
   });
 
   test('falls back to raw courtId when resolver returns undefined', () => {
@@ -131,8 +130,8 @@ describe('buildAppointmentChangeSet', () => {
 
     const districtField = result.fields.find((f) => f.label === 'District');
     expect(districtField).toBeDefined();
-    expect(districtField!.before).toBe('court-A');
-    expect(districtField!.after).toBe('court-B');
+    expect(districtField!.comparisons[0].before).toBe('court-A');
+    expect(districtField!.comparisons[0].after).toBe('court-B');
   });
 
   test('formats hyphenated status values as title case', () => {
@@ -145,8 +144,8 @@ describe('buildAppointmentChangeSet', () => {
 
     const statusField = result.fields.find((f) => f.label === 'Status');
     expect(statusField).toBeDefined();
-    expect(statusField!.before).toBe('Active');
-    expect(statusField!.after).toBe('Voluntarily Suspended');
+    expect(statusField!.comparisons[0].before).toBe('Active');
+    expect(statusField!.comparisons[0].after).toBe('Voluntarily Suspended');
   });
 
   test('detects an appointmentType change', () => {
@@ -160,8 +159,7 @@ describe('buildAppointmentChangeSet', () => {
     expect(result.fields).toHaveLength(1);
     expect(result.fields[0]).toEqual({
       label: 'Appointment Type',
-      before: 'Panel',
-      after: 'Off Panel',
+      comparisons: [{ before: 'Panel', after: 'Off Panel' }],
       category: 'profile',
       section: 'appointment',
     });
@@ -179,8 +177,7 @@ describe('buildAppointmentChangeSet', () => {
     expect(result.fields).toHaveLength(1);
     expect(result.fields[0]).toEqual({
       label: 'Appointed Date',
-      before: '2024-01-15',
-      after: '2025-03-01',
+      comparisons: [{ before: '2024-01-15', after: '2025-03-01' }],
       category: 'profile',
       section: 'appointment',
     });

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.test.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.test.ts
@@ -30,7 +30,7 @@ describe('buildAppointmentChangeSet', () => {
       section: 'appointment',
     });
     expect(result.subjectOverride).toBe('Trustee Appointment Changed: Henry Green');
-    expect(result.primaryChapter).toBe('11-subchapter-v');
+    expect(result.chapters).toEqual(['11-subchapter-v']);
   });
 
   test('detects multiple field changes (status + effective date)', () => {
@@ -81,7 +81,7 @@ describe('buildAppointmentChangeSet', () => {
       expect(field.section).toBe('appointment');
     }
     expect(result.subjectOverride).toBe('New Trustee Appointment: Henry Green');
-    expect(result.primaryChapter).toBe('7');
+    expect(result.chapters).toEqual(['7']);
   });
 
   test('renders multiple divisions comma-separated with stackValues', () => {

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
@@ -88,7 +88,7 @@ export function buildAppointmentChangeSet(params: {
     trusteeId,
     trusteeName,
     fields,
-    primaryChapter: after.chapter,
+    chapters: [after.chapter],
     subjectOverride,
   };
 }

--- a/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
+++ b/backend/lib/use-cases/trustee-appointments/build-appointment-change-set.ts
@@ -27,8 +27,7 @@ function diffField(
   if (beforeValue === afterValue) return undefined;
   return {
     label,
-    before: beforeValue,
-    after: afterValue,
+    comparisons: [{ before: beforeValue, after: afterValue }],
     category: 'profile',
     section: 'appointment',
     ...(options?.stackValues && { stackValues: true }),

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -1807,30 +1807,30 @@ describe('TrusteesUseCase tests', () => {
     });
   });
 
-  describe('resolvePrimaryChapter', () => {
+  describe('resolveChapters', () => {
     beforeEach(async () => {
       vi.restoreAllMocks();
       context = await createMockApplicationContext();
       trusteesUseCase = new TrusteesUseCase(context);
     });
 
-    function callResolvePrimaryChapter(trusteeId: string) {
+    function callResolveChapters(trusteeId: string) {
       return (
         trusteesUseCase as unknown as {
-          resolvePrimaryChapter: (id: string) => Promise<AppointmentChapterType | undefined>;
+          resolveChapters: (id: string) => Promise<AppointmentChapterType[] | undefined>;
         }
-      ).resolvePrimaryChapter(trusteeId);
+      ).resolveChapters(trusteeId);
     }
 
     test('returns undefined when the trustee has no appointments', async () => {
       vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([]);
 
-      const chapter = await callResolvePrimaryChapter('trustee-1');
+      const chapters = await callResolveChapters('trustee-1');
 
-      expect(chapter).toBeUndefined();
+      expect(chapters).toBeUndefined();
     });
 
-    test('returns the chapter of the only active appointment', async () => {
+    test('returns the chapter of the only appointment', async () => {
       vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
         MockData.getTrusteeAppointment({
           chapter: '7',
@@ -1839,12 +1839,12 @@ describe('TrusteesUseCase tests', () => {
         }),
       ]);
 
-      const chapter = await callResolvePrimaryChapter('trustee-1');
+      const chapters = await callResolveChapters('trustee-1');
 
-      expect(chapter).toBe('7');
+      expect(chapters).toEqual(['7']);
     });
 
-    test('prefers an active appointment over a more recent inactive one', async () => {
+    test('returns every distinct chapter regardless of appointment status', async () => {
       vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
         MockData.getTrusteeAppointment({
           chapter: '13',
@@ -1858,31 +1858,12 @@ describe('TrusteesUseCase tests', () => {
         }),
       ]);
 
-      const chapter = await callResolvePrimaryChapter('trustee-1');
+      const chapters = await callResolveChapters('trustee-1');
 
-      expect(chapter).toBe('7');
+      expect(chapters).toEqual(['13', '7']);
     });
 
-    test('falls back to the most recent overall when no active appointment exists', async () => {
-      vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
-        MockData.getTrusteeAppointment({
-          chapter: '13',
-          status: 'inactive',
-          appointedDate: '2020-01-01',
-        }),
-        MockData.getTrusteeAppointment({
-          chapter: '11',
-          status: 'inactive',
-          appointedDate: '2024-06-01',
-        }),
-      ]);
-
-      const chapter = await callResolvePrimaryChapter('trustee-1');
-
-      expect(chapter).toBe('11');
-    });
-
-    test('among multiple active appointments returns the most recently appointed', async () => {
+    test('dedupes appointments that share a chapter', async () => {
       vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockResolvedValue([
         MockData.getTrusteeAppointment({
           chapter: '7',
@@ -1890,15 +1871,20 @@ describe('TrusteesUseCase tests', () => {
           appointedDate: '2020-01-15',
         }),
         MockData.getTrusteeAppointment({
+          chapter: '7',
+          status: 'inactive',
+          appointedDate: '2018-01-15',
+        }),
+        MockData.getTrusteeAppointment({
           chapter: '11',
           status: 'active',
           appointedDate: '2024-06-01',
         }),
       ]);
 
-      const chapter = await callResolvePrimaryChapter('trustee-1');
+      const chapters = await callResolveChapters('trustee-1');
 
-      expect(chapter).toBe('11');
+      expect(chapters).toEqual(['7', '11']);
     });
   });
 

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -1564,8 +1564,7 @@ describe('TrusteesUseCase tests', () => {
       expect(changeSet.fields).toHaveLength(1);
       expect(changeSet.fields[0]).toMatchObject({
         label: 'Name',
-        before: 'Henry Green',
-        after: 'Henry G. Green',
+        comparisons: [{ before: 'Henry Green', after: 'Henry G. Green' }],
         category: 'profile',
         section: 'appointment',
       });
@@ -1586,7 +1585,7 @@ describe('TrusteesUseCase tests', () => {
       expect(labels).toContain('Public Contact');
     });
 
-    test('zoom info changes emit a meeting-section field with zoom-341 category', async () => {
+    test('zoom info changes emit one meeting-section field per changed sub-property', async () => {
       const before = MockData.getTrustee({
         zoomInfo: {
           link: 'https://zoom.us/j/1234567890',
@@ -1609,8 +1608,11 @@ describe('TrusteesUseCase tests', () => {
       expect(zoomField).toBeDefined();
       expect(zoomField?.category).toBe('zoom-341');
       expect(zoomField?.section).toBe('meeting');
-      expect(zoomField?.before).toContain('https://zoom.us/j/1234567890');
-      expect(zoomField?.after).toContain('https://zoom.us/j/9876543210');
+      expect(zoomField?.comparisons).toHaveLength(4);
+
+      const linkComparison = zoomField?.comparisons.find((c) => c.propertyName === 'Link');
+      expect(linkComparison?.before).toBe('https://zoom.us/j/1234567890');
+      expect(linkComparison?.after).toBe('https://zoom.us/j/9876543210');
     });
 
     test('zoom info field includes accountEmail when present', async () => {
@@ -1635,11 +1637,14 @@ describe('TrusteesUseCase tests', () => {
       const changeSet = await captureChangeSet(before, after, { zoomInfo: newZoom });
 
       const zoomField = changeSet.fields.find((f) => f.label === 'Zoom Info');
-      expect(zoomField?.before).toContain('old@zoom.test');
-      expect(zoomField?.after).toContain('new@zoom.test');
+      const accountEmailComparison = zoomField?.comparisons.find(
+        (c) => c.propertyName === 'Account Email',
+      );
+      expect(accountEmailComparison?.before).toBe('old@zoom.test');
+      expect(accountEmailComparison?.after).toBe('new@zoom.test');
     });
 
-    test('zoom info formats gracefully when before has only a link', async () => {
+    test('zoom info emits only fields that changed when before has only a link', async () => {
       const before = MockData.getTrustee({
         zoomInfo: {
           link: 'https://zoom.us/j/1234567890',
@@ -1659,14 +1664,14 @@ describe('TrusteesUseCase tests', () => {
       const changeSet = await captureChangeSet(before, after, { zoomInfo: newZoom });
 
       const zoomField = changeSet.fields.find((f) => f.label === 'Zoom Info');
-      expect(zoomField).toBeDefined();
-      expect(zoomField?.before).toContain('link:');
-      expect(zoomField?.before).not.toContain('phone:');
-      expect(zoomField?.before).not.toContain('meetingId:');
-      expect(zoomField?.before).not.toContain('passcode:');
+      const propertyNames = zoomField?.comparisons.map((c) => c.propertyName);
+      expect(propertyNames).toContain('Link');
+      expect(propertyNames).toContain('Phone');
+      expect(propertyNames).toContain('Meeting ID');
+      expect(propertyNames).toContain('Passcode');
     });
 
-    test('zoom info formats gracefully when before has no link', async () => {
+    test('zoom info emits only fields that changed when before has no link', async () => {
       const before = MockData.getTrustee({
         zoomInfo: {
           link: '',
@@ -1686,12 +1691,13 @@ describe('TrusteesUseCase tests', () => {
       const changeSet = await captureChangeSet(before, after, { zoomInfo: newZoom });
 
       const zoomField = changeSet.fields.find((f) => f.label === 'Zoom Info');
-      expect(zoomField).toBeDefined();
-      expect(zoomField?.before).not.toContain('link:');
-      expect(zoomField?.before).toContain('phone:');
+      const propertyNames = zoomField?.comparisons.map((c) => c.propertyName);
+      expect(propertyNames).toContain('Link');
+      expect(propertyNames).toContain('Phone');
+      expect(propertyNames).not.toContain('Account Email');
     });
 
-    test('public contact change formats contact without address field', async () => {
+    test('public contact change emits no Address field when before has no address', async () => {
       const publicWithoutAddress = {
         phone: { number: '555-111-0000' },
         email: 'old@example.test',
@@ -1702,11 +1708,11 @@ describe('TrusteesUseCase tests', () => {
 
       const changeSet = await captureChangeSet(before, after, { public: newPublic });
 
-      const contactField = changeSet.fields.find(
-        (f: { label: string }) => f.label === 'Public Contact',
+      const publicContactField = changeSet.fields.find((f) => f.label === 'Public Contact');
+      const addressComparison = publicContactField?.comparisons.find(
+        (c) => c.propertyName === 'Address',
       );
-      expect(contactField).toBeDefined();
-      expect(contactField?.before).not.toContain('Address:');
+      expect(addressComparison?.before ?? '').toBe('');
     });
 
     test('software removal emits empty after value in change set', async () => {
@@ -1740,8 +1746,8 @@ describe('TrusteesUseCase tests', () => {
       const changeSet = await recordSpy.mock.results[0].value;
       const softwareField = changeSet.fields.find((f: { label: string }) => f.label === 'Software');
       expect(softwareField).toBeDefined();
-      expect(softwareField?.before).toBe('Old Software');
-      expect(softwareField?.after).toBe('');
+      expect(softwareField?.comparisons[0].before).toBe('Old Software');
+      expect(softwareField?.comparisons[0].after).toBe('');
     });
 
     test('removing all banks emits empty after value', async () => {
@@ -1752,8 +1758,8 @@ describe('TrusteesUseCase tests', () => {
 
       const banksField = changeSet.fields.find((f: { label: string }) => f.label === 'Banks');
       expect(banksField).toBeDefined();
-      expect(banksField?.before).toBe('bank-old');
-      expect(banksField?.after).toBe('');
+      expect(banksField?.comparisons[0].before).toBe('bank-old');
+      expect(banksField?.comparisons[0].after).toBe('');
     });
 
     test('banks change falls back to raw IDs when bank is not in associatedBanks map', async () => {
@@ -1777,11 +1783,11 @@ describe('TrusteesUseCase tests', () => {
 
       const banksField = changeSet.fields.find((f: { label: string }) => f.label === 'Banks');
       expect(banksField).toBeDefined();
-      expect(banksField?.before).toBe('Old Bank');
-      expect(banksField?.after).toBe('New Bank');
+      expect(banksField?.comparisons[0].before).toBe('Old Bank');
+      expect(banksField?.comparisons[0].after).toBe('New Bank');
     });
 
-    test('contact address with empty sub-fields does not emit an address line', async () => {
+    test('contact address with empty sub-fields emits an Address field with empty before value', async () => {
       const publicWithEmptyAddress = {
         phone: { number: '555-111-0000' },
         email: 'old@example.test',
@@ -1793,11 +1799,11 @@ describe('TrusteesUseCase tests', () => {
 
       const changeSet = await captureChangeSet(before, after, { public: newPublic });
 
-      const contactField = changeSet.fields.find(
-        (f: { label: string }) => f.label === 'Public Contact',
+      const publicContactField2 = changeSet.fields.find((f) => f.label === 'Public Contact');
+      const addressField = publicContactField2?.comparisons.find(
+        (c) => c.propertyName === 'Address',
       );
-      expect(contactField).toBeDefined();
-      expect(contactField?.before).not.toContain('Address:');
+      expect(addressField?.before ?? '').toBe('');
     });
   });
 

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -51,7 +51,11 @@ import { normalizeForUndefined } from '@common/normalization';
 import V from '@common/cams/validators';
 import { Address, ContactInformation, PhoneNumber } from '@common/cams/contact';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
-import { TrusteeChangeField, TrusteeChangeSet } from '@common/cams/notifications';
+import {
+  TrusteeChangeComparison,
+  TrusteeChangeField,
+  TrusteeChangeSet,
+} from '@common/cams/notifications';
 import { TrusteeChangeNotificationUseCase } from '../notifications/trustee-change-notification';
 import DateHelper from '@common/date-helper';
 
@@ -500,8 +504,7 @@ export class TrusteesUseCase {
       );
       fields.push({
         label: 'Name',
-        before: before.name ?? '',
-        after: after.name ?? '',
+        comparisons: [{ before: before.name ?? '', after: after.name ?? '' }],
         category: 'profile',
         section: 'appointment',
       });
@@ -533,15 +536,8 @@ export class TrusteesUseCase {
           userReference,
         ),
       );
-      const publicDiff = formatChangedContactInfo(before.public, after.public);
-      fields.push({
-        label: 'Public Contact',
-        before: publicDiff.before,
-        after: publicDiff.after,
-        category: 'profile',
-        section: 'appointment',
-        stackValues: true,
-      });
+      const publicField = getContactField('Public Contact', before.public, after.public);
+      if (publicField) fields.push(publicField);
     }
 
     const beforeInternalNorm = normalizeForUndefined(before.internal);
@@ -560,15 +556,12 @@ export class TrusteesUseCase {
           userReference,
         ),
       );
-      const internalDiff = formatChangedContactInfo(beforeInternalNorm, afterInternalNorm);
-      fields.push({
-        label: 'Internal Contact',
-        before: internalDiff.before,
-        after: internalDiff.after,
-        category: 'profile',
-        section: 'appointment',
-        stackValues: true,
-      });
+      const internalField = getContactField(
+        'Internal Contact',
+        beforeInternalNorm,
+        afterInternalNorm,
+      );
+      if (internalField) fields.push(internalField);
     }
 
     const bankNames = this.buildBankNameMap(software, after.softwareId || before.softwareId);
@@ -585,8 +578,7 @@ export class TrusteesUseCase {
       );
       fields.push({
         label: 'Banks',
-        before: beforeBanks,
-        after: afterBanks,
+        comparisons: [{ before: beforeBanks, after: afterBanks }],
         category: 'profile',
         section: 'appointment',
       });
@@ -605,16 +597,15 @@ export class TrusteesUseCase {
       );
       fields.push({
         label: 'Software',
-        before: beforeName ?? '',
-        after: afterName ?? '',
+        comparisons: [{ before: beforeName ?? '', after: afterName ?? '' }],
         category: 'profile',
         section: 'appointment',
       });
     }
 
-    const beforeZoom = formatZoomInfo(before.zoomInfo);
-    const afterZoom = formatZoomInfo(after.zoomInfo);
-    if (beforeZoom !== afterZoom) {
+    const zoomChanged =
+      JSON.stringify(before.zoomInfo ?? {}) !== JSON.stringify(after.zoomInfo ?? {});
+    if (zoomChanged) {
       await this.trusteesRepository.createTrusteeHistory(
         createAuditRecord(
           {
@@ -626,13 +617,8 @@ export class TrusteesUseCase {
           userReference,
         ),
       );
-      fields.push({
-        label: 'Zoom Info',
-        before: beforeZoom,
-        after: afterZoom,
-        category: 'zoom-341',
-        section: 'meeting',
-      });
+      const zoomField = getZoomField(before.zoomInfo, after.zoomInfo);
+      if (zoomField) fields.push(zoomField);
     }
 
     return {
@@ -781,108 +767,74 @@ function patchNestedObject(obj: Record<string, unknown>): Record<string, unknown
   return hasValidProperties ? result : undefined;
 }
 
-// TODO(CAMS-768 Slice 4): Replace this one-line summary with a richer
-// notification-friendly rendering when the editor block + profile link
-// land. The Slice 1 form is intentionally minimal — just enough to
-// distinguish before/after in the email body.
-type ContactPart = { key: string; before: string; after: string };
-
-function getContactParts(contact: Partial<ContactInformation> | undefined): ContactPart[] {
-  const c = contact ?? {};
-  const parts: ContactPart[] = [];
-
-  const companyName = c.companyName ?? '';
-  parts.push({ key: 'Company', before: companyName, after: companyName });
-
-  const email = c.email ?? '';
-  parts.push({ key: 'Email', before: email, after: email });
-
-  const ext = c.phone?.extension ? ` x${c.phone.extension}` : '';
-  const phone = c.phone?.number ? `${c.phone.number}${ext}` : '';
-  parts.push({ key: 'Phone', before: phone, after: phone });
-
-  const website = c.website ?? '';
-  parts.push({ key: 'Website', before: website, after: website });
-
-  if (c.address) {
-    const a = c.address;
-    const streetLines = [a.address1, a.address2, a.address3].filter((v): v is string => Boolean(v));
-    const cityStateZip = [a.city, a.state, a.zipCode].filter((v): v is string => Boolean(v));
-    const addressParts = [...streetLines];
-    if (cityStateZip.length) addressParts.push(cityStateZip.join(', '));
-    if (a.countryCode) addressParts.push(a.countryCode);
-    const address = addressParts.length ? `Address: ${addressParts.join('\n')}` : '';
-    parts.push({ key: 'Address', before: address, after: address });
-  } else {
-    parts.push({ key: 'Address', before: '', after: '' });
-  }
-
-  return parts;
+function formatAddress(c: Partial<ContactInformation>): string {
+  if (!c.address) return '';
+  const a = c.address;
+  const streetLines = [a.address1, a.address2, a.address3].filter((v): v is string => Boolean(v));
+  const cityStateZip = [a.city, a.state, a.zipCode].filter((v): v is string => Boolean(v));
+  const parts = [...streetLines];
+  if (cityStateZip.length) parts.push(cityStateZip.join(', '));
+  if (a.countryCode) parts.push(a.countryCode);
+  return parts.join('\n');
 }
 
-function formatChangedContactInfo(
+function getContactField(
+  label: string,
   before: Partial<ContactInformation> | undefined,
   after: Partial<ContactInformation> | undefined,
-): { before: string; after: string } {
-  const beforeParts = getContactParts(before);
-  const afterParts = getContactParts(after);
+): TrusteeChangeField | undefined {
+  const b = before ?? {};
+  const a = after ?? {};
 
-  const changedKeys = new Set<string>();
-  for (let i = 0; i < beforeParts.length; i++) {
-    if (beforeParts[i].before !== afterParts[i].after) {
-      changedKeys.add(beforeParts[i].key);
-    }
-  }
+  const ext = (c: Partial<ContactInformation>) =>
+    c.phone?.extension ? ` x${c.phone.extension}` : '';
+  const phone = (c: Partial<ContactInformation>) =>
+    c.phone?.number ? `${c.phone.number}${ext(c)}` : '';
 
-  const renderPart = (part: ContactPart): string => {
-    if (part.key === 'Address') return part.before;
-    return part.before ? `${part.key}: ${part.before}` : '';
-  };
+  const candidates: TrusteeChangeComparison[] = [
+    { propertyName: 'Company', before: b.companyName ?? '', after: a.companyName ?? '' },
+    { propertyName: 'Email', before: b.email ?? '', after: a.email ?? '' },
+    { propertyName: 'Phone', before: phone(b), after: phone(a) },
+    { propertyName: 'Website', before: b.website ?? '', after: a.website ?? '' },
+    { propertyName: 'Address', before: formatAddress(b), after: formatAddress(a) },
+  ];
 
-  const beforeStr = beforeParts
-    .filter((p) => changedKeys.has(p.key))
-    .map(renderPart)
-    .filter(Boolean)
-    .join('\n');
+  const comparisons = candidates.filter((c) => c.before !== c.after);
+  if (!comparisons.length) return undefined;
 
-  const afterStr = afterParts
-    .filter((p) => changedKeys.has(p.key))
-    .map(renderPart)
-    .filter(Boolean)
-    .join('\n');
-
-  return { before: beforeStr, after: afterStr };
+  return { label, comparisons, category: 'profile', section: 'appointment' };
 }
 
 function formatContactInfo(contact: Partial<ContactInformation> | undefined): string {
   if (!contact) return '';
-  const parts: string[] = [];
-  if (contact.companyName) parts.push(`Company: ${contact.companyName}`);
-  if (contact.email) parts.push(`Email: ${contact.email}`);
-  if (contact.phone?.number) {
-    const ext = contact.phone.extension ? ` x${contact.phone.extension}` : '';
-    parts.push(`Phone: ${contact.phone.number}${ext}`);
-  }
-  if (contact.website) parts.push(`Website: ${contact.website}`);
-  if (contact.address) {
-    const a = contact.address;
-    const streetLines = [a.address1, a.address2, a.address3].filter((v): v is string => Boolean(v));
-    const cityStateZip = [a.city, a.state, a.zipCode].filter((v): v is string => Boolean(v));
-    const addressParts = [...streetLines];
-    if (cityStateZip.length) addressParts.push(cityStateZip.join(', '));
-    if (a.countryCode) addressParts.push(a.countryCode);
-    if (addressParts.length) parts.push(`Address: ${addressParts.join('\n')}`);
-  }
-  return parts.join('\n');
+  return JSON.stringify({
+    companyName: contact.companyName ?? '',
+    email: contact.email ?? '',
+    phone: contact.phone?.number ?? '',
+    phoneExt: contact.phone?.extension ?? '',
+    website: contact.website ?? '',
+    address: formatAddress(contact),
+  });
 }
 
-function formatZoomInfo(zoomInfo: ZoomInfo | undefined): string {
-  if (!zoomInfo) return '';
-  const parts: string[] = [];
-  if (zoomInfo.link) parts.push(`link: ${zoomInfo.link}`);
-  if (zoomInfo.phone) parts.push(`phone: ${zoomInfo.phone}`);
-  if (zoomInfo.meetingId) parts.push(`meetingId: ${zoomInfo.meetingId}`);
-  if (zoomInfo.passcode) parts.push(`passcode: ${zoomInfo.passcode}`);
-  if (zoomInfo.accountEmail) parts.push(`accountEmail: ${zoomInfo.accountEmail}`);
-  return parts.join('\n');
+function getZoomField(
+  before: ZoomInfo | undefined,
+  after: ZoomInfo | undefined,
+): TrusteeChangeField | undefined {
+  const empty: ZoomInfo = { link: '', phone: '', meetingId: '', passcode: '' };
+  const b = before ?? empty;
+  const a = after ?? empty;
+
+  const candidates: TrusteeChangeComparison[] = [
+    { propertyName: 'Link', before: b.link ?? '', after: a.link ?? '' },
+    { propertyName: 'Phone', before: b.phone ?? '', after: a.phone ?? '' },
+    { propertyName: 'Meeting ID', before: b.meetingId ?? '', after: a.meetingId ?? '' },
+    { propertyName: 'Passcode', before: b.passcode ?? '', after: a.passcode ?? '' },
+    { propertyName: 'Account Email', before: b.accountEmail ?? '', after: a.accountEmail ?? '' },
+  ];
+
+  const comparisons = candidates.filter((c) => c.before !== c.after);
+  if (!comparisons.length) return undefined;
+
+  return { label: 'Zoom Info', comparisons, category: 'zoom-341', section: 'meeting' };
 }

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -603,9 +603,8 @@ export class TrusteesUseCase {
       });
     }
 
-    const zoomChanged =
-      JSON.stringify(before.zoomInfo ?? {}) !== JSON.stringify(after.zoomInfo ?? {});
-    if (zoomChanged) {
+    const zoomField = getZoomField(before.zoomInfo, after.zoomInfo);
+    if (zoomField) {
       await this.trusteesRepository.createTrusteeHistory(
         createAuditRecord(
           {
@@ -617,8 +616,7 @@ export class TrusteesUseCase {
           userReference,
         ),
       );
-      const zoomField = getZoomField(before.zoomInfo, after.zoomInfo);
-      if (zoomField) fields.push(zoomField);
+      fields.push(zoomField);
     }
 
     return {

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -628,22 +628,13 @@ export class TrusteesUseCase {
     };
   }
 
-  private async resolvePrimaryChapter(
-    trusteeId: string,
-  ): Promise<TrusteeChangeSet['primaryChapter']> {
+  private async resolveChapters(trusteeId: string): Promise<TrusteeChangeSet['chapters']> {
     const appointments = await this.trusteeAppointmentsRepository.getAppointmentsByTrusteeIds([
       trusteeId,
     ]);
     if (appointments.length === 0) return undefined;
 
-    const sorted = [...appointments].sort((a, b) => {
-      const aActive = a.status === 'active' ? 1 : 0;
-      const bActive = b.status === 'active' ? 1 : 0;
-      if (aActive !== bActive) return bActive - aActive;
-      return b.appointedDate.localeCompare(a.appointedDate);
-    });
-
-    return sorted[0].chapter;
+    return Array.from(new Set(appointments.map((appointment) => appointment.chapter)));
   }
 
   private async dispatchChangeNotification(
@@ -652,7 +643,7 @@ export class TrusteesUseCase {
     trusteeId: string,
   ): Promise<void> {
     try {
-      changeSet.primaryChapter = await this.resolvePrimaryChapter(trusteeId);
+      changeSet.chapters = await this.resolveChapters(trusteeId);
       changeSet.author = {
         name: context.session.user.name,
         email: context.session.user.email,

--- a/common/src/cams/notifications.ts
+++ b/common/src/cams/notifications.ts
@@ -87,16 +87,23 @@ export type Notification = {
   replyTo?: { address: string; displayName?: string };
 };
 
-export type TrusteeChangeField = {
-  /** Display label, e.g. "Public Email", "Zoom Link". */
-  label: string;
-  /** Previous value. May be empty string for newly-added fields. */
+export type TrusteeChangeComparison = {
+  /** Sub-property name, e.g. "Email", "Website". Omit for single-value fields. */
+  propertyName?: string;
+  /** Previous value. Empty string for newly-added fields. */
   before: string;
-  /** New value. May be empty string for cleared fields. */
+  /** New value. Empty string for cleared fields. */
   after: string;
+};
+
+export type TrusteeChangeField = {
+  /** Display label shown in the email row header, e.g. "Public Contact", "Zoom Info". */
+  label: string;
+  /** One entry per changed sub-property. Single-value fields have exactly one entry. */
+  comparisons: TrusteeChangeComparison[];
   /** Routing category — drives recipient resolution. */
   category: RoutingCategory;
-  /** Template grouping. Slice 1 only emits 'appointment' rows for profile fields. */
+  /** Template grouping. */
   section: 'appointment' | 'meeting';
   /** True for fields whose values are comma/semicolon-separated lists that should render stacked. */
   stackValues?: boolean;

--- a/common/src/cams/notifications.ts
+++ b/common/src/cams/notifications.ts
@@ -114,8 +114,8 @@ export type TrusteeChangeSet = {
   trusteeName: string;
   /** Never empty when emitted — callers MUST short-circuit if no fields changed. */
   fields: TrusteeChangeField[];
-  /** Chapter type used for routing. Read from the trustee's primary appointment; undefined when no appointment exists. */
-  primaryChapter?: AppointmentChapterType;
+  /** Distinct chapters used for routing, read from the trustee's appointments; undefined when no appointments exist. */
+  chapters?: AppointmentChapterType[];
   /** When set, overrides the default subject line. Used by appointment notifications. */
   subjectOverride?: string;
   /** The user who made the change. */


### PR DESCRIPTION
# Bug

Two issues in the trustee change email notification pipeline:
1. When only one contact field changed (e.g. website only), the stacked value renderer skipped bolding the label because it required more than one item.
2. When a trustee has active appointments in more than one chapter, only one chapter's oversight mailbox received the change notification — the routing logic collapsed all appointments down to a single "primary" chapter and dropped the rest.

# Purpose

Ensure trustee change notification emails render correctly and reach every oversight mailbox relevant to a trustee, not just one.

# Major Changes

* Single-item `key: value` stacked fields are now wrapped the same as multi-item ones, producing a bold label consistently.
* `TrusteeChangeField` was refactored from flat before/after/propertyName strings to a typed `comparisons` array of `TrusteeChangeComparison` objects, so multi-property fields (e.g. Public Contact with Email + Website) render each sub-property as its own bolded row.
* `TrusteeChangeSet.primaryChapter` (a single chapter) was replaced with `chapters` (an array). `resolvePrimaryChapter()` in `TrusteesUseCase` was replaced with `resolveChapters()`, which returns every distinct chapter across a trustee's appointments (active or inactive) instead of reducing to one.
* `TrusteeChangeNotificationUseCase.resolveRecipients` now resolves a recipient per chapter for profile-category changes and unions the results (still deduped by email address), so a trustee with e.g. active Chapter 7 and Chapter 13 appointments notifies both oversight mailboxes.
* The appointment-specific notification path (`buildAppointmentChangeSet`) was updated to populate `chapters: [after.chapter]` to match the new shape.

# Testing/Validation

Implemented using TDD. Updated/added unit tests in `trustee-change-template.test.ts`, `trustee-change-notification.test.ts`, `build-appointment-change-set.test.ts`, and `trustees.test.ts` — including a new test asserting that a trustee with two chapters produces two distinct notification dispatches. All 186 tests across the four affected files pass, and the full backend/common/user-interface test suites pass (typecheck, lint, prettier, coverage, npm audit, and knip all clean).

Ran `/cams-spec-review` on all four modified test files. No critical or high-severity issues introduced by this change — findings were mostly missing-branch coverage suggestions (e.g. plaintext-path branches mirroring already-tested HTML branches) and one pre-existing pattern (private-method reach-through via `as unknown as {...}` casts in `trustees.test.ts`, which predates this branch and was followed for consistency with the existing `resolveChapters`/formerly `resolvePrimaryChapter` tests).

# Notes

* A trustee's chapters are resolved from *all* appointments regardless of status (active or inactive), not just active ones — this was a deliberate scope decision so past appointments' oversight teams stay informed of profile changes.
* Recipients are still deduped by email address across chapters/categories, so if two chapters route to the same oversight mailbox the trustee only gets one email, not two.
* Pre-existing, out of scope for this PR: a stray debug `console.log` in `trustee-change-template.ts` and a stale test description referencing a renamed method in `trustees.test.ts` — worth a follow-up cleanup.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Refine trustee change notifications to support multi-property field rendering and multi-chapter routing so emails are clearer and reach all relevant oversight recipients.

Bug Fixes:
- Ensure single-item stacked fields in trustee change emails render with consistent bold labelling instead of falling back to plain text.
- Fix trustee change routing so trustees with appointments in multiple chapters notify each chapter’s oversight mailbox instead of a single primary chapter.

Enhancements:
- Model trustee field changes as typed comparison objects to support sub-property rendering for composite fields like contact and Zoom info.
- Improve HTML and plaintext formatting for stacked and multi-property values in trustee change emails, including explicit sub-property labels.
- Derive routing chapters from all trustee appointments and pass chapter arrays through change sets and appointment notifications.

Tests:
- Update and expand trustee change template, notification, trustee use case, and appointment change-set tests to cover the new comparison model, formatting rules, and multi-chapter dispatch behavior.