### PR TITLE
Fix trustee-case-list scenario test after appt split

### DIFF
--- a/dev-tools/db_scripts/scenarios/scenarios.test.ts
+++ b/dev-tools/db_scripts/scenarios/scenarios.test.ts
@@ -573,11 +573,12 @@ describe('trustee-case-list scenario', () => {
     seedOps = await generateTrusteeCaseList(multiIdContext());
   });
 
-  test('has 180 DXTR operations and 4 Cosmos operations', async () => {
+  test('has 180 DXTR operations and 5 Cosmos operations', async () => {
     const ops = seedOps;
     expect(ops.filter((o) => o.db === 'dxtr')).toHaveLength(180);
-    // trustees + cases + case-appointments + TRUSTEE_APPOINTMENT for panel membership
-    expect(ops.filter((o) => o.db === 'cams')).toHaveLength(4);
+    // trustees + cases + case-trustee-appointments + trustee-case-appointments
+    // (dual-write to both appointment partitions) + TRUSTEE_APPOINTMENT for panel membership
+    expect(ops.filter((o) => o.db === 'cams')).toHaveLength(5);
   });
 
   test('all DXTR operations use compound primary keys and insertOnly flag', () => {
@@ -634,7 +635,7 @@ describe('trustee-case-list scenario', () => {
 
   test('appointments batch contains 60 CASE_APPOINTMENT documents all linked to paginated trustee', () => {
     const ops = seedOps;
-    const apptOp = ops.find((o) => o.collectionOrTable === 'trustee-appointments');
+    const apptOp = ops.find((o) => o.collectionOrTable === 'trustee-case-appointments');
     expect(apptOp).toBeDefined();
     expect(apptOp?.db).toBe('cams');
     expect(apptOp?.data).toHaveLength(60);
@@ -660,7 +661,7 @@ describe('trustee-case-list scenario', () => {
   test('each appointment has distinct appointedDate (15th) vs dateFiled in its SYNCED_CASE (1st)', () => {
     const ops = seedOps;
     const casesOp = ops.find((o) => o.collectionOrTable === 'cases');
-    const apptOp = ops.find((o) => o.collectionOrTable === 'trustee-appointments');
+    const apptOp = ops.find((o) => o.collectionOrTable === 'trustee-case-appointments');
     expect(casesOp).toBeDefined();
     expect(apptOp).toBeDefined();
     const caseMap = new Map(casesOp!.data.map((c) => [c.caseId as string, c.dateFiled as string]));


### PR DESCRIPTION
# Bug

`scenarios.test.ts` had 3 failing assertions for the `trustee-case-list` scenario. The scenario correctly dual-writes appointment documents to both `case-trustee-appointments` and `trustee-case-appointments` collections (per the CAMS-746 appointment partition split), but the test still expected the old pre-split shape — looking for 60 `CASE_APPOINTMENT` documents under the `trustee-appointments` collection and expecting only 4 Cosmos operations total.

# Purpose

Keep the dev-tools seed-scenario test suite green and accurate, so future changes to the `trustee-case-list` scenario (or the underlying appointment collections) are validated against the current, correct data shape.

# Major Changes

- Updated collection lookup from `trustee-appointments` to `trustee-case-appointments` in the two tests asserting on the 60 seeded `CASE_APPOINTMENT` documents
- Updated expected Cosmos operation count from 4 to 5 to account for the dual-write split (`trustees`, `cases`, `case-trustee-appointments`, `trustee-case-appointments`, `trustee-appointments` for panel membership)

# Testing/Validation

- `npm test` in `dev-tools/`: 253 passed, 1 pre-existing skip (was 3 failing before this fix)
- `npm run typecheck` and `npm run lint`: clean, no new warnings introduced
- No production code changed — test-only fix

# Notes

This drift was discovered while auditing `dev-tools/db_scripts` for fixture gaps related to the `fix-trustee-case-query` branch (PR #2662). It predates that branch — confirmed via `git diff origin/main..HEAD --stat` showing no `dev-tools/` changes on that branch. Unrelated to and independent of that PR.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Update trustee-case-list scenario tests to reflect dual-write appointment partitioning and current Cosmos operation counts.

Bug Fixes:
- Align trustee-case-list scenario test expectations with the dual-write across case-trustee-appointments and trustee-case-appointments collections.
- Adjust expected Cosmos operation count in trustee-case-list scenario tests to match the additional appointment partition write.