### PR TITLE
Pin vulnerable transitive dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5267,12 +5267,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
-      "integrity": "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.9.0.tgz",
+      "integrity": "sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1"
+        "@opentelemetry/core": "2.9.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -6779,12 +6779,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -9604,20 +9598,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -13260,9 +13254,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -16261,9 +16255,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
-      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -16273,7 +16267,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
       "eslint": "$eslint"
     },
     "form-data": "4.0.6",
-    "js-yaml": "4.2.0",
+    "body-parser": "2.3.0",
+    "js-yaml": "4.3.0",
     "semver": "7.8.4",
     "@babel/runtime": "7.29.7",
     "node-forge": "1.4.0",
@@ -92,7 +93,8 @@
     "@okta/okta-sdk-nodejs": {
       "lodash": "4.18.1"
     },
-    "protobufjs": "7.6.3",
+    "@opentelemetry/propagator-jaeger": "2.9.0",
+    "protobufjs": "7.6.5",
     "undici": "7.28.0"
   }
 }


### PR DESCRIPTION
# Purpose

Unblock the Renovate dependency update PR (#2633) by resolving 4 new CVEs that appeared in transitive packages. None of these packages have a direct upgrade path — the parent packages (express, @okta/okta-sdk-nodejs, applicationinsights) are already at their latest versions.

# Major Changes

Updated `overrides` in root `package.json` to pin 4 transitive packages to their minimum fixed versions, and surgically updated the corresponding entries in `package-lock.json`:

- `body-parser` 2.2.2 → 2.3.0 — new entry (transitive via `express@5.2.1`)
- `js-yaml` 4.2.0 → 4.3.0 — was already pinned to the vulnerable version
- `@opentelemetry/propagator-jaeger` 2.7.1 → 2.9.0 — new entry (transitive via `applicationinsights`)
- `protobufjs` 7.6.3 → 7.6.5 — was already pinned to the vulnerable version

# Testing/Validation

- `npm audit` shows 0 high/critical vulnerabilities after the changes (1 unrelated low remains)
- Backend builds (`build:common`, `build:backend`, `build:api`) all pass
- `package-lock.json` was patched surgically — only the 4 affected entries changed (39 lines), keeping the diff minimal and reviewable

# Notes

The lock file was patched directly rather than regenerated to avoid a multi-thousand-line churn diff. Version, resolved URL, integrity hash, and dependency sub-objects for each entry were all updated to match the registry metadata for the new versions.

Two of the four (`js-yaml`, `protobufjs`) were already present in `overrides` but pinned to vulnerable versions — those were bumped. The other two (`body-parser`, `@opentelemetry/propagator-jaeger`) are new override entries.

Snyk vuln IDs: SNYK-JS-BODYPARSER-17906397 (Medium), SNYK-JS-JSYAML-17900054 (High), SNYK-JS-OPENTELEMETRYPROPAGATORJAEGER-17901201 (High), SNYK-JS-PROTOBUFJS-17900550 (High).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Pin vulnerable transitive dependencies via npm overrides to resolve newly reported CVEs in transitive packages.

Bug Fixes:
- Address security vulnerabilities in transitive dependencies by bumping js-yaml and protobufjs to fixed versions.
- Add overrides for body-parser and @opentelemetry/propagator-jaeger to enforce non-vulnerable versions in the dependency tree.