### PR TITLE
CAMS-795 Sort associated banks alphabetically

### DIFF
--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
@@ -48,6 +48,33 @@ describe('BankruptcySoftwareUseCase', () => {
 
       expect(result).toEqual(mockSoftware);
     });
+
+    test('should return associatedBanks sorted alphabetically case-insensitively', async () => {
+      const mockSoftware: BankruptcySoftwareProfile[] = [
+        {
+          id: 'sw-1',
+          documentType: 'BANKRUPTCY_SOFTWARE',
+          name: 'Axos',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+          associatedBanks: [
+            { bankId: 'bank-3', bankName: 'wells fargo', status: 'active' },
+            { bankId: 'bank-1', bankName: 'Bank of America', status: 'active' },
+            { bankId: 'bank-2', bankName: 'Chase', status: 'active' },
+          ],
+        },
+      ];
+      vi.spyOn(MockMongoRepository.prototype, 'getSoftwareList').mockResolvedValue(mockSoftware);
+
+      const result = await useCase.getSoftwareList();
+
+      expect(result[0].associatedBanks!.map((b) => b.bankName)).toEqual([
+        'Bank of America',
+        'Chase',
+        'wells fargo',
+      ]);
+    });
   });
 
   describe('getSoftware', () => {
@@ -75,6 +102,31 @@ describe('BankruptcySoftwareUseCase', () => {
       const result = await useCase.getSoftware('sw-1');
 
       expect(result).toEqual(software);
+    });
+
+    test('should return associatedBanks sorted alphabetically case-insensitively', async () => {
+      const software: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-3', bankName: 'wells fargo', status: 'active' },
+          { bankId: 'bank-1', bankName: 'Bank of America', status: 'active' },
+          { bankId: 'bank-2', bankName: 'Chase', status: 'active' },
+        ],
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue(software);
+
+      const result = await useCase.getSoftware('sw-1');
+
+      expect(result.associatedBanks!.map((b) => b.bankName)).toEqual([
+        'Bank of America',
+        'Chase',
+        'wells fargo',
+      ]);
     });
   });
 
@@ -208,27 +260,21 @@ describe('BankruptcySoftwareUseCase', () => {
       );
     });
 
-    test('should append bank to existing associatedBanks array', async () => {
+    test('should add bank to existing associatedBanks array sorted alphabetically', async () => {
       const softwareWithBanks: BankruptcySoftwareProfile = {
         ...baseSoftware,
-        associatedBanks: [{ bankId: 'bank-1', bankName: 'Chase', status: 'active' }],
+        associatedBanks: [{ bankId: 'bank-2', bankName: 'Wells Fargo', status: 'active' }],
       };
       vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue(
         softwareWithBanks,
       );
       const updateSpy = vi
         .spyOn(MockMongoRepository.prototype, 'updateSoftware')
-        .mockResolvedValue({
-          ...softwareWithBanks,
-          associatedBanks: [
-            { bankId: 'bank-1', bankName: 'Chase', status: 'active' },
-            { bankId: 'bank-2', bankName: 'Wells Fargo', status: 'active' },
-          ],
-        });
+        .mockImplementation((_id, profile) => Promise.resolve(profile));
       vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord').mockResolvedValue();
 
       await useCase.updateSoftware('sw-1', {
-        addBank: { bankId: 'bank-2', bankName: 'Wells Fargo' },
+        addBank: { bankId: 'bank-1', bankName: 'Chase' },
       });
 
       expect(updateSpy).toHaveBeenCalledWith(
@@ -240,6 +286,34 @@ describe('BankruptcySoftwareUseCase', () => {
           ],
         }),
       );
+    });
+
+    test('should sort associatedBanks alphabetically, case-insensitively, when adding a bank', async () => {
+      const softwareWithBanks: BankruptcySoftwareProfile = {
+        ...baseSoftware,
+        associatedBanks: [
+          { bankId: 'bank-1', bankName: 'wells fargo', status: 'active' },
+          { bankId: 'bank-2', bankName: 'Chase', status: 'active' },
+        ],
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue(
+        softwareWithBanks,
+      );
+      const updateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'updateSoftware')
+        .mockImplementation((_id, profile) => Promise.resolve(profile));
+      vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord').mockResolvedValue();
+
+      await useCase.updateSoftware('sw-1', {
+        addBank: { bankId: 'bank-3', bankName: 'Bank of America' },
+      });
+
+      const passedBanks = updateSpy.mock.calls[0][1].associatedBanks!;
+      expect(passedBanks.map((b) => b.bankName)).toEqual([
+        'Bank of America',
+        'Chase',
+        'wells fargo',
+      ]);
     });
 
     test('should reject duplicate bankId', async () => {

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.test.ts
@@ -184,6 +184,37 @@ describe('BankruptcySoftwareUseCase', () => {
       expect(result).toEqual(updated);
     });
 
+    test('should preserve associatedBanks sort order on non-bank field updates', async () => {
+      const current: BankruptcySoftwareProfile = {
+        id: 'sw-1',
+        documentType: 'BANKRUPTCY_SOFTWARE',
+        name: 'Axos',
+        status: 'active',
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: { id: 'user-1', name: 'User One' },
+        associatedBanks: [
+          { bankId: 'bank-3', bankName: 'wells fargo', status: 'active' },
+          { bankId: 'bank-1', bankName: 'Bank of America', status: 'active' },
+          { bankId: 'bank-2', bankName: 'Chase', status: 'active' },
+        ],
+      };
+
+      vi.spyOn(MockMongoRepository.prototype, 'findSoftwareById').mockResolvedValue(current);
+      const updateSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'updateSoftware')
+        .mockImplementation((_id, profile) => Promise.resolve(profile));
+      vi.spyOn(MockMongoRepository.prototype, 'createSoftwareAuditRecord').mockResolvedValue();
+
+      await useCase.updateSoftware('sw-1', { name: 'Axos Renamed' });
+
+      const passedBanks = updateSpy.mock.calls[0][1].associatedBanks!;
+      expect(passedBanks.map((b) => b.bankName)).toEqual([
+        'Bank of America',
+        'Chase',
+        'wells fargo',
+      ]);
+    });
+
     test('should set updatedBy and updatedOn from context user on field updates', async () => {
       const current: BankruptcySoftwareProfile = {
         id: 'sw-1',

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
@@ -202,7 +202,7 @@ export class BankruptcySoftwareUseCase {
         update.updateBankAssociation.status,
       );
     }
-    return { ...base, ...update };
+    return this.withSortedBanks({ ...base, ...update });
   }
 
   private withSortedBanks(software: BankruptcySoftwareProfile): BankruptcySoftwareProfile {
@@ -246,7 +246,7 @@ export class BankruptcySoftwareUseCase {
     }
     const updatedBanks = [...existingBanks];
     updatedBanks[index] = { ...updatedBanks[index], status };
-    return { ...software, associatedBanks: updatedBanks };
+    return this.withSortedBanks({ ...software, associatedBanks: updatedBanks });
   }
 
   private async saveWithAudit(

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
@@ -210,7 +210,7 @@ export class BankruptcySoftwareUseCase {
     return {
       ...software,
       associatedBanks: [...software.associatedBanks].sort((a, b) =>
-        a.bankName.localeCompare(b.bankName, undefined, { sensitivity: 'base' }),
+        a.bankName.localeCompare(b.bankName, 'en-US', { sensitivity: 'base' }),
       ),
     };
   }

--- a/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
+++ b/backend/lib/use-cases/bankruptcy-software/bankruptcy-software.ts
@@ -31,7 +31,8 @@ export class BankruptcySoftwareUseCase {
 
   async getSoftwareList(): Promise<BankruptcySoftwareProfile[]> {
     try {
-      return await this.repository.getSoftwareList();
+      const list = await this.repository.getSoftwareList();
+      return list.map((s) => this.withSortedBanks(s));
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve bankruptcy software.');
     }
@@ -39,7 +40,7 @@ export class BankruptcySoftwareUseCase {
 
   async getSoftware(id: string): Promise<BankruptcySoftwareProfile> {
     try {
-      return await this.repository.findSoftwareById(id);
+      return this.withSortedBanks(await this.repository.findSoftwareById(id));
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve bankruptcy software.');
     }
@@ -204,6 +205,16 @@ export class BankruptcySoftwareUseCase {
     return { ...base, ...update };
   }
 
+  private withSortedBanks(software: BankruptcySoftwareProfile): BankruptcySoftwareProfile {
+    if (!software.associatedBanks?.length) return software;
+    return {
+      ...software,
+      associatedBanks: [...software.associatedBanks].sort((a, b) =>
+        a.bankName.localeCompare(b.bankName, undefined, { sensitivity: 'base' }),
+      ),
+    };
+  }
+
   private addBankAssociation(
     software: BankruptcySoftwareProfile,
     bankId: string,
@@ -215,10 +226,10 @@ export class BankruptcySoftwareUseCase {
         message: 'This bank is already associated with this software.',
       });
     }
-    return {
+    return this.withSortedBanks({
       ...software,
       associatedBanks: [...existingBanks, { bankId, bankName, status: 'active' }],
-    };
+    });
   }
 
   private updateBankAssociationStatus(

--- a/backend/lib/use-cases/banks/banks.test.ts
+++ b/backend/lib/use-cases/banks/banks.test.ts
@@ -38,6 +38,44 @@ describe('BanksUseCase', () => {
       expect(result).toEqual(mockBanks);
     });
 
+    test('should return banks sorted alphabetically case-insensitively', async () => {
+      const mockBanks: BankProfile[] = [
+        {
+          id: 'bank-3',
+          documentType: 'BANK_PROFILE',
+          name: 'foo bank',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+        {
+          id: 'bank-1',
+          documentType: 'BANK_PROFILE',
+          name: 'JP Morgan Chase Bank',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+        {
+          id: 'bank-2',
+          documentType: 'BANK_PROFILE',
+          name: 'Fifth Third Bank',
+          status: 'active',
+          updatedOn: '2024-01-01T00:00:00.000Z',
+          updatedBy: { id: 'user-1', name: 'User One' },
+        },
+      ];
+      vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue(mockBanks);
+
+      const result = await useCase.getBanks();
+
+      expect(result.map((b) => b.name)).toEqual([
+        'Fifth Third Bank',
+        'foo bank',
+        'JP Morgan Chase Bank',
+      ]);
+    });
+
     test('should return empty array when no banks exist', async () => {
       vi.spyOn(MockMongoRepository.prototype, 'getBanks').mockResolvedValue([]);
 

--- a/backend/lib/use-cases/banks/banks.ts
+++ b/backend/lib/use-cases/banks/banks.ts
@@ -26,7 +26,10 @@ export class BanksUseCase {
 
   async getBanks(): Promise<BankProfile[]> {
     try {
-      return await this.repository.getBanks();
+      const banks = await this.repository.getBanks();
+      return [...banks].sort((a, b) =>
+        a.name.localeCompare(b.name, 'en-US', { sensitivity: 'base' }),
+      );
     } catch (originalError) {
       throw getCamsError(originalError, MODULE_NAME, 'Unable to retrieve banks.');
     }


### PR DESCRIPTION
# Purpose

Users scanning the bank list on the Software Vendor page and the trustee bank combobox had to scan an arbitrarily-ordered list. This sorts banks A–Z (case-insensitive) so they're easy to find.

# Major Changes

- Added `withSortedBanks` helper to `BankruptcySoftwareUseCase` that sorts `associatedBanks` by name using locale-aware, case-insensitive comparison
- Applied sorting in `getSoftwareList`, `getSoftware`, and `addBankAssociation` so all consumers receive pre-sorted data from the API
- No frontend changes needed — `AssociatedBanksTable`, the add-bank combobox, and `TrusteeOtherInfoForm`'s bank combobox all consume `associatedBanks` directly from API responses

# Testing/Validation

Implemented using TDD. Added tests covering:
- `getSoftwareList` returns banks sorted A–Z case-insensitively
- `getSoftware` returns banks sorted A–Z case-insensitively
- `addBankAssociation` inserts new bank in correct alphabetical position
- Case-insensitive sort (e.g. "wells fargo" sorts after "Chase")

All 40 use-case tests pass.

# Notes

The fix lives entirely in the use-case layer rather than each component, so existing data loaded from the database (insertion-order) is also sorted on read. The `addBankAssociation` write path sorts before persisting, keeping the stored data tidy as well.

The top-level `/banks` list was already sorted server-side via `orderBy(['name','ASCENDING'])` in the Mongo repository — this PR brings `associatedBanks` in line with the same behavior.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Sort bankruptcy software associated banks alphabetically in API responses and when adding new associations.

New Features:
- Ensure associatedBanks values are consistently returned in locale-aware, case-insensitive alphabetical order from getSoftwareList and getSoftware.

Bug Fixes:
- Prevent arbitrarily ordered associated bank lists by sorting them before returning or persisting updates.

Enhancements:
- Centralize associated bank sorting logic in a dedicated helper within the BankruptcySoftwareUseCase to keep stored and retrieved data ordered.

Tests:
- Add unit tests verifying associatedBanks are sorted case-insensitively for list retrieval, single software retrieval, and when adding new bank associations.