### PR TITLE
Fix common clean script to remove correct buildinfo

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "npx tsc -p tsconfig.build.json",
-    "clean": "rm -rf ./dist && rm -rf ./node_modules && rm -rf ./coverage && rm -f tsconfig.tsbuildinfo",
+    "clean": "rm -rf ./dist && rm -rf ./node_modules && rm -rf ./coverage && rm -f *.tsbuildinfo",
     "coverage": "vitest run --coverage",
     "coverage:ci": "vitest run --coverage",
     "dependency-cruiser-ci": "npx depcruise --output-type err-long src",


### PR DESCRIPTION
# Purpose

`npm run clean-and-build` was leaving `common/dist` incomplete after a
clean rebuild. `common`'s `clean` script deleted `tsconfig.tsbuildinfo`,
but `tsc -p tsconfig.build.json` (the actual build config) writes its
incremental cache to `tsconfig.build.tsbuildinfo` instead. Since the
real cache file was never removed, `dist` was wiped but `tsc` still
trusted stale content hashes and skipped re-emitting most declaration
files on the next build — leaving a corrupt, partial `common/dist`.
Downstream, `backend`'s project reference to `../common` then failed
with a flood of `TS6305: Output file ... has not been built from
source file ...` errors during `npm run typecheck`, even though CI
never showed this (a fresh CI checkout has no leftover
`tsconfig.build.tsbuildinfo` to go stale in the first place).

# Major Changes

- `common/package.json`: change `clean` script to `rm -f
  *.tsbuildinfo` instead of the wrong, hardcoded
  `tsconfig.tsbuildinfo` filename, so it actually clears whatever
  buildinfo file the active build config produces.

# Testing/Validation

- Ran `npm run clean-and-build` from a clean worktree, then confirmed
  `common/dist` contains all 67 expected `.d.ts` files (previously
  only 3 were present).
- Ran `npm run typecheck --workspace=backend` afterward — zero errors.

# Notes

Only `common` uses `composite`/`incremental` TypeScript builds, so
this was the only clean script affected; `backend`,
`function-apps/*`, and `user-interface` clean scripts don't need
this fix.

# Definition of Done:

- [x] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed: More important code doesn't directly depend on less important code
- [x] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [x] No regressions: Changes do not cause regression in related or unrelated areas of the application