### PR TITLE
Increase DXTR trustee appointments sync timeout

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
@@ -1779,6 +1779,37 @@ describe('getAppointmentDatesByCaseIds', () => {
   });
 });
 
+describe('getTrusteeAppointments', () => {
+  let querySpy: ReturnType<typeof vi.spyOn>;
+  let applicationContext: Awaited<ReturnType<typeof createMockApplicationContext>>;
+  let gateway: CasesDxtrGateway;
+
+  beforeEach(async () => {
+    applicationContext = await createMockApplicationContext();
+    gateway = new CasesDxtrGateway(applicationContext);
+    querySpy = vi.spyOn(AbstractMssqlClient.prototype, 'executeQuery').mockResolvedValue({
+      success: true,
+      results: { recordset: [] },
+      message: '',
+    } as QueryResults);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('overrides the pool default requestTimeout with the trustee appointments timeout', async () => {
+    await gateway.getTrusteeAppointments(applicationContext, '2018-01-01T00:00:00.000Z');
+
+    expect(querySpy).toHaveBeenCalledWith(
+      applicationContext,
+      expect.any(String),
+      expect.any(Array),
+      600000,
+    );
+  });
+});
+
 describe('parseDxtrDate', () => {
   test('converts YYMMDD string to ISO date', () => {
     expect(parseDxtrDate('260407')).toBe('2026-04-07');

--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -25,6 +25,20 @@ import { Trustee } from '@common/cams/trustees';
 
 const MODULE_NAME = 'CASES-DXTR-GATEWAY';
 
+// Trustee appointments sync read timeout in milliseconds. Defaults to 10 minutes.
+const TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS = (() => {
+  const raw = process.env.TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS;
+  if (!raw) return 600000; // 10 minutes default
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(
+      `[${MODULE_NAME}] Invalid TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS="${raw}", using default 600000ms (10 min)`,
+    );
+    return 600000;
+  }
+  return parsed;
+})();
+
 export function parseDxtrDate(yymmdd: string | undefined): string | undefined {
   if (!yymmdd) return undefined;
   const s = yymmdd.trim();
@@ -1256,7 +1270,14 @@ class CasesDxtrGateway extends AbstractMssqlClient implements CasesInterface {
       ORDER BY TX.TX_DATE DESC, TX.CS_CASEID DESC
     `;
 
-    const queryResult: QueryResults = await this.executeQuery(context, query, params);
+    // Large fetch: set per-request timeout to TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS to
+    // accommodate large syncs without changing the global pool requestTimeout used by other queries.
+    const queryResult: QueryResults = await this.executeQuery(
+      context,
+      query,
+      params,
+      TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS,
+    );
 
     type TrusteeAppointmentRecord = {
       caseId: string;

--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -25,16 +25,17 @@ import { Trustee } from '@common/cams/trustees';
 
 const MODULE_NAME = 'CASES-DXTR-GATEWAY';
 
-// Trustee appointments sync read timeout in milliseconds. Defaults to 10 minutes.
+const DEFAULT_TRUSTEE_APPOINTMENTS_TIMEOUT_MS = 600000; // 10 minutes
+
 const TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS = (() => {
   const raw = process.env.TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS;
-  if (!raw) return 600000; // 10 minutes default
+  if (!raw) return DEFAULT_TRUSTEE_APPOINTMENTS_TIMEOUT_MS;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     console.warn(
-      `[${MODULE_NAME}] Invalid TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS="${raw}", using default 600000ms (10 min)`,
+      `[${MODULE_NAME}] Invalid TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS="${raw}", using default ${DEFAULT_TRUSTEE_APPOINTMENTS_TIMEOUT_MS}ms (10 min)`,
     );
-    return 600000;
+    return DEFAULT_TRUSTEE_APPOINTMENTS_TIMEOUT_MS;
   }
   return parsed;
 })();
@@ -1270,8 +1271,6 @@ class CasesDxtrGateway extends AbstractMssqlClient implements CasesInterface {
       ORDER BY TX.TX_DATE DESC, TX.CS_CASEID DESC
     `;
 
-    // Large fetch: set per-request timeout to TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS to
-    // accommodate large syncs without changing the global pool requestTimeout used by other queries.
     const queryResult: QueryResults = await this.executeQuery(
       context,
       query,


### PR DESCRIPTION
# Bug

Production `sync-trustee-appointments-dlq` was failing with `ETIMEOUT` errors — the DXTR trustee appointments sync query (`getTrusteeAppointments`) was exceeding the pool-wide 30-second MSSQL request timeout.

# Purpose

Give the trustee appointments sync query enough time to complete without changing the timeout for any other query sharing the DXTR connection pool (including synchronous, user-facing API requests).

# Major Changes

* Added a per-query `requestTimeout` override in `CasesDxtrGateway.getTrusteeAppointments`, defaulting to 600000ms (10 minutes) and configurable via a new `TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS` env var.
* Followed the existing pattern already used by the ACMS gateway (`ACMS_REQUEST_TIMEOUT_MS`) for large fetches, so the global pool `requestTimeout` (`MSSQL_REQUEST_TIMEOUT`) and every other DXTR/API query keep their current, shorter timeout.

# Testing/Validation

Added a unit test asserting `executeQuery` is invoked with the `600000` timeout override for `getTrusteeAppointments`. Full validation suite run before commit: prettier, eslint, `tsc --noEmit` across workspaces, full test suite (common/backend/user-interface — 3295 + 3321 tests passing), backend coverage, `npm audit` (0 vulnerabilities), and `knip` (no unused code).

# Notes

Deliberately scoped this as a per-query override rather than raising the shared `MSSQL_REQUEST_TIMEOUT` deployment parameter, since that parameter also feeds ACMS and ATS connections and synchronous API requests — a global 10-minute timeout there would let an unrelated runaway query hang a user-facing request.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Extend trustee appointments DXTR sync queries with a dedicated, longer request timeout without affecting other MSSQL pool consumers.

Bug Fixes:
- Prevent ETIMEOUT failures in the DXTR trustee appointments sync by allowing long-running appointment fetches to complete.

Enhancements:
- Introduce a configurable TRUSTEE_APPOINTMENTS_REQUEST_TIMEOUT_MS env-based override for the getTrusteeAppointments query timeout.
- Add a unit test ensuring getTrusteeAppointments invokes executeQuery with the trustee appointments-specific timeout override.