### PR TITLE
CAMS-813 Fix Data Verification crash when taskDate is undefined

### DIFF
--- a/common/src/cams/data-verification.test.ts
+++ b/common/src/cams/data-verification.test.ts
@@ -139,4 +139,12 @@ describe('computeTaskDate', () => {
     };
     expect(computeTaskDate(verification)).toBe(isoString);
   });
+
+  test('should return empty string when taskDate is undefined on TrusteeMatchVerificationListItem', () => {
+    const verification: TrusteeMatchVerificationListItem = {
+      ...baseVerification,
+      taskDate: undefined,
+    };
+    expect(computeTaskDate(verification)).toBe('');
+  });
 });

--- a/common/src/cams/data-verification.ts
+++ b/common/src/cams/data-verification.ts
@@ -30,6 +30,9 @@ export function computeTaskDate(item: DataVerificationItem | TrusteeMatchVerific
     const createdOn = 'createdOn' in item ? item.createdOn : undefined;
     const updatedOn = 'updatedOn' in item ? item.updatedOn : undefined;
     const date = createdOn ?? updatedOn ?? item.taskDate;
+    // Returns '' (not 'N/A') intentionally — this is an internal sort/computation
+    // value, not a display string. Callers that render dates use formatDate, which
+    // returns INVALID_DATE_FALLBACK for nullish inputs.
     return date instanceof Date ? date.toISOString() : (date ?? '');
   }
   return (item as Order).orderDate;

--- a/common/src/cams/data-verification.ts
+++ b/common/src/cams/data-verification.ts
@@ -30,7 +30,7 @@ export function computeTaskDate(item: DataVerificationItem | TrusteeMatchVerific
     const createdOn = 'createdOn' in item ? item.createdOn : undefined;
     const updatedOn = 'updatedOn' in item ? item.updatedOn : undefined;
     const date = createdOn ?? updatedOn ?? item.taskDate;
-    return date instanceof Date ? date.toISOString() : date;
+    return date instanceof Date ? date.toISOString() : (date ?? '');
   }
   return (item as Order).orderDate;
 }

--- a/common/src/cams/orders.ts
+++ b/common/src/cams/orders.ts
@@ -48,7 +48,7 @@ export type TransferOrder = CaseSummary & {
   id: string;
   taskType: 'transfer';
   orderDate: string;
-  taskDate: string | Date;
+  taskDate?: string | Date;
   status: OrderStatus;
   docketEntries: CaseDocketEntry[];
   docketSuggestedCaseNumber?: string;
@@ -88,7 +88,7 @@ export type ConsolidationOrder = CamsDocument & {
   consolidationType?: ConsolidationType;
   taskType: 'consolidation';
   orderDate: string;
-  taskDate: string | Date;
+  taskDate?: string | Date;
   status: OrderStatus;
   courtName: string;
   courtDivisionCode: string;

--- a/common/src/cams/trustee-match-verification.ts
+++ b/common/src/cams/trustee-match-verification.ts
@@ -24,7 +24,7 @@ export type TrusteeMatchVerification = Auditable & {
   taskType: 'trustee-match';
   reason?: string;
   inactiveAppointmentStatus?: AppointmentStatus;
-  taskDate: string | Date;
+  taskDate?: string | Date;
 };
 
 /**

--- a/user-interface/src/data-verification/DataVerificationScreen.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.test.tsx
@@ -553,6 +553,32 @@ describe('Review Orders screen', () => {
     ).toBeTruthy();
   });
 
+  test('should render without crashing when a verification order has no taskDate', async () => {
+    setupFeatureFlags({ 'trustee-verification-enabled': true });
+    vi.spyOn(Api2, 'getOrders').mockResolvedValue({ data: [] });
+
+    const verificationWithoutTaskDate: TrusteeMatchVerificationListItem = {
+      ...sampleVerificationOrder,
+      id: 'verification-no-taskdate',
+      taskDate: undefined,
+    };
+    vi.spyOn(Api2, 'getTrusteeMatchVerifications').mockResolvedValue({
+      data: [verificationWithoutTaskDate],
+    });
+
+    render(
+      <BrowserRouter>
+        <DataVerificationScreen />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`accordion-order-list-${verificationWithoutTaskDate.id}`),
+      ).toBeInTheDocument();
+    });
+  });
+
   test('should not render a list if an API error is encountered', async () => {
     const mock = vi.spyOn(Api2, 'getOrders');
     mock.mockRejectedValue({});

--- a/user-interface/src/data-verification/DataVerificationScreen.test.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.test.tsx
@@ -553,7 +553,7 @@ describe('Review Orders screen', () => {
     ).toBeTruthy();
   });
 
-  test('should render without crashing when a verification order has no taskDate', async () => {
+  test('should render and sort a verification order with no taskDate to the top', async () => {
     setupFeatureFlags({ 'trustee-verification-enabled': true });
     vi.spyOn(Api2, 'getOrders').mockResolvedValue({ data: [] });
 
@@ -562,8 +562,14 @@ describe('Review Orders screen', () => {
       id: 'verification-no-taskdate',
       taskDate: undefined,
     };
+    const verificationWithTaskDate: TrusteeMatchVerificationListItem = {
+      ...sampleVerificationOrder,
+      id: 'verification-with-taskdate',
+      taskDate: '2026-01-10T10:00:00.000Z',
+    };
+    // API returns dated record first; missing-date record should sort to top
     vi.spyOn(Api2, 'getTrusteeMatchVerifications').mockResolvedValue({
-      data: [verificationWithoutTaskDate],
+      data: [verificationWithTaskDate, verificationWithoutTaskDate],
     });
 
     render(
@@ -576,7 +582,17 @@ describe('Review Orders screen', () => {
       expect(
         screen.getByTestId(`accordion-order-list-${verificationWithoutTaskDate.id}`),
       ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(`accordion-order-list-${verificationWithTaskDate.id}`),
+      ).toBeInTheDocument();
     });
+
+    // Missing taskDate sorts to top (MISSING_TASK_DATE_SORT_KEY = '' < any ISO date)
+    const undatedEl = screen.getByTestId(`accordion-order-list-${verificationWithoutTaskDate.id}`);
+    const datedEl = screen.getByTestId(`accordion-order-list-${verificationWithTaskDate.id}`);
+    expect(
+      undatedEl.compareDocumentPosition(datedEl) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   test('should not render a list if an API error is encountered', async () => {

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -232,7 +232,15 @@ export default function DataVerificationScreen() {
         return true;
       }
     })
-    .sort((a, b) => sortByDate(a.taskDate ?? '', b.taskDate ?? ''))
+    .sort((a, b) => {
+      // Records missing taskDate sort to the TOP of the list ('' < any ISO date).
+      // To sort them to the BOTTOM instead, change '' to '9999-12-31'.
+      const MISSING_TASK_DATE_SORT_KEY = '';
+      return sortByDate(
+        a.taskDate ?? MISSING_TASK_DATE_SORT_KEY,
+        b.taskDate ?? MISSING_TASK_DATE_SORT_KEY,
+      );
+    })
     .map((order) => {
       const noFiltersSelected = typeFilter.length === 0 && statusFilter.length === 0;
       const statusMismatch =

--- a/user-interface/src/data-verification/DataVerificationScreen.tsx
+++ b/user-interface/src/data-verification/DataVerificationScreen.tsx
@@ -232,7 +232,7 @@ export default function DataVerificationScreen() {
         return true;
       }
     })
-    .sort((a, b) => sortByDate(a.taskDate, b.taskDate))
+    .sort((a, b) => sortByDate(a.taskDate ?? '', b.taskDate ?? ''))
     .map((order) => {
       const noFiltersSelected = typeFilter.length === 0 && statusFilter.length === 0;
       const statusMismatch =

--- a/user-interface/src/lib/utils/datetime.test.ts
+++ b/user-interface/src/lib/utils/datetime.test.ts
@@ -23,12 +23,12 @@ describe('Date/Time utilities', () => {
       expect(actual).toEqual('unparsable');
     });
 
-    test('should return N/A for undefined', () => {
-      expect(formatDate(undefined)).toEqual('N/A');
+    test('should return Not Available for undefined', () => {
+      expect(formatDate(undefined)).toEqual('Not Available');
     });
 
-    test('should return N/A for null', () => {
-      expect(formatDate(null)).toEqual('N/A');
+    test('should return Not Available for null', () => {
+      expect(formatDate(null)).toEqual('Not Available');
     });
   });
 
@@ -50,12 +50,12 @@ describe('Date/Time utilities', () => {
       expect(actual).toEqual('unparsable');
     });
 
-    test('should return N/A for undefined', () => {
-      expect(formatDateTime(undefined)).toEqual('N/A');
+    test('should return Not Available for undefined', () => {
+      expect(formatDateTime(undefined)).toEqual('Not Available');
     });
 
-    test('should return N/A for null', () => {
-      expect(formatDateTime(null)).toEqual('N/A');
+    test('should return Not Available for null', () => {
+      expect(formatDateTime(null)).toEqual('Not Available');
     });
 
     test('should format a Date in MM/dd/YYYY HH:mm PM format with appropriate time zone', async () => {

--- a/user-interface/src/lib/utils/datetime.test.ts
+++ b/user-interface/src/lib/utils/datetime.test.ts
@@ -22,6 +22,14 @@ describe('Date/Time utilities', () => {
       const actual = formatDate('unparsable');
       expect(actual).toEqual('unparsable');
     });
+
+    test('should return N/A for undefined', () => {
+      expect(formatDate(undefined)).toEqual('N/A');
+    });
+
+    test('should return N/A for null', () => {
+      expect(formatDate(null)).toEqual('N/A');
+    });
   });
 
   describe('formatDateTime', () => {
@@ -40,6 +48,14 @@ describe('Date/Time utilities', () => {
     test('should return the input if the date cannot be parsed', async () => {
       const actual = formatDateTime('unparsable');
       expect(actual).toEqual('unparsable');
+    });
+
+    test('should return N/A for undefined', () => {
+      expect(formatDateTime(undefined)).toEqual('N/A');
+    });
+
+    test('should return N/A for null', () => {
+      expect(formatDateTime(null)).toEqual('N/A');
     });
 
     test('should format a Date in MM/dd/YYYY HH:mm PM format with appropriate time zone', async () => {

--- a/user-interface/src/lib/utils/datetime.ts
+++ b/user-interface/src/lib/utils/datetime.ts
@@ -1,4 +1,4 @@
-const INVALID_DATE_FALLBACK = 'N/A';
+const INVALID_DATE_FALLBACK = 'Not Available';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   timeZone: 'UTC',

--- a/user-interface/src/lib/utils/datetime.ts
+++ b/user-interface/src/lib/utils/datetime.ts
@@ -1,3 +1,5 @@
+const INVALID_DATE_FALLBACK = 'N/A';
+
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   timeZone: 'UTC',
   day: '2-digit',
@@ -5,12 +7,13 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 });
 
-export function formatDate(dateOrString: Date | string): string {
+export function formatDate(dateOrString: Date | string | undefined | null): string {
+  if (dateOrString == null) return INVALID_DATE_FALLBACK;
   try {
     const date = dateOrString instanceof Date ? dateOrString : new Date(dateOrString);
     return dateFormatter.format(date);
   } catch {
-    return dateOrString.toString();
+    return dateOrString?.toString() ?? INVALID_DATE_FALLBACK;
   }
 }
 
@@ -25,12 +28,13 @@ const dateTimeFormatter = new Intl.DateTimeFormat('en-US', {
   timeZoneName: 'short',
 });
 
-export function formatDateTime(dateOrString: Date | string): string {
+export function formatDateTime(dateOrString: Date | string | undefined | null): string {
+  if (dateOrString == null) return INVALID_DATE_FALLBACK;
   try {
     const date = dateOrString instanceof Date ? dateOrString : new Date(dateOrString);
     return dateTimeFormatter.format(date).replace(',', '');
   } catch {
-    return dateOrString.toString();
+    return dateOrString?.toString() ?? INVALID_DATE_FALLBACK;
   }
 }
 


### PR DESCRIPTION
# Bug

The Data Verification tab threw a client-side error ("Something went wrong") whenever any order or verification record in the list had an undefined `taskDate`. The crash path: `new Date(undefined)` silently produces an `Invalid Date`; `Intl.DateTimeFormat.format(Invalid Date)` throws a `RangeError`; the catch block called `dateOrString.toString()`, but `undefined.toString()` throws a `TypeError` that propagates to React's error boundary. The same bug existed in `formatDateTime`. The entire tab was unusable for all users until the offending record was patched.

# Purpose

Prevent legacy order/verification records with a missing `taskDate` from crashing the Data Verification tab, and make the type system enforce the guard at every call site going forward.

# Major Changes

- `formatDate` and `formatDateTime` in `datetime.ts` now accept `Date | string | undefined | null`; a named `INVALID_DATE_FALLBACK` constant (`'N/A'`) is returned for nullish input
- `taskDate` marked optional (`?`) on `TransferOrder`, `ConsolidationOrder`, and `TrusteeMatchVerification` in the shared common types — the type now reflects reality
- `computeTaskDate` in `data-verification.ts` and the `sortByDate` call in `DataVerificationScreen.tsx` updated to handle the now-visible `undefined` case

# Testing/Validation

Implemented using TDD. Added regression tests:

- `formatDate(undefined)` and `formatDate(null)` → `'N/A'`
- `formatDateTime(undefined)` and `formatDateTime(null)` → `'N/A'`
- `computeTaskDate` returns `''` when `taskDate` is `undefined` on a `TrusteeMatchVerificationListItem`
- `DataVerificationScreen` renders without crashing when a verification record has no `taskDate`

All 229 test files pass (3,284 tests).

# Notes

The root cause was a type lie: `taskDate` was declared `string | Date` (required) but the backfill dataflows intentionally skip records they cannot compute a date for, leaving the field permanently absent in MongoDB. Making the field optional in the shared types caused TypeScript to surface only two downstream errors, both fixable with a `?? ''` fallback — confirming the rest of the codebase was already handling this correctly.

The backend backfill dataflows that skip un-computable records are a separate data-quality concern flagged in the original issue and not addressed here.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Guard against missing task dates in data verification flows to prevent UI crashes and align shared types with real data.

Bug Fixes:
- Prevent DataVerificationScreen from crashing when a verification order has an undefined taskDate by handling nullish dates in formatting and sorting utilities.

Enhancements:
- Allow date/time formatting utilities to accept nullish input and return a consistent fallback value.
- Update computeTaskDate to return an empty string when no applicable date is present on verification items.
- Mark taskDate as optional on transfer, consolidation, and trustee match verification types so the type system reflects possible absence of the field.

Tests:
- Add regression tests for formatDate and formatDateTime handling of undefined and null inputs.
- Add tests ensuring computeTaskDate returns an empty string when taskDate is undefined on TrusteeMatchVerificationListItem.
- Add a UI test verifying DataVerificationScreen renders without crashing when a verification record has no taskDate.