### PR TITLE
Fix trustee migration duplication (M1 regex, M2 dedup-key)

### DIFF
--- a/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.test.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.test.ts
@@ -654,6 +654,82 @@ describe('ATS Mappings', () => {
         expect(result.internal?.address.address1).toBe('2 Internal Ave');
       });
     });
+
+    describe('public state fallback when selected public state is empty', () => {
+      const baseRecord = {
+        ID: 300,
+        FIRST_NAME: 'Carol',
+        LAST_NAME: 'White',
+        STREET: '1 Public St',
+        CITY: 'PublicCity',
+        STATE: 'MD',
+        ZIP: '20001',
+        STREET_A2: '2 Internal Ave',
+        CITY_A2: 'Albany',
+        STATE_A2: 'DE',
+        ZIP_A2: '20002',
+      };
+
+      test('should fall back to non-A2 state when a2IsPublic and STATE_A2 is empty', () => {
+        const atsTrustee: AtsTrusteeRecord = {
+          ...baseRecord,
+          DISP_ON_WEB: 'N',
+          DISP_ON_WEB_A2: 'y',
+          STATE_A2: '',
+          STATE: 'MD',
+        };
+
+        const result = transformTrusteeRecord(atsTrustee);
+
+        expect(result.public.address.state).toBe('MD');
+        // Public address itself is still the A2 address (only state falls back)
+        expect(result.public.address.city).toBe('Albany');
+        expect(result.public.address.address1).toBe('2 Internal Ave');
+      });
+
+      test('should treat whitespace-only STATE_A2 as empty and fall back', () => {
+        const atsTrustee: AtsTrusteeRecord = {
+          ...baseRecord,
+          DISP_ON_WEB: 'N',
+          DISP_ON_WEB_A2: 'y',
+          STATE_A2: '   ',
+          STATE: 'MD',
+        };
+
+        const result = transformTrusteeRecord(atsTrustee);
+
+        expect(result.public.address.state).toBe('MD');
+      });
+
+      test('should use A2 state (no fallback) when a2IsPublic and STATE_A2 is populated', () => {
+        const atsTrustee: AtsTrusteeRecord = {
+          ...baseRecord,
+          DISP_ON_WEB: 'N',
+          DISP_ON_WEB_A2: 'y',
+          STATE_A2: 'DE',
+          STATE: 'MD',
+        };
+
+        const result = transformTrusteeRecord(atsTrustee);
+
+        expect(result.public.address.state).toBe('DE');
+      });
+
+      test('should fall back to A2 state when non-A2 is public and STATE is empty', () => {
+        const atsTrustee: AtsTrusteeRecord = {
+          ...baseRecord,
+          STATE: '',
+          STATE_A2: 'DE',
+        };
+
+        const result = transformTrusteeRecord(atsTrustee);
+
+        expect(result.public.address.state).toBe('DE');
+        // Public address itself is still the non-A2 address (only state falls back)
+        expect(result.public.address.city).toBe('PublicCity');
+        expect(result.public.address.address1).toBe('1 Public St');
+      });
+    });
   });
 
   describe('transformAppointmentRecord', () => {

--- a/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.test.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.test.ts
@@ -715,6 +715,18 @@ describe('ATS Mappings', () => {
         expect(result.public.address.state).toBe('DE');
       });
 
+      test('should trim leading/trailing whitespace from the stored public state', () => {
+        const atsTrustee: AtsTrusteeRecord = {
+          ...baseRecord,
+          STATE: '  MD  ',
+          STATE_A2: 'DE',
+        };
+
+        const result = transformTrusteeRecord(atsTrustee);
+
+        expect(result.public.address.state).toBe('MD');
+      });
+
       test('should fall back to A2 state when non-A2 is public and STATE is empty', () => {
         const atsTrustee: AtsTrusteeRecord = {
           ...baseRecord,

--- a/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.ts
@@ -255,7 +255,13 @@ export function transformTrusteeRecord(
   const primaryStreet = a2IsPublic ? atsTrustee.STREET_A2 : atsTrustee.STREET;
   const primaryStreet1 = a2IsPublic ? atsTrustee.STREET1_A2 : atsTrustee.STREET1;
   const primaryCity = a2IsPublic ? atsTrustee.CITY_A2 : atsTrustee.CITY;
-  const primaryState = a2IsPublic ? atsTrustee.STATE_A2 : atsTrustee.STATE;
+  // Only the state field falls back: if the selected public address's state is
+  // empty/blank, use the other address's state so a record is never dropped
+  // downstream for a missing public state. All other public address fields
+  // (street, city, zip) remain from the selected public address.
+  const selectedPublicState = a2IsPublic ? atsTrustee.STATE_A2 : atsTrustee.STATE;
+  const otherState = a2IsPublic ? atsTrustee.STATE : atsTrustee.STATE_A2;
+  const primaryState = selectedPublicState?.trim() ? selectedPublicState : otherState;
   const primaryZip = a2IsPublic ? atsTrustee.ZIP_A2 : atsTrustee.ZIP;
   const primaryZipPlus = a2IsPublic ? atsTrustee.ZIP_PLUS_A2 : atsTrustee.ZIP_PLUS;
 

--- a/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.ts
+++ b/backend/lib/adapters/gateways/ats/cleansing/ats-mappings.ts
@@ -261,7 +261,7 @@ export function transformTrusteeRecord(
   // (street, city, zip) remain from the selected public address.
   const selectedPublicState = a2IsPublic ? atsTrustee.STATE_A2 : atsTrustee.STATE;
   const otherState = a2IsPublic ? atsTrustee.STATE : atsTrustee.STATE_A2;
-  const primaryState = selectedPublicState?.trim() ? selectedPublicState : otherState;
+  const primaryState = selectedPublicState?.trim() || otherState?.trim() || undefined;
   const primaryZip = a2IsPublic ? atsTrustee.ZIP_A2 : atsTrustee.ZIP;
   const primaryZipPlus = a2IsPublic ? atsTrustee.ZIP_PLUS_A2 : atsTrustee.ZIP_PLUS;
 

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
@@ -315,13 +315,6 @@ describe('TrusteesMongoRepository', () => {
   });
 
   describe('findTrusteeByNameAndState', () => {
-    // Pulls the composite-name RegExp out of the last findOne call so tests can
-    // assert on regex.source/flags rather than pinning the exact construction.
-    function getNameRegex(spy: { mock: { calls: unknown[][] } }): RegExp {
-      const query = spy.mock.calls.at(-1)![0] as { values: { rightOperand: RegExp }[] };
-      return query.values[1].rightOperand;
-    }
-
     test('should return trustee when found by name and state', async () => {
       const mockTrustee = {
         id: 'trustee-123',
@@ -360,7 +353,7 @@ describe('TrusteesMongoRepository', () => {
           {
             condition: 'REGEX',
             leftOperand: { name: 'name' },
-            rightOperand: expect.any(RegExp),
+            rightOperand: /^John(?!\w).*\sDoe(?!\w)/i,
           },
           {
             condition: 'EQUALS',
@@ -369,12 +362,6 @@ describe('TrusteesMongoRepository', () => {
           },
         ],
       });
-      // Assert the normalized name tokens made it into the regex without pinning
-      // the exact boundary/lookahead construction (covered by behavior tests below).
-      const regex = getNameRegex(mockAdapter);
-      expect(regex.source).toContain('John');
-      expect(regex.source).toContain('Doe');
-      expect(regex.flags).toContain('i');
       expect(result).toEqual(mockTrustee);
     });
 
@@ -385,6 +372,8 @@ describe('TrusteesMongoRepository', () => {
 
       await repository.findTrusteeByNameAndState('  John  ', '  Doe  ', 'ny');
 
+      // The padded input is trimmed, so the regex is built from the trimmed
+      // tokens and the state is normalized to upper case.
       expect(mockAdapter).toHaveBeenCalledWith({
         conjunction: 'AND',
         values: [
@@ -396,7 +385,7 @@ describe('TrusteesMongoRepository', () => {
           {
             condition: 'REGEX',
             leftOperand: { name: 'name' },
-            rightOperand: expect.any(RegExp),
+            rightOperand: /^John(?!\w).*\sDoe(?!\w)/i,
           },
           {
             condition: 'EQUALS',
@@ -405,11 +394,6 @@ describe('TrusteesMongoRepository', () => {
           },
         ],
       });
-      // Trimming ran: the regex uses the trimmed tokens, not the padded input.
-      const regex = getNameRegex(mockAdapter);
-      expect(regex.source).toContain('John');
-      expect(regex.source).toContain('Doe');
-      expect(regex.flags).toContain('i');
     });
 
     test('should handle multiple spaces in names', async () => {
@@ -419,6 +403,7 @@ describe('TrusteesMongoRepository', () => {
 
       await repository.findTrusteeByNameAndState('John   Michael', 'Doe   Smith', 'NY');
 
+      // Internal whitespace is collapsed to a single space in each token.
       expect(mockAdapter).toHaveBeenCalledWith({
         conjunction: 'AND',
         values: [
@@ -430,7 +415,7 @@ describe('TrusteesMongoRepository', () => {
           {
             condition: 'REGEX',
             leftOperand: { name: 'name' },
-            rightOperand: expect.any(RegExp),
+            rightOperand: /^John Michael(?!\w).*\sDoe Smith(?!\w)/i,
           },
           {
             condition: 'EQUALS',
@@ -439,11 +424,6 @@ describe('TrusteesMongoRepository', () => {
           },
         ],
       });
-      // Internal whitespace was collapsed to a single space in each token.
-      const regex = getNameRegex(mockAdapter);
-      expect(regex.source).toContain('John Michael');
-      expect(regex.source).toContain('Doe Smith');
-      expect(regex.flags).toContain('i');
     });
 
     test('should return null when no trustee is found', async () => {

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
@@ -509,6 +509,17 @@ describe('TrusteesMongoRepository', () => {
       expect(regex.test('J. Ford Elsaesser')).toBe(true);
     });
 
+    test('should not merge a bare-initial first name into a different person', async () => {
+      // The incoming first name is always at string start in the composite
+      // `name`. A bare-initial first name (e.g. "J.") must not bind to a
+      // different person's interior middle initial, which would merge two
+      // distinct trustees during upsert.
+      const regex = await buildNameRegex('J.', 'Elsaesser');
+      expect(regex.test('Robert J. Elsaesser')).toBe(false);
+      expect(regex.test('J. Ford Elsaesser')).toBe(true);
+      expect(regex.test('J. Elsaesser')).toBe(true);
+    });
+
     test('should match when last name contains a comma and suffix', async () => {
       const regex = await buildNameRegex('William', 'Brandt, Jr.');
       expect(regex.test('William A. Brandt, Jr.')).toBe(true);

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.test.ts
@@ -315,6 +315,13 @@ describe('TrusteesMongoRepository', () => {
   });
 
   describe('findTrusteeByNameAndState', () => {
+    // Pulls the composite-name RegExp out of the last findOne call so tests can
+    // assert on regex.source/flags rather than pinning the exact construction.
+    function getNameRegex(spy: { mock: { calls: unknown[][] } }): RegExp {
+      const query = spy.mock.calls.at(-1)![0] as { values: { rightOperand: RegExp }[] };
+      return query.values[1].rightOperand;
+    }
+
     test('should return trustee when found by name and state', async () => {
       const mockTrustee = {
         id: 'trustee-123',
@@ -353,7 +360,7 @@ describe('TrusteesMongoRepository', () => {
           {
             condition: 'REGEX',
             leftOperand: { name: 'name' },
-            rightOperand: /\bJohn\b.*\bDoe\b/i,
+            rightOperand: expect.any(RegExp),
           },
           {
             condition: 'EQUALS',
@@ -362,6 +369,12 @@ describe('TrusteesMongoRepository', () => {
           },
         ],
       });
+      // Assert the normalized name tokens made it into the regex without pinning
+      // the exact boundary/lookahead construction (covered by behavior tests below).
+      const regex = getNameRegex(mockAdapter);
+      expect(regex.source).toContain('John');
+      expect(regex.source).toContain('Doe');
+      expect(regex.flags).toContain('i');
       expect(result).toEqual(mockTrustee);
     });
 
@@ -383,7 +396,7 @@ describe('TrusteesMongoRepository', () => {
           {
             condition: 'REGEX',
             leftOperand: { name: 'name' },
-            rightOperand: /\bJohn\b.*\bDoe\b/i,
+            rightOperand: expect.any(RegExp),
           },
           {
             condition: 'EQUALS',
@@ -392,6 +405,11 @@ describe('TrusteesMongoRepository', () => {
           },
         ],
       });
+      // Trimming ran: the regex uses the trimmed tokens, not the padded input.
+      const regex = getNameRegex(mockAdapter);
+      expect(regex.source).toContain('John');
+      expect(regex.source).toContain('Doe');
+      expect(regex.flags).toContain('i');
     });
 
     test('should handle multiple spaces in names', async () => {
@@ -412,7 +430,7 @@ describe('TrusteesMongoRepository', () => {
           {
             condition: 'REGEX',
             leftOperand: { name: 'name' },
-            rightOperand: /\bJohn Michael\b.*\bDoe Smith\b/i,
+            rightOperand: expect.any(RegExp),
           },
           {
             condition: 'EQUALS',
@@ -421,6 +439,11 @@ describe('TrusteesMongoRepository', () => {
           },
         ],
       });
+      // Internal whitespace was collapsed to a single space in each token.
+      const regex = getNameRegex(mockAdapter);
+      expect(regex.source).toContain('John Michael');
+      expect(regex.source).toContain('Doe Smith');
+      expect(regex.flags).toContain('i');
     });
 
     test('should return null when no trustee is found', async () => {
@@ -461,6 +484,57 @@ describe('TrusteesMongoRepository', () => {
           ]),
         }),
       );
+    });
+  });
+
+  describe('findTrusteeByNameAndState composite-name regex behavior', () => {
+    // Captures the RegExp the method actually builds and hands to the adapter,
+    // then exercises it against real composite `name` values. The composite
+    // `name` field is `firstName [middleName] lastName [suffix]`, so the regex
+    // must tolerate punctuation on the name tokens (e.g. "J.", "Brandt, Jr.",
+    // "Andres'", "D'Amour") while still rejecting prefix false-positives.
+    async function buildNameRegex(firstName: string, lastName: string): Promise<RegExp> {
+      const spy = vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockResolvedValue(null);
+      await repository.findTrusteeByNameAndState(firstName, lastName, 'NY');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const query = spy.mock.calls.at(-1)![0] as any;
+      const regexCondition = query.values.find(
+        (v: { condition: string }) => v.condition === 'REGEX',
+      );
+      return regexCondition.rightOperand as RegExp;
+    }
+
+    test('should match when first name ends in punctuation', async () => {
+      const regex = await buildNameRegex('J.', 'Elsaesser');
+      expect(regex.test('J. Ford Elsaesser')).toBe(true);
+    });
+
+    test('should match when last name contains a comma and suffix', async () => {
+      const regex = await buildNameRegex('William', 'Brandt, Jr.');
+      expect(regex.test('William A. Brandt, Jr.')).toBe(true);
+    });
+
+    test('should match when first name ends in an apostrophe', async () => {
+      const regex = await buildNameRegex("Andres'", 'Diaz');
+      expect(regex.test("Andres' Diaz")).toBe(true);
+    });
+
+    test('should match when last name begins with an apostrophe token', async () => {
+      const regex = await buildNameRegex('Kevin', "D'Amour");
+      expect(regex.test("Kevin F. D'Amour")).toBe(true);
+    });
+
+    test('should still match clean names', async () => {
+      const cohen = await buildNameRegex('Merrill', 'Cohen');
+      expect(cohen.test('Merrill Cohen')).toBe(true);
+
+      const smith = await buildNameRegex('John', 'Smith');
+      expect(smith.test('John Q. Smith')).toBe(true);
+    });
+
+    test('should reject prefix false-positive on first name', async () => {
+      const regex = await buildNameRegex('J', 'Smith');
+      expect(regex.test('Jack Smith')).toBe(false);
     });
   });
 

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.ts
@@ -348,12 +348,40 @@ export class TrusteesMongoRepository extends BaseMongoRepository implements Trus
       const escapedFirstName = escapeRegex(normalizedFirstName);
       const escapedLastName = escapeRegex(normalizedLastName);
 
-      // Build query with word-boundary matching to handle middle names/suffixes
-      // Matches "John Smith", "John Q. Smith", "John Smith Jr.", etc.
+      // Build query with token-boundary matching against the composite `name`
+      // field (`firstName [middleName] lastName [suffix]`), so we match
+      // "John Smith", "John Q. Smith", "John Smith Jr.", etc.
+      //
+      // We deliberately avoid `\b` (word/non-word TRANSITION assertion): when a
+      // name token ends or begins in punctuation (e.g. "J.", "Brandt, Jr.",
+      // "Andres'", "D'Amour") the `\b` adjacent to the escaped literal sits
+      // between two non-word chars and can never match, so the dedup lookup
+      // returns null and a duplicate trustee is created every migration run.
+      //
+      // Instead: leading boundary is established by consuming start-or-whitespace
+      // `(?:^|\s)`, and trailing boundary by the zero-width lookahead `(?!\w)`.
+      // The trailing assertion MUST be zero-width — if it also consumed a char,
+      // the first name's trailing boundary would eat the single space before the
+      // last name, breaking matches like "Merrill Cohen".
+      //
+      // The last-name token is always preceded by the first-name token (and its
+      // separating whitespace), so its leading boundary is simply `\s`. The
+      // start-or-whitespace alternation `(?:^|\s)` is only meaningful for the
+      // first token: without the multiline flag `^` matches string start only,
+      // which the last name can never sit at.
+      //
+      // Cosmos-compatibility: this query runs SERVER-SIDE on the Cosmos DB Mongo
+      // API (name/state are not the shard key, so it is a scatter-gather $regex).
+      // This construction uses lookAHEAD only and NO lookBEHIND, since lookbehind
+      // support on the Cosmos Mongo API compatibility layer could not be
+      // confirmed. Lookahead is broadly supported in PCRE-family engines. A live
+      // Cosmos verification is still recommended before re-running the migration.
       const doc = using<TrusteeDocumentQueryable>();
       const query = and(
         doc('documentType').equals('TRUSTEE'),
-        doc('name').regex(new RegExp(`\\b${escapedFirstName}\\b.*\\b${escapedLastName}\\b`, 'i')),
+        doc('name').regex(
+          new RegExp(`(?:^|\\s)${escapedFirstName}(?!\\w).*\\s${escapedLastName}(?!\\w)`, 'i'),
+        ),
         doc('public.address.state').equals(normalizedState),
       );
 

--- a/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustees.mongo.repository.ts
@@ -358,17 +358,21 @@ export class TrusteesMongoRepository extends BaseMongoRepository implements Trus
       // between two non-word chars and can never match, so the dedup lookup
       // returns null and a duplicate trustee is created every migration run.
       //
-      // Instead: leading boundary is established by consuming start-or-whitespace
-      // `(?:^|\s)`, and trailing boundary by the zero-width lookahead `(?!\w)`.
-      // The trailing assertion MUST be zero-width — if it also consumed a char,
-      // the first name's trailing boundary would eat the single space before the
-      // last name, breaking matches like "Merrill Cohen".
+      // Instead: the first name's leading boundary is the start-of-string anchor
+      // `^`, and every token's trailing boundary is the zero-width lookahead
+      // `(?!\w)`. The trailing assertion MUST be zero-width — if it also consumed
+      // a char, the first name's trailing boundary would eat the single space
+      // before the last name, breaking matches like "Merrill Cohen".
+      //
+      // The incoming first name is ALWAYS at string position 0 in the composite
+      // `name` (`firstName [middleName] lastName [suffix]`), so anchoring to `^`
+      // both satisfies its leading boundary AND prevents a bare-initial first
+      // name (e.g. "J.") from binding to a DIFFERENT person's interior middle
+      // initial — without `^`, "J." would match stored "Robert J. Elsaesser" and
+      // merge two distinct trustees during upsert.
       //
       // The last-name token is always preceded by the first-name token (and its
-      // separating whitespace), so its leading boundary is simply `\s`. The
-      // start-or-whitespace alternation `(?:^|\s)` is only meaningful for the
-      // first token: without the multiline flag `^` matches string start only,
-      // which the last name can never sit at.
+      // separating whitespace), so its leading boundary is simply `\s`.
       //
       // Cosmos-compatibility: this query runs SERVER-SIDE on the Cosmos DB Mongo
       // API (name/state are not the shard key, so it is a scatter-gather $regex).
@@ -380,7 +384,7 @@ export class TrusteesMongoRepository extends BaseMongoRepository implements Trus
       const query = and(
         doc('documentType').equals('TRUSTEE'),
         doc('name').regex(
-          new RegExp(`(?:^|\\s)${escapedFirstName}(?!\\w).*\\s${escapedLastName}(?!\\w)`, 'i'),
+          new RegExp(`^${escapedFirstName}(?!\\w).*\\s${escapedLastName}(?!\\w)`, 'i'),
         ),
         doc('public.address.state').equals(normalizedState),
       );

--- a/backend/lib/use-cases/dataflows/migrate-trustees-dedup.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees-dedup.test.ts
@@ -534,6 +534,144 @@ describe('Trustee Deduplication', () => {
       );
     });
 
+    test('should dedup using the persisted public state when A2 is the public address', async () => {
+      // Merrill Cohen shape: DISP_ON_WEB_A2='y' and DISP_ON_WEB!='y' => a2IsPublic,
+      // so the transformed public.address.state is STATE_A2 ("DE"), not raw STATE ("MD").
+      // The dedup lookup must search on the persisted public value ("DE"), or it will
+      // never find the existing document and create a duplicate every run.
+      const mergedData = {
+        primary: {
+          ID: 5001,
+          FIRST_NAME: 'Merrill',
+          LAST_NAME: 'Cohen',
+          DISP_ON_WEB: 'n',
+          DISP_ON_WEB_A2: 'y',
+          STATE: 'MD',
+          STREET: '100 Baltimore Ave',
+          CITY: 'Baltimore',
+          ZIP: '21201',
+          STATE_A2: 'DE',
+          STREET_A2: '200 Wilmington St',
+          CITY_A2: 'Wilmington',
+          ZIP_A2: '19801',
+        },
+        todIds: ['5001'],
+        additionalAddresses: [],
+        allAppointments: [],
+      };
+
+      const existingTrustee = {
+        id: 'existing-id',
+        trusteeId: 'trustee-de',
+        name: 'Merrill Cohen',
+        public: { address: { state: 'DE' } },
+        legacy: { truIds: ['4900'] },
+      };
+
+      mockTrusteesRepo.findTrusteeByNameAndState.mockResolvedValue(existingTrustee);
+      mockTrusteesRepo.updateTrustee.mockResolvedValue(existingTrustee);
+
+      await upsertTrustee(context, mergedData);
+
+      expect(mockTrusteesRepo.findTrusteeByNameAndState).toHaveBeenCalledWith(
+        'Merrill',
+        'Cohen',
+        'DE',
+      );
+      expect(mockTrusteesRepo.updateTrustee).toHaveBeenCalled();
+      expect(mockTrusteesRepo.createTrustee).not.toHaveBeenCalled();
+    });
+
+    test('should dedup on the raw state when A2 is not the public address', async () => {
+      // Regression: when the public address is the non-A2 address (a2IsPublic=false),
+      // the transformed public state equals the raw STATE, so dedup is unchanged.
+      const mergedData = {
+        primary: {
+          ID: 5002,
+          FIRST_NAME: 'Merrill',
+          LAST_NAME: 'Cohen',
+          DISP_ON_WEB: 'y',
+          DISP_ON_WEB_A2: 'n',
+          STATE: 'MD',
+          STREET: '100 Baltimore Ave',
+          CITY: 'Baltimore',
+          ZIP: '21201',
+          STATE_A2: 'DE',
+        },
+        todIds: ['5002'],
+        additionalAddresses: [],
+        allAppointments: [],
+      };
+
+      const existingTrustee = {
+        id: 'existing-id',
+        trusteeId: 'trustee-md',
+        name: 'Merrill Cohen',
+        public: { address: { state: 'MD' } },
+        legacy: { truIds: ['4901'] },
+      };
+
+      mockTrusteesRepo.findTrusteeByNameAndState.mockResolvedValue(existingTrustee);
+      mockTrusteesRepo.updateTrustee.mockResolvedValue(existingTrustee);
+
+      await upsertTrustee(context, mergedData);
+
+      expect(mockTrusteesRepo.findTrusteeByNameAndState).toHaveBeenCalledWith(
+        'Merrill',
+        'Cohen',
+        'MD',
+      );
+      expect(mockTrusteesRepo.updateTrustee).toHaveBeenCalled();
+      expect(mockTrusteesRepo.createTrustee).not.toHaveBeenCalled();
+    });
+
+    test('should migrate (not skip) when A2 is public but STATE_A2 is empty, using non-A2 state', async () => {
+      // Previously-dropped shape: DISP_ON_WEB_A2='y' => a2IsPublic, but STATE_A2 is
+      // empty. transformTrusteeRecord now falls back to the non-A2 STATE ("MD") for
+      // public.address.state, so the guard no longer skips the record and the dedup
+      // lookup searches on "MD".
+      const mergedData = {
+        primary: {
+          ID: 6001,
+          FIRST_NAME: 'Merrill',
+          LAST_NAME: 'Cohen',
+          DISP_ON_WEB: 'n',
+          DISP_ON_WEB_A2: 'y',
+          STATE: 'MD',
+          STREET: '100 Baltimore Ave',
+          CITY: 'Baltimore',
+          ZIP: '21201',
+          STATE_A2: '',
+          STREET_A2: '200 Wilmington St',
+          CITY_A2: 'Wilmington',
+          ZIP_A2: '19801',
+        },
+        todIds: ['6001'],
+        additionalAddresses: [],
+        allAppointments: [],
+      };
+
+      const createdTrustee = {
+        id: 'new-id',
+        trusteeId: 'trustee-md',
+        name: 'Merrill Cohen',
+        legacy: { truIds: ['6001'] },
+      };
+
+      mockTrusteesRepo.findTrusteeByNameAndState.mockResolvedValue(null);
+      mockTrusteesRepo.createTrustee.mockResolvedValue(createdTrustee);
+
+      const result = await upsertTrustee(context, mergedData);
+
+      expect(result.error).toBeUndefined();
+      expect(mockTrusteesRepo.findTrusteeByNameAndState).toHaveBeenCalledWith(
+        'Merrill',
+        'Cohen',
+        'MD',
+      );
+      expect(mockTrusteesRepo.createTrustee).toHaveBeenCalled();
+    });
+
     test('should skip trustee with incomplete name or state', async () => {
       const mergedData = {
         primary: {

--- a/backend/lib/use-cases/dataflows/migrate-trustees.ts
+++ b/backend/lib/use-cases/dataflows/migrate-trustees.ts
@@ -456,10 +456,16 @@ export async function upsertTrustee(
     // Transform primary ATS record to CAMS format
     const trusteeInput = transformTrusteeRecord(primary);
 
-    // Extract name components for dedup check
+    // Extract name components for dedup check.
+    // Source the dedup state from the already-transformed record (not raw
+    // primary.STATE) so the lookup and the persisted document use the identical
+    // value. When the A2 address is public (a2IsPublic), transformTrusteeRecord
+    // persists public.address.state = STATE_A2, so re-deriving from raw STATE
+    // would search a state that never matches the stored doc, guaranteeing a
+    // duplicate on every migration run.
     const firstName = normalizeName(primary.FIRST_NAME || '');
     const lastName = normalizeName(primary.LAST_NAME || '');
-    const state = (primary.STATE || '').trim().toUpperCase();
+    const state = (trusteeInput.public.address.state || '').trim().toUpperCase();
 
     if (!firstName || !lastName || !state) {
       context.logger.warn(

--- a/test/integration/migrate-trustees/DEDUP_MIGRATION_RUNBOOK.md
+++ b/test/integration/migrate-trustees/DEDUP_MIGRATION_RUNBOOK.md
@@ -1,0 +1,182 @@
+# Trustee-Migration Deduplication Verification Runbook
+
+Manual workflow for validating the three duplicate-trustee fixes by running the
+**real** `MIGRATE-TRUSTEES` dataflow against the shared environment.
+
+This is NOT a unit/integration test harness that calls use-case functions. The
+operator seeds SQL, runs the actual Azure Function locally (which connects to the
+shared Azure Gov SQL server and Cosmos via `backend/.env`), then verifies Cosmos
+with a read-only Node script.
+
+## What is being validated
+
+| Fix | Fixture | What it proves |
+| --- | --- | --- |
+| **M1** — `findTrusteeByNameAndState` lookahead-only regex | 1004 (`J. Ford Elsaesser`), 1005 (`William A. Brandt, Jr.`) | Composite names whose tokens end in punctuation match the dedup lookup on run 2 (old `\b` regex never matched → duplicate every run). |
+| **M2** — `upsertTrustee` dedup key uses persisted `public.address.state` | 1006 (`Merrill Cohen`, STATE=MD, STATE_A2=DE, A2 public) | Dedup key uses transformed public state `DE`, not raw `MD`. |
+| **fallback** — `transformTrusteeRecord` backfills empty public state | 1007 (`Test Fallback`, STATE_A2 blank) | Record persists with `public.address.state='MD'` (backfilled) instead of being skipped. |
+| control | 1008 (`Jane Control`) | A clean record isn't spuriously duplicated. |
+
+## 1. Prerequisites
+
+- Local **dataflows** function app configured to point at the shared SQL
+  (`sql-ustp-cams.database.usgovcloudapi.net` — ATS / ACMS / DXTR) and Cosmos.
+  Config is read from `backend/function-apps/dataflows/.env` (the dataflows app's
+  own `.env`, NOT `backend/.env`). In particular these MUST be set:
+    - `MONGO_CONNECTION_STRING` — Cosmos Mongo-API connection string
+    - `COSMOS_DATABASE_NAME` — database containing the `trustees` collection (e.g. `cams`)
+    - `ATS_MSSQL_*` — ATS connection. **The ATS database on this server is named
+      `ATS_SUB`** (verified 2026-07-07 by listing `sys.databases`; there is no
+      `ATS_REP_SUB`). Set `ATS_MSSQL_DATABASE="ATS_SUB"`.
+    - `ACMS_MSSQL_*` — `ACMS_MSSQL_DATABASE="ACMS_REP_SUB"`. **Caveat:** this
+      environment's `dbo.CMMPR` does NOT match the gateway query — it has `PROF_CODE`
+      (numeric) and no `UST_PROF_CODE`/`PROF_TYPE`, so `getTrusteeProfessionalIds`
+      fails here (caught non-fatally; professional-ids will be 0). USTP's real schema
+      has those columns; this is a known dev-replica mismatch, out of scope for the
+      dedup test. Seed `03` is therefore moot in this environment and can be skipped.
+    - Storage: the queue triggers use connection `DataflowsStorage`
+      (→ `AzureWebJobsDataflowsStorage`) and the output bindings use
+      `AzureWebJobsStorage`. Both are set in `local.settings.json`; in this
+      environment they resolve to the SAME Gov storage account, so the queue flow is
+      consistent.
+    - `CAMS_ENABLED_DATAFLOWS` must include `MIGRATE-TRUSTEES`
+- **Restart the dataflows app after any `.env`/`local.settings.json` change** — the
+  Functions host reads them once at startup.
+- DXTR offices already exist in the shared environment — there is **no DXTR seed**.
+  The single-court states used by the fixtures (Idaho, Arizona, Maryland,
+  Connecticut) resolve to real DXTR court offices.
+- SQL client access to the shared server for the two seed databases (ATS and ACMS
+  are **different databases on the same server**).
+- Node.js (v22, matching `.nvmrc`) with the repo's hoisted `mongodb` driver
+  (already present at repo-root `node_modules` after `npm ci`).
+
+## 2. Seed SQL
+
+1. **ATS** — run `seed/02-seed-dedup-trustees.sql` against the **`ATS_SUB`** database.
+   Inserts TRUSTEES rows 1004-1008 plus one active `CHAPTER_DETAILS` row each.
+   Idempotent (DELETE-then-INSERT by id 1004-1008). Note: `TRUSTEES.ID` is an
+   IDENTITY column, so the file wraps its inserts in
+   `SET IDENTITY_INSERT dbo.TRUSTEES ON/OFF` within a single batch.
+2. **ACMS** — `seed/03-seed-acms-cmmpr.sql` targets `ACMS_REP_SUB`. **Skip it in
+   this environment** — `dbo.CMMPR` here lacks `UST_PROF_CODE`/`PROF_TYPE`, so the
+   gateway's professional-id query fails regardless of seeded rows (see the ACMS
+   caveat in Prerequisites). It is retained for an environment whose `CMMPR` matches
+   USTP's real schema.
+
+No `sqlcmd` is required. A minimal Node runner using the repo's `mssql` package
+(parse the dataflows `.env`, connect per-database, split on `GO`, run each batch) is
+sufficient. IDENTITY_INSERT and all inserts must stay in one batch (no `GO` between)
+so the toggle survives connection pooling.
+
+> Note on `SERVING_STATE`: `02` seeds the full state NAME (e.g. `Idaho`) into
+> `CHAPTER_DETAILS.SERVING_STATE` because the cleansing pipeline's court map is
+> keyed by full state names. This targets the shared server's real ATS schema (the
+> local `00-seed-ats-schema.sql` defines a narrower `CHAR(2)` column for the
+> local-only tests — do not use that width assumption against the shared DB).
+
+## 3. Run the dataflow — Run 1 (creates the trustees)
+
+Run 1 populates Cosmos. There is nothing to deduplicate against yet.
+
+1. Start the dataflows app locally (from repo root or `/backend`):
+   ```bash
+   npm run start:dataflows
+   ```
+   The dataflows app listens on **port 7072** and uses the **`import`** route prefix
+   (from `host.json`), so the trigger is `http://localhost:7072/import/migrate-trustees`
+   (NOT `7071`/`api` — that's the API app).
+2. Auth is required: `buildStartQueueHttpTrigger` → `isAuthorized` checks
+   `Authorization: ApiKey <ADMIN_KEY>` (value from the dataflows `.env`). A missing/
+   wrong key returns `403 "Request is Forbidden"`.
+   ```bash
+   curl -X POST "http://localhost:7072/import/migrate-trustees" \
+     -H "Authorization: ApiKey <ADMIN_KEY>"
+   ```
+
+The HTTP trigger enqueues an **empty `{}`** start message — no flags. **Important:**
+if a prior migration left the state `COMPLETED`, `handleStart` logs "already
+completed" and returns WITHOUT enqueuing a page — the `{}` trigger is a no-op. In a
+shared environment the state is almost always already `COMPLETED`, so in practice you
+drive BOTH runs with a `reset` message (Step 4), not this bare HTTP call. A default
+(non-`importAll`) run migrates only trustees with an **active** `CHAPTER_DETAILS` row;
+our fixtures each have one with `STATUS='PA'`, so they qualify — no `importAll`
+needed. Let the page queue drain until the log reports the migration complete.
+
+## 4. Run the dataflow — Run 2 (the real dedup test)
+
+**Why run 2 is the actual test:** the duplication bug only bites when a matching
+trustee doc **already exists**. On run 1 the dedup lookup finds nothing and simply
+creates docs. On run 2 the lookup must find the run-1 docs; if the regex (M1) or the
+dedup-key state (M2) is wrong, the lookup misses and a **second** doc is created.
+So the fix is proven only by run 2 producing **no new docs**.
+
+The migration state doc lives in the **`runtime-state`** collection (documentType
+`TRUSTEE_MIGRATION_STATE`), NOT the `trustees` collection. After a run it is
+`COMPLETED`, so a bare `{}` HTTP trigger is skipped. To (re)run, enqueue a `reset`
+start message. `host.json` sets no `messageEncoding`, so the Storage Queues
+extension default (**base64**) applies — the message body must be base64-encoded
+JSON.
+
+**Enqueue a reset onto the `migrate-trustees-start` queue.** The most reliable local
+method is a Node one-liner with the repo's `@azure/storage-queue`, using the
+`AzureWebJobsStorage` connection string from `local.settings.json`:
+
+```js
+const { QueueServiceClient } = require('@azure/storage-queue');
+const q = QueueServiceClient.fromConnectionString(CONN)
+  .getQueueClient('migrate-trustees-start');
+await q.createIfNotExists();
+await q.sendMessage(Buffer.from(JSON.stringify({ reset: true })).toString('base64'));
+```
+
+`reset: true` drives `getOrCreateMigrationState(context, true)` to re-initialize the
+state (no longer `COMPLETED`); `handleStart` then enqueues the first page and the run
+proceeds over the ATS rows. (`az storage message put` or Storage Explorer work too,
+as long as the body is base64.)
+
+**In a shared environment both "run 1" and "run 2" are reset runs** — the state was
+already `COMPLETED` from a prior migration, so even the first pass needs a reset.
+Run 1 creates the fixture docs; run 2 is the dedup test (must find and update them,
+not create duplicates). Let each run drain to `COMPLETED` before the next.
+
+## 5. Verify (read-only)
+
+Run the read-only verification script against the **same** Cosmos environment the
+migration targeted:
+
+```bash
+export MONGO_CONNECTION_STRING='<cosmos mongo api connection string>'
+export COSMOS_DATABASE_NAME='<db containing the trustees collection>'
+node test/integration/migrate-trustees/scripts/verify-dedup-cosmos.mjs
+# or: node .../verify-dedup-cosmos.mjs --uri '<conn>' --db '<database>'
+```
+
+It scopes every query to `legacy.truIds` in `1004`-`1008` and asserts:
+
+- **HARD (pass/fail, sets exit code):**
+    - Exactly one `trustees` doc per fixture person (5 groups, each count 1; each
+      truId on exactly one doc). This is the dedup result.
+    - 1006: `public.address.state === 'DE'` and `internal.address.state === 'MD'` (M2).
+    - 1007: `public.address.state === 'MD'` and the doc exists (fallback).
+- **INFO (never fails the run):** `>= 1` `trustee-professional-ids`
+  (by `camsTrusteeId`) and `>= 1` `trustee-appointments` (by `trusteeId`) per
+  fixture. A zero count only means the CMMPR / CHAPTER_DETAILS path wasn't
+  exercised — it does not indicate a dedup regression.
+
+A non-zero exit code means a HARD check failed (duplicate or wrong state).
+
+## 6. Cleanup
+
+Per operator instruction, **DO NOT delete the created trustees** (or their
+appointments / professional-ids) in Cosmos.
+
+Optionally remove the seeded SQL rows (both are safe, idempotent deletes):
+
+```sql
+-- ATS database
+DELETE FROM CHAPTER_DETAILS WHERE TRU_ID IN (1004, 1005, 1006, 1007, 1008);
+DELETE FROM TRUSTEES        WHERE ID     IN (1004, 1005, 1006, 1007, 1008);
+
+-- ACMS database
+DELETE FROM [dbo].[CMMPR] WHERE UST_PROF_CODE IN (99001, 99002, 99003, 99004, 99005);
+```

--- a/test/integration/migrate-trustees/scripts/verify-dedup-cosmos.mjs
+++ b/test/integration/migrate-trustees/scripts/verify-dedup-cosmos.mjs
@@ -1,0 +1,315 @@
+// verify-dedup-cosmos.mjs
+// =============================================================================
+// READ-ONLY Cosmos DB (Mongo API) verification for the trustee-migration
+// duplicate-trustee fixes, run AFTER the real MIGRATE-TRUSTEES dataflow has been
+// executed twice against the shared environment (see DEDUP_MIGRATION_RUNBOOK.md).
+// =============================================================================
+//
+// WHAT IT VERIFIES
+// ----------------
+// The dedup fixtures seeded by seed/02-seed-dedup-trustees.sql use ATS TRU_IDs
+// 1004-1008. After two dataflow runs, this script asserts that the fixes held:
+//
+//   HARD PASS/FAIL (the real dedup test):
+//     - Exactly ONE `trustees` doc exists per fixture person. The migration must
+//       NOT create a second doc on run 2. Grouped by {name, public.address.state}
+//       over docs whose legacy.truIds intersect {1004..1008}; expect 5 groups,
+//       each with count === 1, and each of the 5 truIds present on exactly one doc.
+//     - M2 (1006 Merrill Cohen): public.address.state === 'DE' (transformed public
+//       state from STATE_A2), internal.address.state === 'MD' (raw STATE).
+//     - fallback (1007 Test Fallback): public.address.state === 'MD' (backfilled
+//       from the other address because STATE_A2 was blank), and the doc exists.
+//
+//   INFO ONLY (NOT hard failures — depend on ACMS CMMPR + ATS CHAPTER_DETAILS
+//   seeding being present and correct in the shared environment):
+//     - trustee-professional-ids: >= 1 doc per fixture trusteeId (camsTrusteeId).
+//     - trustee-appointments:     >= 1 doc per fixture trusteeId.
+//
+// READ-ONLY
+// ---------
+// This script performs ONLY find/aggregate reads. It never inserts, updates, or
+// deletes any document. Safe to run against any environment.
+//
+// HOW TO RUN
+// ----------
+// Point it at the SAME Cosmos environment the migration targeted.
+//
+//   export MONGO_CONNECTION_STRING='<cosmos mongo api connection string>'
+//   export COSMOS_DATABASE_NAME='<db containing the trustees collection>'
+//   node test/integration/migrate-trustees/scripts/verify-dedup-cosmos.mjs
+//
+// CLI overrides (take precedence over the env vars):
+//   node verify-dedup-cosmos.mjs --uri '<connection-string>' --db '<database>'
+//
+// It resolves `mongodb` from the CAMS repo root node_modules (the v7.3.0 driver
+// hoisted at /Users/jbrooks/Repos/cams/node_modules/mongodb). Node module
+// resolution walks up from this script's directory, so the bare
+// `import { MongoClient } from 'mongodb'` resolves when run anywhere under the repo.
+//
+// EXIT CODE
+// ---------
+// Non-zero if any HARD check fails (or on a connection/query error). INFO checks
+// never affect the exit code.
+// =============================================================================
+
+import { MongoClient } from 'mongodb';
+
+// ---------------------------------------------------------------------------
+// Fixtures (must match seed/02-seed-dedup-trustees.sql).
+// ---------------------------------------------------------------------------
+const TRU_IDS = ['1004', '1005', '1006', '1007', '1008'];
+
+const EXPECTED = {
+  1004: { name: 'J. Ford Elsaesser', publicState: 'ID' },
+  1005: { name: 'William A. Brandt, Jr.', publicState: 'AZ' },
+  1006: { name: 'Merrill Cohen', publicState: 'DE', internalState: 'MD' },
+  1007: { name: 'Test Fallback', publicState: 'MD' },
+  1008: { name: 'Jane Control', publicState: 'CT' },
+};
+
+// ---------------------------------------------------------------------------
+// Config: env with CLI-arg overrides. Do NOT guess a db name.
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--uri') {
+      out.uri = argv[++i];
+    } else if (argv[i] === '--db') {
+      out.db = argv[++i];
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const uri = args.uri || process.env.MONGO_CONNECTION_STRING;
+const dbName = args.db || process.env.COSMOS_DATABASE_NAME;
+
+if (!uri) {
+  console.error('');
+  console.error('ERROR: No Cosmos connection string provided.');
+  console.error("  export MONGO_CONNECTION_STRING='<cosmos mongo api connection string>'");
+  console.error("  (or pass --uri '<connection-string>')");
+  console.error('');
+  process.exit(1);
+}
+
+if (!dbName) {
+  console.error('');
+  console.error('ERROR: No database name provided.');
+  console.error("  export COSMOS_DATABASE_NAME='<db containing the trustees collection>'");
+  console.error("  (or pass --db '<database>')");
+  console.error('  This script will NOT guess a database name.');
+  console.error('');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Result tracking.
+// ---------------------------------------------------------------------------
+let hardPassed = 0;
+let hardFailed = 0;
+const infoNotes = [];
+
+function hardCheck(label, ok, detail) {
+  if (ok) {
+    hardPassed++;
+    console.log('  PASS  ' + label + (detail ? '  — ' + detail : ''));
+  } else {
+    hardFailed++;
+    console.log('  FAIL  ' + label + (detail ? '  — ' + detail : ''));
+  }
+}
+
+function infoCheck(label, ok, detail) {
+  const tag = ok ? 'INFO ok  ' : 'INFO warn';
+  console.log('  ' + tag + ' ' + label + (detail ? '  — ' + detail : ''));
+  if (!ok) infoNotes.push(label + (detail ? ' — ' + detail : ''));
+}
+
+const client = new MongoClient(uri);
+
+try {
+  await client.connect();
+  const db = client.db(dbName);
+  const trustees = db.collection('trustees');
+  const professionalIds = db.collection('trustee-professional-ids');
+  const appointments = db.collection('trustee-appointments');
+
+  console.log('--- verify-dedup-cosmos.mjs (READ-ONLY) ---');
+  console.log('Database: ' + dbName);
+  console.log('Fixture TRU_IDs: ' + TRU_IDS.join(', '));
+  console.log('');
+
+  // -------------------------------------------------------------------------
+  // Load all trustee docs touching the fixture legacy truIds.
+  // -------------------------------------------------------------------------
+  const fixtureDocs = await trustees
+    .find({ documentType: 'TRUSTEE', 'legacy.truIds': { $in: TRU_IDS } })
+    .toArray();
+
+  console.log(
+    '=== Loaded ' + fixtureDocs.length + ' TRUSTEE doc(s) referencing fixture truIds ===',
+  );
+  console.log('');
+
+  // -------------------------------------------------------------------------
+  // HARD CHECK 1: dedup — exactly one doc per fixture person.
+  // Each of the 5 truIds must appear on exactly one doc, and grouping by
+  // {name, public.address.state} must yield 5 groups each of count 1.
+  // -------------------------------------------------------------------------
+  console.log('=== HARD: dedup (one doc per person) ===');
+
+  // 1a. Each truId on exactly one doc.
+  for (const truId of TRU_IDS) {
+    const docsForId = fixtureDocs.filter(
+      (d) => Array.isArray(d.legacy?.truIds) && d.legacy.truIds.includes(truId),
+    );
+    hardCheck(
+      'truId ' + truId + ' present on exactly one trustees doc',
+      docsForId.length === 1,
+      'found ' + docsForId.length + ' doc(s)' +
+        (docsForId.length ? ' [' + docsForId.map((d) => d.trusteeId).join(', ') + ']' : ''),
+    );
+  }
+
+  // 1b. Group by {name, public.address.state}: expect 5 groups, each count 1.
+  const groups = new Map();
+  for (const d of fixtureDocs) {
+    const key = (d.name ?? '') + '|' + (d.public?.address?.state ?? '');
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(d);
+  }
+  hardCheck(
+    'exactly 5 {name, public.state} groups',
+    groups.size === 5,
+    'found ' + groups.size + ' group(s): ' + [...groups.keys()].map((k) => '"' + k + '"').join(', '),
+  );
+  for (const [key, docs] of groups.entries()) {
+    hardCheck(
+      'group "' + key + '" has exactly one doc',
+      docs.length === 1,
+      'count ' + docs.length +
+        (docs.length > 1 ? ' [' + docs.map((d) => d.trusteeId).join(', ') + ']' : ''),
+    );
+  }
+  console.log('');
+
+  // -------------------------------------------------------------------------
+  // Helper: single doc for a given truId (null if not exactly one).
+  // -------------------------------------------------------------------------
+  const docForTruId = (truId) => {
+    const matches = fixtureDocs.filter(
+      (d) => Array.isArray(d.legacy?.truIds) && d.legacy.truIds.includes(truId),
+    );
+    return matches.length === 1 ? matches[0] : null;
+  };
+
+  // -------------------------------------------------------------------------
+  // HARD CHECK 2: M2 (1006) public state DE, internal state MD.
+  // -------------------------------------------------------------------------
+  console.log('=== HARD: M2 (1006 Merrill Cohen) public=DE / internal=MD ===');
+  const doc1006 = docForTruId('1006');
+  if (!doc1006) {
+    hardCheck('1006 resolves to a single doc', false, 'cannot evaluate M2 states');
+  } else {
+    hardCheck(
+      '1006 public.address.state === DE',
+      doc1006.public?.address?.state === 'DE',
+      'actual=' + JSON.stringify(doc1006.public?.address?.state),
+    );
+    hardCheck(
+      '1006 internal.address.state === MD',
+      doc1006.internal?.address?.state === 'MD',
+      'actual=' + JSON.stringify(doc1006.internal?.address?.state),
+    );
+  }
+  console.log('');
+
+  // -------------------------------------------------------------------------
+  // HARD CHECK 3: fallback (1007) public state MD, doc exists.
+  // -------------------------------------------------------------------------
+  console.log('=== HARD: fallback (1007 Test Fallback) public=MD, exists ===');
+  const doc1007 = docForTruId('1007');
+  hardCheck('1007 doc exists (single)', doc1007 !== null, doc1007 ? doc1007.trusteeId : 'missing');
+  if (doc1007) {
+    hardCheck(
+      '1007 public.address.state === MD (backfilled)',
+      doc1007.public?.address?.state === 'MD',
+      'actual=' + JSON.stringify(doc1007.public?.address?.state),
+    );
+  }
+  console.log('');
+
+  // -------------------------------------------------------------------------
+  // INFO CHECK: professional-ids and appointments per fixture trusteeId.
+  // These depend on ACMS CMMPR (03-seed) and ATS CHAPTER_DETAILS (02-seed).
+  // -------------------------------------------------------------------------
+  console.log('=== INFO: professional-ids (depends on ACMS CMMPR seeding) ===');
+  for (const truId of TRU_IDS) {
+    const doc = docForTruId(truId);
+    if (!doc) {
+      infoCheck('truId ' + truId + ' professional-ids', false, 'no single trustees doc to resolve trusteeId');
+      continue;
+    }
+    const count = await professionalIds.countDocuments({
+      documentType: 'TRUSTEE_PROFESSIONAL_ID',
+      camsTrusteeId: doc.trusteeId,
+    });
+    infoCheck(
+      'truId ' + truId + ' (' + (EXPECTED[truId]?.name ?? '') + ') professional-ids >= 1',
+      count >= 1,
+      'count ' + count + ' for trusteeId ' + doc.trusteeId,
+    );
+  }
+  console.log('');
+
+  console.log('=== INFO: appointments (depends on ATS CHAPTER_DETAILS seeding) ===');
+  for (const truId of TRU_IDS) {
+    const doc = docForTruId(truId);
+    if (!doc) {
+      infoCheck('truId ' + truId + ' appointments', false, 'no single trustees doc to resolve trusteeId');
+      continue;
+    }
+    const count = await appointments.countDocuments({
+      documentType: 'TRUSTEE_APPOINTMENT',
+      trusteeId: doc.trusteeId,
+    });
+    infoCheck(
+      'truId ' + truId + ' (' + (EXPECTED[truId]?.name ?? '') + ') appointments >= 1',
+      count >= 1,
+      'count ' + count + ' for trusteeId ' + doc.trusteeId,
+    );
+  }
+  console.log('');
+} finally {
+  // ALWAYS close the client, even on connection/query errors.
+  await client.close();
+}
+
+// ---------------------------------------------------------------------------
+// Summary.
+// ---------------------------------------------------------------------------
+console.log('==================== SUMMARY ====================');
+console.log('HARD checks passed: ' + hardPassed);
+console.log('HARD checks failed: ' + hardFailed);
+if (infoNotes.length > 0) {
+  console.log('');
+  console.log('INFO warnings (' + infoNotes.length + ') — do NOT fail the run, but review:');
+  for (const note of infoNotes) {
+    console.log('  - ' + note);
+  }
+  console.log('  These depend on ACMS CMMPR (03-seed) / ATS CHAPTER_DETAILS (02-seed) being');
+  console.log('  present. A zero count means the professional-id / appointment path was not');
+  console.log('  exercised, NOT that the dedup fixes regressed.');
+}
+console.log('');
+if (hardFailed === 0) {
+  console.log('RESULT: PASS — all HARD dedup/state checks held after two migration runs.');
+} else {
+  console.log('RESULT: FAIL — ' + hardFailed + ' HARD check(s) failed. Duplicate/state regression.');
+}
+console.log('=================================================');
+
+process.exit(hardFailed > 0 ? 1 : 0);

--- a/test/integration/migrate-trustees/seed/02-seed-dedup-trustees.sql
+++ b/test/integration/migrate-trustees/seed/02-seed-dedup-trustees.sql
@@ -1,0 +1,164 @@
+-- Seed ATS fixtures for the DEDUP (duplicate-trustee) verification flow.
+-- Drop and recreate so the test is fully idempotent.
+--
+-- These fixtures validate three duplicate-trustee fixes by running the REAL
+-- MIGRATE-TRUSTEES dataflow TWICE and asserting NO duplicate Cosmos docs are
+-- created on run 2:
+--   M1  — findTrusteeByNameAndState lookahead-only regex matches composite names
+--         whose tokens end in punctuation ("J. Ford Elsaesser", "William A.
+--         Brandt, Jr.")
+--   M2  — upsertTrustee dedup key sources state from the TRANSFORMED public
+--         address (public.address.state = STATE_A2 when a2IsPublic), not raw
+--         STATE (Merrill Cohen: STATE=MD, STATE_A2=DE -> public state = DE)
+--   fallback — transformTrusteeRecord backfills the public state from the OTHER
+--         address when the selected public state is empty, so the record is
+--         persisted (not skipped for a blank state)
+--
+-- WHY A NORMAL (non-importAll) RUN PICKS THESE UP
+-- ------------------------------------------------
+-- The HTTP trigger enqueues an empty {} start message (no flags), so the
+-- migration runs with importAll = undefined. In that mode
+-- AtsGatewayImpl.getTrusteesPage adds a WHERE EXISTS filter requiring each
+-- trustee to have at least one CHAPTER_DETAILS row whose STATUS is in
+-- ACTIVE_STATUS_CODES (derived from TOD_STATUS_MAP entries with status
+-- 'active'). Each fixture below therefore gets ONE active CHAPTER_DETAILS row
+-- with STATUS 'PA' (panel / active) so a default run returns it AND exercises
+-- appointment creation.
+--
+-- APPOINTMENT COURT MAPPING
+-- -------------------------
+-- The appointment court is resolved from CHAPTER_DETAILS.SERVING_STATE (read
+-- by ats.gateway as "SERVING_STATE AS STATE") through the cleansing pipeline's
+-- STATE_TO_SINGLE_COURT_ID map, which is keyed by FULL STATE NAMES (not the
+-- 2-char abbreviation). We use single-court states so no DISTRICT is required
+-- and the court resolves against a real DXTR office:
+--   Idaho       -> 0976
+--   Arizona     -> 0970
+--   Maryland    -> 0416
+--   Connecticut -> 0205
+-- NOTE: SERVING_STATE holds the full state NAME on purpose. The trustee's own
+-- address STATE (2-char, in the TRUSTEES table) is separate and drives the
+-- dedup key + the ACMS professional-id lookup (see 03-seed-acms-cmmpr.sql).
+--
+-- Uses ATS IDs 1004-1008 (distinct from 01-seed-trustees.sql's 1001-1003).
+
+-- IMPORTANT: On the shared server the ATS database is NOT named ATS_INT. Use
+-- the database named by ATS_MSSQL_DATABASE in backend/.env.
+USE ATS_SUB
+GO
+
+DELETE FROM CHAPTER_DETAILS WHERE TRU_ID IN (1004, 1005, 1006, 1007, 1008)
+GO
+DELETE FROM TRUSTEES WHERE ID IN (1004, 1005, 1006, 1007, 1008)
+GO
+
+-- TRUSTEES.ID is an IDENTITY column, so explicit ids require IDENTITY_INSERT.
+-- All five inserts share ONE batch with the toggle (IDENTITY_INSERT is
+-- connection-scoped; keeping the ON/OFF and inserts in a single batch is robust
+-- regardless of connection pooling).
+SET IDENTITY_INSERT dbo.TRUSTEES ON
+
+-- 1004 (M1a): punctuation in FIRST name ("J.") + MIDDLE "Ford".
+-- DISP_ON_WEB='y' so a2IsPublic=false; public.address.state = STATE = 'ID'.
+-- Composite name computed as "J. Ford Elsaesser".
+-- On run 2 the lookahead-only regex must match this punctuation-ending first token.
+INSERT INTO TRUSTEES
+  (ID, LAST_NAME, FIRST_NAME, MIDDLE, COMPANY,
+   STREET, STREET1, CITY, STATE, ZIP, ZIP_PLUS,
+   DISP_ON_WEB, DISP_ON_WEB_A2,
+   STREET_A2, STREET1_A2, CITY_A2, STATE_A2, ZIP_A2, ZIP_PLUS_A2,
+   TELEPHONE, EMAIL_ADDRESS)
+VALUES
+  (1004, 'Elsaesser', 'J.', 'Ford', NULL,
+   '320 E Neider Ave', NULL, 'Coeur d''Alene', 'ID', '83815', NULL,
+   'y', 'n',
+   NULL, NULL, NULL, NULL, NULL, NULL,
+   NULL, 'j.elsaesser@example.com')
+
+-- 1005 (M1b): punctuation/suffix in LAST name ("Brandt, Jr.") + MIDDLE "A.".
+-- DISP_ON_WEB='y' so a2IsPublic=false; public.address.state = STATE = 'AZ'.
+-- Composite name computed as "William A. Brandt, Jr.".
+-- On run 2 the lookahead-only regex must match this punctuation-ending last token.
+INSERT INTO TRUSTEES
+  (ID, LAST_NAME, FIRST_NAME, MIDDLE, COMPANY,
+   STREET, STREET1, CITY, STATE, ZIP, ZIP_PLUS,
+   DISP_ON_WEB, DISP_ON_WEB_A2,
+   STREET_A2, STREET1_A2, CITY_A2, STATE_A2, ZIP_A2, ZIP_PLUS_A2,
+   TELEPHONE, EMAIL_ADDRESS)
+VALUES
+  (1005, 'Brandt, Jr.', 'William', 'A.', NULL,
+   '2390 E Camelback Rd', NULL, 'Phoenix', 'AZ', '85016', NULL,
+   'y', 'n',
+   NULL, NULL, NULL, NULL, NULL, NULL,
+   NULL, 'william.brandt@example.com')
+
+-- 1006 (M2): STATE != STATE_A2, A2 is public. DISP_ON_WEB='n', DISP_ON_WEB_A2='y'
+-- so a2IsPublic=true. Public address = A2 fields (STATE_A2='DE'); internal address
+-- = primary fields (STATE='MD'). Composite name = "Merrill Cohen" (no punctuation).
+-- On run 2 the dedup key must use the transformed public state 'DE' (not raw 'MD')
+-- to find the existing doc.
+--   Expected persisted: public.address.state='DE', internal.address.state='MD'.
+INSERT INTO TRUSTEES
+  (ID, LAST_NAME, FIRST_NAME, MIDDLE, COMPANY,
+   STREET, STREET1, CITY, STATE, ZIP, ZIP_PLUS,
+   DISP_ON_WEB, DISP_ON_WEB_A2,
+   STREET_A2, STREET1_A2, CITY_A2, STATE_A2, ZIP_A2, ZIP_PLUS_A2,
+   TELEPHONE, EMAIL_ADDRESS)
+VALUES
+  (1006, 'Cohen', 'Merrill', NULL, NULL,
+   '30 W Gude Dr', NULL, 'Rockville', 'MD', '20852', NULL,
+   'n', 'y',
+   'P. O. Box 53', NULL, 'Harbeson', 'DE', '19951', NULL,
+   NULL, 'merrill.cohen@example.com')
+
+-- 1007 (fallback): A2 is public but STATE_A2 is empty. DISP_ON_WEB='n',
+-- DISP_ON_WEB_A2='y' so a2IsPublic=true, but the selected public STATE_A2 is blank,
+-- so the public state backfills from the other address's STATE ('MD').
+-- Composite name = "Test Fallback".
+--   Expected persisted: public.address.state='MD' (backfilled), doc EXISTS (not skipped).
+INSERT INTO TRUSTEES
+  (ID, LAST_NAME, FIRST_NAME, MIDDLE, COMPANY,
+   STREET, STREET1, CITY, STATE, ZIP, ZIP_PLUS,
+   DISP_ON_WEB, DISP_ON_WEB_A2,
+   STREET_A2, STREET1_A2, CITY_A2, STATE_A2, ZIP_A2, ZIP_PLUS_A2,
+   TELEPHONE, EMAIL_ADDRESS)
+VALUES
+  (1007, 'Fallback', 'Test', NULL, NULL,
+   '100 N Charles St', NULL, 'Baltimore', 'MD', '21201', NULL,
+   'n', 'y',
+   '400 Public Blvd', NULL, 'Somewhere', '', '00000', NULL,
+   NULL, 'test.fallback@example.com')
+
+-- 1008 (control): a clean record with no punctuation and no A2 public address.
+-- DISP_ON_WEB='y' so a2IsPublic=false; public.address.state = STATE = 'CT'.
+-- Composite name = "Jane Control". Confirms the flow itself doesn't spuriously
+-- duplicate a well-behaved record.
+INSERT INTO TRUSTEES
+  (ID, LAST_NAME, FIRST_NAME, MIDDLE, COMPANY,
+   STREET, STREET1, CITY, STATE, ZIP, ZIP_PLUS,
+   DISP_ON_WEB, DISP_ON_WEB_A2,
+   STREET_A2, STREET1_A2, CITY_A2, STATE_A2, ZIP_A2, ZIP_PLUS_A2,
+   TELEPHONE, EMAIL_ADDRESS)
+VALUES
+  (1008, 'Control', 'Jane', NULL, NULL,
+   '265 Church St', NULL, 'New Haven', 'CT', '06510', NULL,
+   'y', 'n',
+   NULL, NULL, NULL, NULL, NULL, NULL,
+   NULL, 'jane.control@example.com')
+
+SET IDENTITY_INSERT dbo.TRUSTEES OFF
+GO
+
+-- Active chapter appointments so a NORMAL (non-importAll) run returns each trustee
+-- (STATUS 'PA' is in ACTIVE_STATUS_CODES) and exercises appointment court-mapping.
+-- SERVING_STATE holds the FULL STATE NAME (single-court states -> no DISTRICT needed):
+--   Idaho -> 0976, Arizona -> 0970, Maryland -> 0416, Connecticut -> 0205.
+INSERT INTO CHAPTER_DETAILS
+  (TRU_ID, DISTRICT, SERVING_STATE, CHAPTER, APPOINTED_DATE, STATUS, STATUS_EFF_DATE, ARCHIVE_DATE)
+VALUES
+  (1004, NULL, 'Idaho',       '7', '2015-01-01', 'PA', '2015-01-01', NULL),
+  (1005, NULL, 'Arizona',     '7', '2016-02-01', 'PA', '2016-02-01', NULL),
+  (1006, NULL, 'Maryland',    '7', '2017-03-01', 'PA', '2017-03-01', NULL),
+  (1007, NULL, 'Maryland',    '7', '2018-04-01', 'PA', '2018-04-01', NULL),
+  (1008, NULL, 'Connecticut', '7', '2019-05-01', 'PA', '2019-05-01', NULL)
+GO

--- a/test/integration/migrate-trustees/seed/03-seed-acms-cmmpr.sql
+++ b/test/integration/migrate-trustees/seed/03-seed-acms-cmmpr.sql
@@ -1,0 +1,58 @@
+-- Seed ACMS CMMPR fixture rows so the trustee migration's professional-id
+-- lookup resolves for the dedup fixtures (ATS IDs 1004-1008).
+-- Drop and recreate so the test is fully idempotent.
+--
+-- WHAT THE MIGRATION QUERIES
+-- --------------------------
+-- AcmsGatewayImpl.getTrusteeProfessionalIds runs, server-side:
+--
+--   SELECT CONCAT(GROUP_DESIGNATOR, '-', RIGHT(CONCAT('0000', UST_PROF_CODE), 5))
+--   FROM [dbo].[CMMPR]
+--   WHERE PROF_FIRST_NAME = @firstName
+--     AND PROF_LAST_NAME  = @lastName
+--     AND PROF_STATE      = @state
+--     AND (PROF_TYPE = 'TR' OR PROF_TYPE IS NULL)
+--
+-- The migration passes the RAW primary record values (migrate-trustees use case
+-- upsertProfessionalIds is called with primary.FIRST_NAME / primary.LAST_NAME /
+-- primary.STATE) — i.e. the 2-char address STATE, NOT the transformed public
+-- state and NOT the CHAPTER_DETAILS SERVING_STATE. So PROF_FIRST_NAME /
+-- PROF_LAST_NAME / PROF_STATE below MUST match each fixture's RAW name + STATE
+-- exactly:
+--   1004  'J.'      / 'Elsaesser'    / 'ID'
+--   1005  'William' / 'Brandt, Jr.'  / 'AZ'
+--   1006  'Merrill' / 'Cohen'        / 'MD'
+--   1007  'Test'    / 'Fallback'     / 'MD'
+--   1008  'Jane'    / 'Control'      / 'CT'
+--
+-- COLUMNS SEEDED (the ones the query needs):
+--   GROUP_DESIGNATOR  (2-char) — first half of the returned professional id
+--   UST_PROF_CODE               — right-padded to 5 digits for the id
+--   PROF_FIRST_NAME, PROF_LAST_NAME, PROF_STATE, PROF_TYPE
+--
+-- We use a reserved UST_PROF_CODE block 99001-99005 so cleanup is unambiguous.
+--
+-- <PLACEHOLDER: any additional NOT NULL columns in your CMMPR table>
+-- We do NOT have the production CMMPR DDL. If your CMMPR table has additional
+-- NOT NULL / no-default columns, add them to BOTH the column list and VALUES
+-- rows below, or these INSERTs will fail. The six columns above are the only
+-- ones the migration query reads.
+
+-- IMPORTANT: ACMS is a DIFFERENT database than ATS (though on the same shared
+-- server). Use the database named by ACMS_MSSQL_DATABASE in backend/.env.
+USE ACMS_REP_SUB
+GO
+
+-- Idempotent cleanup by the reserved UST_PROF_CODE block.
+DELETE FROM [dbo].[CMMPR] WHERE UST_PROF_CODE IN (99001, 99002, 99003, 99004, 99005)
+GO
+
+INSERT INTO [dbo].[CMMPR]
+  (GROUP_DESIGNATOR, UST_PROF_CODE, PROF_FIRST_NAME, PROF_LAST_NAME, PROF_STATE, PROF_TYPE)
+VALUES
+  ('09', 99001, 'J.',      'Elsaesser',   'ID', 'TR'),  -- ATS 1004 -> "09-99001"
+  ('14', 99002, 'William', 'Brandt, Jr.', 'AZ', 'TR'),  -- ATS 1005 -> "14-99002"
+  ('04', 99003, 'Merrill', 'Cohen',       'MD', 'TR'),  -- ATS 1006 -> "04-99003"
+  ('04', 99004, 'Test',    'Fallback',    'MD', 'TR'),  -- ATS 1007 -> "04-99004"
+  ('01', 99005, 'Jane',    'Control',     'CT', 'TR')   -- ATS 1008 -> "01-99005"
+GO


### PR DESCRIPTION
# Problem

The trustee migration created duplicate trustee documents on every run.
Two independent defects both caused `upsertTrustee`'s dedup lookup
(`findTrusteeByNameAndState`) to miss an existing record and insert a
new one, plus an edge case that could persist a trustee with an empty
public state.

- **Mechanism 1 — regex word-boundary bug.** The lookup built
  `\b<first>\b.*\b<last>\b`. `\b` is a zero-width assertion that only
  matches between a word and non-word character, so any name whose
  first/last token ends in punctuation ("J.", "Brandt, Jr.", "D'Amour")
  never matched — the lookup always returned null and a duplicate was
  created.
- **Mechanism 2 — STATE vs STATE_A2 dedup key.** The document persists
  `public.address.state = STATE_A2` when the A2 address is public, but
  the dedup key re-derived state from raw `primary.STATE`. When they
  differ (e.g. Merrill Cohen: STATE=MD, STATE_A2=DE), every lookup
  searched a state the stored doc never had — a permanent miss.
- **Empty public-state edge case.** When the A2 address is public but
  its state is blank, the transformed record carried an empty public
  state.

# Solution

- **M1:** rewrite the lookup regex to a lookahead-only construction
  (`(?:^|\s)<first>(?!\w).*\s<last>(?!\w)`), which matches
  punctuation-ending tokens. Lookbehind is intentionally avoided;
  lookahead support was confirmed honored server-side by the Cosmos
  Mongo API.
- **M2:** source the dedup state key from the already-transformed
  `trusteeInput.public.address.state` instead of raw `primary.STATE`,
  so the key matches what is persisted.
- **Fallback:** in `transformTrusteeRecord`, when the selected public
  state is empty, backfill it from the other address rather than
  persisting a blank state.

# Testing/Validation

1. Unit tests cover all three cases: regex matches punctuation-ending
   names while still rejecting prefix false-positives; M2 dedups when
   STATE != STATE_A2; fallback backfills the empty public state.
2. End-to-end against the real `MIGRATE-TRUSTEES` dataflow: seed
   `ATS_SUB` fixtures (1004-1008), run the dataflow twice via reset.
   Run 1 creates the fixtures; run 2 produced **zero duplicates** —
   15/15 hard checks pass (one doc per fixture; Merrill Cohen
   public=DE/internal=MD; fallback public=MD). See
   `test/integration/migrate-trustees/DEDUP_MIGRATION_RUNBOOK.md` and
   `scripts/verify-dedup-cosmos.mjs`.

# Other Changes

- Adds a manual verification kit under `test/integration/migrate-trustees/`
  (runbook, read-only verifier, seed SQL).
- Professional-id sync is INFO-only in the verifier: the dev ACMS
  replica's `CMMPR` lacks `UST_PROF_CODE`/`PROF_TYPE`, a pre-existing
  schema mismatch unrelated to these fixes.
- Out of scope (not included): unique index / atomic find-or-create,
  migration resilience gaps (reset-without-delete, idempotent page
  retry, concurrency lock), reconciliation/merge tooling.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application