### PR TITLE
Guard out-of-band index step, disable for now

### DIFF
--- a/ops/scripts/pipeline/az-cosmos-deploy.sh
+++ b/ops/scripts/pipeline/az-cosmos-deploy.sh
@@ -121,18 +121,29 @@ az deployment group create -g "${resourceGroup}" -f ./ops/cloud-deployment/ustp-
     -p ./ops/cloud-deployment/params/ustp-cams-mongo-collections.parameters.json \
     -p resourceGroupName="${resourceGroup}" accountName="${account}" databaseName="${database}" allowedNetworks="${allowedNetworks}" allowedIps="${allowedIps}" analyticsWorkspaceId="${analyticsWorkspaceId}" allowAllNetworks="${allowAllNetworks}" keyVaultName="${keyVaultName}" kvResourceGroup="${kvResourceGroup}" createAlerts=${createAlerts} actionGroupResourceGroupName="${actionGroupResourceGroup}" actionGroupName="${actionGroupName}" e2eDatabaseName="${e2eDatabaseName}" deployE2eDatabase=true
 
-# trustee-case-appointments carries an out-of-band mixed-direction sort index
-# that Cosmos DB Mongo API's Bicep/ARM `keys` array cannot express (see the
-# NOTE in cosmos-collections.bicep). index-trustee-case-appointments.js owns
-# that collection's non-default indexes and is idempotent -- safe to run on
-# every deploy. Runs against both the main database and the e2e database,
-# since cosmos-collections.bicep provisions trustee-case-appointments in both.
-# The connection string is passed via MONGO_CONNECTION_STRING rather than a
-# CLI argument so it never appears in `ps` output or shell history on the CI
-# runner.
-MONGO_CONNECTION_STRING=$(az keyvault secret show --vault-name "${keyVaultName}" --name MONGO-CONNECTION-STRING --query value -o tsv)
-echo "::add-mask::${MONGO_CONNECTION_STRING}"
-export MONGO_CONNECTION_STRING
-node ./ops/cloud-deployment/lib/cosmos/mongo/index-trustee-case-appointments.js "${database}"
-node ./ops/cloud-deployment/lib/cosmos/mongo/index-trustee-case-appointments.js "${e2eDatabaseName}"
-unset MONGO_CONNECTION_STRING
+# TEMPORARY GUARD (cams-ez2y): the CI runner's managed identity currently lacks
+# Microsoft.KeyVault/vaults/secrets/getSecret/action RBAC on the
+# mongo-connection-string secret (ForbiddenByRbac), which fails main's deploy
+# at the keyvault fetch below. Set to "true" once that RBAC grant has been
+# verified, to resume out-of-band index management for trustee-case-appointments.
+applyTrusteeCaseAppointmentsIndex=false
+
+if [[ "${applyTrusteeCaseAppointmentsIndex}" == "true" ]]; then
+    # trustee-case-appointments carries an out-of-band mixed-direction sort index
+    # that Cosmos DB Mongo API's Bicep/ARM `keys` array cannot express (see the
+    # NOTE in cosmos-collections.bicep). index-trustee-case-appointments.js owns
+    # that collection's non-default indexes and is idempotent -- safe to run on
+    # every deploy. Runs against both the main database and the e2e database,
+    # since cosmos-collections.bicep provisions trustee-case-appointments in both.
+    # The connection string is passed via MONGO_CONNECTION_STRING rather than a
+    # CLI argument so it never appears in `ps` output or shell history on the CI
+    # runner.
+    MONGO_CONNECTION_STRING=$(az keyvault secret show --vault-name "${keyVaultName}" --name MONGO-CONNECTION-STRING --query value -o tsv)
+    echo "::add-mask::${MONGO_CONNECTION_STRING}"
+    export MONGO_CONNECTION_STRING
+    node ./ops/cloud-deployment/lib/cosmos/mongo/index-trustee-case-appointments.js "${database}"
+    node ./ops/cloud-deployment/lib/cosmos/mongo/index-trustee-case-appointments.js "${e2eDatabaseName}"
+    unset MONGO_CONNECTION_STRING
+else
+    echo "Skipping trustee-case-appointments out-of-band index management (applyTrusteeCaseAppointmentsIndex=false) -- see cams-ez2y"
+fi


### PR DESCRIPTION
# Bug

Merging PR #2669 (which moved `trustee-case-appointments` index management out of Bicep and into an out-of-band script run from `az-cosmos-deploy.sh`) broke `main`'s Cosmos deploy. The CI runner's managed identity lacks `Microsoft.KeyVault/vaults/secrets/getSecret/action` RBAC on the `mongo-connection-string` secret:

```
ERROR: (Forbidden) Caller is not authorized to perform action on resource.
Action: 'Microsoft.KeyVault/vaults/secrets/getSecret/action'
Resource: '.../vaults/***/secrets/mongo-connection-string'
Code: Forbidden / ForbiddenByRbac
```

The deploy step that fetches `MONGO_CONNECTION_STRING` to run `index-trustee-case-appointments.js` fails outright, taking the whole deploy down with it.

# Purpose

Restore a healthy CI pipeline on `main` immediately, without waiting on the RBAC grant to be sorted out first.

# Major Changes

* Wrap the out-of-band index step in `az-cosmos-deploy.sh` in a boolean guard (`applyTrusteeCaseAppointmentsIndex`), defaulted to `false`. The deploy no longer attempts the Key Vault fetch or invokes `index-trustee-case-appointments.js` while the guard is off.
* Bicep-managed collection/database provisioning is unaffected — only the `trustee-case-appointments` sort/filter indexes stop being reapplied until the guard is flipped back on.
* Tracked the re-enable work as `cams-ez2y` so this doesn't get silently forgotten once RBAC access is granted.

# Testing/Validation

Verified shell syntax (`bash -n`) and confirmed the guarded block is skipped cleanly via the pre-commit shellcheck hook. No application code touched, so no unit/integration tests apply. Live verification is the next CI run against `main` completing successfully.

# Notes

This branch was originally cut from a stack that included an unrelated commit (`Remove HTTP trigger from migrate-trustees dataflow`). Rebuilt the branch from a clean `main` + this single guard commit before opening this PR, so the diff here is scoped to exactly this fix.

Once `cams-ez2y` confirms the managed identity has `getSecret` access on `mongo-connection-string`, flip `applyTrusteeCaseAppointmentsIndex` back to `true` in `az-cosmos-deploy.sh` to resume out-of-band index management.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Guard the out-of-band Cosmos trustee-case-appointments index step behind a temporary flag to prevent deploy failures when Key Vault access is unavailable.

Bug Fixes:
- Prevent Cosmos deployment failures in CI caused by missing Key Vault RBAC for the mongo connection string secret by disabling the out-of-band index script by default.

Enhancements:
- Introduce a configurable boolean flag to control whether the trustee-case-appointments out-of-band index management step runs during deployment, with logging when it is skipped.

CI:
- Stabilize the main branch CI Cosmos deployment pipeline by skipping the Key Vault-dependent index management step until RBAC is fixed.