### PR TITLE
CAMS-774 Fix premature logout from activity detection gaps

### DIFF
--- a/user-interface/src/login/session-timer.test.ts
+++ b/user-interface/src/login/session-timer.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import LocalStorage from '../lib/utils/local-storage';
 import * as UseCamsNavigator from '@/lib/hooks/UseCamsNavigator';
+import { mockConfiguration } from '@/lib/testing/mock-configuration';
 import {
   SESSION_TIMEOUT,
   AUTH_EXPIRY_WARNING,
@@ -21,9 +22,19 @@ import {
   cancelPendingLogout,
 } from './session-timer';
 
+function stubWindowLocation() {
+  Object.defineProperty(window, 'location', {
+    value: {
+      host: 'example.com',
+      protocol: 'https:',
+    },
+    writable: true,
+  });
+}
+
 describe('Timer Factory', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   test('createTimer should create a timer and return id and clear function', () => {
@@ -49,7 +60,7 @@ describe('Stateless Helper Functions', () => {
   const NOW = 100000;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.spyOn(Date, 'now').mockReturnValue(NOW);
   });
 
@@ -76,7 +87,7 @@ describe('Session Interaction Functions', () => {
   const NOW = 100000;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.spyOn(Date, 'now').mockReturnValue(NOW);
   });
 
@@ -99,145 +110,103 @@ describe('Session Interaction Functions', () => {
 });
 
 describe('logout function', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stubWindowLocation();
+  });
+
   test('should construct logout URI and call redirectTo', () => {
     const redirectToSpy = vi.spyOn(UseCamsNavigator, 'redirectTo').mockImplementation(() => {});
-
-    // Mock window.location
-    Object.defineProperty(window, 'location', {
-      value: {
-        host: 'example.com',
-        protocol: 'https:',
-      },
-      writable: true,
-    });
 
     logout();
 
     expect(redirectToSpy).toHaveBeenCalledWith('https://example.com/logout');
-    redirectToSpy.mockRestore();
   });
 });
 
 describe('checkForInactivity function', () => {
   const NOW = 100000;
+  const TIMEOUT = 30 * 60 * 1000; // 30 minutes
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.spyOn(Date, 'now').mockReturnValue(NOW);
+    stubWindowLocation();
   });
 
-  test('should call logout if lastInteraction is null', () => {
-    const getLastInteractionSpy = vi
-      .spyOn(LocalStorage, 'getLastInteraction')
-      .mockReturnValue(null);
+  test.each([
+    ['lastInteraction is null', null],
+    ['timeout has passed', NOW - (TIMEOUT + 1000)],
+  ])('should call logout when %s', (_description, lastInteraction) => {
+    vi.spyOn(LocalStorage, 'getLastInteraction').mockReturnValue(lastInteraction);
     const redirectToSpy = vi.spyOn(UseCamsNavigator, 'redirectTo').mockImplementation(() => {});
-
-    Object.defineProperty(window, 'location', {
-      value: {
-        host: 'example.com',
-        protocol: 'https:',
-      },
-      writable: true,
-    });
 
     checkForInactivity();
 
-    expect(getLastInteractionSpy).toHaveBeenCalled();
     expect(redirectToSpy).toHaveBeenCalledWith('https://example.com/logout');
-
-    getLastInteractionSpy.mockRestore();
-    redirectToSpy.mockRestore();
   });
 
-  test('should call logout when timeout has passed', () => {
-    const TIMEOUT = 30 * 60 * 1000; // 30 minutes
-    const lastInteraction = NOW - (TIMEOUT + 1000); // 1 second past timeout
-
-    const getLastInteractionSpy = vi
-      .spyOn(LocalStorage, 'getLastInteraction')
-      .mockReturnValue(lastInteraction);
-    const redirectToSpy = vi.spyOn(UseCamsNavigator, 'redirectTo').mockImplementation(() => {});
-
-    Object.defineProperty(window, 'location', {
-      value: {
-        host: 'example.com',
-        protocol: 'https:',
-      },
-      writable: true,
-    });
-
-    checkForInactivity();
-
-    expect(getLastInteractionSpy).toHaveBeenCalled();
-    expect(redirectToSpy).toHaveBeenCalledWith('https://example.com/logout');
-
-    getLastInteractionSpy.mockRestore();
-    redirectToSpy.mockRestore();
-  });
-
-  test('should do nothing when user is active and not within warning threshold', () => {
+  test('should not call logout when user is active', () => {
     const lastInteraction = NOW - 5 * 60 * 1000; // 5 minutes ago (well before timeout)
-
-    const getLastInteractionSpy = vi
-      .spyOn(LocalStorage, 'getLastInteraction')
-      .mockReturnValue(lastInteraction);
-    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+    vi.spyOn(LocalStorage, 'getLastInteraction').mockReturnValue(lastInteraction);
     const redirectToSpy = vi.spyOn(UseCamsNavigator, 'redirectTo').mockImplementation(() => {});
 
     checkForInactivity();
 
-    expect(getLastInteractionSpy).toHaveBeenCalled();
-    expect(dispatchEventSpy).not.toHaveBeenCalled();
     expect(redirectToSpy).not.toHaveBeenCalled();
+  });
 
-    getLastInteractionSpy.mockRestore();
-    dispatchEventSpy.mockRestore();
-    redirectToSpy.mockRestore();
+  test('should not call logout when running in test feature flag mode, even if idle', () => {
+    mockConfiguration({ featureFlagsMode: 'test' });
+    vi.spyOn(LocalStorage, 'getLastInteraction').mockReturnValue(null);
+    const redirectToSpy = vi.spyOn(UseCamsNavigator, 'redirectTo').mockImplementation(() => {});
+
+    checkForInactivity();
+
+    expect(redirectToSpy).not.toHaveBeenCalled();
   });
 });
 
 describe('initializeInteractionListeners function', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   afterEach(() => {
     // Clean up event listeners
-    document.body.removeEventListener('click', resetLastInteraction);
-    document.body.removeEventListener('keydown', resetLastInteraction);
-    document.body.removeEventListener('mousemove', throttledResetLastInteraction);
+    document.removeEventListener('click', resetLastInteraction, true);
+    document.removeEventListener('keydown', resetLastInteraction, true);
+    document.removeEventListener('mousemove', throttledResetLastInteraction, true);
     document.removeEventListener('scroll', throttledResetLastInteraction, true);
   });
 
-  test('should register click and keydown listeners that reset last interaction immediately', () => {
-    const addEventListenerSpy = vi.spyOn(document.body, 'addEventListener');
+  test('should register click and keydown listeners in the capture phase', () => {
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
 
     initializeInteractionListeners();
 
-    expect(addEventListenerSpy).toHaveBeenCalledWith('click', resetLastInteraction);
-    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', resetLastInteraction);
-
-    addEventListenerSpy.mockRestore();
+    expect(addEventListenerSpy).toHaveBeenCalledWith('click', resetLastInteraction, true);
+    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', resetLastInteraction, true);
   });
 
   test('should not register a keypress listener, since it misses non-printable keys like Tab/Arrow/Escape', () => {
-    const addEventListenerSpy = vi.spyOn(document.body, 'addEventListener');
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
 
     initializeInteractionListeners();
 
     expect(addEventListenerSpy).not.toHaveBeenCalledWith('keypress', expect.anything());
-
-    addEventListenerSpy.mockRestore();
   });
 
-  test('should register a throttled mousemove listener on document.body', () => {
-    const addEventListenerSpy = vi.spyOn(document.body, 'addEventListener');
+  test('should register a throttled mousemove listener in the capture phase', () => {
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
 
     initializeInteractionListeners();
 
-    expect(addEventListenerSpy).toHaveBeenCalledWith('mousemove', throttledResetLastInteraction);
-
-    addEventListenerSpy.mockRestore();
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'mousemove',
+      throttledResetLastInteraction,
+      true,
+    );
   });
 
   test('should register a throttled scroll listener on document in the capture phase, since scroll does not bubble', () => {
@@ -246,8 +215,36 @@ describe('initializeInteractionListeners function', () => {
     initializeInteractionListeners();
 
     expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', throttledResetLastInteraction, true);
+  });
 
-    addEventListenerSpy.mockRestore();
+  test('should record activity from a click that a descendant stops from bubbling', () => {
+    const setLastInteractionSpy = vi.spyOn(LocalStorage, 'setLastInteraction');
+    initializeInteractionListeners();
+
+    const descendant = document.createElement('button');
+    descendant.addEventListener('click', (event) => event.stopPropagation());
+    document.body.appendChild(descendant);
+
+    descendant.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    document.body.removeChild(descendant);
+
+    expect(setLastInteractionSpy).toHaveBeenCalled();
+  });
+
+  test('should record activity from a keydown that a descendant stops from bubbling', () => {
+    const setLastInteractionSpy = vi.spyOn(LocalStorage, 'setLastInteraction');
+    initializeInteractionListeners();
+
+    const descendant = document.createElement('input');
+    descendant.addEventListener('keydown', (event) => event.stopPropagation());
+    document.body.appendChild(descendant);
+
+    descendant.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+    document.body.removeChild(descendant);
+
+    expect(setLastInteractionSpy).toHaveBeenCalled();
   });
 });
 
@@ -255,7 +252,7 @@ describe('throttledResetLastInteraction function', () => {
   const NOW = 500000;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     resetActivityThrottle();
     vi.spyOn(Date, 'now').mockReturnValue(NOW);
   });
@@ -296,23 +293,12 @@ describe('throttledResetLastInteraction function', () => {
 
 describe('Logout cleanup handler', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   afterEach(() => {
     // Reset module-level state to prevent test interdependence
     unregisterLogoutCleanupHandler();
-  });
-
-  test('registerLogoutCleanupHandler should register a cleanup handler', () => {
-    const cleanupHandler = vi.fn();
-
-    registerLogoutCleanupHandler(cleanupHandler);
-
-    // Verify handler is registered by calling cancelPendingLogout
-    cancelPendingLogout();
-
-    expect(cleanupHandler).toHaveBeenCalledTimes(1);
   });
 
   test('cancelPendingLogout should reset last interaction', () => {
@@ -323,8 +309,6 @@ describe('Logout cleanup handler', () => {
     cancelPendingLogout();
 
     expect(setLastInteractionSpy).toHaveBeenCalledWith(now);
-
-    setLastInteractionSpy.mockRestore();
   });
 
   test('cancelPendingLogout should call registered cleanup handler', () => {
@@ -344,8 +328,6 @@ describe('Logout cleanup handler', () => {
 
     expect(() => cancelPendingLogout()).not.toThrow();
     expect(setLastInteractionSpy).toHaveBeenCalled();
-
-    setLastInteractionSpy.mockRestore();
   });
 
   test('unregisterLogoutCleanupHandler should clear the handler', () => {
@@ -375,19 +357,12 @@ describe('Logout cleanup handler', () => {
 });
 
 describe('Constants', () => {
-  test('SESSION_TIMEOUT should be exported', () => {
-    expect(SESSION_TIMEOUT).toBe('session-timeout');
-  });
-
-  test('AUTH_EXPIRY_WARNING should be exported', () => {
-    expect(AUTH_EXPIRY_WARNING).toBe('auth-expiry-warning');
-  });
-
-  test('HEARTBEAT should be 1 minute', () => {
-    expect(HEARTBEAT).toBe(60000); // 60 * 1000
-  });
-
-  test('LOGOUT_TIMER should be 1 minute', () => {
-    expect(LOGOUT_TIMER).toBe(60000); // 60 * 1000
+  test.each([
+    ['SESSION_TIMEOUT', SESSION_TIMEOUT, 'session-timeout'],
+    ['AUTH_EXPIRY_WARNING', AUTH_EXPIRY_WARNING, 'auth-expiry-warning'],
+    ['HEARTBEAT', HEARTBEAT, 60000],
+    ['LOGOUT_TIMER', LOGOUT_TIMER, 60000],
+  ])('%s should be %s', (_name, actual, expected) => {
+    expect(actual).toBe(expected);
   });
 });

--- a/user-interface/src/login/session-timer.test.ts
+++ b/user-interface/src/login/session-timer.test.ts
@@ -6,6 +6,7 @@ import {
   AUTH_EXPIRY_WARNING,
   HEARTBEAT,
   LOGOUT_TIMER,
+  ACTIVITY_THROTTLE_MS,
   createTimer,
   isUserActive,
   resetLastInteraction,
@@ -13,6 +14,8 @@ import {
   checkForInactivity,
   logout,
   initializeInteractionListeners,
+  throttledResetLastInteraction,
+  resetActivityThrottle,
   registerLogoutCleanupHandler,
   unregisterLogoutCleanupHandler,
   cancelPendingLogout,
@@ -201,19 +204,93 @@ describe('initializeInteractionListeners function', () => {
   afterEach(() => {
     // Clean up event listeners
     document.body.removeEventListener('click', resetLastInteraction);
-    document.body.removeEventListener('keypress', resetLastInteraction);
+    document.body.removeEventListener('keydown', resetLastInteraction);
+    document.body.removeEventListener('mousemove', throttledResetLastInteraction);
+    document.removeEventListener('scroll', throttledResetLastInteraction, true);
   });
 
-  test('should set up event listeners for user activity tracking', () => {
+  test('should register click and keydown listeners that reset last interaction immediately', () => {
     const addEventListenerSpy = vi.spyOn(document.body, 'addEventListener');
 
     initializeInteractionListeners();
 
     expect(addEventListenerSpy).toHaveBeenCalledWith('click', resetLastInteraction);
-    expect(addEventListenerSpy).toHaveBeenCalledWith('keypress', resetLastInteraction);
-    expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
+    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', resetLastInteraction);
 
     addEventListenerSpy.mockRestore();
+  });
+
+  test('should not register a keypress listener, since it misses non-printable keys like Tab/Arrow/Escape', () => {
+    const addEventListenerSpy = vi.spyOn(document.body, 'addEventListener');
+
+    initializeInteractionListeners();
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('keypress', expect.anything());
+
+    addEventListenerSpy.mockRestore();
+  });
+
+  test('should register a throttled mousemove listener on document.body', () => {
+    const addEventListenerSpy = vi.spyOn(document.body, 'addEventListener');
+
+    initializeInteractionListeners();
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('mousemove', throttledResetLastInteraction);
+
+    addEventListenerSpy.mockRestore();
+  });
+
+  test('should register a throttled scroll listener on document in the capture phase, since scroll does not bubble', () => {
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+
+    initializeInteractionListeners();
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', throttledResetLastInteraction, true);
+
+    addEventListenerSpy.mockRestore();
+  });
+});
+
+describe('throttledResetLastInteraction function', () => {
+  const NOW = 500000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetActivityThrottle();
+    vi.spyOn(Date, 'now').mockReturnValue(NOW);
+  });
+
+  test('should reset last interaction on the first call', () => {
+    const setLastInteractionSpy = vi.spyOn(LocalStorage, 'setLastInteraction');
+
+    throttledResetLastInteraction();
+
+    expect(setLastInteractionSpy).toHaveBeenCalledWith(NOW);
+  });
+
+  test('should not reset last interaction again within the throttle window', () => {
+    const setLastInteractionSpy = vi.spyOn(LocalStorage, 'setLastInteraction');
+
+    throttledResetLastInteraction();
+    setLastInteractionSpy.mockClear();
+
+    vi.spyOn(Date, 'now').mockReturnValue(NOW + ACTIVITY_THROTTLE_MS - 1);
+    throttledResetLastInteraction();
+
+    expect(setLastInteractionSpy).not.toHaveBeenCalled();
+  });
+
+  test('should reset last interaction again once the throttle window has elapsed', () => {
+    const setLastInteractionSpy = vi.spyOn(LocalStorage, 'setLastInteraction');
+
+    throttledResetLastInteraction();
+    setLastInteractionSpy.mockClear();
+
+    const later = NOW + ACTIVITY_THROTTLE_MS;
+    vi.spyOn(Date, 'now').mockReturnValue(later);
+    throttledResetLastInteraction();
+
+    expect(setLastInteractionSpy).toHaveBeenCalledWith(later);
   });
 });
 

--- a/user-interface/src/login/session-timer.test.ts
+++ b/user-interface/src/login/session-timer.test.ts
@@ -176,8 +176,8 @@ describe('initializeInteractionListeners function', () => {
     // Clean up event listeners
     document.removeEventListener('click', resetLastInteraction, true);
     document.removeEventListener('keydown', resetLastInteraction, true);
-    document.removeEventListener('mousemove', throttledResetLastInteraction, true);
-    document.removeEventListener('scroll', throttledResetLastInteraction, true);
+    document.removeEventListener('mousemove', throttledResetLastInteraction, { capture: true });
+    document.removeEventListener('scroll', throttledResetLastInteraction, { capture: true });
   });
 
   test('should register click and keydown listeners in the capture phase', () => {
@@ -197,24 +197,26 @@ describe('initializeInteractionListeners function', () => {
     expect(addEventListenerSpy).not.toHaveBeenCalledWith('keypress', expect.anything());
   });
 
-  test('should register a throttled mousemove listener in the capture phase', () => {
+  test('should register a throttled, passive, capture-phase mousemove listener', () => {
     const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
 
     initializeInteractionListeners();
 
-    expect(addEventListenerSpy).toHaveBeenCalledWith(
-      'mousemove',
-      throttledResetLastInteraction,
-      true,
-    );
+    expect(addEventListenerSpy).toHaveBeenCalledWith('mousemove', throttledResetLastInteraction, {
+      capture: true,
+      passive: true,
+    });
   });
 
-  test('should register a throttled scroll listener on document in the capture phase, since scroll does not bubble', () => {
+  test('should register a throttled, passive, capture-phase scroll listener, since scroll does not bubble', () => {
     const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
 
     initializeInteractionListeners();
 
-    expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', throttledResetLastInteraction, true);
+    expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', throttledResetLastInteraction, {
+      capture: true,
+      passive: true,
+    });
   });
 
   test('should record activity from a click that a descendant stops from bubbling', () => {

--- a/user-interface/src/login/session-timer.ts
+++ b/user-interface/src/login/session-timer.ts
@@ -108,10 +108,12 @@ export function cancelPendingLogout(): void {
 }
 
 export function initializeInteractionListeners() {
-  document.body.addEventListener('click', resetLastInteraction);
+  // Registered on the capture phase so activity is recorded even when a descendant
+  // (e.g. ComboBox, DropdownMenu) calls stopPropagation() during the bubble phase.
+  document.addEventListener('click', resetLastInteraction, true);
   // 'keydown' (not 'keypress') so non-printable keys like Tab/Arrow/Escape count as activity.
-  document.body.addEventListener('keydown', resetLastInteraction);
-  document.body.addEventListener('mousemove', throttledResetLastInteraction);
+  document.addEventListener('keydown', resetLastInteraction, true);
+  document.addEventListener('mousemove', throttledResetLastInteraction, true);
   // 'scroll' doesn't bubble, so it must be registered on document with capture.
   document.addEventListener('scroll', throttledResetLastInteraction, true);
 }

--- a/user-interface/src/login/session-timer.ts
+++ b/user-interface/src/login/session-timer.ts
@@ -113,7 +113,15 @@ export function initializeInteractionListeners() {
   document.addEventListener('click', resetLastInteraction, true);
   // 'keydown' (not 'keypress') so non-printable keys like Tab/Arrow/Escape count as activity.
   document.addEventListener('keydown', resetLastInteraction, true);
-  document.addEventListener('mousemove', throttledResetLastInteraction, true);
+  // passive: neither handler calls preventDefault, so the browser can skip
+  // waiting on them before scrolling/painting.
+  document.addEventListener('mousemove', throttledResetLastInteraction, {
+    capture: true,
+    passive: true,
+  });
   // 'scroll' doesn't bubble, so it must be registered on document with capture.
-  document.addEventListener('scroll', throttledResetLastInteraction, true);
+  document.addEventListener('scroll', throttledResetLastInteraction, {
+    capture: true,
+    passive: true,
+  });
 }

--- a/user-interface/src/login/session-timer.ts
+++ b/user-interface/src/login/session-timer.ts
@@ -8,6 +8,7 @@ export const AUTH_EXPIRY_WARNING = 'auth-expiry-warning';
 export const SIXTY_SECONDS = 60;
 export const HEARTBEAT = 1000 * SIXTY_SECONDS;
 export const LOGOUT_TIMER = 1000 * SIXTY_SECONDS;
+export const ACTIVITY_THROTTLE_MS = 5000;
 
 const TIMEOUT_MINUTES = getAppConfiguration().inactiveTimeout ?? 30;
 const TIMEOUT = TIMEOUT_MINUTES * SIXTY_SECONDS * 1000;
@@ -38,6 +39,21 @@ export function isUserActive(lastInteraction: number | null): boolean {
 
 export function resetLastInteraction(): void {
   LocalStorage.setLastInteraction(Date.now());
+}
+
+let lastThrottledReset = 0;
+
+export function resetActivityThrottle(): void {
+  lastThrottledReset = 0;
+}
+
+export function throttledResetLastInteraction(): void {
+  const now = Date.now();
+  if (now - lastThrottledReset < ACTIVITY_THROTTLE_MS) {
+    return;
+  }
+  lastThrottledReset = now;
+  resetLastInteraction();
 }
 
 export function getLastInteraction(): number | null {
@@ -93,5 +109,9 @@ export function cancelPendingLogout(): void {
 
 export function initializeInteractionListeners() {
   document.body.addEventListener('click', resetLastInteraction);
-  document.body.addEventListener('keypress', resetLastInteraction);
+  // 'keydown' (not 'keypress') so non-printable keys like Tab/Arrow/Escape count as activity.
+  document.body.addEventListener('keydown', resetLastInteraction);
+  document.body.addEventListener('mousemove', throttledResetLastInteraction);
+  // 'scroll' doesn't bubble, so it must be registered on document with capture.
+  document.addEventListener('scroll', throttledResetLastInteraction, true);
 }


### PR DESCRIPTION
# Bug

Users were being logged out despite being actively interacting with the application. Two separate gaps in activity detection caused this:

1. The session timer only reset on `click` and `keypress` events on `document.body`. `keypress` does not fire for non-printable keys (Tab, Arrow, Escape), so keyboard-only navigation (e.g. through ComboBox filters) wasn't counted as activity. Mouse movement and scrolling also weren't tracked at all.
2. After adding `mousemove`/`scroll`/`keydown` tracking, those listeners were still registered on `document.body` in the bubble phase. Components like `ComboBox` and `DropdownMenu` call `event.stopPropagation()` during keydown handling (Escape, Arrow keys, Tab), which prevented those events from ever reaching the session-timer listener — so users navigating those components purely via keyboard could still be logged out as idle.

# Purpose

Ensure the session-timeout activity detector reliably recognizes real user interaction (clicks, keyboard navigation, mouse movement, scrolling) so users are not logged out while actively using the application.

# Major Changes

* Replaced `keypress` with `keydown` and added throttled `mousemove`/`scroll` listeners so those interactions count as activity.
* Moved all activity listeners (`click`, `keydown`, `mousemove`, `scroll`) to the capture phase on `document`, so a descendant's `stopPropagation()` call can no longer suppress activity detection.
* Rewrote `session-timer.test.ts` to remove test-quality issues found in review: switched to `vi.restoreAllMocks()` in `beforeEach` instead of `vi.clearAllMocks()` + scattered manual `mockRestore()` calls, added a behavioral test that dispatches a real event through a `stopPropagation()`-calling descendant to prove capture-phase detection works, added coverage for the untested `featureFlagsMode === 'test'` short-circuit branch, removed a vacuous `dispatchEvent` assertion and a duplicate cleanup-handler test, and consolidated near-identical cases into `test.each`.

# Testing/Validation

* Extended and reviewed `session-timer.test.ts` (29 tests, all passing) via `/cams-spec-review`, which flagged mock-restoration convention violations, an implementation-detail-only test, a missing coverage branch, a vacuous assertion, and a duplicate test — all addressed.
* Full `user-interface` test suite and coverage run confirmed no regressions (pre-existing unrelated flaky failures in other files verified identical before/after this change).
* Manually verified locally end-to-end using Okta login with temporarily shortened timeout constants: confirmed continuous scrolling/mouse movement no longer triggers the warning modal, and confirmed keyboard-only navigation through a ComboBox (Escape/Arrow keys, which call `stopPropagation()`) keeps the session alive.

# Notes

Capture-phase listeners fire top-down before any descendant can call `stopPropagation()`, so they can't be suppressed the way bubble-phase listeners can — this matches the existing `scroll` listener's registration, which already used capture (scroll doesn't bubble at all).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve session timeout activity detection to prevent active users from being logged out prematurely and strengthen related tests.

Bug Fixes:
- Ensure session activity is tracked for clicks, keydown events (including non-printable keys), mouse movement, and scrolling, even when descendants stop event propagation.
- Prevent test-mode feature flag configurations from triggering real logouts during inactivity checks.

Enhancements:
- Add throttled activity handling to reduce redundant session updates from high-frequency mousemove and scroll events.
- Refactor session timer tests for clearer structure, better mock restoration, and consolidated constant assertions.

Tests:
- Expand session timer test coverage to include capture-phase listeners, throttled activity behavior, featureFlagsMode 'test' behavior, and stopPropagation scenarios.