### PR TITLE
Remove redundant tests in function-apps

### DIFF
--- a/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.test.ts
+++ b/backend/function-apps/api/bankruptcy-software/bankruptcy-software.function.test.ts
@@ -127,18 +127,18 @@ describe('Bankruptcy Software Function tests', () => {
       expect(response).toEqual(azureHttpResponse);
     });
 
-    test('should return error response when controller throws', async () => {
+    test('should be wired to SoftwareTrusteesController when the controller throws', async () => {
       const request = createMockAzureFunctionRequest({ method: 'GET' });
       const error = new CamsError('SOFTWARE-TRUSTEES-CONTROLLER', {
         message: 'Something went wrong.',
       });
-      const { azureHttpResponse, loggerCamsErrorSpy } = buildTestResponseError(error);
-      vi.spyOn(SoftwareTrusteesController.prototype, 'handleRequest').mockRejectedValue(error);
+      const handleRequestSpy = vi
+        .spyOn(SoftwareTrusteesController.prototype, 'handleRequest')
+        .mockRejectedValue(error);
 
-      const response = await trusteesHandler(request, context);
+      await trusteesHandler(request, context);
 
-      expect(response).toMatchObject(azureHttpResponse);
-      expect(loggerCamsErrorSpy).toHaveBeenCalledWith(error);
+      expect(handleRequestSpy).toHaveBeenCalled();
     });
   });
 
@@ -155,18 +155,18 @@ describe('Bankruptcy Software Function tests', () => {
       expect(response).toEqual(azureHttpResponse);
     });
 
-    test('should return error response when controller throws', async () => {
+    test('should be wired to SoftwareBankTrusteesController when the controller throws', async () => {
       const request = createMockAzureFunctionRequest({ method: 'GET' });
       const error = new CamsError('SOFTWARE-BANK-TRUSTEES-CONTROLLER', {
         message: 'Something went wrong.',
       });
-      const { azureHttpResponse, loggerCamsErrorSpy } = buildTestResponseError(error);
-      vi.spyOn(SoftwareBankTrusteesController.prototype, 'handleRequest').mockRejectedValue(error);
+      const handleRequestSpy = vi
+        .spyOn(SoftwareBankTrusteesController.prototype, 'handleRequest')
+        .mockRejectedValue(error);
 
-      const response = await bankTrusteesHandler(request, context);
+      await bankTrusteesHandler(request, context);
 
-      expect(response).toMatchObject(azureHttpResponse);
-      expect(loggerCamsErrorSpy).toHaveBeenCalledWith(error);
+      expect(handleRequestSpy).toHaveBeenCalled();
     });
   });
 
@@ -183,20 +183,18 @@ describe('Bankruptcy Software Function tests', () => {
       expect(response).toEqual(azureHttpResponse);
     });
 
-    test('should return error response when controller throws', async () => {
+    test('should be wired to BankruptcySoftwareHistoryController when the controller throws', async () => {
       const request = createMockAzureFunctionRequest({ method: 'GET' });
       const error = new CamsError('BANKRUPTCY-SOFTWARE-HISTORY-CONTROLLER', {
         message: 'Something went wrong.',
       });
-      const { azureHttpResponse, loggerCamsErrorSpy } = buildTestResponseError(error);
-      vi.spyOn(BankruptcySoftwareHistoryController.prototype, 'handleRequest').mockRejectedValue(
-        error,
-      );
+      const handleRequestSpy = vi
+        .spyOn(BankruptcySoftwareHistoryController.prototype, 'handleRequest')
+        .mockRejectedValue(error);
 
-      const response = await historyHandler(request, context);
+      await historyHandler(request, context);
 
-      expect(response).toMatchObject(azureHttpResponse);
-      expect(loggerCamsErrorSpy).toHaveBeenCalledWith(error);
+      expect(handleRequestSpy).toHaveBeenCalled();
     });
   });
 });

--- a/backend/function-apps/api/case-assignments/case.assignment.function.test.ts
+++ b/backend/function-apps/api/case-assignments/case.assignment.function.test.ts
@@ -2,7 +2,6 @@ import { vi } from 'vitest';
 import handler from './case.assignment.function';
 import { CaseAssignmentController } from '../../../lib/controllers/case-assignment/case.assignment.controller';
 import ContextCreator from '../../azure/application-context-creator';
-import { CaseAssignment } from '@common/cams/assignments';
 import MockData from '@common/cams/test-utilities/mock-data';
 import { createMockApplicationContext } from '../../../lib/testing/testing-utilities';
 import { CamsHttpRequest } from '../../../lib/adapters/types/http';
@@ -12,7 +11,6 @@ import {
   buildTestResponseSuccess,
   createMockAzureFunctionRequest,
 } from '../../azure/testing-helpers';
-import { CamsError } from '../../../lib/common-errors/cams-error';
 import { UnknownError } from '../../../lib/common-errors/unknown-error';
 import HttpStatusCodes from '@common/api/http-status-codes';
 
@@ -55,45 +53,6 @@ describe('Case Assignment Function Tests', () => {
     expect(response).toEqual(azureHttpResponse);
   });
 
-  const errorTestCases = [
-    ['caseId not present', '', 'TrialAttorney', 'Required parameter(s) caseId is/are absent.'],
-    ['invalid caseId format', '123', 'TrialAttorney', 'caseId must be formatted like 01-12345.'],
-    [
-      'role not present',
-      '001-90-90123',
-      '',
-      'Invalid role for the attorney. Requires role to be a TrialAttorney for case assignment. Required parameter(s) role is/are absent.',
-    ],
-    [
-      'invalid role',
-      '001-90-90123',
-      'TrialDragon',
-      'Invalid role for the attorney. Requires role to be a TrialAttorney for case assignment.',
-    ],
-  ];
-  test.each(errorTestCases)(
-    'should return proper error response for %s',
-    async (_caseName: string, caseId: string, role: string, message: string) => {
-      const requestOverride = {
-        body: {
-          caseId,
-          attorneyList: ['Bob', 'Denise'],
-          role,
-        },
-      };
-      const error = new CamsError('MOCK_CASE_ASSIGNMENT_MODULE', { message });
-      const request = createMockAzureFunctionRequest({
-        ...defaultRequestProps,
-        ...requestOverride,
-      });
-      const { azureHttpResponse } = buildTestResponseError(error);
-      vi.spyOn(CaseAssignmentController.prototype, 'handleRequest').mockRejectedValue(error);
-
-      const response = await handler(request, context);
-      expect(response).toEqual(azureHttpResponse);
-    },
-  );
-
   test('Should return an HTTP Error if the controller throws an error during assignment creation', async () => {
     const error = new UnknownError('MOCK_CASE_ASSIGNMENT_MODULE');
     const { azureHttpResponse } = buildTestResponseError(error);
@@ -114,33 +73,5 @@ describe('Case Assignment Function Tests', () => {
 
     const response = await handler(request, context);
     expect(response).toEqual(azureHttpResponse);
-  });
-
-  test('Should return a list of assignments when valid caseId is supplied for GET request', async () => {
-    const caseId = '001-67-89012';
-    const requestOverride: Partial<CamsHttpRequest> = {
-      method: 'GET',
-      params: {
-        id: caseId,
-      },
-      body: undefined,
-    };
-
-    const request = createMockAzureFunctionRequest({
-      ...defaultRequestProps,
-      ...requestOverride,
-    });
-
-    const assignments: CaseAssignment[] = MockData.buildArray(MockData.getAttorneyAssignment, 3);
-
-    const appContext = await createMockApplicationContext();
-    const assignmentController: CaseAssignmentController = new CaseAssignmentController(appContext);
-
-    const getAssignmentRequestSpy = vi
-      .spyOn(Object.getPrototypeOf(assignmentController), 'handleRequest')
-      .mockReturnValue(assignments);
-    await handler(request, context);
-
-    expect(getAssignmentRequestSpy).toHaveReturnedWith(assignments);
   });
 });

--- a/backend/function-apps/api/case-notes/case.notes.function.test.ts
+++ b/backend/function-apps/api/case-notes/case.notes.function.test.ts
@@ -3,23 +3,12 @@ import handler from './case.notes.function';
 import { CaseNotesController } from '../../../lib/controllers/case-notes/case.notes.controller';
 import ContextCreator from '../../azure/application-context-creator';
 import MockData from '@common/cams/test-utilities/mock-data';
-import { CamsHttpRequest } from '../../../lib/adapters/types/http';
 import { InvocationContext } from '@azure/functions';
 import {
   buildTestResponseError,
   buildTestResponseSuccess,
   createMockAzureFunctionRequest,
 } from '../../azure/testing-helpers';
-import { UnknownError } from '../../../lib/common-errors/unknown-error';
-import { CaseNote } from '@common/cams/cases';
-
-const defaultRequestProps: Partial<CamsHttpRequest> = {
-  method: 'POST',
-  body: {
-    caseId: '081-67-89123',
-    note: 'Sample note text',
-  },
-};
 
 describe('Case Notes Function Tests', () => {
   let context;
@@ -58,54 +47,6 @@ describe('Case Notes Function Tests', () => {
     const { azureHttpResponse } = buildTestResponseError(error);
     vi.spyOn(CaseNotesController.prototype, 'handleRequest').mockRejectedValue(error);
     const response = await handler(req, context);
-    expect(response).toEqual(azureHttpResponse);
-  });
-
-  test('Should return an HTTP Error if the controller throws an error during note creation', async () => {
-    const error = new UnknownError('MOCK_CASE_NOTE_MODULE');
-    const { azureHttpResponse } = buildTestResponseError(error);
-    vi.spyOn(CaseNotesController.prototype, 'handleRequest').mockRejectedValue(error);
-
-    const requestOverride = {
-      body: {
-        caseId: '001-67-89123',
-      },
-    };
-
-    const request = createMockAzureFunctionRequest({
-      ...defaultRequestProps,
-      ...requestOverride,
-    });
-
-    const response = await handler(request, context);
-    expect(response).toEqual(azureHttpResponse);
-  });
-
-  test('Should return a list of notes when valid caseId is supplied for GET request', async () => {
-    const caseId = '001-67-89012';
-    const requestOverride: Partial<CamsHttpRequest> = {
-      method: 'GET',
-      params: {
-        id: caseId,
-      },
-      body: undefined,
-    };
-
-    const request = createMockAzureFunctionRequest({
-      ...defaultRequestProps,
-      ...requestOverride,
-    });
-
-    const expectedNoteList = MockData.buildArray(MockData.getCaseNote, 3);
-    const { azureHttpResponse, camsHttpResponse } = buildTestResponseSuccess<CaseNote[]>({
-      meta: {
-        self: request.url,
-      },
-      data: expectedNoteList,
-    });
-    vi.spyOn(CaseNotesController.prototype, 'handleRequest').mockResolvedValue(camsHttpResponse);
-
-    const response = await handler(request, context);
     expect(response).toEqual(azureHttpResponse);
   });
 });

--- a/backend/function-apps/api/case-summary/case-summary.function.test.ts
+++ b/backend/function-apps/api/case-summary/case-summary.function.test.ts
@@ -62,7 +62,6 @@ describe('Case summary function', () => {
     };
     const request = createMockAzureFunctionRequest(requestObject);
     const response = await handler(request, context);
-    expect(response.status).toEqual(404);
     expect(response).toEqual(azureHttpResponse);
   });
 });

--- a/backend/function-apps/api/healthcheck/healthcheck.test.ts
+++ b/backend/function-apps/api/healthcheck/healthcheck.test.ts
@@ -88,6 +88,12 @@ describe('healthcheck tests', () => {
     const response = await handler(request, context);
 
     expect(response.status).toEqual(200);
+    expect(response.jsonBody.data.info).toEqual({
+      version: '',
+      branch: '',
+      sha: '',
+      releasedTimestamp: '',
+    });
   }, 10000);
 
   test('Healthcheck endpoint should return an error response', async () => {

--- a/backend/function-apps/api/lists/lists.function.test.ts
+++ b/backend/function-apps/api/lists/lists.function.test.ts
@@ -8,7 +8,7 @@ import {
   createMockAzureFunctionRequest,
 } from '../../azure/testing-helpers';
 import { ListsController } from '../../../lib/controllers/lists/lists.controller';
-import { BankList, BankruptcySoftwareList } from '@common/cams/lists';
+import { BankList } from '@common/cams/lists';
 
 describe('Lists Function tests', () => {
   let request;
@@ -37,27 +37,6 @@ describe('Lists Function tests', () => {
 
     // Set up the request with listName parameter
     request.params = { listName: 'banks' };
-
-    const response = await handler(request, context);
-
-    expect(response).toEqual(azureHttpResponse);
-  });
-
-  test('should set successful response for bankruptcy software list', async () => {
-    const mockSoftwareList: BankruptcySoftwareList = [
-      { _id: '1', list: 'bankruptcy-software', key: 'software1', value: 'Software One' },
-      { _id: '2', list: 'bankruptcy-software', key: 'software2', value: 'Software Two' },
-    ];
-
-    const { camsHttpResponse, azureHttpResponse } =
-      buildTestResponseSuccess<BankruptcySoftwareList>({
-        data: mockSoftwareList,
-      });
-
-    vi.spyOn(ListsController.prototype, 'handleRequest').mockResolvedValue(camsHttpResponse);
-
-    // Set up the request with listName parameter
-    request.params = { listName: 'bankruptcy-software' };
 
     const response = await handler(request, context);
 

--- a/backend/function-apps/api/staff/staff.function.test.ts
+++ b/backend/function-apps/api/staff/staff.function.test.ts
@@ -1,6 +1,5 @@
 import { vi } from 'vitest';
 import { StaffController } from '../../../lib/controllers/staff/staff.controller';
-import { CamsError } from '../../../lib/common-errors/cams-error';
 import MockData from '@common/cams/test-utilities/mock-data';
 import {
   buildTestResponseError,
@@ -27,23 +26,15 @@ describe('Staff Azure Function tests', () => {
     vi.spyOn(StaffUseCase.prototype, 'getOversightStaff').mockResolvedValue({} as any);
   });
 
-  const errorTestCases = [
-    ['unexpected error', () => new Error()],
-    ['CamsError error', () => new CamsError('fake-module')],
-  ] as const;
+  test('Should return an HTTP Error if getOversightStaff() throws', async () => {
+    const error = new Error();
+    const { azureHttpResponse } = buildTestResponseError(error);
+    vi.spyOn(StaffController.prototype, 'handleRequest').mockRejectedValue(error);
 
-  test.each(errorTestCases)(
-    'Should return an HTTP Error if getOversightStaff() throws %s',
-    async (_errorType, errorFactory) => {
-      const error = errorFactory();
-      const { azureHttpResponse } = buildTestResponseError(error);
-      vi.spyOn(StaffController.prototype, 'handleRequest').mockRejectedValue(error);
+    const response = await handler(request, context);
 
-      const response = await handler(request, context);
-
-      expect(response).toEqual(azureHttpResponse);
-    },
-  );
+    expect(response).toEqual(azureHttpResponse);
+  });
 
   test('should return success with a Record of oversight staff grouped by role', async () => {
     const oversightStaff: Record<OversightRoleType, Staff[]> = {
@@ -64,11 +55,5 @@ describe('Staff Azure Function tests', () => {
     const response = await handler(request, context);
 
     expect(response).toEqual(azureHttpResponse);
-    expect(response.status).toBe(200);
-
-    // Verify Record structure
-    expect(oversightStaff.TrialAttorney).toHaveLength(3);
-    expect(oversightStaff.Auditor).toHaveLength(2);
-    expect(oversightStaff.Paralegal).toHaveLength(1);
   });
 });

--- a/backend/function-apps/api/trustee-search/trustee-search.function.test.ts
+++ b/backend/function-apps/api/trustee-search/trustee-search.function.test.ts
@@ -67,47 +67,12 @@ describe('Trustee Search Function', () => {
     expect(TrusteeSearchController.prototype.handleRequest).toHaveBeenCalled();
   });
 
-  test('should handle search with courtId parameter', async () => {
-    const req = createMockAzureFunctionRequest({
-      method: 'GET',
-      query: { name: 'smith', courtId: '081' },
-    });
-    const { azureHttpResponse, camsHttpResponse } = buildTestResponseSuccess({
-      meta: {
-        self: req.url,
-      },
-      data: mockSearchResults,
-    });
-
-    vi.spyOn(TrusteeSearchController.prototype, 'handleRequest').mockResolvedValue(
-      camsHttpResponse,
-    );
-
-    const result = await handler(req, context);
-    expect(result).toEqual(azureHttpResponse);
-  });
-
   test('should handle errors and return azure error response', async () => {
     const req = createMockAzureFunctionRequest({
       method: 'GET',
       query: { name: 'smith' },
     });
     const error = new Error('Search failed');
-    const { azureHttpResponse } = buildTestResponseError(error);
-
-    vi.spyOn(TrusteeSearchController.prototype, 'handleRequest').mockRejectedValue(error);
-
-    const result = await handler(req, context);
-
-    expect(result).toEqual(azureHttpResponse);
-  });
-
-  test('should handle validation errors for missing name parameter', async () => {
-    const req = createMockAzureFunctionRequest({
-      method: 'GET',
-      query: {},
-    });
-    const error = new Error('Missing name parameter');
     const { azureHttpResponse } = buildTestResponseError(error);
 
     vi.spyOn(TrusteeSearchController.prototype, 'handleRequest').mockRejectedValue(error);

--- a/backend/function-apps/api/trustee-upcoming-key-dates/trustee-upcoming-key-dates.function.test.ts
+++ b/backend/function-apps/api/trustee-upcoming-key-dates/trustee-upcoming-key-dates.function.test.ts
@@ -8,7 +8,6 @@ import {
   buildTestResponseSuccess,
   createMockAzureFunctionRequest,
 } from '../../azure/testing-helpers';
-import { UnknownError } from '../../../lib/common-errors/unknown-error';
 import { createMockApplicationContext } from '../../../lib/testing/testing-utilities';
 
 describe('TrusteeUpcomingKeyDates Function Tests', () => {
@@ -37,17 +36,6 @@ describe('TrusteeUpcomingKeyDates Function Tests', () => {
     const camsContext = await createMockApplicationContext();
     vi.spyOn(ContextCreator, 'applicationContextCreator').mockResolvedValue(camsContext);
     const error = new Error('Some unknown error');
-    const { azureHttpResponse } = buildTestResponseError(error);
-    vi.spyOn(TrusteeUpcomingKeyDatesController.prototype, 'handleRequest').mockRejectedValue(error);
-
-    const response = await handler(request, context);
-    expect(response).toEqual(azureHttpResponse);
-  });
-
-  test('should handle UnknownError from controller', async () => {
-    const camsContext = await createMockApplicationContext();
-    vi.spyOn(ContextCreator, 'applicationContextCreator').mockResolvedValue(camsContext);
-    const error = new UnknownError('MOCK_MODULE');
     const { azureHttpResponse } = buildTestResponseError(error);
     vi.spyOn(TrusteeUpcomingKeyDatesController.prototype, 'handleRequest').mockRejectedValue(error);
 

--- a/backend/function-apps/azure/application-context-creator.test.ts
+++ b/backend/function-apps/azure/application-context-creator.test.ts
@@ -38,7 +38,7 @@ describe('Application Context Creator', () => {
           invocationContext,
           observability: mockObservability,
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow('Authorization header missing.');
     });
 
     test('should throw when malicious input is included in request', async () => {
@@ -110,13 +110,6 @@ describe('Application Context Creator', () => {
     let context: ApplicationContext;
     beforeEach(async () => {
       context = await createMockApplicationContext();
-    });
-
-    test('should throw an UnauthorizedError if there is no request', async () => {
-      delete context.request;
-      await expect(ContextCreator.getApplicationContextSession(context)).rejects.toThrow(
-        'Authorization header missing.',
-      );
     });
 
     test('should throw an UnauthorizedError if authorization header is missing', async () => {

--- a/backend/function-apps/dataflows/dataflows-common.test.ts
+++ b/backend/function-apps/dataflows/dataflows-common.test.ts
@@ -35,10 +35,6 @@ describe('Dataflows Common', () => {
       expect(buildContainerName('MIGRATE_CASE_HISTORY', 'out')).toEqual('migrate-case-history-out');
     });
 
-    test('should handle mixed case with underscores and hyphens', () => {
-      expect(buildContainerName('PROCESS_LARGE-FILE', 'in')).toEqual('process-large-file-in');
-    });
-
     test('should normalize spaces to hyphens', () => {
       expect(buildContainerName('SYNC OFFICE STAFF', 'in')).toEqual('sync-office-staff-in');
     });
@@ -65,14 +61,12 @@ describe('Dataflows Common', () => {
       expect(buildContainerName('AB', 'in')).toEqual('ab-in'); // 5 chars, valid
     });
 
-    test('should throw error for invalid container names that are too short', () => {
-      // Empty module name would create container name that's too short after normalization
+    test('should throw error when normalization yields an empty base name', () => {
+      // Empty, or all-invalid-character, module names normalize to '', producing
+      // a container name that fails the leading-alphanumeric-character check.
       expect(() => buildContainerName('', 'in')).toThrow(
         /Invalid Azure container name.*Container names must be 3–63 characters/,
       );
-    });
-
-    test('should throw error for module names with only invalid characters', () => {
       expect(() => buildContainerName('___', 'in')).toThrow(
         /Invalid Azure container name.*Container names must be 3–63 characters/,
       );
@@ -206,15 +200,11 @@ describe('Dataflows Common', () => {
 
   describe('ensureContainersExist', () => {
     test('should return immediately for empty container list', () => {
-      // Should not throw
-      ensureContainersExist([], 'TEST');
-      expect(true).toBeTruthy();
+      expect(() => ensureContainersExist([], 'TEST')).not.toThrow();
     });
 
     test('should return immediately for undefined container list', () => {
-      // Should not throw
-      ensureContainersExist(undefined as unknown as string[], 'TEST');
-      expect(true).toBeTruthy();
+      expect(() => ensureContainersExist(undefined as unknown as string[], 'TEST')).not.toThrow();
     });
 
     test('should schedule async container creation for valid container names', () => {
@@ -222,13 +212,6 @@ describe('Dataflows Common', () => {
       // The async work happens in background via fire-and-forget IIFE
       expect(() => {
         ensureContainersExist(['test-container-in', 'test-container-out'], 'TEST');
-      }).not.toThrow();
-    });
-
-    test('should handle single container name', () => {
-      // Function should return immediately without throwing
-      expect(() => {
-        ensureContainersExist(['single-container'], 'TEST');
       }).not.toThrow();
     });
   });

--- a/backend/function-apps/dataflows/dataflows-rate-limit.test.ts
+++ b/backend/function-apps/dataflows/dataflows-rate-limit.test.ts
@@ -156,24 +156,6 @@ describe('handleRateLimitRetry', () => {
     }
   });
 
-  test('returns "exhausted" when retryCount is exactly at RATE_LIMIT_RETRY_LIMIT (boundary)', async () => {
-    const error = new TooManyRequestsError('TEST', { message: 'Rate limited' });
-    const message = { retryCount: RATE_LIMIT_RETRY_LIMIT };
-
-    const result = await handleRateLimitRetry({
-      error,
-      message,
-      checkQueueName: 'test-check',
-      dlqOutput: mockDlqOutput,
-      context: mockApplicationContext,
-      moduleName: 'TEST_MODULE',
-      activityName: 'testActivity',
-      connectionString: TEST_CONNECTION_STRING,
-    });
-
-    expect(result).toBe('exhausted');
-  });
-
   test('returns "retried" when retryCount is one below RATE_LIMIT_RETRY_LIMIT (boundary)', async () => {
     const error = new TooManyRequestsError('TEST', { message: 'Rate limited' });
     const message = { retryCount: RATE_LIMIT_RETRY_LIMIT - 1 };
@@ -246,29 +228,6 @@ describe('handleRateLimitRetry', () => {
     });
   });
 
-  test('info log includes correlationId, moduleName, and visibility timeout on first retry', async () => {
-    const error = new TooManyRequestsError('TEST', { message: 'Rate limited' });
-    const message = { retryCount: 0 };
-
-    await handleRateLimitRetry({
-      error,
-      message,
-      checkQueueName: 'test-check',
-      dlqOutput: mockDlqOutput,
-      context: mockApplicationContext,
-      moduleName: 'TEST_MODULE',
-      activityName: 'testActivity',
-      correlationId: 'CASE-999',
-      connectionString: TEST_CONNECTION_STRING,
-    });
-
-    const [loggedModule, loggedMessage] = vi.mocked(mockApplicationContext.logger.info).mock
-      .calls[0];
-    expect(loggedModule).toBe('TEST_MODULE');
-    expect(loggedMessage).toContain('CASE-999');
-    expect(loggedMessage).toContain('60');
-  });
-
   test('DLQ exhaustion entry does not include originalMessage', async () => {
     const error = new TooManyRequestsError('TEST', { message: 'Rate limited' });
     const message = { caseId: 'CASE-123', cursor: 'some-cursor', retryCount: 10 };
@@ -334,6 +293,7 @@ describe('handleRateLimitRetry', () => {
     expect(infoCall[1]).toContain('attempt 1/');
     expect(infoCall[1]).toContain('CORR-123');
     expect(infoCall[1]).toContain('TEST_MODULE');
+    expect(infoCall[1]).toContain('60');
   });
 
   test('second retry (nextRetryCount > 1) produces no log', async () => {

--- a/backend/function-apps/dataflows/downstream/acms-cams-transition.test.ts
+++ b/backend/function-apps/dataflows/downstream/acms-cams-transition.test.ts
@@ -153,17 +153,6 @@ describe('staffAssignmentHandler', () => {
     expect(mockRequest.query).toHaveBeenCalledTimes(2);
   });
 
-  test('routes to DLQ when required fields are missing', async () => {
-    const ctx = makeContext();
-
-    await staffAssignmentHandler({ caseId: '081-24-12345' }, ctx, mockDlq);
-
-    expect(mockExtraOutputs.set).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ type: 'QUEUE_ERROR' }),
-    );
-  });
-
   test('routes to DLQ when assignedOn is missing', async () => {
     const ctx = makeContext();
     const { assignedOn: _, ...eventWithoutAssignedOn } = validEvent;
@@ -245,17 +234,6 @@ describe('trusteeAppointmentHandler', () => {
     await trusteeAppointmentHandler(JSON.stringify(validEvent), ctx, mockDlq);
 
     expect(mockRequest.query).toHaveBeenCalledTimes(2);
-  });
-
-  test('routes to DLQ when required fields are missing', async () => {
-    const ctx = makeContext();
-
-    await trusteeAppointmentHandler({ caseId: '081-24-12345' }, ctx, mockDlq);
-
-    expect(mockExtraOutputs.set).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ type: 'QUEUE_ERROR' }),
-    );
   });
 
   test('routes to DLQ when assignedOn is missing', async () => {
@@ -666,9 +644,12 @@ describe('transformStaffAssignmentToRow', () => {
     expect(result.PROF_CODE).toBe(63);
   });
 
-  test('handles multi-character group designators', () => {
-    const result = transformStaffAssignmentToRow({ ...baseEvent, acmsProfessionalId: 'UT-05321' });
-    expect(result.GROUP_DESIGNATOR).toBe('UT');
+  test('handles a group designator longer than two characters', () => {
+    const result = transformStaffAssignmentToRow({
+      ...baseEvent,
+      acmsProfessionalId: 'CTR-05321',
+    });
+    expect(result.GROUP_DESIGNATOR).toBe('CTR');
     expect(result.PROF_CODE).toBe(5321);
   });
 
@@ -782,12 +763,12 @@ describe('transformTrusteeAppointmentToRow', () => {
     expect(result.PROF_CODE).toBe(63);
   });
 
-  test('handles multi-character group designators', () => {
+  test('handles a group designator longer than two characters', () => {
     const result = transformTrusteeAppointmentToRow({
       ...baseEvent,
-      acmsProfessionalId: 'UT-05321',
+      acmsProfessionalId: 'CTR-05321',
     });
-    expect(result.GROUP_DESIGNATOR).toBe('UT');
+    expect(result.GROUP_DESIGNATOR).toBe('CTR');
     expect(result.PROF_CODE).toBe(5321);
   });
 
@@ -1070,19 +1051,6 @@ describe('AcmsDailySync', () => {
       );
       const runAt: Date = lastSyncDateCall[2];
       expect(runAt.getTime()).toBeLessThanOrEqual(mergeStartedAt);
-    });
-
-    test('upserts CMMAP_SYNC_CONTROL row when missing after full load', async () => {
-      mockRequest.query
-        .mockResolvedValueOnce({ recordset: [] })
-        .mockResolvedValueOnce({ recordset: [] })
-        .mockResolvedValueOnce({ rowsAffected: [1] });
-
-      const ctx = makeContext();
-      await AcmsDailySync.syncAcmsToAll(ctx);
-
-      const watermarkQuery: string = mockRequest.query.mock.calls[2][0];
-      expect(watermarkQuery).toContain('MERGE INTO CMMAP_SYNC_CONTROL');
     });
   });
 });

--- a/backend/function-apps/dataflows/import/sync-cases.test.ts
+++ b/backend/function-apps/dataflows/import/sync-cases.test.ts
@@ -64,7 +64,7 @@ describe('sync-cases handlePage', () => {
     );
   });
 
-  test('should re-enqueue with backoff on 429 error', async () => {
+  test('should re-enqueue with backoff and emit rate-limited-requeued telemetry on 429', async () => {
     const { handlePage } = await import('./sync-cases');
     const events = [makeCaseSyncEvent('001-25-00001')];
     const message = { events, retryCount: 0 };
@@ -81,30 +81,11 @@ describe('sync-cases handlePage', () => {
       sendMessage: mockSendMessage,
     } as unknown as StorageQueueHumbleObject);
 
-    await handlePage(message, invocationContext);
-
-    expect(mockSendMessage).toHaveBeenCalled();
-  });
-
-  test('should emit rate-limited-requeued telemetry on 429 retry', async () => {
-    const { handlePage } = await import('./sync-cases');
-    const events = [makeCaseSyncEvent('001-25-00001')];
-    const message = { events, retryCount: 0 };
-    const invocationContext = makeInvocationContext();
-
-    const tooManyError = new TooManyRequestsError('SYNC-CASES');
-    vi.spyOn(ExportAndLoadCaseModule.default, 'exportAndLoad').mockRejectedValue(tooManyError);
-    vi.spyOn(ApplicationContextCreator, 'getApplicationContext').mockResolvedValue(
-      await createMockApplicationContext(),
-    );
-    vi.spyOn(StorageQueueHumbleObject, 'fromConnectionString').mockReturnValue({
-      sendMessage: vi.fn().mockResolvedValue(undefined),
-    } as unknown as StorageQueueHumbleObject);
-
     const telemetrySpy = vi.spyOn(DataflowTelemetry, 'completeDataflowTrace');
 
     await handlePage(message, invocationContext);
 
+    expect(mockSendMessage).toHaveBeenCalled();
     expect(telemetrySpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),


### PR DESCRIPTION
# Purpose

Backend function-apps unit tests had accumulated duplicate, subset, and tautological assertions over time. This PR removes confirmed redundancy so the suite stays fast and every remaining assertion actually gates behavior.

# Major Changes

* Removed duplicate/subset test cases across 14 test files under `backend/function-apps` (api, azure, dataflows)
* Fixed a few vacuous assertions that could never fail (e.g. `expect(true).toBeTruthy()` in `dataflows-common.test.ts`, an unasserted "uses defaults" test in `healthcheck.test.ts`) so they actually verify behavior
* Converted 3 duplicate full-response error tests in `bankruptcy-software.function.test.ts` (trusteesHandler, bankTrusteesHandler, historyHandler) into lighter wiring-only checks, since the shared error-mapping logic is already covered once by the default handler's test
* Merged near-identical setup/assertion pairs in `dataflows-rate-limit.test.ts` and `sync-cases.test.ts`
* Collapsed redundant `test.each` rows in `staff.function.test.ts` and `case.assignment.function.test.ts` where every row exercised the same line of code

# Testing/Validation

* Ran a redundant-tests-focused spec review (`/cams-spec-review --focus=redundant`) across all 44 `backend/function-apps` test files to identify candidates; 14 files had genuine findings
* Verified backend statement/branch/function/line coverage is unchanged before and after (re-ran the full backend coverage suite twice to rule out flakiness): Statements 95.72%, Branches 90.66%, Functions 96.65%, Lines 95.84% — identical in both runs
* `npm run typecheck` and `eslint` on all touched files pass clean
* All 227 backend test files still pass (3277 tests, down from 3299 — exactly the confirmed-redundant tests removed)

# Notes

* `backend/vitest.config.ts` excludes `function-apps/dataflows/**` from coverage instrumentation, so changes to `dataflows-common`, `dataflows-rate-limit`, `acms-cams-transition`, and `sync-cases` carried no coverage risk by construction
* Before removing a duplicate "no request" test in `application-context-creator.test.ts`, verified via the v8 coverage branch map that optional chaining (`?.`) isn't tracked as a separate branch there — confirming it was safe to dedupe
* One coverage re-run showed a transient dip in an unrelated file (`lib/use-cases/orders/orders.ts`, untouched by this PR) that resolved on a second run — confirmed as pre-existing test-order flakiness, not a regression from this change

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Streamline backend function-apps tests by removing redundant coverage while preserving behavior verification and wiring checks.

Tests:
- Remove duplicate, subset, and tautological test cases across multiple backend function-apps suites to reduce noise without impacting coverage.
- Tighten existing tests to focus on meaningful assertions, including more precise container name validation and healthcheck default-info verification.
- Simplify several error-handling tests to confirm controller wiring rather than revalidating already-covered response semantics.