### PR TITLE
Add nightly branch deployment cleanup

### DIFF
--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -2,6 +2,10 @@ name: Clean up Flexion Azure Resources
 
 on:
   delete:
+  schedule:
+    # Run at 9 PM Pacific. GitHub schedules use UTC, so run both possible
+    # UTC hours and gate on America/Los_Angeles local time in the check job.
+    - cron: '0 4,5 * * *'
   workflow_dispatch:
     inputs:
       hashId:
@@ -32,14 +36,14 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
-    if: ${{ inputs.hashId != ''  || github.event.ref_type == 'branch' }}
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.hashId != '') || github.event.ref_type == 'branch' }}
     environment: 'remove-branch'
     permissions:
       contents: read
       id-token: write
     outputs:
       executeCleanup: ${{ steps.check.outputs.executeCleanup }}
-      targetBranchHashId: ${{ steps.check.outputs.targetBranchHashId }}
+      targetBranchHashIds: ${{ steps.check.outputs.targetBranchHashIds }}
       stackName: ${{ steps.check.outputs.stackName }}
     steps:
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -51,7 +55,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Generate Target Branch Hash
         id: hash
-        if: ${{ github.event.ref_type == 'branch' }}
+        if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
         env:
           GITHUB_EVENT_REF: ${{ github.event.ref }}
         run: |
@@ -64,22 +68,45 @@ jobs:
       - name: Validate resources
         id: check
         env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
           HASH_ID_OVERRIDE: ${{ inputs.hashId }}
           STEP_HASH_ID: ${{ steps.hash.outputs.hashId }}
           APP_NAME: ${{ vars.APP_NAME }}
           DEV_SUFFIX: ${{ vars.DEV_SUFFIX }}
         run: |
-          target="${HASH_ID_OVERRIDE:-${STEP_HASH_ID}}"
-          echo "targetBranchHashId=$target" >> $GITHUB_OUTPUT
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            localHour=$(TZ=America/Los_Angeles date +%H)
+            if [[ "${localHour}" != "21" ]]; then
+              echo "Skipping scheduled cleanup because Pacific local hour is ${localHour}, not 21."
+              echo "executeCleanup=false" >> "$GITHUB_OUTPUT"
+              echo 'targetBranchHashIds=[]' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
 
-          echo "Do resources with $target exist?"
-          count=$(az group list --query "length([?id.contains(@,'$target')])")
-          if [[ $count -eq 2 ]]; then
-            echo 'Expected resources found.'
-            echo "executeCleanup=true" >> $GITHUB_OUTPUT
+            targets=$(az group list --query "[?tags.isBranchDeployment == 'true' && tags.branchHashId != null].tags.branchHashId" -o tsv | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "targetBranchHashIds=${targets}" >> "$GITHUB_OUTPUT"
+
+            targetCount=$(echo "${targets}" | jq length)
+            if [[ "${targetCount}" -gt 0 ]]; then
+              echo "Found ${targetCount} branch deployment(s) to clean up."
+              echo "executeCleanup=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "No branch deployments found to clean up."
+              echo "executeCleanup=false" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo 'Did not find existing Azure resources with matching hash id.'
-            echo "executeCleanup=false" >> $GITHUB_OUTPUT
+            target="${HASH_ID_OVERRIDE:-${STEP_HASH_ID}}"
+            echo "targetBranchHashIds=[\"${target}\"]" >> "$GITHUB_OUTPUT"
+
+            echo "Do branch resources with $target exist?"
+            count=$(az group list --query "length([?tags.isBranchDeployment == 'true' && tags.branchHashId == '$target'])")
+            if [[ $count -gt 0 ]]; then
+              echo 'Expected resources found.'
+              echo "executeCleanup=true" >> $GITHUB_OUTPUT
+            else
+              echo 'Did not find existing Azure resources with matching hash id.'
+              echo "executeCleanup=false" >> $GITHUB_OUTPUT
+            fi
           fi
 
           # Generate base stack name (without hash) for resource naming
@@ -91,6 +118,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check]
     if: needs.check.outputs.executeCleanup == 'true'
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        hashId: ${{ fromJSON(needs.check.outputs.targetBranchHashIds) }}
     environment: 'remove-branch'
     permissions:
       contents: read
@@ -141,7 +173,7 @@ jobs:
         env:
           AZ_SQL_SERVER_NAME: ${{ secrets.AZ_SQL_SERVER_NAME }}
           STACK_NAME: ${{ needs.check.outputs.stackName }}
-          SHORT_HASH: ${{ needs.check.outputs.targetBranchHashId }}
+          SHORT_HASH: ${{ matrix.hashId }}
         with:
           azcliversion: 2.62.0
           inlineScript: |

--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -29,10 +29,10 @@ jobs:
           tenant-id: ${{ secrets.AZ_TENANT_ID }}
           subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
           environment: ${{ vars.AZURE_ENVIRONMENT }}
-      - name: List existing branch deployments
+      - name: List existing tagged Azure branch resources
         run: |
-          echo "List Azure resource groups of current branch deployment"
-          az group list --query "[?tags.branchName].{ Name:name Branch:tags.branchName HashId:tags.branchHashId }" -o table
+          echo "List Azure resource groups tagged as branch deployment resources"
+          az group list --query "[?tags.isBranchDeployment == 'true'].{ Name:name Branch:tags.branchName HashId:tags.branchHashId }" -o table
 
   check:
     runs-on: ubuntu-latest
@@ -74,6 +74,8 @@ jobs:
           APP_NAME: ${{ vars.APP_NAME }}
           DEV_SUFFIX: ${{ vars.DEV_SUFFIX }}
         run: |
+          set -euo pipefail
+
           if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
             localHour=$(TZ=America/Los_Angeles date +%H)
             if [[ "${localHour}" != "21" ]]; then
@@ -83,29 +85,57 @@ jobs:
               exit 0
             fi
 
-            targets=$(az group list --query "[?tags.isBranchDeployment == 'true' && tags.branchHashId != null].tags.branchHashId" -o tsv | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            branchResources=$(az group list --query "[?tags.isBranchDeployment == 'true' && tags.branchHashId != null].{name:name, branchName:tags.branchName, branchHashId:tags.branchHashId}" -o json)
+            targets=$(echo "${branchResources}" | jq -c '
+              [
+                .[]
+                | select(.branchHashId | test("^[0-9a-f]{6}$"))
+                | select((.branchName // "") as $branch | $branch != "main" and $branch != "refs/heads/main")
+                | .branchHashId as $branchHashId
+                | select(.name | endswith("-" + $branchHashId))
+                | .branchHashId
+              ]
+              | unique
+            ')
             echo "targetBranchHashIds=${targets}" >> "$GITHUB_OUTPUT"
 
             targetCount=$(echo "${targets}" | jq length)
             if [[ "${targetCount}" -gt 0 ]]; then
-              echo "Found ${targetCount} branch deployment(s) to clean up."
+              echo "Found ${targetCount} existing Azure branch resource set(s) to clean up."
               echo "executeCleanup=true" >> "$GITHUB_OUTPUT"
             else
-              echo "No branch deployments found to clean up."
+              echo "No existing Azure branch resources found to clean up."
               echo "executeCleanup=false" >> "$GITHUB_OUTPUT"
             fi
           else
             target="${HASH_ID_OVERRIDE:-${STEP_HASH_ID}}"
-            echo "targetBranchHashIds=[\"${target}\"]" >> "$GITHUB_OUTPUT"
+            if [[ ! "${target}" =~ ^[0-9a-f]{6}$ ]]; then
+              echo "Target branch hash '${target}' is not a valid six-character hex hash."
+              echo "executeCleanup=false" >> "$GITHUB_OUTPUT"
+              echo 'targetBranchHashIds=[]' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
 
-            echo "Do branch resources with $target exist?"
-            count=$(az group list --query "length([?tags.isBranchDeployment == 'true' && tags.branchHashId == '$target'])")
+            echo "Do existing Azure branch resources with hash $target exist?"
+            branchResources=$(az group list --query "[?tags.isBranchDeployment == 'true' && tags.branchHashId == '$target'].{name:name, branchName:tags.branchName, branchHashId:tags.branchHashId}" -o json)
+            count=$(echo "${branchResources}" | jq '
+              [
+                .[]
+                | select(.branchHashId | test("^[0-9a-f]{6}$"))
+                | select((.branchName // "") as $branch | $branch != "main" and $branch != "refs/heads/main")
+                | .branchHashId as $branchHashId
+                | select(.name | endswith("-" + $branchHashId))
+              ]
+              | length
+            ')
             if [[ $count -gt 0 ]]; then
-              echo 'Expected resources found.'
-              echo "executeCleanup=true" >> $GITHUB_OUTPUT
+              echo 'Expected Azure branch resources found.'
+              echo "targetBranchHashIds=[\"${target}\"]" >> "$GITHUB_OUTPUT"
+              echo "executeCleanup=true" >> "$GITHUB_OUTPUT"
             else
-              echo 'Did not find existing Azure resources with matching hash id.'
-              echo "executeCleanup=false" >> $GITHUB_OUTPUT
+              echo 'Did not find existing Azure branch resources with matching hash id.'
+              echo "targetBranchHashIds=[]" >> "$GITHUB_OUTPUT"
+              echo "executeCleanup=false" >> "$GITHUB_OUTPUT"
             fi
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ backend/dev-users.json
 .github/instructions/*
 **/CLAUDE.md
 .claude/*
+.codex/
 
 # Flexion AI
 .gitmodules

--- a/docs/operations/workflow-diagram.md
+++ b/docs/operations/workflow-diagram.md
@@ -609,6 +609,7 @@ flowchart LR
 ### Schedule Triggered Workflows
 
 Workflows triggered by `schedule`:
+- **Clean up Flexion Azure Resources** (`azure-remove-branch.yml`)
 - **Prune E2E Image Cache** (`prune-e2e-image-cache.yml`)
 - **Refresh E2E Base Image Cache** (`refresh-e2e-base-images.yml`)
 - **Constrained Test Report** (`constrained-test-report.yml`)
@@ -618,6 +619,10 @@ Workflows triggered by `schedule`:
 ```mermaid
 flowchart LR
     trigger_schedule(["schedule"])
+    azure_remove_branch_yml["Clean up Flexion Azure Resources"]
+    azure_remove_branch_yml_list["list"]
+    azure_remove_branch_yml_check["check"]
+    azure_remove_branch_yml_clean_up["clean-up"]
     prune_e2e_image_cache_yml["Prune E2E Image Cache"]
     prune_e2e_image_cache_yml_prune["Delete e2e-deps images older than 30 days"]
     refresh_e2e_base_images_yml["Refresh E2E Base Image Cache"]
@@ -634,6 +639,10 @@ flowchart LR
     reusable_dast_yml["reusable-dast.yml"]
     reusable_dast_yml_zap_dast_scan["zap-dast-scan"]
 
+    trigger_schedule --> azure_remove_branch_yml
+    azure_remove_branch_yml --> azure_remove_branch_yml_list
+    azure_remove_branch_yml --> azure_remove_branch_yml_check
+    azure_remove_branch_yml --> azure_remove_branch_yml_clean_up
     trigger_schedule --> prune_e2e_image_cache_yml
     prune_e2e_image_cache_yml --> prune_e2e_image_cache_yml_prune
     trigger_schedule --> refresh_e2e_base_images_yml
@@ -656,6 +665,10 @@ flowchart LR
     classDef job fill:#f1f8e9,stroke:#33691e,stroke-width:1px,color:#000000
 
     class trigger_schedule trigger
+    class azure_remove_branch_yml mainWorkflow
+    class azure_remove_branch_yml_list job
+    class azure_remove_branch_yml_check job
+    class azure_remove_branch_yml_clean_up job
     class prune_e2e_image_cache_yml mainWorkflow
     class prune_e2e_image_cache_yml_prune job
     class refresh_e2e_base_images_yml mainWorkflow
@@ -1555,6 +1568,7 @@ flowchart LR
     trigger_delete(["delete"])
     azure_remove_branch_yml["Clean up Flexion Azure Resources"]
     trigger_schedule(["schedule"])
+    azure_remove_branch_yml["Clean up Flexion Azure Resources"]
     prune_e2e_image_cache_yml["Prune E2E Image Cache"]
     refresh_e2e_base_images_yml["Refresh E2E Base Image Cache"]
     constrained_test_report_yml["Constrained Test Report"]
@@ -1583,6 +1597,7 @@ flowchart LR
     trigger_push --> deploy_pages_yml
     trigger_push --> continuous_deployment_yml
     trigger_delete --> azure_remove_branch_yml
+    trigger_schedule --> azure_remove_branch_yml
     trigger_schedule --> prune_e2e_image_cache_yml
     trigger_schedule --> refresh_e2e_base_images_yml
     trigger_schedule --> constrained_test_report_yml
@@ -1638,7 +1653,7 @@ flowchart LR
   - Triggers: workflow_dispatch
   - Jobs: 2
 - **Clean up Flexion Azure Resources** (`azure-remove-branch.yml`)
-  - Triggers: delete, workflow_dispatch
+  - Triggers: delete, schedule, workflow_dispatch
   - Jobs: 3
 - **Prune E2E Image Cache** (`prune-e2e-image-cache.yml`)
   - Triggers: schedule, workflow_dispatch


### PR DESCRIPTION
# Purpose

Add a nightly cleanup path for branch deployments so temporary Azure resources are torn down each night at 9 PM Pacific while the main deployment remains in place.

# Major Changes

- Added a scheduled trigger to the existing branch cleanup workflow.
- Gated scheduled runs on America/Los_Angeles local time so the cleanup runs at 9 PM Pacific across DST changes.
- Discover branch deployments using Azure resource group tags and clean each branch hash through the existing deletion script.
- Preserved existing delete/manual cleanup behavior through the same matrix cleanup path.
- Added .codex/ to the AI tooling block in .gitignore.
- Updated the generated workflow diagram.

# Testing/Validation

- Pre-commit hooks passed during commits, including YAML validation and GitHub workflow validation.
- Workflow diagram generation hook passed after updating docs/operations/workflow-diagram.md.
- Verified branch is pushed and tracking origin/codex/nightly-branch-teardown.

# Notes

- actionlint was not installed locally, but the repository's pre-commit GitHub workflow validation hook passed.
- The cleanup is limited to resources tagged as branch deployments, so main deployment resources are not targeted.

# Definition of Done:

- [x] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [x] Dependency rule followed: More important code doesn’t directly depend on less important code
- [x] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [x] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add a scheduled nightly Azure branch deployment cleanup that safely tears down tagged branch resources while preserving existing manual delete behavior.

New Features:
- Introduce a cron-based schedule trigger to run branch deployment cleanup nightly at 9 PM Pacific.
- Support cleaning multiple branch deployment hashes in a single run using a matrix strategy derived from discovered resources.

Enhancements:
- Restrict Azure resource discovery and validation to resources explicitly tagged as branch deployments and exclude main branch resources.
- Gate scheduled cleanup execution on America/Los_Angeles local time to keep runs aligned to 9 PM Pacific across daylight saving changes.
- Refine workflow outputs and job conditions to distinguish scheduled runs from manual and delete-triggered runs.

Build:
- Extend .gitignore to exclude .codex/ from version control.

Documentation:
- Update the workflow diagram documentation to reflect the new scheduled trigger and job structure for the Azure branch cleanup workflow.