### PR TITLE
HOT FIX - Fix sort composite index for getCasesForTrustee

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/offices.dxtr.gateway.ts
@@ -107,26 +107,7 @@ export default class OfficesDxtrGateway extends AbstractMssqlClient implements O
       const flatOfficeDetails = (queryResult.results as mssql.IResult<DxtrFlatOfficeDetails>)
         .recordset;
 
-      context.logger.info(
-        MODULE_NAME,
-        `CAMS-710 DIAGNOSTIC: DXTR query returned ${flatOfficeDetails.length} rows.`,
-        { rowCount: flatOfficeDetails.length },
-      );
-
       const offices = toUstpOfficeDetails(flatOfficeDetails);
-
-      context.logger.info(
-        MODULE_NAME,
-        `CAMS-710 DIAGNOSTIC: Transformed into ${offices.length} office objects.`,
-        {
-          officeCount: offices.length,
-          offices: offices.map((o) => ({
-            officeCode: o.officeCode,
-            officeName: o.officeName,
-            idpGroupName: o.idpGroupName,
-          })),
-        },
-      );
 
       return offices;
     } else {

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.test.ts
@@ -1131,10 +1131,13 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
   });
 
   describe('createCompoundIndex', () => {
-    test('creates (trusteeId, unassignedOn, dateFiled, caseStatus) index on trustee collection', async () => {
+    test('creates filter and sort indexes and drops old sort index', async () => {
       const createIndexSpy = vi
         .spyOn(CollectionHumble.prototype, 'createIndex')
-        .mockResolvedValue('trusteeId_1_unassignedOn_1_dateFiled_1_caseStatus_1');
+        .mockResolvedValue('index-name');
+      const dropIndexSpy = vi
+        .spyOn(CollectionHumble.prototype, 'dropIndex')
+        .mockResolvedValue(undefined);
       const context = await createMockApplicationContext();
       const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
 
@@ -1146,6 +1149,8 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
         dateFiled: 1,
         caseStatus: 1,
       });
+      expect(createIndexSpy).toHaveBeenCalledWith({ trusteeId: 1, dateFiled: -1, caseId: 1 });
+      expect(dropIndexSpy).toHaveBeenCalledWith('dateFiled_-1_caseId_1');
       repo.release();
     });
   });

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -510,8 +510,11 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     // Drop the old 2-field sort index if it exists from a previous reindex run
     try {
       await collection.dropIndex('dateFiled_-1_caseId_1');
-    } catch {
-      // Index doesn't exist — nothing to drop
+    } catch (dropError) {
+      const msg = dropError instanceof Error ? dropError.message : String(dropError);
+      if (!msg.includes('index not found') && !msg.includes('IndexNotFound')) {
+        this.context.logger.warn(MODULE_NAME, `Failed to drop old sort index: ${msg}`);
+      }
     }
   }
 

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -507,7 +507,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     const collection = this.getTrusteeCollection();
     await collection.createIndex({ trusteeId: 1, unassignedOn: 1, dateFiled: 1, caseStatus: 1 });
     // Sort index to serve ORDER BY dateFiled DESC, caseId ASC in getCasesForTrustee
-    await collection.createIndex({ dateFiled: -1, caseId: 1 });
+    await collection.createIndex({ trusteeId: 1, dateFiled: -1, caseId: 1 });
   }
 
   async dropIndex(indexName: string): Promise<void> {

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -506,8 +506,13 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
   async createCompoundIndex(): Promise<void> {
     const collection = this.getTrusteeCollection();
     await collection.createIndex({ trusteeId: 1, unassignedOn: 1, dateFiled: 1, caseStatus: 1 });
-    // Sort index to serve ORDER BY dateFiled DESC, caseId ASC in getCasesForTrustee
     await collection.createIndex({ trusteeId: 1, dateFiled: -1, caseId: 1 });
+    // Drop the old 2-field sort index if it exists from a previous reindex run
+    try {
+      await collection.dropIndex('dateFiled_-1_caseId_1');
+    } catch {
+      // Index doesn't exist — nothing to drop
+    }
   }
 
   async dropIndex(indexName: string): Promise<void> {

--- a/backend/lib/adapters/gateways/okta/okta-gateway.ts
+++ b/backend/lib/adapters/gateways/okta/okta-gateway.ts
@@ -89,7 +89,7 @@ async function verifyToken(token: string): Promise<CamsJwt> {
 }
 
 async function getUser(
-  context: ApplicationContext,
+  _context: ApplicationContext,
   accessToken: string,
 ): Promise<{ user: CamsUserReference; jwt: CamsJwt }> {
   const { userInfoUri } = getAuthorizationConfig();
@@ -121,33 +121,8 @@ async function getUser(
         return acc;
       }, []);
 
-      // DIAGNOSTIC: Log JWT groups before merging
-      const originalGroups = jwt.claims.groups ?? [];
-      context.logger.info(
-        MODULE_NAME,
-        `CAMS-710 DIAGNOSTIC: JWT for user ${user.name} (${user.id}) contains ${originalGroups.length} standard groups and ${adGroups.flat().length} ad_groups.`,
-        {
-          userId: user.id,
-          userName: user.name,
-          standardGroupCount: originalGroups.length,
-          adGroupCount: adGroups.flat().length,
-        },
-      );
-
       jwt.claims.groups = Array.from(
         new Set<string>([].concat(jwt.claims.groups ?? [], ...adGroups)),
-      );
-
-      // DIAGNOSTIC: Log merged groups
-      context.logger.info(
-        MODULE_NAME,
-        `CAMS-710 DIAGNOSTIC: After merging, JWT has ${jwt.claims.groups.length} total groups.`,
-        {
-          userId: user.id,
-          userName: user.name,
-          totalGroupCount: jwt.claims.groups.length,
-          groups: jwt.claims.groups,
-        },
       );
 
       return { user, jwt };

--- a/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
+++ b/ops/cloud-deployment/lib/cosmos/mongo/cosmos-collections.bicep
@@ -472,6 +472,7 @@ resource trusteeCaseAppointmentsCollection 'Microsoft.DocumentDB/databaseAccount
         {
           key: {
             keys: [
+              'trusteeId'
               '-dateFiled'
               'caseId'
             ]

--- a/test/integration/migrate-case-appointments/scripts/migrate-case-appointments-harness.ts
+++ b/test/integration/migrate-case-appointments/scripts/migrate-case-appointments-harness.ts
@@ -441,8 +441,8 @@ async function seedCosmos() {
     await db
       .collection(TRUSTEE_CASE_APPOINTMENTS_COLLECTION)
       .createIndex(
-        { dateFiled: -1, caseId: 1 },
-        { name: 'dateFiled_-1_caseId_1', background: true },
+        { trusteeId: 1, dateFiled: -1, caseId: 1 },
+        { name: 'trusteeId_1_dateFiled_-1_caseId_1', background: true },
       );
     console.log(`  ℹ  Created compound and sort indexes on '${TRUSTEE_CASE_APPOINTMENTS_COLLECTION}'`);
   } finally {
@@ -753,7 +753,7 @@ async function assertHappyPath(db: ReturnType<MongoClient['db']>) {
     }
 
     const hasSortIndex = indexKeys.some(
-      (k) => k === JSON.stringify({ dateFiled: -1, caseId: 1 }),
+      (k) => k === JSON.stringify({ trusteeId: 1, dateFiled: -1, caseId: 1 }),
     );
     if (hasSortIndex) {
       pass('sort index (dateFiled DESC, caseId ASC) exists');

--- a/test/integration/migrate-case-appointments/scripts/migrate-case-appointments-harness.ts
+++ b/test/integration/migrate-case-appointments/scripts/migrate-case-appointments-harness.ts
@@ -756,9 +756,9 @@ async function assertHappyPath(db: ReturnType<MongoClient['db']>) {
       (k) => k === JSON.stringify({ trusteeId: 1, dateFiled: -1, caseId: 1 }),
     );
     if (hasSortIndex) {
-      pass('sort index (dateFiled DESC, caseId ASC) exists');
+      pass('sort index (trusteeId ASC, dateFiled DESC, caseId ASC) exists');
     } else {
-      fail('sort index (dateFiled DESC, caseId ASC) missing from trustee-case-appointments');
+      fail('sort index (trusteeId ASC, dateFiled DESC, caseId ASC) missing from trustee-case-appointments');
     }
   } finally {
     await idxClient.close();

--- a/test/integration/trustee-case-filter/scripts/run-tests.ts
+++ b/test/integration/trustee-case-filter/scripts/run-tests.ts
@@ -437,8 +437,8 @@ async function seed() {
       { name: 'trusteeId_1_unassignedOn_1_dateFiled_1_caseStatus_1' },
     );
     await appointments.createIndex(
-      { dateFiled: -1, caseId: 1 },
-      { name: 'dateFiled_-1_caseId_1' },
+      { trusteeId: 1, dateFiled: -1, caseId: 1 },
+      { name: 'trusteeId_1_dateFiled_-1_caseId_1' },
     );
 
     console.log(`  Inserted ${apptResult.insertedCount} appointments`);
@@ -537,16 +537,17 @@ async function run() {
       const hasSortIndex = indexes.some(
         (idx) =>
           idx.key &&
+          idx.key.trusteeId === 1 &&
           idx.key.dateFiled === -1 &&
           idx.key.caseId === 1 &&
-          Object.keys(idx.key).length === 2,
+          Object.keys(idx.key).length === 3,
       );
       if (hasSortIndex) {
-        pass('sort composite index (dateFiled: -1, caseId: 1) present');
+        pass('sort composite index (trusteeId: 1, dateFiled: -1, caseId: 1) present');
       } else {
         fail(
           'sort composite index MISSING — Cosmos will reject ORDER BY dateFiled DESC, caseId ASC. ' +
-            'Run the cams-dug4 reindex intent to create it.',
+            'Run the reindex intent to create it.',
         );
       }
     } finally {

--- a/test/integration/trustee-case-filter/scripts/run-tests.ts
+++ b/test/integration/trustee-case-filter/scripts/run-tests.ts
@@ -534,13 +534,9 @@ async function run() {
     const { client: idxClient, appointments: idxAppts } = await getDb();
     try {
       const indexes = await idxAppts.indexes();
+      const expectedSortKey = { trusteeId: 1, dateFiled: -1, caseId: 1 };
       const hasSortIndex = indexes.some(
-        (idx) =>
-          idx.key &&
-          idx.key.trusteeId === 1 &&
-          idx.key.dateFiled === -1 &&
-          idx.key.caseId === 1 &&
-          Object.keys(idx.key).length === 3,
+        (idx) => JSON.stringify(idx.key) === JSON.stringify(expectedSortKey),
       );
       if (hasSortIndex) {
         pass('sort composite index (trusteeId: 1, dateFiled: -1, caseId: 1) present');


### PR DESCRIPTION
# Bug

The Trustee Case List was returning a 500 error in staging and production with:
> `The order by query does not have a corresponding composite index that it can be served from.`

Cosmos DB for MongoDB requires that ORDER BY composite indexes in aggregation pipelines include the shard key as the leading field. The sort index `(dateFiled DESC, caseId ASC)` was missing `trusteeId` as the leading key.

# Purpose

Unblock the Trustee Case List screen in staging/production. The index was created via the `reindex` intent but with the wrong key shape, causing Cosmos to reject the sort.

# Major Changes

- Changed sort index from `(dateFiled: -1, caseId: 1)` to `(trusteeId: 1, dateFiled: -1, caseId: 1)` in the repository `createCompoundIndex` method
- Updated Bicep declaration to match
- Updated integration test harnesses to create and assert the correct 3-field index

# Testing/Validation

- Integration test harness (`trustee-case-filter`) seeds and asserts the correct sort index exists before executing any sort queries
- `reindex` intent must be re-triggered in staging to replace the incorrect 2-field index with the correct 3-field index

# Notes

Cosmos DB's requirement: when an aggregation pipeline includes a `$sort` on non-partition-key fields, the composite index for that sort must be prefixed by the shard key (`trusteeId`). Native MongoDB does not enforce this, which is why the issue only surfaces in Cosmos.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Ensure trustee case list queries use a Cosmos-compliant composite index for sorting case appointments.

Bug Fixes:
- Fix trustee case appointments sort index to include trusteeId so ORDER BY dateFiled DESC, caseId ASC can be served without errors in Cosmos DB.

Enhancements:
- Align repository, integration harnesses, and Cosmos Bicep configuration to use a consistent three-field sort index on trustee case appointments.

Tests:
- Update integration test harnesses to create and assert the presence of the trusteeId-prefixed sort index for trustee case appointments.