### PR TITLE
Ignore local dev artifacts (Azurite, coverage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,14 @@ vitest.config.js.map
 
 # Temp directory for local work
 temp
+
+# Azurite (local Azure Storage emulator) state
+AzuriteConfig
+__azurite_db_*.json
+__blobstorage__/
+
+# Test coverage output
+**/coverage/
+
+# Local scratch images
+img/


### PR DESCRIPTION
# Purpose

Local dev artifacts were cluttering `git status` with 2K+ files, making it hard to focus on actual changes.

# Major Changes

Add `.gitignore` entries for:
- Azurite (local Azure Storage emulator) state — `AzuriteConfig`, `__azurite_db_*.json`, `__blobstorage__/`
- Test coverage output — `**/coverage/`
- Local scratch images — `img/`

# Testing/Validation

- `git status` is clean after the change (only the `.gitignore` edit shows).
- No tracked files are affected — these are all untracked local artifacts.

# Notes

Housekeeping only; no functional/code changes.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application
