### PR TITLE
Fix flushQueues aborting on missing DLQ

### DIFF
--- a/backend/function-apps/dataflows/migrations/migrate-trustees.test.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-trustees.test.ts
@@ -14,6 +14,28 @@ const makeInvocationContext = (): InvocationContext =>
     log: vi.fn(),
   }) as unknown as InvocationContext;
 
+// Wires up the QueueServiceClient and object storage gateway mocks shared by every
+// flushQueues test. `receiveMessages` is the only behavior that varies per test.
+function setUpQueueAndStorageMocks(receiveMessages: ReturnType<typeof vi.fn>) {
+  const deleteMessage = vi.fn().mockResolvedValue(undefined);
+  vi.spyOn(StorageQueue.QueueServiceClient, 'fromConnectionString').mockReturnValue({
+    getQueueClient: vi.fn().mockReturnValue({ receiveMessages, deleteMessage }),
+  } as unknown as StorageQueue.QueueServiceClient);
+
+  const writeObject = vi.fn();
+  return {
+    deleteMessage,
+    writeObject,
+    setupFactory: async () => {
+      const factoryModule = (await import('../../../lib/factory')).default;
+      vi.spyOn(factoryModule, 'getObjectStorageGateway').mockReturnValue({
+        writeObject,
+        readObject: vi.fn(),
+      });
+    },
+  };
+}
+
 describe('migrate-trustees', () => {
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -30,16 +52,8 @@ describe('migrate-trustees', () => {
       const invocationContext = makeInvocationContext();
 
       const mockReceiveMessages = vi.fn().mockResolvedValue({ receivedMessageItems: [] });
-      vi.spyOn(StorageQueue.QueueServiceClient, 'fromConnectionString').mockReturnValue({
-        getQueueClient: vi.fn().mockReturnValue({ receiveMessages: mockReceiveMessages }),
-      } as unknown as StorageQueue.QueueServiceClient);
-
-      const factoryModule = (await import('../../../lib/factory')).default;
-      const writeObject = vi.fn();
-      vi.spyOn(factoryModule, 'getObjectStorageGateway').mockReturnValue({
-        writeObject,
-        readObject: vi.fn(),
-      });
+      const { writeObject, setupFactory } = setUpQueueAndStorageMocks(mockReceiveMessages);
+      await setupFactory();
 
       await handleStart({ flushQueues: true } as MigrationStartMessage, invocationContext);
 
@@ -47,6 +61,46 @@ describe('migrate-trustees', () => {
       expect(writeObject).not.toHaveBeenCalled();
       const outputs = [...(invocationContext.extraOutputs as Map<unknown, unknown>).values()];
       expect(outputs).toHaveLength(0);
+    });
+
+    test('drains queued messages, deletes them, and writes decoded JSONL to blob storage', async () => {
+      const { handleStart } = await import('./migrate-trustees');
+      const invocationContext = makeInvocationContext();
+
+      const message1 = { type: 'FAILED_APPOINTMENT', trusteeId: '111' };
+      const message2 = { type: 'FAILED_APPOINTMENT', trusteeId: '222' };
+      const toQueueItem = (payload: unknown, messageId: string) => ({
+        messageId,
+        popReceipt: `pop-${messageId}`,
+        messageText: Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64'),
+      });
+
+      // START and PAGE are empty; FAILED_APPOINTMENTS has two messages across two pages;
+      // DLQ is empty.
+      const mockReceiveMessages = vi
+        .fn()
+        .mockResolvedValueOnce({ receivedMessageItems: [] }) // START
+        .mockResolvedValueOnce({ receivedMessageItems: [] }) // PAGE
+        .mockResolvedValueOnce({ receivedMessageItems: [] }) // DLQ
+        .mockResolvedValueOnce({ receivedMessageItems: [toQueueItem(message1, 'msg-1')] }) // FAILED_APPOINTMENTS page 1
+        .mockResolvedValueOnce({ receivedMessageItems: [toQueueItem(message2, 'msg-2')] }) // FAILED_APPOINTMENTS page 2
+        .mockResolvedValueOnce({ receivedMessageItems: [] }); // FAILED_APPOINTMENTS drained
+
+      const { deleteMessage, writeObject, setupFactory } =
+        setUpQueueAndStorageMocks(mockReceiveMessages);
+      await setupFactory();
+
+      await handleStart({ flushQueues: true } as MigrationStartMessage, invocationContext);
+
+      expect(deleteMessage).toHaveBeenCalledTimes(2);
+      expect(deleteMessage).toHaveBeenCalledWith('msg-1', 'pop-msg-1');
+      expect(deleteMessage).toHaveBeenCalledWith('msg-2', 'pop-msg-2');
+
+      expect(writeObject).toHaveBeenCalledTimes(1);
+      const [containerName, blobName, content] = writeObject.mock.calls[0];
+      expect(containerName).toBe('migrate-trustees-out');
+      expect(blobName).toMatch(/^flush-failed-appointments-.*\.jsonl$/);
+      expect(content).toBe(`${JSON.stringify(message1)}\n${JSON.stringify(message2)}`);
     });
 
     test('treats a queue that does not exist (404) as empty instead of aborting the flush', async () => {
@@ -69,16 +123,8 @@ describe('migrate-trustees', () => {
         .mockRejectedValueOnce(notFoundError) // DLQ — never created
         .mockRejectedValueOnce(notFoundError); // FAILED_APPOINTMENTS — never created
 
-      vi.spyOn(StorageQueue.QueueServiceClient, 'fromConnectionString').mockReturnValue({
-        getQueueClient: vi.fn().mockReturnValue({ receiveMessages: mockReceiveMessages }),
-      } as unknown as StorageQueue.QueueServiceClient);
-
-      const factoryModule = (await import('../../../lib/factory')).default;
-      const writeObject = vi.fn();
-      vi.spyOn(factoryModule, 'getObjectStorageGateway').mockReturnValue({
-        writeObject,
-        readObject: vi.fn(),
-      });
+      const { writeObject, setupFactory } = setUpQueueAndStorageMocks(mockReceiveMessages);
+      await setupFactory();
 
       await expect(
         handleStart({ flushQueues: true } as MigrationStartMessage, invocationContext),
@@ -97,15 +143,8 @@ describe('migrate-trustees', () => {
       });
 
       const mockReceiveMessages = vi.fn().mockRejectedValueOnce(serverError);
-      vi.spyOn(StorageQueue.QueueServiceClient, 'fromConnectionString').mockReturnValue({
-        getQueueClient: vi.fn().mockReturnValue({ receiveMessages: mockReceiveMessages }),
-      } as unknown as StorageQueue.QueueServiceClient);
-
-      const factoryModule = (await import('../../../lib/factory')).default;
-      vi.spyOn(factoryModule, 'getObjectStorageGateway').mockReturnValue({
-        writeObject: vi.fn(),
-        readObject: vi.fn(),
-      });
+      const { setupFactory } = setUpQueueAndStorageMocks(mockReceiveMessages);
+      await setupFactory();
 
       await expect(
         handleStart({ flushQueues: true } as MigrationStartMessage, invocationContext),

--- a/backend/function-apps/dataflows/migrations/migrate-trustees.test.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-trustees.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { InvocationContext } from '@azure/functions';
+import * as StorageQueue from '@azure/storage-queue';
+import ApplicationContextCreator from '../../azure/application-context-creator';
+import { createMockApplicationContext } from '../../../lib/testing/testing-utilities';
+import * as DataflowTelemetry from '../../../lib/use-cases/dataflows/dataflow-telemetry';
+import type { MigrationStartMessage } from './migrate-trustees';
+
+const makeInvocationContext = (): InvocationContext =>
+  ({
+    invocationId: 'test-invocation-id',
+    functionName: 'migrate-trustees-handleStart',
+    extraOutputs: new Map(),
+    log: vi.fn(),
+  }) as unknown as InvocationContext;
+
+describe('migrate-trustees', () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    process.env.AzureWebJobsStorage = 'UseDevelopmentStorage=true';
+
+    const mockContext = await createMockApplicationContext();
+    vi.spyOn(ApplicationContextCreator, 'getApplicationContext').mockResolvedValue(mockContext);
+    vi.spyOn(DataflowTelemetry, 'completeDataflowTrace').mockReturnValue(undefined);
+  });
+
+  describe('handleStart — flushQueues', () => {
+    test('dumps all queues to blobs when every queue exists', async () => {
+      const { handleStart } = await import('./migrate-trustees');
+      const invocationContext = makeInvocationContext();
+
+      const mockReceiveMessages = vi.fn().mockResolvedValue({ receivedMessageItems: [] });
+      vi.spyOn(StorageQueue.QueueServiceClient, 'fromConnectionString').mockReturnValue({
+        getQueueClient: vi.fn().mockReturnValue({ receiveMessages: mockReceiveMessages }),
+      } as unknown as StorageQueue.QueueServiceClient);
+
+      const factoryModule = (await import('../../../lib/factory')).default;
+      const writeObject = vi.fn();
+      vi.spyOn(factoryModule, 'getObjectStorageGateway').mockReturnValue({
+        writeObject,
+        readObject: vi.fn(),
+      });
+
+      await handleStart({ flushQueues: true } as MigrationStartMessage, invocationContext);
+
+      expect(mockReceiveMessages).toHaveBeenCalledTimes(4);
+      expect(writeObject).not.toHaveBeenCalled();
+      const outputs = [...(invocationContext.extraOutputs as Map<unknown, unknown>).values()];
+      expect(outputs).toHaveLength(0);
+    });
+
+    test('treats a queue that does not exist (404) as empty instead of aborting the flush', async () => {
+      // Regression test: DLQ and FAILED_APPOINTMENTS are only created lazily the first
+      // time a message is enqueued to them. In production, neither queue had ever
+      // received a message, so receiveMessages() threw "QueueNotFound" (404) on DLQ —
+      // aborting handleStart before it ever reached FAILED_APPOINTMENTS, and causing
+      // the flushQueues start message to be retried and poison-queued.
+      const { handleStart } = await import('./migrate-trustees');
+      const invocationContext = makeInvocationContext();
+
+      const notFoundError = new StorageQueue.RestError('The specified queue does not exist.', {
+        statusCode: 404,
+      });
+
+      const mockReceiveMessages = vi
+        .fn()
+        .mockResolvedValueOnce({ receivedMessageItems: [] }) // START
+        .mockResolvedValueOnce({ receivedMessageItems: [] }) // PAGE
+        .mockRejectedValueOnce(notFoundError) // DLQ — never created
+        .mockRejectedValueOnce(notFoundError); // FAILED_APPOINTMENTS — never created
+
+      vi.spyOn(StorageQueue.QueueServiceClient, 'fromConnectionString').mockReturnValue({
+        getQueueClient: vi.fn().mockReturnValue({ receiveMessages: mockReceiveMessages }),
+      } as unknown as StorageQueue.QueueServiceClient);
+
+      const factoryModule = (await import('../../../lib/factory')).default;
+      const writeObject = vi.fn();
+      vi.spyOn(factoryModule, 'getObjectStorageGateway').mockReturnValue({
+        writeObject,
+        readObject: vi.fn(),
+      });
+
+      await expect(
+        handleStart({ flushQueues: true } as MigrationStartMessage, invocationContext),
+      ).resolves.toBeUndefined();
+
+      expect(mockReceiveMessages).toHaveBeenCalledTimes(4);
+      expect(writeObject).not.toHaveBeenCalled();
+    });
+
+    test('rethrows non-404 errors instead of swallowing them', async () => {
+      const { handleStart } = await import('./migrate-trustees');
+      const invocationContext = makeInvocationContext();
+
+      const serverError = new StorageQueue.RestError('Internal server error.', {
+        statusCode: 500,
+      });
+
+      const mockReceiveMessages = vi.fn().mockRejectedValueOnce(serverError);
+      vi.spyOn(StorageQueue.QueueServiceClient, 'fromConnectionString').mockReturnValue({
+        getQueueClient: vi.fn().mockReturnValue({ receiveMessages: mockReceiveMessages }),
+      } as unknown as StorageQueue.QueueServiceClient);
+
+      const factoryModule = (await import('../../../lib/factory')).default;
+      vi.spyOn(factoryModule, 'getObjectStorageGateway').mockReturnValue({
+        writeObject: vi.fn(),
+        readObject: vi.fn(),
+      });
+
+      await expect(
+        handleStart({ flushQueues: true } as MigrationStartMessage, invocationContext),
+      ).rejects.toThrow('Internal server error.');
+    });
+  });
+});

--- a/backend/function-apps/dataflows/migrations/migrate-trustees.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-trustees.ts
@@ -6,7 +6,6 @@ import {
   buildContainerName,
   buildFunctionName,
   buildQueueName,
-  buildStartQueueHttpTrigger,
   CursorMessage,
   ensureContainersExist,
   StartMessage,
@@ -49,7 +48,6 @@ const FAILED_APPOINTMENTS = output.storageQueue({
 const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
 const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
 const HANDLE_ERROR = buildFunctionName(MODULE_NAME, 'handleError');
-const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 
 type MigrationStartMessage = StartMessage &
   TrusteeMigrationStartEvent & {
@@ -544,13 +542,6 @@ function setup() {
     queueName: DLQ.queueName,
     handler: handleError,
     extraOutputs: [],
-  });
-
-  app.http(HTTP_TRIGGER, {
-    route: 'migrate-trustees',
-    methods: ['POST'],
-    extraOutputs: [START],
-    handler: buildStartQueueHttpTrigger(MODULE_NAME, START),
   });
 }
 

--- a/backend/function-apps/dataflows/migrations/migrate-trustees.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-trustees.ts
@@ -1,5 +1,5 @@
 import { app, InvocationContext, output } from '@azure/functions';
-import { QueueServiceClient } from '@azure/storage-queue';
+import { QueueServiceClient, RestError } from '@azure/storage-queue';
 
 import ApplicationContextCreator from '../../azure/application-context-creator';
 import {
@@ -49,7 +49,7 @@ const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
 const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
 const HANDLE_ERROR = buildFunctionName(MODULE_NAME, 'handleError');
 
-type MigrationStartMessage = StartMessage &
+export type MigrationStartMessage = StartMessage &
   TrusteeMigrationStartEvent & {
     flushQueues?: boolean;
   };
@@ -74,13 +74,25 @@ async function dumpQueueToBlob(
 
   const lines: string[] = [];
 
-  let response = await queueClient.receiveMessages({ numberOfMessages: 32 });
-  while (response.receivedMessageItems.length > 0) {
-    for (const msg of response.receivedMessageItems) {
-      lines.push(Buffer.from(msg.messageText, 'base64').toString('utf-8'));
-      await queueClient.deleteMessage(msg.messageId, msg.popReceipt);
+  try {
+    let response = await queueClient.receiveMessages({ numberOfMessages: 32 });
+    while (response.receivedMessageItems.length > 0) {
+      for (const msg of response.receivedMessageItems) {
+        lines.push(Buffer.from(msg.messageText, 'base64').toString('utf-8'));
+        await queueClient.deleteMessage(msg.messageId, msg.popReceipt);
+      }
+      response = await queueClient.receiveMessages({ numberOfMessages: 32 });
     }
-    response = await queueClient.receiveMessages({ numberOfMessages: 32 });
+  } catch (err) {
+    // Queues are created lazily by their output binding on first use — a queue
+    // that has never received a message (e.g. DLQ or FAILED_APPOINTMENTS before
+    // any failure has occurred) won't exist yet. Treat that as empty rather than
+    // aborting the whole flush and poison-queuing the flushQueues start message.
+    if (err instanceof RestError && err.statusCode === 404) {
+      logger.info(MODULE_NAME, `flushQueues: ${queueName} does not exist — skipping`);
+      return 0;
+    }
+    throw err;
   }
 
   if (lines.length === 0) {
@@ -108,7 +120,10 @@ function requiresDeleteAll(start: MigrationStartMessage): boolean {
  * If deleteAll flag is present, delete all existing trustees and appointments before starting.
  * If flushQueues flag is present, dump all queues to blob storage and return.
  */
-async function handleStart(start: MigrationStartMessage, invocationContext: InvocationContext) {
+export async function handleStart(
+  start: MigrationStartMessage,
+  invocationContext: InvocationContext,
+) {
   const context = await ApplicationContextCreator.getApplicationContext({ invocationContext });
   const { logger } = context;
   const trace = context.observability.startTrace(invocationContext.invocationId);

--- a/test/integration/migrate-trustees/DEDUP_MIGRATION_RUNBOOK.md
+++ b/test/integration/migrate-trustees/DEDUP_MIGRATION_RUNBOOK.md
@@ -1,78 +1,72 @@
 # Trustee-Migration Deduplication Verification Runbook
 
-Manual workflow for validating the three duplicate-trustee fixes by running the
-**real** `MIGRATE-TRUSTEES` dataflow against the shared environment.
+Manual workflow for validating the three duplicate-trustee fixes by running the **real**
+`MIGRATE-TRUSTEES` dataflow against the shared environment.
 
-This is NOT a unit/integration test harness that calls use-case functions. The
-operator seeds SQL, runs the actual Azure Function locally (which connects to the
-shared Azure Gov SQL server and Cosmos via `backend/.env`), then verifies Cosmos
-with a read-only Node script.
+This is NOT a unit/integration test harness that calls use-case functions. The operator seeds SQL,
+runs the actual Azure Function locally (which connects to the shared Azure Gov SQL server and Cosmos
+via `backend/.env`), then verifies Cosmos with a read-only Node script.
 
 ## What is being validated
 
-| Fix | Fixture | What it proves |
-| --- | --- | --- |
-| **M1** — `findTrusteeByNameAndState` lookahead-only regex | 1004 (`J. Ford Elsaesser`), 1005 (`William A. Brandt, Jr.`) | Composite names whose tokens end in punctuation match the dedup lookup on run 2 (old `\b` regex never matched → duplicate every run). |
-| **M2** — `upsertTrustee` dedup key uses persisted `public.address.state` | 1006 (`Merrill Cohen`, STATE=MD, STATE_A2=DE, A2 public) | Dedup key uses transformed public state `DE`, not raw `MD`. |
-| **fallback** — `transformTrusteeRecord` backfills empty public state | 1007 (`Test Fallback`, STATE_A2 blank) | Record persists with `public.address.state='MD'` (backfilled) instead of being skipped. |
-| control | 1008 (`Jane Control`) | A clean record isn't spuriously duplicated. |
+| Fix                                                                      | Fixture                                                     | What it proves                                                                                                                        |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **M1** — `findTrusteeByNameAndState` lookahead-only regex                | 1004 (`J. Ford Elsaesser`), 1005 (`William A. Brandt, Jr.`) | Composite names whose tokens end in punctuation match the dedup lookup on run 2 (old `\b` regex never matched → duplicate every run). |
+| **M2** — `upsertTrustee` dedup key uses persisted `public.address.state` | 1006 (`Merrill Cohen`, STATE=MD, STATE_A2=DE, A2 public)    | Dedup key uses transformed public state `DE`, not raw `MD`.                                                                           |
+| **fallback** — `transformTrusteeRecord` backfills empty public state     | 1007 (`Test Fallback`, STATE_A2 blank)                      | Record persists with `public.address.state='MD'` (backfilled) instead of being skipped.                                               |
+| control                                                                  | 1008 (`Jane Control`)                                       | A clean record isn't spuriously duplicated.                                                                                           |
 
 ## 1. Prerequisites
 
 - Local **dataflows** function app configured to point at the shared SQL
-  (`sql-ustp-cams.database.usgovcloudapi.net` — ATS / ACMS / DXTR) and Cosmos.
-  Config is read from `backend/function-apps/dataflows/.env` (the dataflows app's
-  own `.env`, NOT `backend/.env`). In particular these MUST be set:
-    - `MONGO_CONNECTION_STRING` — Cosmos Mongo-API connection string
-    - `COSMOS_DATABASE_NAME` — database containing the `trustees` collection (e.g. `cams`)
-    - `ATS_MSSQL_*` — ATS connection. **The ATS database on this server is named
-      `ATS_SUB`** (verified 2026-07-07 by listing `sys.databases`; there is no
-      `ATS_REP_SUB`). Set `ATS_MSSQL_DATABASE="ATS_SUB"`.
-    - `ACMS_MSSQL_*` — `ACMS_MSSQL_DATABASE="ACMS_REP_SUB"`. **Caveat:** this
-      environment's `dbo.CMMPR` does NOT match the gateway query — it has `PROF_CODE`
-      (numeric) and no `UST_PROF_CODE`/`PROF_TYPE`, so `getTrusteeProfessionalIds`
-      fails here (caught non-fatally; professional-ids will be 0). USTP's real schema
-      has those columns; this is a known dev-replica mismatch, out of scope for the
-      dedup test. Seed `03` is therefore moot in this environment and can be skipped.
-    - Storage: the queue triggers use connection `DataflowsStorage`
-      (→ `AzureWebJobsDataflowsStorage`) and the output bindings use
-      `AzureWebJobsStorage`. Both are set in `local.settings.json`; in this
-      environment they resolve to the SAME Gov storage account, so the queue flow is
-      consistent.
-    - `CAMS_ENABLED_DATAFLOWS` must include `MIGRATE-TRUSTEES`
-- **Restart the dataflows app after any `.env`/`local.settings.json` change** — the
-  Functions host reads them once at startup.
-- DXTR offices already exist in the shared environment — there is **no DXTR seed**.
-  The single-court states used by the fixtures (Idaho, Arizona, Maryland,
-  Connecticut) resolve to real DXTR court offices.
-- SQL client access to the shared server for the two seed databases (ATS and ACMS
-  are **different databases on the same server**).
-- Node.js (v22, matching `.nvmrc`) with the repo's hoisted `mongodb` driver
-  (already present at repo-root `node_modules` after `npm ci`).
+  (`sql-ustp-cams.database.usgovcloudapi.net` — ATS / ACMS / DXTR) and Cosmos. Config is read from
+  `backend/function-apps/dataflows/.env` (the dataflows app's own `.env`, NOT `backend/.env`). In
+  particular these MUST be set:
+  - `MONGO_CONNECTION_STRING` — Cosmos Mongo-API connection string
+  - `COSMOS_DATABASE_NAME` — database containing the `trustees` collection (e.g. `cams`)
+  - `ATS_MSSQL_*` — ATS connection. **The ATS database on this server is named `ATS_SUB`** (verified
+    2026-07-07 by listing `sys.databases`; there is no `ATS_REP_SUB`). Set
+    `ATS_MSSQL_DATABASE="ATS_SUB"`.
+  - `ACMS_MSSQL_*` — `ACMS_MSSQL_DATABASE="ACMS_REP_SUB"`. **Caveat:** this environment's
+    `dbo.CMMPR` does NOT match the gateway query — it has `PROF_CODE` (numeric) and no
+    `UST_PROF_CODE`/`PROF_TYPE`, so `getTrusteeProfessionalIds` fails here (caught non-fatally;
+    professional-ids will be 0). USTP's real schema has those columns; this is a known dev-replica
+    mismatch, out of scope for the dedup test. Seed `03` is therefore moot in this environment and
+    can be skipped.
+  - Storage: the queue triggers use connection `DataflowsStorage` (→ `AzureWebJobsDataflowsStorage`)
+    and the output bindings use `AzureWebJobsStorage`. Both are set in `local.settings.json`; in
+    this environment they resolve to the SAME Gov storage account, so the queue flow is consistent.
+  - `CAMS_ENABLED_DATAFLOWS` must include `MIGRATE-TRUSTEES`
+- **Restart the dataflows app after any `.env`/`local.settings.json` change** — the Functions host
+  reads them once at startup.
+- DXTR offices already exist in the shared environment — there is **no DXTR seed**. The single-court
+  states used by the fixtures (Idaho, Arizona, Maryland, Connecticut) resolve to real DXTR court
+  offices.
+- SQL client access to the shared server for the two seed databases (ATS and ACMS are **different
+  databases on the same server**).
+- Node.js (v22, matching `.nvmrc`) with the repo's hoisted `mongodb` driver (already present at
+  repo-root `node_modules` after `npm ci`).
 
 ## 2. Seed SQL
 
-1. **ATS** — run `seed/02-seed-dedup-trustees.sql` against the **`ATS_SUB`** database.
-   Inserts TRUSTEES rows 1004-1008 plus one active `CHAPTER_DETAILS` row each.
-   Idempotent (DELETE-then-INSERT by id 1004-1008). Note: `TRUSTEES.ID` is an
-   IDENTITY column, so the file wraps its inserts in
-   `SET IDENTITY_INSERT dbo.TRUSTEES ON/OFF` within a single batch.
-2. **ACMS** — `seed/03-seed-acms-cmmpr.sql` targets `ACMS_REP_SUB`. **Skip it in
-   this environment** — `dbo.CMMPR` here lacks `UST_PROF_CODE`/`PROF_TYPE`, so the
-   gateway's professional-id query fails regardless of seeded rows (see the ACMS
-   caveat in Prerequisites). It is retained for an environment whose `CMMPR` matches
-   USTP's real schema.
+1. **ATS** — run `seed/02-seed-dedup-trustees.sql` against the **`ATS_SUB`** database. Inserts
+   TRUSTEES rows 1004-1008 plus one active `CHAPTER_DETAILS` row each. Idempotent
+   (DELETE-then-INSERT by id 1004-1008). Note: `TRUSTEES.ID` is an IDENTITY column, so the file
+   wraps its inserts in `SET IDENTITY_INSERT dbo.TRUSTEES ON/OFF` within a single batch.
+2. **ACMS** — `seed/03-seed-acms-cmmpr.sql` targets `ACMS_REP_SUB`. **Skip it in this environment**
+   — `dbo.CMMPR` here lacks `UST_PROF_CODE`/`PROF_TYPE`, so the gateway's professional-id query
+   fails regardless of seeded rows (see the ACMS caveat in Prerequisites). It is retained for an
+   environment whose `CMMPR` matches USTP's real schema.
 
-No `sqlcmd` is required. A minimal Node runner using the repo's `mssql` package
-(parse the dataflows `.env`, connect per-database, split on `GO`, run each batch) is
-sufficient. IDENTITY_INSERT and all inserts must stay in one batch (no `GO` between)
-so the toggle survives connection pooling.
+No `sqlcmd` is required. A minimal Node runner using the repo's `mssql` package (parse the dataflows
+`.env`, connect per-database, split on `GO`, run each batch) is sufficient. IDENTITY_INSERT and all
+inserts must stay in one batch (no `GO` between) so the toggle survives connection pooling.
 
 > Note on `SERVING_STATE`: `02` seeds the full state NAME (e.g. `Idaho`) into
-> `CHAPTER_DETAILS.SERVING_STATE` because the cleansing pipeline's court map is
-> keyed by full state names. This targets the shared server's real ATS schema (the
-> local `00-seed-ats-schema.sql` defines a narrower `CHAR(2)` column for the
-> local-only tests — do not use that width assumption against the shared DB).
+> `CHAPTER_DETAILS.SERVING_STATE` because the cleansing pipeline's court map is keyed by full state
+> names. This targets the shared server's real ATS schema (the local `00-seed-ats-schema.sql`
+> defines a narrower `CHAR(2)` column for the local-only tests — do not use that width assumption
+> against the shared DB).
 
 ## 3. Run the dataflow — Run 1 (creates the trustees)
 
@@ -82,67 +76,64 @@ Run 1 populates Cosmos. There is nothing to deduplicate against yet.
    ```bash
    npm run start:dataflows
    ```
-   The dataflows app listens on **port 7072** and uses the **`import`** route prefix
-   (from `host.json`), so the trigger is `http://localhost:7072/import/migrate-trustees`
-   (NOT `7071`/`api` — that's the API app).
-2. Auth is required: `buildStartQueueHttpTrigger` → `isAuthorized` checks
-   `Authorization: ApiKey <ADMIN_KEY>` (value from the dataflows `.env`). A missing/
-   wrong key returns `403 "Request is Forbidden"`.
-   ```bash
-   curl -X POST "http://localhost:7072/import/migrate-trustees" \
-     -H "Authorization: ApiKey <ADMIN_KEY>"
+   `MIGRATE-TRUSTEES` has no HTTP trigger — all start messages go directly onto the
+   `migrate-trustees-start` queue (Azure Storage Queue triggers only; HTTP start triggers are no
+   longer used in this dataflow).
+2. Enqueue an empty `{}` start message using the repo's `@azure/storage-queue` package (same pattern
+   as the `reset` message in Step 4):
+   ```js
+   const { QueueServiceClient } = require('@azure/storage-queue');
+   const q = QueueServiceClient.fromConnectionString(CONN).getQueueClient('migrate-trustees-start');
+   await q.createIfNotExists();
+   await q.sendMessage(Buffer.from(JSON.stringify({})).toString('base64'));
    ```
 
-The HTTP trigger enqueues an **empty `{}`** start message — no flags. **Important:**
-if a prior migration left the state `COMPLETED`, `handleStart` logs "already
-completed" and returns WITHOUT enqueuing a page — the `{}` trigger is a no-op. In a
-shared environment the state is almost always already `COMPLETED`, so in practice you
-drive BOTH runs with a `reset` message (Step 4), not this bare HTTP call. A default
-(non-`importAll`) run migrates only trustees with an **active** `CHAPTER_DETAILS` row;
-our fixtures each have one with `STATUS='PA'`, so they qualify — no `importAll`
-needed. Let the page queue drain until the log reports the migration complete.
+An empty `{}` start message has no flags. **Important:** if a prior migration left the state
+`COMPLETED`, `handleStart` logs "already completed" and returns WITHOUT enqueuing a page — the `{}`
+message is a no-op. In a shared environment the state is almost always already `COMPLETED`, so in
+practice you drive BOTH runs with a `reset` message (Step 4), not this bare `{}` message. A default
+(non-`importAll`) run migrates only trustees with an **active** `CHAPTER_DETAILS` row; our fixtures
+each have one with `STATUS='PA'`, so they qualify — no `importAll` needed. Let the page queue drain
+until the log reports the migration complete.
 
 ## 4. Run the dataflow — Run 2 (the real dedup test)
 
-**Why run 2 is the actual test:** the duplication bug only bites when a matching
-trustee doc **already exists**. On run 1 the dedup lookup finds nothing and simply
-creates docs. On run 2 the lookup must find the run-1 docs; if the regex (M1) or the
-dedup-key state (M2) is wrong, the lookup misses and a **second** doc is created.
-So the fix is proven only by run 2 producing **no new docs**.
+**Why run 2 is the actual test:** the duplication bug only bites when a matching trustee doc
+**already exists**. On run 1 the dedup lookup finds nothing and simply creates docs. On run 2 the
+lookup must find the run-1 docs; if the regex (M1) or the dedup-key state (M2) is wrong, the lookup
+misses and a **second** doc is created. So the fix is proven only by run 2 producing **no new
+docs**.
 
 The migration state doc lives in the **`runtime-state`** collection (documentType
-`TRUSTEE_MIGRATION_STATE`), NOT the `trustees` collection. After a run it is
-`COMPLETED`, so a bare `{}` HTTP trigger is skipped. To (re)run, enqueue a `reset`
-start message. `host.json` sets no `messageEncoding`, so the Storage Queues
-extension default (**base64**) applies — the message body must be base64-encoded
-JSON.
+`TRUSTEE_MIGRATION_STATE`), NOT the `trustees` collection. After a run it is `COMPLETED`, so a bare
+`{}` HTTP trigger is skipped. To (re)run, enqueue a `reset` start message. `host.json` sets no
+`messageEncoding`, so the Storage Queues extension default (**base64**) applies — the message body
+must be base64-encoded JSON.
 
-**Enqueue a reset onto the `migrate-trustees-start` queue.** The most reliable local
-method is a Node one-liner with the repo's `@azure/storage-queue`, using the
-`AzureWebJobsStorage` connection string from `local.settings.json`:
+**Enqueue a reset onto the `migrate-trustees-start` queue.** The most reliable local method is a
+Node one-liner with the repo's `@azure/storage-queue`, using the `AzureWebJobsStorage` connection
+string from `local.settings.json`:
 
 ```js
 const { QueueServiceClient } = require('@azure/storage-queue');
-const q = QueueServiceClient.fromConnectionString(CONN)
-  .getQueueClient('migrate-trustees-start');
+const q = QueueServiceClient.fromConnectionString(CONN).getQueueClient('migrate-trustees-start');
 await q.createIfNotExists();
 await q.sendMessage(Buffer.from(JSON.stringify({ reset: true })).toString('base64'));
 ```
 
-`reset: true` drives `getOrCreateMigrationState(context, true)` to re-initialize the
-state (no longer `COMPLETED`); `handleStart` then enqueues the first page and the run
-proceeds over the ATS rows. (`az storage message put` or Storage Explorer work too,
-as long as the body is base64.)
+`reset: true` drives `getOrCreateMigrationState(context, true)` to re-initialize the state (no
+longer `COMPLETED`); `handleStart` then enqueues the first page and the run proceeds over the ATS
+rows. (`az storage message put` or Storage Explorer work too, as long as the body is base64.)
 
-**In a shared environment both "run 1" and "run 2" are reset runs** — the state was
-already `COMPLETED` from a prior migration, so even the first pass needs a reset.
-Run 1 creates the fixture docs; run 2 is the dedup test (must find and update them,
-not create duplicates). Let each run drain to `COMPLETED` before the next.
+**In a shared environment both "run 1" and "run 2" are reset runs** — the state was already
+`COMPLETED` from a prior migration, so even the first pass needs a reset. Run 1 creates the fixture
+docs; run 2 is the dedup test (must find and update them, not create duplicates). Let each run drain
+to `COMPLETED` before the next.
 
 ## 5. Verify (read-only)
 
-Run the read-only verification script against the **same** Cosmos environment the
-migration targeted:
+Run the read-only verification script against the **same** Cosmos environment the migration
+targeted:
 
 ```bash
 export MONGO_CONNECTION_STRING='<cosmos mongo api connection string>'
@@ -154,21 +145,20 @@ node test/integration/migrate-trustees/scripts/verify-dedup-cosmos.mjs
 It scopes every query to `legacy.truIds` in `1004`-`1008` and asserts:
 
 - **HARD (pass/fail, sets exit code):**
-    - Exactly one `trustees` doc per fixture person (5 groups, each count 1; each
-      truId on exactly one doc). This is the dedup result.
-    - 1006: `public.address.state === 'DE'` and `internal.address.state === 'MD'` (M2).
-    - 1007: `public.address.state === 'MD'` and the doc exists (fallback).
-- **INFO (never fails the run):** `>= 1` `trustee-professional-ids`
-  (by `camsTrusteeId`) and `>= 1` `trustee-appointments` (by `trusteeId`) per
-  fixture. A zero count only means the CMMPR / CHAPTER_DETAILS path wasn't
-  exercised — it does not indicate a dedup regression.
+  - Exactly one `trustees` doc per fixture person (5 groups, each count 1; each truId on exactly one
+    doc). This is the dedup result.
+  - 1006: `public.address.state === 'DE'` and `internal.address.state === 'MD'` (M2).
+  - 1007: `public.address.state === 'MD'` and the doc exists (fallback).
+- **INFO (never fails the run):** `>= 1` `trustee-professional-ids` (by `camsTrusteeId`) and `>= 1`
+  `trustee-appointments` (by `trusteeId`) per fixture. A zero count only means the CMMPR /
+  CHAPTER_DETAILS path wasn't exercised — it does not indicate a dedup regression.
 
 A non-zero exit code means a HARD check failed (duplicate or wrong state).
 
 ## 6. Cleanup
 
-Per operator instruction, **DO NOT delete the created trustees** (or their
-appointments / professional-ids) in Cosmos.
+Per operator instruction, **DO NOT delete the created trustees** (or their appointments /
+professional-ids) in Cosmos.
 
 Optionally remove the seeded SQL rows (both are safe, idempotent deletes):
 


### PR DESCRIPTION
# Bug

In production, sending `flushQueues: true` to the trustee migration's start queue caused `handleStart` to abort partway through and retry until the message landed in the poison queue. The `migrate-trustees-dlq` and `migrate-trustees-failed-appointments` queues are created lazily by their output bindings only when a message is first enqueued to them; since neither queue had ever received a message in this environment, `dumpQueueToBlob`'s `receiveMessages()` call threw a 404 `QueueNotFound` error while draining `DLQ` — third in the sequence — aborting `handleStart` before it ever reached the `FAILED_APPOINTMENTS` flush.

# Purpose

Make `flushQueues` resilient to queues that haven't been created yet, so an idle DLQ or failed-appointments queue doesn't block the whole flush operation or poison-queue the triggering message.

# Major Changes

* `dumpQueueToBlob` now catches a 404 (`QueueNotFound`) from the queue client and treats it the same as an empty queue, logging and returning `0` instead of throwing
* Other errors are still rethrown unchanged
* Removed the `migrate-trustees` HTTP trigger — it always enqueued an empty `{}` start message regardless of the POST body, so flags like `flushQueues` never reached `handleStart` through that route; start messages must be enqueued directly, matching the `MIGRATE_CASE_APPOINTMENTS` dataflow, which has no HTTP trigger. Updated the dedup migration runbook to enqueue directly instead of curling the removed route.
* Exported `handleStart` and `MigrationStartMessage` from `migrate-trustees.ts` to make the handler testable, matching the existing convention in `migrate-case-appointments.ts`

# Testing/Validation

Added `migrate-trustees.test.ts` (new file — this handler previously had no test coverage). Covers:
* the happy path where all four queues are drained without error
* the regression case: a 404 from one queue is treated as empty rather than aborting the flush
* non-404 errors are still rethrown
* the core drain-and-write behavior — messages are decoded, deleted, and written as joined JSONL to blob storage

Verified the regression test actually fails against the pre-fix code (confirmed it reproduces the exact `RestError: The specified queue does not exist.` seen in the production logs) and passes with the fix. Full backend/common/user-interface test suites, typecheck, lint, coverage, `npm audit`, and `knip` all pass.

# Notes

Root-caused directly from a production exception log (`ustp-cams-prd-dataflows`, `MIGRATE-TRUSTEES-handleStart`) showing `RestError: The specified queue does not exist.` thrown from `dumpQueueToBlob`, confirming the DLQ queue had never been created because no processing error had occurred yet in that environment.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Handle trustee migration queue flushing more robustly when queues may not yet exist and align the migration entrypoints and docs with the queue-based start pattern.

Bug Fixes:
- Treat missing Azure Storage queues as empty during flush operations instead of aborting the trustee migration and poisoning the start message.
- Ensure non-404 queue errors during flush still surface normally rather than being swallowed.

Enhancements:
- Remove the HTTP trigger for the MIGRATE-TRUSTEES dataflow so it is started exclusively via storage queues, consistent with other migrations.
- Export the trustee migration start handler and message type to support direct unit testing of handleStart.
- Improve the trustee migration dedup runbook to document the queue-based start flow and shared-environment nuances more clearly.

Tests:
- Add unit tests for the trustee migrate handleStart flushQueues path, covering successful drains, missing-queue behavior, and non-404 error propagation.