### PR TITLE
Pin @babel/runtime override against Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -131,6 +131,11 @@
       "description": "Do not auto-update npm overrides — they are deliberate security/compatibility pins (e.g. protobufjs held at 7.x, @opentelemetry/exporter-prometheus kept in lockstep with sdk-node). Bumping them desyncs from the packages that pin them exactly and breaks lockfile resolution. Change override values by hand.",
       "matchDepTypes": ["overrides"],
       "enabled": false
+    },
+    {
+      "description": "Belt-and-suspenders: @babel/runtime is pinned via root overrides and must not be auto-bumped (PR #2695 bumped it to v8 despite the depType rule above, desyncing the lockfile). Change by hand.",
+      "matchPackageNames": ["@babel/runtime"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
# Purpose

Renovate PR #2695 bumped the `@babel/runtime` root override from `7.29.7` to `8.0.0`, despite an existing `matchDepTypes: ["overrides"]` rule intended to disable all override updates. Other dependents in the tree still require `^7.x`, so npm pruned conflicting entries from the lockfile, breaking `npm ci` (`Missing: @babel/runtime@8.0.0/@7.29.7 from lock file`).

# Major Changes

* Added an explicit `matchPackageNames: ["@babel/runtime"]` rule in `renovate.json` disabling updates for this package, as a backstop to the depType-based rule that failed to catch it.

# Testing/Validation

Config-only change; validated `renovate.json` is well-formed JSON. No code or test changes.

# Notes

`@babel/runtime@8.0.0` is also a fresh major release (2026-06-16) with breaking changes and wouldn't clear the 30-day major-version age gate regardless. PR #2695 should be closed without merging.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

CI:
- Update Renovate configuration to explicitly disable upgrades of @babel/runtime overrides to incompatible versions.