### PR TITLE
Treat blank/null trustee website as unset, not invalid

### DIFF
--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -681,6 +681,45 @@ describe('TrusteesUseCase tests', () => {
       );
     });
 
+    test.each([
+      ['empty string', ''],
+      ['null', null],
+      ['undefined', undefined],
+    ])(
+      'should update trustee public contact with website cleared (%s)',
+      async (_label, website) => {
+        const newPublicContact = {
+          ...MockData.getContactInformation(),
+          website,
+        };
+        const updateData = { public: newPublicContact };
+        const updatedTrustee = { ...existingTrustee, public: newPublicContact };
+
+        const updateTrusteeSpy = vi
+          .spyOn(MockMongoRepository.prototype, 'updateTrustee')
+          .mockResolvedValue(updatedTrustee);
+        vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+
+        await trusteesUseCase.updateTrustee(context, trusteeId, updateData);
+
+        expect(updateTrusteeSpy).toHaveBeenCalled();
+      },
+    );
+
+    test('should throw BadRequestError when public contact website is an invalid non-empty string', async () => {
+      const newPublicContact = {
+        ...MockData.getContactInformation(),
+        website: 'not a valid website!!',
+      };
+      const updateData = { public: newPublicContact };
+
+      const error = await getTheThrownError(() =>
+        trusteesUseCase.updateTrustee(context, trusteeId, updateData),
+      );
+      expect(error.isCamsError).toBe(true);
+      expect(error.message).toContain(FIELD_VALIDATION_MESSAGES.WEBSITE);
+    });
+
     test('should update trustee and create internal contact history when internal contact changes', async () => {
       const updatedBy = getCamsUserReference(context.session.user);
       const newInternalContact = MockData.getContactInformation();

--- a/common/src/cams/contact-validators.ts
+++ b/common/src/cams/contact-validators.ts
@@ -6,7 +6,10 @@ export const email = V.checkFirst(V.matches(EMAIL_REGEX, FIELD_VALIDATION_MESSAG
   V.maxLength(254),
 );
 
-export const website = V.optional(
-  V.matches(WEBSITE_RELAXED_REGEX, FIELD_VALIDATION_MESSAGES.WEBSITE),
-  V.maxLength(255, FIELD_VALIDATION_MESSAGES.WEBSITE_MAX_LENGTH),
+export const website = V.skip(
+  (v) => v === undefined || v === null || v === '',
+  [
+    V.matches(WEBSITE_RELAXED_REGEX, FIELD_VALIDATION_MESSAGES.WEBSITE),
+    V.maxLength(255, FIELD_VALIDATION_MESSAGES.WEBSITE_MAX_LENGTH),
+  ],
 );

--- a/common/src/cams/trustees-validators.test.ts
+++ b/common/src/cams/trustees-validators.test.ts
@@ -205,6 +205,8 @@ describe('trustees-validators', () => {
       { value: 'http://example.com', expected: VALID },
       { value: 'www.example.com', expected: VALID },
       { value: undefined, expected: VALID },
+      { value: null, expected: VALID },
+      { value: '', expected: VALID },
       {
         value: 'invalid website',
         expected: { reasons: [FIELD_VALIDATION_MESSAGES.WEBSITE] },


### PR DESCRIPTION
# Bug

Editing a trustee and clearing the public website field failed with `$.public.website: Website must be a valid URL.`, even though the user wasn't entering an invalid URL — they were clearing the field entirely. The API rejected `''` and `null` the same way it would reject a malformed URL string.

# Purpose

Let users clear a trustee's public website without triggering a spurious validation error, while still rejecting genuinely malformed non-empty URL strings.

# Major Changes

* `website` in `common/src/cams/contact-validators.ts` no longer uses `V.optional(...)`, which only skips validation for `undefined`. It now uses `V.skip((v) => v === undefined || v === null || v === '', [...])`, so all three "not set" representations are treated as valid/unset before the URL regex and max-length checks ever run.
* This validator is shared by both the frontend (`trusteePublicSpec`) and backend (`contactInformationSpec` in `trustees.ts`), so both layers pick up the fix automatically — no separate frontend change was needed. The frontend form was already sending `website: formData.website || ''` when the field is blank.

# Testing/Validation

Implemented using TDD. Added test cases to `common/src/cams/trustees-validators.test.ts` covering `undefined`, `null`, and `''` for the `website` validator (previously only `undefined` was tested). Added tests to `backend/lib/use-cases/trustees/trustees.test.ts` covering the full `updateTrustee` path with website cleared via empty string/null/undefined, plus a regression test confirming a genuinely invalid non-empty website string still throws `BadRequestError` with the `Website must be a valid URL` message.

All 3202 backend tests, 1108 common tests, and 3245 frontend tests pass (including the pre-existing frontend regression test that already asserts the form submits `website: ''` on blank). Typecheck, lint, prettier, coverage, npm audit, and knip are all clean.

Ran `/cams-spec-review` on both changed test files. No issues introduced by this change — findings were either pre-existing (a HIGH-severity private-method-spying pattern in `trustees.test.ts` that predates this branch and that my new tests don't use) or independently-surfaced observations that the same `V.optional`-only-skips-`undefined` gap likely also affects other fields (`companyName`, `addressLine2`, `addressLine3`, `trusteeMiddleName`, `phoneExtension`) which aren't in scope for this fix since they aren't currently triggering the bug for any known caller.

# Notes

* Scoped the fix to the `website` validator specifically rather than broadening the shared `V.optional` helper, because other callers of `V.optional` (e.g. `caseNumber`, `debtorName` in `search-validators.ts`) intentionally reject `''` as invalid input. Broadening `optional` globally would have silently changed their behavior.
* `phoneExtension` has the identical `V.optional(V.matches(...))` shape and would exhibit the same bug if any caller ever sent `''` instead of `undefined` for a blank extension. It's not fixed here because the one form that uses it currently sends `undefined` when blank, so it isn't actively broken — flagging as a candidate for a follow-up if it's ever reported.
* This work isn't tracked under a Jira/CAMS ticket.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Treat trustee public website as an optional field that can be cleared without triggering validation errors while preserving validation for malformed URLs.

Bug Fixes:
- Allow clearing a trustee's public website (empty string, null, or undefined) without raising a URL validation error.
- Ensure invalid non-empty website strings on trustee public contact still return a BadRequestError with the website validation message.

Enhancements:
- Adjust shared website validator to skip validation when the value is unset (undefined, null, or empty string).

Tests:
- Expand website validator tests to cover null and empty string as valid unset values.
- Add updateTrustee tests to cover clearing the website and to assert rejection of invalid non-empty website values.