### PR TITLE
CAMS-796 Enforce unique bank names

### DIFF
--- a/backend/function-apps/api/cases/cases.function.test.ts
+++ b/backend/function-apps/api/cases/cases.function.test.ts
@@ -58,6 +58,10 @@ describe('Cases function', () => {
     const error = new CamsError('test-module', { message: 'Some CAMS error.' });
     vi.spyOn(CasesController.prototype, 'handleRequest').mockRejectedValue(error);
     const response = await handler(request, context);
-    expect(response).toEqual({ headers: commonHeaders, status: 500, jsonBody: error.message });
+    expect(response).toEqual({
+      headers: commonHeaders,
+      status: 500,
+      jsonBody: { message: error.message, status: 500 },
+    });
   });
 });

--- a/backend/function-apps/azure/functions.ts
+++ b/backend/function-apps/azure/functions.ts
@@ -85,6 +85,6 @@ export function toAzureError(
   return {
     headers: commonHeaders,
     status: error.status,
-    jsonBody: error.message,
+    jsonBody: { message: error.message, status: error.status },
   };
 }

--- a/backend/lib/adapters/gateways/mongo/banks.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/banks.mongo.repository.test.ts
@@ -6,6 +6,7 @@ import { BanksMongoRepository } from './banks.mongo.repository';
 import { MongoCollectionAdapter } from './utils/mongo-adapter';
 import { BankAuditHistory, BankProfile } from '@common/cams/banks';
 import { Creatable } from '@common/cams/creatable';
+import { NotFoundError } from '../../../common-errors/not-found-error';
 
 describe('BanksMongoRepository', () => {
   let context: ApplicationContext;
@@ -65,6 +66,48 @@ describe('BanksMongoRepository', () => {
       await expect(repo.getBanks()).rejects.toThrow(
         expect.objectContaining({
           message: 'Unable to retrieve banks.',
+          status: 500,
+          module: 'BANKS-MONGO-REPOSITORY',
+        }),
+      );
+    });
+  });
+
+  describe('findBankByName', () => {
+    test('should return the matching bank when found', async () => {
+      const bank: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockResolvedValue(bank);
+
+      const result = await repo.findBankByName('alpha bank');
+
+      expect(result).toEqual(bank);
+    });
+
+    test('should return null when no matching bank is found', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockRejectedValue(
+        new NotFoundError('BANKS-MONGO-REPOSITORY', { message: 'No matching item found.' }),
+      );
+
+      const result = await repo.findBankByName('nonexistent bank');
+
+      expect(result).toBeNull();
+    });
+
+    test('should throw CamsError when findOne fails for a non-not-found reason', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'findOne').mockRejectedValue(
+        new Error('connection error'),
+      );
+
+      await expect(repo.findBankByName('alpha bank')).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Unable to find bank by name.',
           status: 500,
           module: 'BANKS-MONGO-REPOSITORY',
         }),

--- a/backend/lib/adapters/gateways/mongo/banks.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/banks.mongo.repository.ts
@@ -1,6 +1,8 @@
 import { BankAuditHistory, BankProfile } from '@common/cams/banks';
 import { Creatable } from '@common/cams/creatable';
+import { isNotFoundError } from '../../../common-errors/not-found-error';
 import { getCamsError } from '../../../common-errors/error-utilities';
+import { escapeRegex } from '../../../use-cases/dataflows/trustee-match.helpers';
 import QueryBuilder from '../../../query/query-builder';
 import { BanksRepository } from '../../../use-cases/gateways.types';
 import { ApplicationContext } from '../../types/basic';
@@ -9,7 +11,7 @@ import { BaseMongoRepository } from './utils/base-mongo-repository';
 const MODULE_NAME = 'BANKS-MONGO-REPOSITORY';
 const COLLECTION_NAME = 'banks';
 
-const { using, orderBy } = QueryBuilder;
+const { using, orderBy, and } = QueryBuilder;
 const doc = using<BankProfile>();
 
 export class BanksMongoRepository extends BaseMongoRepository implements BanksRepository {
@@ -60,6 +62,22 @@ export class BanksMongoRepository extends BaseMongoRepository implements BanksRe
       );
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve banks.');
+    }
+  }
+
+  async findBankByName(normalizedName: string): Promise<BankProfile | null> {
+    const escaped = escapeRegex(normalizedName);
+    const query = and(
+      doc('documentType').equals('BANK_PROFILE'),
+      doc('name').regex(new RegExp(`^${escaped}$`, 'i')),
+    );
+    try {
+      return await this.getAdapter<BankProfile>().findOne(query);
+    } catch (originalError) {
+      if (isNotFoundError(originalError)) {
+        return null;
+      }
+      throw getCamsError(originalError, MODULE_NAME, 'Unable to find bank by name.');
     }
   }
 

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -119,6 +119,10 @@ export class MockMongoRepository
     throw new Error('Method not implemented.');
   }
 
+  findBankByName(_normalizedName: string): Promise<BankProfile | null> {
+    throw new Error('Method not implemented.');
+  }
+
   createBank(_bank: Creatable<BankProfile>): Promise<BankProfile> {
     throw new Error('Method not implemented.');
   }

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -100,6 +100,7 @@ describe('BanksUseCase', () => {
       };
 
       vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing]);
       const updateSpy = vi
         .spyOn(MockMongoRepository.prototype, 'updateBank')
         .mockResolvedValue(updated);
@@ -137,6 +138,7 @@ describe('BanksUseCase', () => {
         updatedOn: '',
         updatedBy: { id: 'u', name: 'u' },
       });
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
       vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockRejectedValue(
         new Error('db error'),
       );
@@ -144,6 +146,62 @@ describe('BanksUseCase', () => {
       await expect(useCase.updateBank('bank-1', { name: 'New', status: 'active' })).rejects.toThrow(
         expect.objectContaining({ message: 'Unable to update bank.', status: 500 }),
       );
+    });
+
+    test('should reject a rename that duplicates another bank (case-insensitive, trimmed)', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const other: BankProfile = {
+        id: 'bank-2',
+        documentType: 'BANK_PROFILE',
+        name: 'Beta Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing, other]);
+      const updateSpy = vi.spyOn(MockMongoRepository.prototype, 'updateBank');
+
+      await expect(
+        useCase.updateBank('bank-1', { name: '  beta bank  ', status: 'active' }),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          message: 'A bank with this name already exists.',
+          status: 400,
+        }),
+      );
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    test('should allow a bank to keep its own name (differing only by case/whitespace)', async () => {
+      const existing: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'Alpha Bank',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      const updated: BankProfile = { ...existing, name: 'Alpha Bank' };
+      vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing]);
+      vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId').mockResolvedValue([]);
+
+      const result = await useCase.updateBank('bank-1', {
+        name: '  alpha bank  ',
+        status: 'active',
+      });
+
+      expect(result).toEqual(updated);
     });
 
     test('should inactivate all software associations and create audit records when bank is set to inactive', async () => {
@@ -251,6 +309,7 @@ describe('BanksUseCase', () => {
       const updated: BankProfile = { ...existing, name: 'Alpha Bank Renamed' };
 
       vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing]);
       vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
       vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
       const findSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId');
@@ -408,6 +467,7 @@ describe('BanksUseCase', () => {
         createdBy: { id: context.session.user.id, name: context.session.user.name },
       };
 
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
       const createBankSpy = vi
         .spyOn(MockMongoRepository.prototype, 'createBank')
         .mockResolvedValue(createdBank);
@@ -438,6 +498,7 @@ describe('BanksUseCase', () => {
     });
 
     test('should wrap repository errors in CamsError', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
       vi.spyOn(MockMongoRepository.prototype, 'createBank').mockRejectedValue(
         new Error('db error'),
       );
@@ -445,6 +506,60 @@ describe('BanksUseCase', () => {
       await expect(useCase.createBank({ name: 'Fail Bank' })).rejects.toThrow(
         expect.objectContaining({ message: 'Unable to create bank.', status: 500 }),
       );
+    });
+
+    test('should reject a name that duplicates an existing bank (case-insensitive, trimmed)', async () => {
+      const existingBanks: BankProfile[] = [
+        {
+          id: 'bank-1',
+          documentType: 'BANK_PROFILE',
+          name: 'First National',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+      ];
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue(existingBanks);
+      const createBankSpy = vi.spyOn(MockMongoRepository.prototype, 'createBank');
+
+      await expect(useCase.createBank({ name: '  first national  ' })).rejects.toThrow(
+        expect.objectContaining({
+          message: 'A bank with this name already exists.',
+          status: 400,
+        }),
+      );
+      expect(createBankSpy).not.toHaveBeenCalled();
+    });
+
+    test('should allow a name that does not duplicate an existing bank', async () => {
+      const existingBanks: BankProfile[] = [
+        {
+          id: 'bank-1',
+          documentType: 'BANK_PROFILE',
+          name: 'First National',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+      ];
+      const createdBank: BankProfile = {
+        id: 'bank-new',
+        documentType: 'BANK_PROFILE',
+        name: 'Second National',
+        status: 'active',
+        updatedOn: expect.any(String) as unknown as string,
+        updatedBy: { id: context.session.user.id, name: context.session.user.name },
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue(existingBanks);
+      const createBankSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'createBank')
+        .mockResolvedValue(createdBank);
+      vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
+
+      const result = await useCase.createBank({ name: 'Second National' });
+
+      expect(createBankSpy).toHaveBeenCalled();
+      expect(result).toEqual(createdBank);
     });
 
     test('should set createdBy and updatedBy from context user', async () => {
@@ -459,6 +574,7 @@ describe('BanksUseCase', () => {
         createdBy: { id: context.session.user.id, name: context.session.user.name },
       };
 
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
       const createBankSpy = vi
         .spyOn(MockMongoRepository.prototype, 'createBank')
         .mockResolvedValue(createdBank);

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -290,11 +290,13 @@ describe('BanksUseCase', () => {
       vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
       vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
       vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
-      const findSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId');
+      const updateSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'updateSoftware');
+      const auditSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord');
 
       await useCase.updateBank('bank-1', { name: 'Alpha Bank', status: 'active' });
 
-      expect(findSoftwareSpy).not.toHaveBeenCalled();
+      expect(updateSoftwareSpy).not.toHaveBeenCalled();
+      expect(auditSoftwareSpy).not.toHaveBeenCalled();
     });
 
     test('should not cascade when already-inactive bank is updated without status change', async () => {
@@ -312,11 +314,13 @@ describe('BanksUseCase', () => {
       vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing]);
       vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
       vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
-      const findSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId');
+      const updateSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'updateSoftware');
+      const auditSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord');
 
       await useCase.updateBank('bank-1', { name: 'Alpha Bank Renamed', status: 'inactive' });
 
-      expect(findSoftwareSpy).not.toHaveBeenCalled();
+      expect(updateSoftwareSpy).not.toHaveBeenCalled();
+      expect(auditSoftwareSpy).not.toHaveBeenCalled();
     });
 
     test('should handle cascade when no software profiles are associated (empty result)', async () => {

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -100,7 +100,7 @@ describe('BanksUseCase', () => {
       };
 
       vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing]);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(null);
       const updateSpy = vi
         .spyOn(MockMongoRepository.prototype, 'updateBank')
         .mockResolvedValue(updated);
@@ -138,7 +138,7 @@ describe('BanksUseCase', () => {
         updatedOn: '',
         updatedBy: { id: 'u', name: 'u' },
       });
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(null);
       vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockRejectedValue(
         new Error('db error'),
       );
@@ -166,7 +166,7 @@ describe('BanksUseCase', () => {
         updatedBy: { id: 'user-1', name: 'User One' },
       };
       vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing, other]);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(other);
       const updateSpy = vi.spyOn(MockMongoRepository.prototype, 'updateBank');
 
       await expect(
@@ -191,7 +191,7 @@ describe('BanksUseCase', () => {
       };
       const updated: BankProfile = { ...existing, name: 'Alpha Bank' };
       vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing]);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(existing);
       vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
       vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
       vi.spyOn(MockMongoRepository.prototype, 'findSoftwareByBankId').mockResolvedValue([]);
@@ -311,7 +311,7 @@ describe('BanksUseCase', () => {
       const updated: BankProfile = { ...existing, name: 'Alpha Bank Renamed' };
 
       vi.spyOn(MockMongoRepository.prototype, 'getBank').mockResolvedValue(existing);
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([existing]);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(null);
       vi.spyOn(MockMongoRepository.prototype, 'updateBank').mockResolvedValue(updated);
       vi.spyOn(MockMongoRepository.prototype, 'createBankAuditRecord').mockResolvedValue();
       const updateSoftwareSpy = vi.spyOn(MockMongoRepository.prototype, 'updateSoftware');
@@ -471,7 +471,7 @@ describe('BanksUseCase', () => {
         createdBy: { id: context.session.user.id, name: context.session.user.name },
       };
 
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(null);
       const createBankSpy = vi
         .spyOn(MockMongoRepository.prototype, 'createBank')
         .mockResolvedValue(createdBank);
@@ -502,7 +502,7 @@ describe('BanksUseCase', () => {
     });
 
     test('should wrap repository errors in CamsError', async () => {
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(null);
       vi.spyOn(MockMongoRepository.prototype, 'createBank').mockRejectedValue(
         new Error('db error'),
       );
@@ -513,17 +513,15 @@ describe('BanksUseCase', () => {
     });
 
     test('should reject a name that duplicates an existing bank (case-insensitive, trimmed)', async () => {
-      const existingBanks: BankProfile[] = [
-        {
-          id: 'bank-1',
-          documentType: 'BANK_PROFILE',
-          name: 'First National',
-          status: 'active',
-          updatedOn: '2024-01-01T00:00:00.000Z',
-          updatedBy: { id: 'user-1', name: 'User One' },
-        },
-      ];
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue(existingBanks);
+      const existingBank: BankProfile = {
+        id: 'bank-1',
+        documentType: 'BANK_PROFILE',
+        name: 'First National',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(existingBank);
       const createBankSpy = vi.spyOn(MockMongoRepository.prototype, 'createBank');
 
       await expect(useCase.createBank({ name: '  first national  ' })).rejects.toThrow(
@@ -536,16 +534,6 @@ describe('BanksUseCase', () => {
     });
 
     test('should allow a name that does not duplicate an existing bank', async () => {
-      const existingBanks: BankProfile[] = [
-        {
-          id: 'bank-1',
-          documentType: 'BANK_PROFILE',
-          name: 'First National',
-          status: 'active',
-          updatedOn: '2024-01-01T00:00:00.000Z',
-          updatedBy: { id: 'user-1', name: 'User One' },
-        },
-      ];
       const createdBank: BankProfile = {
         id: 'bank-new',
         documentType: 'BANK_PROFILE',
@@ -554,7 +542,7 @@ describe('BanksUseCase', () => {
         updatedOn: expect.any(String) as unknown as string,
         updatedBy: { id: context.session.user.id, name: context.session.user.name },
       };
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue(existingBanks);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(null);
       const createBankSpy = vi
         .spyOn(MockMongoRepository.prototype, 'createBank')
         .mockResolvedValue(createdBank);
@@ -578,7 +566,7 @@ describe('BanksUseCase', () => {
         createdBy: { id: context.session.user.id, name: context.session.user.name },
       };
 
-      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
+      vi.spyOn(MockMongoRepository.prototype, 'findBankByName').mockResolvedValue(null);
       const createBankSpy = vi
         .spyOn(MockMongoRepository.prototype, 'createBank')
         .mockResolvedValue(createdBank);

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -6,6 +6,7 @@ import { getCamsUserReference } from '@common/cams/session';
 import { ApplicationContext } from '../../adapters/types/basic';
 import factory from '../../factory';
 import { getCamsError } from '../../common-errors/error-utilities';
+import { BadRequestError } from '../../common-errors/bad-request';
 import { CamsPaginationResponse } from '../gateways.types';
 
 const MODULE_NAME = 'BANKS-USE-CASE';
@@ -41,6 +42,10 @@ export class BanksUseCase {
   ): Promise<BankProfile> {
     const userRef = getCamsUserReference(this.context.session.user);
     const existing = await this.repository.getBank(id);
+
+    if (input.name.trim().toLowerCase() !== existing.name.trim().toLowerCase()) {
+      await this.assertNameIsUnique(input.name, id);
+    }
 
     const bankData: BankProfile = {
       ...existing,
@@ -164,6 +169,8 @@ export class BanksUseCase {
   async createBank(input: { name: string }): Promise<BankProfile> {
     const userRef = getCamsUserReference(this.context.session.user);
 
+    await this.assertNameIsUnique(input.name);
+
     const bankData = createAuditRecord<BankProfile>(
       {
         documentType: 'BANK_PROFILE',
@@ -191,6 +198,19 @@ export class BanksUseCase {
       return createdBank;
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME, 'Unable to create bank.');
+    }
+  }
+
+  private async assertNameIsUnique(name: string, excludeId?: string): Promise<void> {
+    const normalized = name.trim().toLowerCase();
+    const banks = await this.repository.getBanks();
+    const duplicate = banks.some(
+      (bank) => bank.id !== excludeId && bank.name.trim().toLowerCase() === normalized,
+    );
+    if (duplicate) {
+      throw new BadRequestError(MODULE_NAME, {
+        message: 'A bank with this name already exists.',
+      });
     }
   }
 }

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -11,6 +11,10 @@ import { CamsPaginationResponse } from '../gateways.types';
 
 const MODULE_NAME = 'BANKS-USE-CASE';
 
+function normalizeBankName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
 export class BanksUseCase {
   private readonly repository;
   private readonly context: ApplicationContext;
@@ -43,7 +47,7 @@ export class BanksUseCase {
     const userRef = getCamsUserReference(this.context.session.user);
     const existing = await this.repository.getBank(id);
 
-    if (input.name.trim().toLowerCase() !== existing.name.trim().toLowerCase()) {
+    if (normalizeBankName(input.name) !== normalizeBankName(existing.name)) {
       await this.assertNameIsUnique(input.name, id);
     }
 
@@ -202,12 +206,9 @@ export class BanksUseCase {
   }
 
   private async assertNameIsUnique(name: string, excludeId?: string): Promise<void> {
-    const normalized = name.trim().toLowerCase();
-    const banks = await this.repository.getBanks();
-    const duplicate = banks.some(
-      (bank) => bank.id !== excludeId && bank.name.trim().toLowerCase() === normalized,
-    );
-    if (duplicate) {
+    const normalized = normalizeBankName(name);
+    const existingBank = await this.repository.findBankByName(normalized);
+    if (existingBank && existingBank.id !== excludeId) {
       throw new BadRequestError(MODULE_NAME, {
         message: 'A bank with this name already exists.',
       });

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -398,6 +398,7 @@ export interface NotificationRoutingRepository extends Releasable {
 export interface BanksRepository extends Releasable {
   getBanks(): Promise<BankProfile[]>;
   getBank(id: string): Promise<BankProfile>;
+  findBankByName(normalizedName: string): Promise<BankProfile | null>;
   createBank(bank: Creatable<BankProfile>): Promise<BankProfile>;
   updateBank(id: string, bank: BankProfile): Promise<BankProfile>;
   createBankAuditRecord(history: Creatable<BankAuditHistory>): Promise<void>;

--- a/docs/operations/_sidebar.md
+++ b/docs/operations/_sidebar.md
@@ -3,6 +3,7 @@
 - [< Back](/)
 - [Application Insights Configuration](/operations/application-insights-configuration.md)
 - [Deployment](/operations/deployment.md)
+- [Identify Duplicate Bank Names](/operations/identify-duplicate-bank-names.md)
 - [Okta Configuration](/operations/okta-configuration.md)
 - [Phonetic Backfill Migration](/operations/phonetic-backfill.md)
 - [Scripts](/operations/scripts.md)

--- a/docs/operations/identify-duplicate-bank-names.md
+++ b/docs/operations/identify-duplicate-bank-names.md
@@ -1,0 +1,31 @@
+# Identify Duplicate Bank Names
+
+Bank-name uniqueness (case-insensitive, trimmed) is enforced in `BanksUseCase`
+(`backend/lib/use-cases/banks/banks.ts`) for both create and rename. Because the check is applied in
+the use case rather than by a database constraint, any duplicates that already existed before
+enforcement was added remain in the `banks` collection and should be identified and resolved
+manually.
+
+Run the following aggregation against the CosmosDB (Mongo API) `banks` collection to report any
+case-insensitive, trimmed duplicate names:
+
+```javascript
+db.banks.aggregate([
+  { $match: { documentType: 'BANK_PROFILE' } },
+  {
+    $group: {
+      _id: { $toLower: { $trim: { input: '$name' } } },
+      count: { $sum: 1 },
+      ids: { $push: '$id' },
+      names: { $push: '$name' },
+    },
+  },
+  { $match: { count: { $gt: 1 } } },
+  { $sort: { count: -1 } },
+]);
+```
+
+Each returned document represents a group of banks that collide under the uniqueness rule. Resolve
+each group manually (rename or inactivate the redundant entries) so the data is consistent with the
+enforced constraint. Running the query and finding no results confirms there are no pre-existing
+duplicates to resolve.

--- a/docs/operations/identify-duplicate-bank-names.md
+++ b/docs/operations/identify-duplicate-bank-names.md
@@ -6,26 +6,18 @@ the use case rather than by a database constraint, any duplicates that already e
 enforcement was added remain in the `banks` collection and should be identified and resolved
 manually.
 
-Run the following aggregation against the CosmosDB (Mongo API) `banks` collection to report any
-case-insensitive, trimmed duplicate names:
+Run the following script (from repo root) to report any case-insensitive, trimmed duplicate names in
+the `banks` collection:
 
-```javascript
-db.banks.aggregate([
-  { $match: { documentType: 'BANK_PROFILE' } },
-  {
-    $group: {
-      _id: { $toLower: { $trim: { input: '$name' } } },
-      count: { $sum: 1 },
-      ids: { $push: '$id' },
-      names: { $push: '$name' },
-    },
-  },
-  { $match: { count: { $gt: 1 } } },
-  { $sort: { count: -1 } },
-]);
+```shell
+npx tsx --tsconfig backend/tsconfig.json ops/migrations/CAMS-796-identify-duplicate-bank-names.ts
 ```
 
-Each returned document represents a group of banks that collide under the uniqueness rule. Resolve
-each group manually (rename or inactivate the redundant entries) so the data is consistent with the
-enforced constraint. Running the query and finding no results confirms there are no pre-existing
-duplicates to resolve.
+The script is read-only — it does not modify any data. It connects using `MONGO_CONNECTION_STRING`
+and `COSMOS_DATABASE_NAME` (loaded from `backend/.env` by default) and prints each group of banks
+that collide under the uniqueness rule, along with their ids and original names. It exits with
+status `1` if any duplicate groups are found, or `0` if there are none, so it can also be used as a
+gate in CI/ops tooling.
+
+Resolve each reported group manually (rename or inactivate the redundant entries) so the data is
+consistent with the enforced constraint.

--- a/ops/migrations/CAMS-796-identify-duplicate-bank-names.ts
+++ b/ops/migrations/CAMS-796-identify-duplicate-bank-names.ts
@@ -1,0 +1,84 @@
+/**
+ * Read-only report: find bank names in the `banks` collection that collide
+ * under case-insensitive, trimmed uniqueness (the rule enforced by
+ * `BanksUseCase`, see backend/lib/use-cases/banks/banks.ts).
+ *
+ * Because that rule is enforced in the use case rather than by a database
+ * constraint, any duplicates that existed before enforcement was added
+ * remain in the collection. This script reports them; it does not modify
+ * any data. Resolve each reported group manually (rename or inactivate the
+ * redundant entries).
+ *
+ * Usage (from repo root):
+ *   npx tsx --tsconfig backend/tsconfig.json \
+ *     ops/migrations/CAMS-796-identify-duplicate-bank-names.ts
+ *
+ * Exits with status 1 if any duplicate groups are found, 0 otherwise, so it
+ * can be used as a CI/ops gate.
+ */
+
+import * as dotenv from 'dotenv';
+import { MongoClient } from 'mongodb';
+
+dotenv.config({ path: 'backend/.env' });
+
+type DuplicateGroup = {
+  _id: string;
+  count: number;
+  ids: string[];
+  names: string[];
+};
+
+async function run(): Promise<DuplicateGroup[]> {
+  const connectionString = process.env.MONGO_CONNECTION_STRING;
+  const databaseName = process.env.COSMOS_DATABASE_NAME;
+  if (!connectionString || !databaseName) {
+    throw new Error('MONGO_CONNECTION_STRING and COSMOS_DATABASE_NAME must be set.');
+  }
+
+  const client = new MongoClient(connectionString);
+  try {
+    await client.connect();
+    const collection = client.db(databaseName).collection('banks');
+
+    return await collection
+      .aggregate<DuplicateGroup>([
+        { $match: { documentType: 'BANK_PROFILE' } },
+        {
+          $group: {
+            _id: { $toLower: { $trim: { input: '$name' } } },
+            count: { $sum: 1 },
+            ids: { $push: '$id' },
+            names: { $push: '$name' },
+          },
+        },
+        { $match: { count: { $gt: 1 } } },
+        { $sort: { count: -1 } },
+      ])
+      .toArray();
+  } finally {
+    await client.close();
+  }
+}
+
+run()
+  .then((duplicateGroups) => {
+    if (duplicateGroups.length === 0) {
+      console.log('No duplicate bank names found.');
+      process.exit(0);
+    }
+
+    console.log(`Found ${duplicateGroups.length} duplicate bank name group(s):\n`);
+    for (const group of duplicateGroups) {
+      console.log(`  "${group._id}" (${group.count} banks)`);
+      for (let i = 0; i < group.ids.length; i++) {
+        console.log(`    - id=${group.ids[i]} name="${group.names[i]}"`);
+      }
+    }
+    console.log('\nResolve each group manually (rename or inactivate the redundant entries).');
+    process.exit(1);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/user-interface/src/admin/banks/AddBankModal.test.tsx
+++ b/user-interface/src/admin/banks/AddBankModal.test.tsx
@@ -4,6 +4,8 @@ import { AddBankModal, AddBankModalRef } from './AddBankModal';
 import Api2 from '@/lib/models/api2';
 import TestingUtilities from '@/lib/testing/testing-utilities';
 import { BankProfile } from '@common/cams/banks';
+import { CamsHttpError } from '@/lib/models/api';
+import HttpStatusCodes from '@common/api/http-status-codes';
 
 const MODAL_ID = 'add-bank-modal';
 const MODAL_WRAPPER = `modal-${MODAL_ID}`;
@@ -125,6 +127,24 @@ describe('AddBankModal', () => {
       expect(onSuccess).not.toHaveBeenCalled();
       expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
     });
+  });
+
+  test('should show a field validation error and keep modal open when the name is a duplicate', async () => {
+    vi.spyOn(Api2, 'createBank').mockRejectedValue(
+      new CamsHttpError(HttpStatusCodes.BAD_REQUEST, 'A bank with this name already exists.'),
+    );
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    fireEvent.change(screen.getByLabelText(/Bank Name/i), { target: { value: 'First National' } });
+    fireEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByText('A bank with this name already exists.')).toBeInTheDocument();
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 
   test('should hide modal when hide() is called imperatively', async () => {

--- a/user-interface/src/admin/banks/AddBankModal.test.tsx
+++ b/user-interface/src/admin/banks/AddBankModal.test.tsx
@@ -24,6 +24,7 @@ const createdBank: BankProfile = {
 describe('AddBankModal', () => {
   let modalRef: React.RefObject<AddBankModalRef | null>;
   let onSuccess: (bank: BankProfile) => void;
+  let alert: ReturnType<typeof TestingUtilities.spyOnGlobalAlert>;
 
   function renderComponent() {
     modalRef = React.createRef<AddBankModalRef>();
@@ -37,7 +38,7 @@ describe('AddBankModal', () => {
 
   beforeEach(() => {
     vi.stubEnv('CAMS_USE_FAKE_API', 'true');
-    TestingUtilities.spyOnGlobalAlert();
+    alert = TestingUtilities.spyOnGlobalAlert();
   });
 
   afterEach(() => {
@@ -112,9 +113,10 @@ describe('AddBankModal', () => {
       expect(onSuccess).toHaveBeenCalledWith(createdBank);
       expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-hidden');
     });
+    expect(alert.success).toHaveBeenCalledWith('Bank added successfully.');
   });
 
-  test('should keep modal open and not call onSuccess when API call fails', async () => {
+  test('should show a global error alert and keep modal open when a generic API error occurs', async () => {
     vi.spyOn(Api2, 'createBank').mockRejectedValue(new Error('server error'));
     renderComponent();
     openModal();
@@ -124,9 +126,10 @@ describe('AddBankModal', () => {
     fireEvent.click(screen.getByTestId(SUBMIT_BTN));
 
     await waitFor(() => {
-      expect(onSuccess).not.toHaveBeenCalled();
-      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+      expect(alert.error).toHaveBeenCalledWith('Failed to add bank. Please try again.');
     });
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
   });
 
   test('should show a field validation error and keep modal open when the name is a duplicate', async () => {
@@ -145,6 +148,7 @@ describe('AddBankModal', () => {
       expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
     });
     expect(onSuccess).not.toHaveBeenCalled();
+    expect(alert.error).not.toHaveBeenCalled();
   });
 
   test('should hide modal when hide() is called imperatively', async () => {

--- a/user-interface/src/admin/banks/AddBankModal.tsx
+++ b/user-interface/src/admin/banks/AddBankModal.tsx
@@ -5,6 +5,8 @@ import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 import { BankProfile } from '@common/cams/banks';
 import Api2 from '@/lib/models/api2';
+import { CamsHttpError } from '@/lib/models/api';
+import HttpStatusCodes from '@common/api/http-status-codes';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 export type AddBankModalRef = {
@@ -57,6 +59,10 @@ export const AddBankModal = forwardRef<AddBankModalRef, AddBankModalProps>(funct
       modalRef.current?.hide();
       alert?.success('Bank added successfully.');
     } catch (error) {
+      if (error instanceof CamsHttpError && error.status === HttpStatusCodes.BAD_REQUEST) {
+        setNameError(error.message);
+        return;
+      }
       getAppInsights().appInsights.trackException({ exception: error as Error });
       alert?.error('Failed to add bank. Please try again.');
     }

--- a/user-interface/src/admin/banks/EditBankModal.test.tsx
+++ b/user-interface/src/admin/banks/EditBankModal.test.tsx
@@ -4,6 +4,8 @@ import { EditBankModal, EditBankModalRef } from './EditBankModal';
 import Api2 from '@/lib/models/api2';
 import TestingUtilities, { CamsUserEvent } from '@/lib/testing/testing-utilities';
 import { BankProfile } from '@common/cams/banks';
+import { CamsHttpError } from '@/lib/models/api';
+import HttpStatusCodes from '@common/api/http-status-codes';
 
 const MODAL_ID = 'edit-bank-modal';
 const MODAL_WRAPPER = `modal-${MODAL_ID}`;
@@ -144,6 +146,26 @@ describe('EditBankModal', () => {
       expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
       expect(alertSpy.error).toHaveBeenCalledWith('Failed to update bank. Please try again.');
     });
+  });
+
+  test('should show a field validation error and keep modal open when the name is a duplicate', async () => {
+    vi.spyOn(Api2, 'updateBank').mockRejectedValue(
+      new CamsHttpError(HttpStatusCodes.BAD_REQUEST, 'A bank with this name already exists.'),
+    );
+    renderComponent();
+    openModal();
+    await waitFor(() => expect(screen.getByTestId(SUBMIT_BTN)).toBeVisible());
+
+    await userEvent.clear(screen.getByLabelText(/bank name/i));
+    await userEvent.type(screen.getByLabelText(/bank name/i), 'Duplicate Bank');
+    await userEvent.click(screen.getByTestId(SUBMIT_BTN));
+
+    await waitFor(() => {
+      expect(screen.getByText('A bank with this name already exists.')).toBeInTheDocument();
+      expect(screen.getByTestId(MODAL_WRAPPER)).toHaveClass('is-visible');
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(alertSpy.error).not.toHaveBeenCalled();
   });
 
   test('should close modal and reset to bank values on cancel', async () => {

--- a/user-interface/src/admin/banks/EditBankModal.tsx
+++ b/user-interface/src/admin/banks/EditBankModal.tsx
@@ -8,6 +8,8 @@ import { useGlobalAlert } from '@/lib/hooks/UseGlobalAlert';
 import { ModalRefType } from '@/lib/components/uswds/modal/modal-refs';
 import { BankProfile } from '@common/cams/banks';
 import Api2 from '@/lib/models/api2';
+import { CamsHttpError } from '@/lib/models/api';
+import HttpStatusCodes from '@common/api/http-status-codes';
 import { getAppInsights } from '@/lib/hooks/UseApplicationInsights';
 
 export type EditBankModalRef = {
@@ -62,6 +64,10 @@ export const EditBankModal = forwardRef<EditBankModalRef, EditBankModalProps>(
         modalRef.current?.hide();
         alert?.success('Bank updated successfully.');
       } catch (error) {
+        if (error instanceof CamsHttpError && error.status === HttpStatusCodes.BAD_REQUEST) {
+          setNameError(error.message);
+          return;
+        }
         getAppInsights()?.appInsights?.trackException({ exception: error as Error });
         alert?.error('Failed to update bank. Please try again.');
       } finally {


### PR DESCRIPTION
# Purpose

Prevent CAMS admins from creating (or renaming to) a bank whose name already exists, avoiding confusion and data-integrity issues from duplicate bank entries.

# Major Changes

* Enforce case-insensitive, trimmed bank-name uniqueness in `BanksUseCase` for both the create and rename paths, returning a 400 `BadRequestError` when a duplicate is detected. The check runs in the use case so it also protects direct API calls that bypass the frontend.
* Surface the duplicate error in `AddBankModal` as an inline field validation message (keeping the modal open) instead of a generic failure alert.
* Fix the Azure Functions error adapter (`toAzureError`) to return a `{ message, status }` JSON body, matching the Express adapter and the frontend error contract. Previously it sent a bare JSON string, so error messages were dropped before reaching the UI — this fix applies to all POST/PUT error messages served via the Functions host, not just banks.
* Add an operations doc (and sidebar entry) with a MongoDB aggregation to identify pre-existing duplicate bank names so they can be resolved manually before enforcement.

# Testing/Validation

Implemented using TDD. Added use-case tests for duplicate rejection and allowance on both create and rename (case-insensitive, trimmed, and the "keep own name" edge case), a modal test asserting the duplicate error renders inline, and updated the one function test that pinned the old bare-string error shape. All affected suites pass (backend banks/adapter: 71 tests; frontend banks + api models: 145 tests). Manually verified end-to-end against the local Functions host: a duplicate `American Express` is now rejected with the message shown in the modal.

# Notes

* Uniqueness is enforced at the use-case layer only (per team decision), so it does not close a concurrent-insert race window that a unique DB index would. Existing duplicates are not auto-removed — use the new ops doc query to find and resolve them.
* The error-adapter fix corrects a real frontend/backend contract drift: the Express adapter and the frontend's own tests already expected `{ message }`; only the Azure adapter had diverged.
* Spec review surfaced two follow-up test-quality items worth a later pass (assert the generic error branch fires `alert.error`/telemetry in `AddBankModal`, and retarget the cascade "not called" assertions to write side-effects). Most other review notes are pre-existing quality debt outside this diff.
* Note: `npm run typecheck` currently reports pre-existing errors in `lib/use-cases/trustees/trustees.ts`, unrelated to this change (present on `main`); the files in this PR type-check clean.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Enforce case-insensitive, trimmed uniqueness of bank names in the banks use case, surface duplicate-name errors as inline validation in the add-bank UI, align Azure Functions error responses with the standard `{ message, status }` contract, and add operations guidance for identifying existing duplicate bank names.

New Features:
- Reject creation and renaming of banks when the name duplicates an existing bank name (case-insensitive, trimmed) via the BanksUseCase.
- Display duplicate bank-name errors inline on the AddBankModal while keeping the modal open.

Bug Fixes:
- Fix Azure Functions error adapter responses to return a structured `{ message, status }` JSON body instead of a bare string, restoring expected error propagation to the frontend.

Enhancements:
- Add use-case-level tests around bank-name uniqueness enforcement for create and rename flows.
- Add tests to verify the AddBankModal handles duplicate-name errors as field validation rather than generic failures.

Documentation:
- Add an operations runbook documenting a MongoDB aggregation to find case-insensitive, trimmed duplicate bank names and link it from the operations sidebar.