### PR TITLE
CAMS-809 Add DXTR-backed trustee petition match integration test

### DIFF
--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.test.ts
@@ -1513,9 +1513,7 @@ describe('Test DXTR Gateway', () => {
       expect(result).toEqual(['081-20-10508', '081-21-12345']);
       expect(querySpy).toHaveBeenCalledWith(
         expect.anything(),
-        expect.stringContaining(
-          "TX.TX_DATE AT TIME ZONE 'UTC' > C.LAST_UPDATE_DATE AT TIME ZONE 'UTC'",
-        ),
+        expect.stringContaining('TX.TX_DATE > C.LAST_UPDATE_DATE'),
         expect.arrayContaining([
           expect.objectContaining({ name: 'cutoffDate', value: '2018-01-01' }),
         ]),

--- a/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
+++ b/backend/lib/adapters/gateways/dxtr/cases.dxtr.gateway.ts
@@ -631,10 +631,10 @@ class CasesDxtrGateway extends AbstractMssqlClient implements CasesInterface {
     const casesQuery = `
       SELECT
         CONCAT(CS_DIV.CS_DIV_ACMS, '-', C.CASE_ID) AS caseId,
-        FORMAT(C.LAST_UPDATE_DATE AT TIME ZONE 'UTC', 'yyyy-MM-ddTHH:mm:ss.fff') + 'Z' AS latestSyncDate
+        CONVERT(VARCHAR(23), C.LAST_UPDATE_DATE, 126) + 'Z' AS latestSyncDate
       FROM AO_CS C
       JOIN AO_CS_DIV AS CS_DIV ON C.CS_DIV = CS_DIV.CS_DIV
-      WHERE C.LAST_UPDATE_DATE AT TIME ZONE 'UTC' > @casesStart
+      WHERE C.LAST_UPDATE_DATE > @casesStart
       ORDER BY C.LAST_UPDATE_DATE DESC, C.CASE_ID DESC
     `;
 
@@ -650,13 +650,13 @@ class CasesDxtrGateway extends AbstractMssqlClient implements CasesInterface {
     const transactionsQuery = `
       SELECT
         CONCAT(CS_DIV.CS_DIV_ACMS, '-', TX.CS_CASEID) AS caseId,
-        FORMAT(TX.TX_DATE AT TIME ZONE 'UTC', 'yyyy-MM-ddTHH:mm:ss.fff') + 'Z' AS latestSyncDate
+        CONVERT(VARCHAR(23), TX.TX_DATE, 126) + 'Z' AS latestSyncDate
       FROM AO_TX TX
       JOIN AO_CS C ON TX.CS_CASEID = C.CS_CASEID AND TX.COURT_ID = C.COURT_ID
       JOIN AO_CS_DIV AS CS_DIV ON C.CS_DIV = CS_DIV.CS_DIV
       WHERE TX.TX_TYPE = 'O'
         AND TX.TX_CODE IN ('CBC', 'CDC', 'OCO', 'CTO')
-        AND TX.TX_DATE AT TIME ZONE 'UTC' > @transactionsStart
+        AND TX.TX_DATE > @transactionsStart
       ORDER BY TX.TX_DATE DESC, TX.CS_CASEID DESC
     `;
 
@@ -704,8 +704,8 @@ class CasesDxtrGateway extends AbstractMssqlClient implements CasesInterface {
       JOIN AO_CS_DIV AS CS_DIV ON C.CS_DIV = CS_DIV.CS_DIV
       WHERE TX.TX_TYPE = 'O'
         AND TX.TX_CODE IN ('CBC', 'CDC', 'OCO', 'CTO')
-        AND TX.TX_DATE AT TIME ZONE 'UTC' > C.LAST_UPDATE_DATE AT TIME ZONE 'UTC'
-        AND TX.TX_DATE AT TIME ZONE 'UTC' >= @cutoffDate
+        AND TX.TX_DATE > C.LAST_UPDATE_DATE
+        AND TX.TX_DATE >= @cutoffDate
     `;
 
     const queryResult: QueryResults = await this.executeQuery(context, query, params);
@@ -1370,7 +1370,7 @@ class CasesDxtrGateway extends AbstractMssqlClient implements CasesInterface {
         P.PY_E_MAIL AS email,
         P.PY_PHONENO AS phone,
         P.PY_FAX_PHONE AS fax,
-        FORMAT(TX.TX_DATE AT TIME ZONE 'UTC', 'yyyy-MM-ddTHH:mm:ss.fff') + 'Z' AS latestSyncDate,
+        CONVERT(VARCHAR(23), TX.TX_DATE, 126) + 'Z' AS latestSyncDate,
         SUBSTRING(TX.REC, ${aptDateOffset}, 6) AS aptDate,
         SUBSTRING(TX.REC, ${profCodeOffset}, 5) AS profCode
       FROM AO_TX TX
@@ -1379,7 +1379,7 @@ class CasesDxtrGateway extends AbstractMssqlClient implements CasesInterface {
       JOIN AO_PY P ON P.CS_CASEID = TX.CS_CASEID AND P.COURT_ID = TX.COURT_ID AND P.PY_ROLE = 'tr'
       WHERE ${txTypeCondition}
         AND ${txCodeCondition}
-        AND TX.TX_DATE AT TIME ZONE 'UTC' > @transactionsStart
+        AND TX.TX_DATE > @transactionsStart
       ORDER BY TX.TX_DATE DESC, TX.CS_CASEID DESC
     `;
   }

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -1,5 +1,6 @@
 import { ApplicationContext } from '../../types/basic';
 import { getCamsErrorWithStack } from '../../../common-errors/error-utilities';
+import { isNotFoundError } from '../../../common-errors/not-found-error';
 import {
   CamsPaginationResponse,
   CaseAppointmentMigrationInput,
@@ -129,6 +130,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
       );
       return await this.casePartition.adapter<CaseAppointmentDocument>().findOne(query);
     } catch (originalError) {
+      if (isNotFoundError(originalError)) return null;
       throw getCamsErrorWithStack(originalError, MODULE_NAME, {
         message: `Failed to retrieve active case appointment for case ${caseId}.`,
       });

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -21,6 +21,9 @@
     "trustee-case-filter:azure": "INTEGRATION_ENV=azure npx tsx --tsconfig ../../backend/tsconfig.json trustee-case-filter/scripts/run-tests.ts",
     "migrate-trustees": "npx tsx --tsconfig ../../backend/tsconfig.json migrate-trustees/scripts/migrate-trustees-address-harness.ts",
     "migrate-trustees:local": "INTEGRATION_ENV=local npx tsx --tsconfig ../../backend/tsconfig.json migrate-trustees/scripts/migrate-trustees-address-harness.ts",
-    "migrate-trustees:azure": "INTEGRATION_ENV=azure npx tsx --tsconfig ../../backend/tsconfig.json migrate-trustees/scripts/migrate-trustees-address-harness.ts"
+    "migrate-trustees:azure": "INTEGRATION_ENV=azure npx tsx --tsconfig ../../backend/tsconfig.json migrate-trustees/scripts/migrate-trustees-address-harness.ts",
+    "trustee-petition-match": "npx tsx --tsconfig ../../backend/tsconfig.json trustee-petition-match/scripts/trustee-petition-match-harness.ts",
+    "trustee-petition-match:local": "INTEGRATION_ENV=local npx tsx --tsconfig ../../backend/tsconfig.json trustee-petition-match/scripts/trustee-petition-match-harness.ts",
+    "trustee-petition-match:azure": "INTEGRATION_ENV=azure npx tsx --tsconfig ../../backend/tsconfig.json trustee-petition-match/scripts/trustee-petition-match-harness.ts"
   }
 }

--- a/test/integration/trustee-petition-match/README.md
+++ b/test/integration/trustee-petition-match/README.md
@@ -1,0 +1,78 @@
+# Trustee Petition Match — Integration Test
+
+Exercises `SyncTrusteeCaseAppointmentsUseCase`
+(`backend/lib/use-cases/dataflows/sync-trustee-case-appointments.ts`) against a real DXTR SQL Server
+instance (mimicked locally with SQL Edge), instead of the mocked recordsets used by the unit tests.
+
+## What it tests
+
+1. **Read path** — `getAppointmentEvents()` reads `AO_TX`/`AO_CS`/`AO_CS_DIV`/`AO_PY` via
+   `CasesDxtrGateway` and returns correctly-parsed events for both transaction types the use case
+   cares about:
+   - `TX_TYPE='A'`, `TX_CODE='TR'` — trustee appointment transactions
+   - `TX_TYPE='1'`, `TX_CODE='1'` — petition transactions
+2. **Match + write path** — `processAppointments()` matches each event to a CAMS trustee via the
+   `acmsProfessionalId` fast path, confirms a "perfect match" against a seeded active
+   `TrusteeAppointment`, and writes a case appointment + an approved `trustee-match-verification`
+   record.
+
+No DDL for the DXTR schema exists elsewhere in this repo — `seed/00-seed-dxtr-schema.sql` is a
+hand-crafted subset covering only the columns/joins those two gateway queries use, see its header
+comment and the `cams-gateways` skill's `dxtr-schema/` reference files for the full column
+definitions this was derived from.
+
+## Environments
+
+Two environments via `INTEGRATION_ENV`:
+
+- `local` (default) — localhost containers started by `start-services.sh`
+- `azure` — lower-env Azure Government databases (VPN required)
+
+## Local workflow
+
+```bash
+cd trustee-petition-match/scripts
+./start-services.sh
+
+cd ../..   # back to test/integration/
+npm run trustee-petition-match -- seed-schema
+npm run trustee-petition-match -- seed-sql
+npm run trustee-petition-match -- seed-cosmos
+npm run trustee-petition-match -- run
+npm run trustee-petition-match -- clean
+
+cd trustee-petition-match/scripts
+./stop-services.sh
+```
+
+Before the first run, copy the env templates and fill in a password:
+
+```bash
+cp .env.local.template .env.local
+cp scripts/.env.template scripts/.env
+# set MSSQL_PASS in scripts/.env, and the same value for MSSQL_PASS in .env.local
+```
+
+## Commands
+
+| Command       | Description                                                                 |
+| ------------- | --------------------------------------------------------------------------- |
+| `check-env`   | Verify required environment variables are set                               |
+| `seed-schema` | (local only) Create `DXTR_INT` database + apply `AO_*` DDL                  |
+| `seed-sql`    | Drop/recreate DXTR fixture rows (idempotent)                                |
+| `seed-cosmos` | Seed synced case, Trustee, TrusteeProfessionalId, active TrusteeAppointment |
+| `run`         | Full test: clean → seed → read DXTR → match/process → assert                |
+| `clean`       | Remove seeded rows/documents from both databases                            |
+| `help`        | Show usage                                                                  |
+
+## Fixture data
+
+See `seed/01-seed-dxtr-data.sql` for the exact DXTR rows and
+`scripts/trustee-petition-match-harness.ts` for the matching Cosmos fixtures. Summary:
+
+- Division `081` (Manhattan), `COURT_ID='0208'`, `GRP_DES='NY'`
+- Case `081-26-99999`, chapter `7`, trustee party "Integration Trustee"
+- Professional id `NY-00063`, mapped to CAMS trustee `integration-trustee-petition-match-001`
+- One appointment transaction (`appointedDate` 2026-06-01) and one petition transaction
+  (`appointedDate` 2026-03-01) for the same case — both should auto-match via the professional-id
+  fast path against a seeded active `TrusteeAppointment` in the same court/division/chapter.

--- a/test/integration/trustee-petition-match/README.md
+++ b/test/integration/trustee-petition-match/README.md
@@ -21,6 +21,15 @@ hand-crafted subset covering only the columns/joins those two gateway queries us
 comment and the `cams-gateways` skill's `dxtr-schema/` reference files for the full column
 definitions this was derived from.
 
+## Warning: isolated databases only
+
+`clean` (and `run`, which calls `clean` first) resets the `TRUSTEE_APPOINTMENTS_SYNC_STATE` and
+`TRUSTEE_PETITION_SYNC_STATE` runtime-state documents. These are dataflow-wide singleton watermarks
+(keyed only by `documentType`, not by case) — there's no way to scope the reset to just this
+harness's fixture case. Only run this harness against an isolated local/test Cosmos database.
+Running it against a shared environment would reset the sync cursor for every case the real
+`sync-trustee-case-appointments` dataflow is tracking, not just this test's data.
+
 ## Environments
 
 Two environments via `INTEGRATION_ENV`:

--- a/test/integration/trustee-petition-match/scripts/.env.template
+++ b/test/integration/trustee-petition-match/scripts/.env.template
@@ -1,0 +1,3 @@
+# SQL Edge SA password — used by start-services.sh to launch the container.
+# Must match MSSQL_PASS in ../.env.local.
+MSSQL_PASS=

--- a/test/integration/trustee-petition-match/scripts/start-services.sh
+++ b/test/integration/trustee-petition-match/scripts/start-services.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Start local infrastructure for trustee-petition-match integration tests.
+# Runs MongoDB and SQL Edge (mimicking DXTR) in standalone containers — no pod, no
+# function app, since the harness calls SyncTrusteeCaseAppointmentsUseCase directly.
+#
+# Usage:
+#   ./start-services.sh         # start containers
+#   ./stop-services.sh          # tear down
+#
+# After this script exits cleanly:
+#   SQL Edge  → localhost:1433  (sa / password from scripts/.env)
+#   MongoDB   → localhost:27017
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+  # shellcheck source=/dev/null
+  source "${SCRIPT_DIR}/.env"
+fi
+
+if [ -z "${MSSQL_PASS}" ]; then
+  echo "ERROR: MSSQL_PASS is not set. Copy scripts/.env.template to scripts/.env and populate it." >&2
+  exit 1
+fi
+
+podman rm -f \
+  cams-trustee-petition-match-mongodb \
+  cams-trustee-petition-match-sqledge 2>/dev/null || true
+
+echo "Starting MongoDB..."
+podman run -d \
+  --name cams-trustee-petition-match-mongodb \
+  -p 27017:27017 \
+  mongo:7.0 --bind_ip_all
+
+echo "Starting SQL Edge..."
+podman run -d \
+  --name cams-trustee-petition-match-sqledge \
+  -p 1433:1433 \
+  -e ACCEPT_EULA=Y \
+  -e MSSQL_SA_PASSWORD="${MSSQL_PASS}" \
+  -e MSSQL_PID=Developer \
+  mcr.microsoft.com/azure-sql-edge:latest
+
+echo "Waiting for SQL Edge..."
+for i in $(seq 1 60); do
+  if bash -c '</dev/tcp/localhost/1433' 2>/dev/null; then
+    echo "  SQL Edge ready"
+    break
+  fi
+  [ "$i" -eq 60 ] && echo "ERROR: SQL Edge failed to start" && exit 1
+  sleep 2
+done
+
+echo "Waiting for MongoDB..."
+for i in $(seq 1 30); do
+  if bash -c '</dev/tcp/localhost/27017' 2>/dev/null; then
+    echo "  MongoDB ready"
+    break
+  fi
+  [ "$i" -eq 30 ] && echo "ERROR: MongoDB failed to start" && exit 1
+  sleep 1
+done
+
+# Give SQL Edge a few extra seconds for the engine to be fully initialized
+sleep 5
+
+echo ""
+echo "All services ready."
+echo "  SQL Edge  → localhost:1433  (user=sa)"
+echo "  MongoDB   → localhost:27017"
+echo ""
+echo "Next steps (from test/integration/):"
+echo "  npm run trustee-petition-match -- seed-schema"
+echo "  npm run trustee-petition-match -- seed-sql"
+echo "  npm run trustee-petition-match -- seed-cosmos"
+echo "  npm run trustee-petition-match -- run"
+echo "  npm run trustee-petition-match -- clean"
+echo "  ./scripts/stop-services.sh"

--- a/test/integration/trustee-petition-match/scripts/stop-services.sh
+++ b/test/integration/trustee-petition-match/scripts/stop-services.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Stop and remove trustee-petition-match local infrastructure containers.
+
+set -e
+
+echo "Stopping trustee-petition-match containers..."
+
+podman stop \
+  cams-trustee-petition-match-mongodb \
+  cams-trustee-petition-match-sqledge 2>/dev/null || true
+
+podman rm \
+  cams-trustee-petition-match-mongodb \
+  cams-trustee-petition-match-sqledge 2>/dev/null || true
+
+echo "Done."

--- a/test/integration/trustee-petition-match/scripts/trustee-petition-match-harness.ts
+++ b/test/integration/trustee-petition-match/scripts/trustee-petition-match-harness.ts
@@ -247,21 +247,21 @@ async function seedSchema() {
     console.error('seed-schema is only for local container runs. Schema already exists in Azure.');
     process.exit(1);
   }
-  console.log('\nCreating DXTR_INT database + applying schema...\n');
+  const dxtrDatabase = process.env.MSSQL_DATABASE_DXTR || 'DXTR_INT';
+  console.log(`\nCreating ${dxtrDatabase} database + applying schema...\n`);
 
   const masterPool = await getDxtrSqlPool('master');
   try {
     await masterPool
       .request()
       .query(
-        `IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = 'DXTR_INT') CREATE DATABASE DXTR_INT`,
+        `IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = '${dxtrDatabase}') CREATE DATABASE [${dxtrDatabase}]`,
       );
-    pass(`Database 'DXTR_INT' ready`);
+    pass(`Database '${dxtrDatabase}' ready`);
   } finally {
     await masterPool.close();
   }
 
-  const dxtrDatabase = process.env.MSSQL_DATABASE_DXTR || 'DXTR_INT';
   const pool = await getDxtrSqlPool(dxtrDatabase);
   try {
     const seedDir = path.join(HARNESS_DIR, 'seed');
@@ -457,6 +457,11 @@ async function clean() {
       .deleteMany({ documentType: 'SYNCED_CASE', caseId: TEST_CASE_ID });
     pass(`Deleted ${r6.deletedCount} synced case doc(s) for ${TEST_CASE_ID}`);
 
+    // These are dataflow-wide singleton watermarks (documentType only, no caseId) —
+    // there is no case-scoped filter possible here. This harness must only be run
+    // against an isolated local/test Cosmos database (see README): running it
+    // against a shared environment would reset the sync cursor for every case the
+    // real dataflow is tracking, not just this test's fixture.
     await db.collection('runtime-state').deleteMany({
       documentType: { $in: ['TRUSTEE_APPOINTMENTS_SYNC_STATE', 'TRUSTEE_PETITION_SYNC_STATE'] },
     });

--- a/test/integration/trustee-petition-match/scripts/trustee-petition-match-harness.ts
+++ b/test/integration/trustee-petition-match/scripts/trustee-petition-match-harness.ts
@@ -1,0 +1,696 @@
+/**
+ * Integration test harness: SyncTrusteeCaseAppointmentsUseCase against real DXTR SQL.
+ *
+ * Exercises the full pipeline:
+ *   1. Seeds a case + trustee party + two AO_TX rows (an 'A'/'TR' appointment
+ *      transaction and a '1'/'1' petition transaction) into a local DXTR mimic.
+ *   2. Seeds a synced case, a Trustee, a TrusteeProfessionalId mapping, and an
+ *      active TrusteeAppointment (perfect-match target) into Cosmos.
+ *   3. Calls SyncTrusteeCaseAppointmentsUseCase.getAppointmentEvents() — reads DXTR,
+ *      asserts both event types (appointment + petition) are parsed correctly.
+ *   4. Calls .processAppointments(events) — asserts professional-id fast-path
+ *      matching auto-links both events to the seeded trustee and writes a
+ *      case appointment + an approved trustee-match-verification record.
+ *
+ * Two environments via INTEGRATION_ENV:
+ *   local  (default) — localhost containers started by start-services.sh
+ *   azure            — lower-env Azure Gov databases (VPN required)
+ *
+ * This is a one-shot script — NOT a Vitest test.
+ *
+ * Usage (from test/integration/):
+ *   npm run trustee-petition-match -- [command]
+ *
+ * Local workflow:
+ *   1. cd trustee-petition-match/scripts && ./start-services.sh
+ *   2. npm run trustee-petition-match -- seed-schema
+ *   3. npm run trustee-petition-match -- seed-sql
+ *   4. npm run trustee-petition-match -- seed-cosmos
+ *   5. npm run trustee-petition-match -- run
+ *   6. npm run trustee-petition-match -- clean
+ *   7. cd trustee-petition-match/scripts && ./stop-services.sh
+ *
+ * Commands:
+ *   check-env     Verify required environment variables are set
+ *   seed-schema   [local] Create DXTR_INT database + apply AO_* DDL
+ *   seed-sql      Drop/recreate DXTR fixture rows (idempotent)
+ *   seed-cosmos   Seed synced case, Trustee, ProfessionalId, TrusteeAppointment
+ *   run           Full test: clean → seed → read DXTR → process → assert
+ *   clean         Remove test documents/rows from both databases
+ *   help          Show this help
+ */
+
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+import { InvocationContext } from '@azure/functions';
+import { MongoClient } from 'mongodb';
+import * as mssql from 'mssql';
+import ApplicationContextCreator from '../../../../backend/function-apps/azure/application-context-creator';
+import SyncTrusteeCaseAppointmentsUseCase from '../../../../backend/lib/use-cases/dataflows/sync-trustee-case-appointments';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../');
+const HARNESS_DIR = path.resolve(__dirname, '../');
+
+const INTEGRATION_ENV = process.env.INTEGRATION_ENV || 'local';
+const IS_LOCAL = INTEGRATION_ENV !== 'azure';
+
+// ---------------------------------------------------------------------------
+// Test fixtures — see seed/01-seed-dxtr-data.sql for the matching DXTR rows
+// ---------------------------------------------------------------------------
+
+const TEST_CS_CASEID = '999999001';
+const TEST_COURT_ID = '0208';
+const TEST_CS_DIV = '081';
+const TEST_GRP_DES = 'NY';
+const TEST_CASE_ID = '081-26-99999'; // CS_DIV_ACMS + '-' + CASE_ID
+const TEST_CHAPTER = '7';
+
+const TEST_PROF_CODE = '00063';
+const TEST_ACMS_PROFESSIONAL_ID = `${TEST_GRP_DES}-${TEST_PROF_CODE}`;
+
+const TEST_TRUSTEE_ID = 'integration-trustee-petition-match-001';
+const TEST_TRUSTEE_NAME = 'Integration Trustee';
+
+const APPOINTMENT_DATE = '2026-06-01'; // packed into the 'A'/'TR' AO_TX row's REC
+const PETITION_DATE = '2026-03-01'; // packed into the '1'/'1' AO_TX row's REC
+
+// ---------------------------------------------------------------------------
+// Environment loading
+// ---------------------------------------------------------------------------
+
+function loadEnv() {
+  if (IS_LOCAL) {
+    const localEnvPath = path.join(HARNESS_DIR, '.env.local');
+    if (!fs.existsSync(localEnvPath)) {
+      console.error(
+        `Missing ${localEnvPath} — run start-services.sh first, then copy .env.local.template to .env.local`,
+      );
+      process.exit(1);
+    }
+    dotenv.config({ path: localEnvPath, override: true });
+  } else {
+    dotenv.config({ path: path.join(REPO_ROOT, 'backend/.env') });
+  }
+}
+
+loadEnv();
+
+// ---------------------------------------------------------------------------
+// Output helpers
+// ---------------------------------------------------------------------------
+
+let hasFailures = false;
+
+function pass(msg: string) {
+  console.log(`  ✓ PASS: ${msg}`);
+}
+
+function fail(msg: string) {
+  hasFailures = true;
+  console.log(`  ✗ FAIL: ${msg}`);
+}
+
+function info(msg: string) {
+  console.log(`  ℹ  ${msg}`);
+}
+
+// ---------------------------------------------------------------------------
+// Connection helpers
+// ---------------------------------------------------------------------------
+
+async function getMongoDb() {
+  const uri = process.env.MONGO_CONNECTION_STRING;
+  const dbName = process.env.COSMOS_DATABASE_NAME;
+  if (!uri || !dbName) {
+    throw new Error('MONGO_CONNECTION_STRING and COSMOS_DATABASE_NAME must be set');
+  }
+  const client = new MongoClient(uri);
+  await client.connect();
+  return { client, db: client.db(dbName) };
+}
+
+async function getDxtrSqlPool(database: string): Promise<mssql.ConnectionPool> {
+  const server = process.env.MSSQL_HOST;
+  if (!server) throw new Error('MSSQL_HOST is not set');
+
+  const port = Number(process.env.MSSQL_PORT) || 1433;
+  const encrypt = process.env.MSSQL_ENCRYPT?.toLowerCase() === 'true';
+  const trustServerCertificate = process.env.MSSQL_TRUST_UNSIGNED_CERT?.toLowerCase() === 'true';
+  const user = process.env.MSSQL_USER;
+  const password = process.env.MSSQL_PASS;
+
+  const config: mssql.config = {
+    server,
+    port,
+    database,
+    options: { encrypt, trustServerCertificate },
+    pool: { max: 5, min: 0, idleTimeoutMillis: 30000 },
+  };
+
+  if (user && password) {
+    config.user = user;
+    config.password = password;
+  } else {
+    config.authentication = { type: 'azure-active-directory-default', options: {} };
+  }
+
+  return mssql.connect(config);
+}
+
+async function executeSqlFile(pool: mssql.ConnectionPool, filePath: string): Promise<void> {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const batches = content
+    .split(/^\s*GO\s*$/im)
+    .map((b) => b.trim())
+    .filter((b) => b.length > 0);
+
+  info(`Executing ${batches.length} batch(es) from ${path.basename(filePath)}`);
+
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    try {
+      const req = pool.request();
+      req.on('info', (msg) => process.stdout.write(msg.message + '\n'));
+      await req.query(batch);
+    } catch (err) {
+      throw new Error(
+        `Batch ${i + 1} of ${batches.length} failed:\n${batch.slice(0, 200)}...\n\nError: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+async function getAppContext() {
+  const invocationContext = new InvocationContext();
+  const context = await ApplicationContextCreator.getApplicationContext({
+    invocationContext,
+    logger: ApplicationContextCreator.getLogger(invocationContext),
+  });
+  // Out of scope for this test: the downstream notification path queries
+  // AO_OFFICE/AO_COURT/AO_GRP_DES/AO_REGION, which aren't part of the DXTR
+  // schema this harness seeds (only AO_CS_DIV/AO_CS/AO_PY/AO_TX).
+  context.featureFlags['downstream-trustee-appointments-enabled'] = false;
+  return context;
+}
+
+// ---------------------------------------------------------------------------
+// check-env
+// ---------------------------------------------------------------------------
+
+async function checkEnv() {
+  console.log('\nChecking required environment variables...\n');
+
+  const required: [string, string][] = [
+    ['MONGO_CONNECTION_STRING', 'MongoDB connection string'],
+    ['COSMOS_DATABASE_NAME', 'Cosmos/Mongo database name'],
+    ['MSSQL_HOST', 'DXTR SQL Server host'],
+  ];
+
+  const optional: [string, string][] = [
+    ['MSSQL_DATABASE_DXTR', 'DXTR database name (default: DXTR_INT)'],
+    ['MSSQL_USER', 'DXTR SQL user (omit for Azure AD auth)'],
+    ['MSSQL_PASS', 'DXTR SQL password'],
+  ];
+
+  let allPresent = true;
+  for (const [name, description] of required) {
+    if (process.env[name]) {
+      pass(`${name} — ${description}`);
+    } else {
+      fail(`${name} — ${description} (MISSING)`);
+      allPresent = false;
+    }
+  }
+
+  console.log('\nOptional / informational:');
+  for (const [name, description] of optional) {
+    const raw = process.env[name];
+    const isSensitive = /pass|key|secret/i.test(name);
+    const display = raw === undefined ? '(not set)' : isSensitive ? '***' : raw;
+    info(`${name}=${display} — ${description}`);
+  }
+
+  if (!allPresent) {
+    console.log('\n  Set missing variables in .env.local before running.');
+  } else {
+    console.log('\n  All required variables present.');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// seed-schema  (create DXTR_INT database + apply AO_* DDL)
+// ---------------------------------------------------------------------------
+
+async function seedSchema() {
+  if (!IS_LOCAL) {
+    console.error('seed-schema is only for local container runs. Schema already exists in Azure.');
+    process.exit(1);
+  }
+  console.log('\nCreating DXTR_INT database + applying schema...\n');
+
+  const masterPool = await getDxtrSqlPool('master');
+  try {
+    await masterPool
+      .request()
+      .query(
+        `IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = 'DXTR_INT') CREATE DATABASE DXTR_INT`,
+      );
+    pass(`Database 'DXTR_INT' ready`);
+  } finally {
+    await masterPool.close();
+  }
+
+  const dxtrDatabase = process.env.MSSQL_DATABASE_DXTR || 'DXTR_INT';
+  const pool = await getDxtrSqlPool(dxtrDatabase);
+  try {
+    const seedDir = path.join(HARNESS_DIR, 'seed');
+    await executeSqlFile(pool, path.join(seedDir, '00-seed-dxtr-schema.sql'));
+    pass('00-seed-dxtr-schema.sql applied (AO_CS_DIV, AO_CS, AO_PY, AO_TX tables created)');
+  } finally {
+    await pool.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// seed-sql  (drop/recreate DXTR fixture rows — idempotent)
+// ---------------------------------------------------------------------------
+
+async function seedSql() {
+  console.log('\nSeeding DXTR fixture rows into DXTR_INT...\n');
+
+  const dxtrDatabase = process.env.MSSQL_DATABASE_DXTR || 'DXTR_INT';
+  const pool = await getDxtrSqlPool(dxtrDatabase);
+  try {
+    const seedDir = path.join(HARNESS_DIR, 'seed');
+    await executeSqlFile(pool, path.join(seedDir, '01-seed-dxtr-data.sql'));
+    pass(
+      `01-seed-dxtr-data.sql seeded (case ${TEST_CASE_ID}, trustee party, appointment + petition AO_TX rows)`,
+    );
+  } finally {
+    await pool.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// seed-cosmos  (synced case, Trustee, ProfessionalId, TrusteeAppointment)
+// ---------------------------------------------------------------------------
+
+async function seedCosmos() {
+  console.log(
+    '\nSeeding synced case, Trustee, ProfessionalId, and TrusteeAppointment into Cosmos...\n',
+  );
+
+  const now = new Date().toISOString();
+  const { client, db } = await getMongoDb();
+  try {
+    await db.collection('cases').replaceOne(
+      { documentType: 'SYNCED_CASE', caseId: TEST_CASE_ID },
+      {
+        documentType: 'SYNCED_CASE',
+        caseId: TEST_CASE_ID,
+        dxtrId: TEST_CASE_ID,
+        courtId: TEST_COURT_ID,
+        courtName: 'Integration Test Court',
+        courtDivisionCode: TEST_CS_DIV,
+        courtDivisionName: 'Manhattan',
+        officeCode: '1',
+        officeName: 'Manhattan',
+        groupDesignator: TEST_GRP_DES,
+        regionId: '02',
+        regionName: 'Region 2',
+        chapter: TEST_CHAPTER,
+        caseTitle: 'Integration Test Debtor',
+        dateFiled: '2026-01-01',
+        debtor: { name: 'Integration Test Debtor' },
+        updatedOn: now,
+        updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
+      },
+      { upsert: true },
+    );
+    pass(`Upserted synced case: ${TEST_CASE_ID}`);
+
+    await db.collection('trustees').replaceOne(
+      { documentType: 'TRUSTEE', trusteeId: TEST_TRUSTEE_ID },
+      {
+        documentType: 'TRUSTEE',
+        trusteeId: TEST_TRUSTEE_ID,
+        name: TEST_TRUSTEE_NAME,
+        firstName: 'Integration',
+        lastName: 'Trustee',
+        public: {
+          address: {
+            address1: '100 Integration Ave',
+            city: 'Washington',
+            state: 'DC',
+            zipCode: '20001',
+            countryCode: 'US',
+          },
+          phone: '202-555-0199',
+          email: 'integration.trustee@example.com',
+        },
+        updatedOn: now,
+        updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
+      },
+      { upsert: true },
+    );
+    pass(`Upserted Trustee: ${TEST_TRUSTEE_ID} (name="${TEST_TRUSTEE_NAME}")`);
+
+    await db.collection('trustee-professional-ids').replaceOne(
+      { acmsProfessionalId: TEST_ACMS_PROFESSIONAL_ID, camsTrusteeId: TEST_TRUSTEE_ID },
+      {
+        documentType: 'TRUSTEE_PROFESSIONAL_ID',
+        camsTrusteeId: TEST_TRUSTEE_ID,
+        acmsProfessionalId: TEST_ACMS_PROFESSIONAL_ID,
+        updatedOn: now,
+        updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
+      },
+      { upsert: true },
+    );
+    pass(`Upserted TrusteeProfessionalId: ${TEST_ACMS_PROFESSIONAL_ID} → ${TEST_TRUSTEE_ID}`);
+
+    // Active appointment in the same court/division/chapter as the DXTR events —
+    // the "perfect match" target so professional-id-matched events auto-link.
+    await db.collection('trustee-appointments').replaceOne(
+      { documentType: 'TRUSTEE_APPOINTMENT', trusteeId: TEST_TRUSTEE_ID, courtId: TEST_COURT_ID },
+      {
+        documentType: 'TRUSTEE_APPOINTMENT',
+        trusteeId: TEST_TRUSTEE_ID,
+        chapter: TEST_CHAPTER,
+        appointmentType: 'panel',
+        courtId: TEST_COURT_ID,
+        divisionCode: TEST_CS_DIV,
+        appointedDate: '2020-01-01',
+        status: 'active',
+        effectiveDate: '2020-01-01',
+        updatedOn: now,
+        updatedBy: { id: 'SYSTEM', name: 'SYSTEM' },
+        createdOn: now,
+        createdBy: { id: 'SYSTEM', name: 'SYSTEM' },
+      },
+      { upsert: true },
+    );
+    pass(
+      `Upserted active TrusteeAppointment for ${TEST_TRUSTEE_ID} (court ${TEST_COURT_ID}, div ${TEST_CS_DIV}, chapter ${TEST_CHAPTER})`,
+    );
+  } finally {
+    await client.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// clean
+// ---------------------------------------------------------------------------
+
+async function clean() {
+  console.log('\nCleaning up test data...\n');
+
+  const dxtrDatabase = process.env.MSSQL_DATABASE_DXTR || 'DXTR_INT';
+  const pool = await getDxtrSqlPool(dxtrDatabase);
+  try {
+    await pool.request().query(`
+      DELETE FROM dbo.AO_TX WHERE CS_CASEID = '${TEST_CS_CASEID}' AND COURT_ID = '${TEST_COURT_ID}';
+      DELETE FROM dbo.AO_PY WHERE CS_CASEID = '${TEST_CS_CASEID}' AND COURT_ID = '${TEST_COURT_ID}';
+      DELETE FROM dbo.AO_CS WHERE CS_CASEID = '${TEST_CS_CASEID}' AND COURT_ID = '${TEST_COURT_ID}';
+      DELETE FROM dbo.AO_CS_DIV WHERE CS_DIV = '${TEST_CS_DIV}' AND GRP_DES = '${TEST_GRP_DES}';
+    `);
+    pass(`Deleted DXTR fixture rows for case ${TEST_CASE_ID}`);
+  } finally {
+    await pool.close();
+  }
+
+  const { client, db } = await getMongoDb();
+  try {
+    const r1a = await db
+      .collection('case-trustee-appointments')
+      .deleteMany({ documentType: 'CASE_APPOINTMENT', caseId: TEST_CASE_ID });
+    const r1b = await db
+      .collection('trustee-case-appointments')
+      .deleteMany({ documentType: 'CASE_APPOINTMENT', caseId: TEST_CASE_ID });
+    pass(
+      `Deleted ${r1a.deletedCount + r1b.deletedCount} CASE_APPOINTMENT(s) for case ${TEST_CASE_ID}`,
+    );
+
+    const r2 = await db
+      .collection('trustee-match-verification')
+      .deleteMany({ caseId: TEST_CASE_ID });
+    pass(`Deleted ${r2.deletedCount} trustee-match-verification doc(s) for case ${TEST_CASE_ID}`);
+
+    const r3 = await db
+      .collection('trustee-appointments')
+      .deleteMany({ documentType: 'TRUSTEE_APPOINTMENT', trusteeId: TEST_TRUSTEE_ID });
+    pass(`Deleted ${r3.deletedCount} TrusteeAppointment(s) for ${TEST_TRUSTEE_ID}`);
+
+    const r4 = await db.collection('trustee-professional-ids').deleteMany({
+      acmsProfessionalId: TEST_ACMS_PROFESSIONAL_ID,
+      camsTrusteeId: TEST_TRUSTEE_ID,
+    });
+    pass(`Deleted ${r4.deletedCount} TrusteeProfessionalId(s)`);
+
+    const r5 = await db
+      .collection('trustees')
+      .deleteMany({ documentType: 'TRUSTEE', trusteeId: TEST_TRUSTEE_ID });
+    pass(`Deleted ${r5.deletedCount} Trustee doc(s) for trusteeId ${TEST_TRUSTEE_ID}`);
+
+    const r6 = await db
+      .collection('cases')
+      .deleteMany({ documentType: 'SYNCED_CASE', caseId: TEST_CASE_ID });
+    pass(`Deleted ${r6.deletedCount} synced case doc(s) for ${TEST_CASE_ID}`);
+
+    await db.collection('runtime-state').deleteMany({
+      documentType: { $in: ['TRUSTEE_APPOINTMENTS_SYNC_STATE', 'TRUSTEE_PETITION_SYNC_STATE'] },
+    });
+    pass(
+      'Removed TRUSTEE_APPOINTMENTS_SYNC_STATE and TRUSTEE_PETITION_SYNC_STATE from runtime-state',
+    );
+  } finally {
+    await client.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// run
+// ---------------------------------------------------------------------------
+
+async function run() {
+  console.log('\nRunning full pipeline integration test...\n');
+
+  console.log('Step 0: Reset to known state');
+  await clean();
+  console.log('');
+
+  console.log('Step 1: Seed DXTR fixture rows');
+  await seedSql();
+  console.log('');
+
+  console.log(
+    'Step 2: Seed Cosmos fixtures (synced case, Trustee, ProfessionalId, TrusteeAppointment)',
+  );
+  await seedCosmos();
+  console.log('');
+
+  // ── Stage 1: Read path ────────────────────────────────────────────────────
+  console.log('Stage 1: SyncTrusteeCaseAppointmentsUseCase.getAppointmentEvents()');
+  console.log('  Reads AO_TX/AO_CS/AO_CS_DIV/AO_PY from DXTR SQL\n');
+
+  const context = await getAppContext();
+  const useCase = new SyncTrusteeCaseAppointmentsUseCase(context);
+
+  const { events } = await useCase.getAppointmentEvents(undefined, true);
+  const testEvents = events.filter((e) => e.caseId === TEST_CASE_ID);
+
+  if (testEvents.length === 2) {
+    pass(`getAppointmentEvents returned 2 events for case ${TEST_CASE_ID}`);
+  } else {
+    fail(`expected 2 events for case ${TEST_CASE_ID}, got ${testEvents.length}`);
+    return;
+  }
+
+  const appointmentEvent = testEvents.find((e) => e.appointedDate === APPOINTMENT_DATE);
+  const petitionEvent = testEvents.find((e) => e.appointedDate === PETITION_DATE);
+
+  if (appointmentEvent) {
+    pass(`Found 'A'/'TR' appointment event with appointedDate=${APPOINTMENT_DATE}`);
+  } else {
+    fail(`No event found with appointedDate=${APPOINTMENT_DATE} (appointment transaction)`);
+  }
+  if (petitionEvent) {
+    pass(`Found '1'/'1' petition event with appointedDate=${PETITION_DATE}`);
+  } else {
+    fail(`No event found with appointedDate=${PETITION_DATE} (petition transaction)`);
+  }
+
+  for (const [label, event] of [
+    ['appointment', appointmentEvent],
+    ['petition', petitionEvent],
+  ] as const) {
+    if (!event) continue;
+    if (event.dxtrTrustee.fullName === TEST_TRUSTEE_NAME) {
+      pass(`${label} event dxtrTrustee.fullName === "${TEST_TRUSTEE_NAME}"`);
+    } else {
+      fail(
+        `${label} event dxtrTrustee.fullName: expected "${TEST_TRUSTEE_NAME}", got "${event.dxtrTrustee.fullName}"`,
+      );
+    }
+    if (event.acmsProfessionalId === TEST_ACMS_PROFESSIONAL_ID) {
+      pass(`${label} event acmsProfessionalId === "${TEST_ACMS_PROFESSIONAL_ID}"`);
+    } else {
+      fail(
+        `${label} event acmsProfessionalId: expected "${TEST_ACMS_PROFESSIONAL_ID}", got "${event.acmsProfessionalId}"`,
+      );
+    }
+    if (
+      event.courtId === TEST_COURT_ID &&
+      event.courtDivisionCode === TEST_CS_DIV &&
+      event.chapter === TEST_CHAPTER
+    ) {
+      pass(`${label} event courtId/courtDivisionCode/chapter match seeded case`);
+    } else {
+      fail(
+        `${label} event court fields mismatch: courtId=${event.courtId}, courtDivisionCode=${event.courtDivisionCode}, chapter=${event.chapter}`,
+      );
+    }
+  }
+
+  if (hasFailures) {
+    console.log('\nAborting — read-path assertions failed.');
+    return;
+  }
+
+  // ── Stage 2: Match + write path ───────────────────────────────────────────
+  console.log('\nStage 2: SyncTrusteeCaseAppointmentsUseCase.processAppointments()');
+  console.log(
+    '  Matches by acmsProfessionalId, auto-links perfect match, writes case appointment\n',
+  );
+
+  const result = await useCase.processAppointments(testEvents);
+
+  if (result.successCount === 2) {
+    pass(`processAppointments successCount === 2`);
+  } else {
+    fail(`expected successCount 2, got ${result.successCount}`);
+  }
+  if (result.scenarioDistribution.autoMatchCount === 2) {
+    pass(`scenarioDistribution.autoMatchCount === 2 (both events perfect-matched)`);
+  } else {
+    fail(`expected autoMatchCount 2, got ${result.scenarioDistribution.autoMatchCount}`);
+  }
+  if (result.dlqMessages.length === 0) {
+    pass('No DLQ messages');
+  } else {
+    fail(
+      `expected 0 DLQ messages, got ${result.dlqMessages.length}: ${JSON.stringify(result.dlqMessages)}`,
+    );
+  }
+  if (result.notYetSyncedEvents.length === 0) {
+    pass('No notYetSyncedEvents (synced case was found)');
+  } else {
+    fail(`expected 0 notYetSyncedEvents, got ${result.notYetSyncedEvents.length}`);
+  }
+
+  // ── Stage 3: Assert Cosmos side effects ───────────────────────────────────
+  console.log('\nStage 3: Asserting Cosmos state\n');
+
+  const { client, db } = await getMongoDb();
+  try {
+    const appointment = await db
+      .collection('case-trustee-appointments')
+      .findOne({ documentType: 'CASE_APPOINTMENT', caseId: TEST_CASE_ID });
+
+    if (appointment?.trusteeId === TEST_TRUSTEE_ID) {
+      pass(`case-trustee-appointments has 1 doc for ${TEST_CASE_ID} linked to ${TEST_TRUSTEE_ID}`);
+    } else {
+      fail(
+        `expected a case appointment linked to ${TEST_TRUSTEE_ID}, got: ${JSON.stringify(appointment)}`,
+      );
+    }
+
+    const verification = await db
+      .collection('trustee-match-verification')
+      .findOne({ caseId: TEST_CASE_ID });
+
+    if (
+      verification?.status === 'approved' &&
+      verification?.resolvedTrusteeId === TEST_TRUSTEE_ID
+    ) {
+      pass(`trustee-match-verification approved for ${TEST_TRUSTEE_ID}`);
+    } else {
+      fail(
+        `expected approved verification for ${TEST_TRUSTEE_ID}, got: ${JSON.stringify(verification)}`,
+      );
+    }
+  } finally {
+    await client.close();
+  }
+
+  console.log('\nResult summary:');
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// CLI dispatch
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const command = process.argv[2] ?? 'help';
+
+  console.log('='.repeat(60));
+  console.log('Trustee Petition Match — Integration Test');
+  console.log(`Environment: ${INTEGRATION_ENV}`);
+  console.log('='.repeat(60));
+
+  switch (command) {
+    case 'check-env':
+      await checkEnv();
+      break;
+    case 'seed-schema':
+      await seedSchema();
+      break;
+    case 'seed-sql':
+      await seedSql();
+      break;
+    case 'seed-cosmos':
+      await seedCosmos();
+      break;
+    case 'run':
+      await run();
+      break;
+    case 'clean':
+      await clean();
+      break;
+    case 'help':
+    default: {
+      const HARNESS = 'npm run trustee-petition-match --';
+      console.log('\nUsage (from test/integration/):');
+      console.log(`  INTEGRATION_ENV=local  ${HARNESS} <command>   (default)`);
+      console.log(`  INTEGRATION_ENV=azure  ${HARNESS} <command>   (VPN required)`);
+      console.log('\nLocal workflow:');
+      console.log('  1. ./trustee-petition-match/scripts/start-services.sh');
+      console.log(`  2. ${HARNESS} seed-schema  (create DXTR_INT + apply AO_* DDL)`);
+      console.log(`  3. ${HARNESS} seed-sql     (seed case/trustee/AO_TX rows in SQL)`);
+      console.log(
+        `  4. ${HARNESS} seed-cosmos  (seed synced case/Trustee/ProfessionalId/TrusteeAppointment)`,
+      );
+      console.log(`  5. ${HARNESS} run          (read DXTR → match → write, then assert)`);
+      console.log(`  6. ${HARNESS} clean        (remove all test data from both databases)`);
+      console.log('  7. ./trustee-petition-match/scripts/stop-services.sh');
+      console.log('\nAll commands:');
+      console.log('  check-env    Verify required environment variables');
+      console.log('  seed-schema  [local] Create DXTR_INT + apply AO_* DDL');
+      console.log('  seed-sql     Seed AO_CS_DIV/AO_CS/AO_PY/AO_TX fixture rows');
+      console.log('  seed-cosmos  Seed synced case, Trustee, ProfessionalId, TrusteeAppointment');
+      console.log('  run          Full test: clean → seed → read DXTR → process → assert');
+      console.log('  clean        Remove seeded data from DXTR SQL + Cosmos');
+      console.log('  help         Show this help');
+      break;
+    }
+  }
+
+  console.log('\n' + '='.repeat(60));
+  process.exit(hasFailures ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/test/integration/trustee-petition-match/seed/00-seed-dxtr-schema.sql
+++ b/test/integration/trustee-petition-match/seed/00-seed-dxtr-schema.sql
@@ -1,0 +1,81 @@
+-- DXTR DDL: creates the tables read by CasesDxtrGateway.getTrusteeAppointments and
+-- getTrusteePetitionEvents. Run against DXTR_INT database (created by seed-schema command).
+--
+-- This is a hand-crafted subset of the real DXTR schema (no authoritative DDL for DXTR
+-- exists in this repo) covering only the columns those two queries actually select or
+-- join on. See skills/cams-gateways dxtr-schema/ (AO_TX.md, AO_CS.md, AO_CS_DIV.md,
+-- AO_PY.md) for the full column reference this was derived from.
+
+IF OBJECT_ID('dbo.AO_TX', 'U') IS NOT NULL DROP TABLE dbo.AO_TX;
+GO
+
+IF OBJECT_ID('dbo.AO_PY', 'U') IS NOT NULL DROP TABLE dbo.AO_PY;
+GO
+
+IF OBJECT_ID('dbo.AO_CS', 'U') IS NOT NULL DROP TABLE dbo.AO_CS;
+GO
+
+IF OBJECT_ID('dbo.AO_CS_DIV', 'U') IS NOT NULL DROP TABLE dbo.AO_CS_DIV;
+GO
+
+-- Division/district mapping. CS_DIV_ACMS is the 3-digit division code used to build
+-- CAMS case IDs and courtDivisionCode; GRP_DES feeds acmsProfessionalId's group prefix.
+CREATE TABLE dbo.AO_CS_DIV (
+  CS_DIV      VARCHAR(3) NOT NULL,
+  GRP_DES     VARCHAR(2) NOT NULL,
+  COURT_ID    VARCHAR(4) NULL,
+  CS_DIV_ACMS VARCHAR(3) NULL,
+  PRIMARY KEY (CS_DIV, GRP_DES)
+);
+GO
+
+-- Case master. Compound key (CS_CASEID, COURT_ID) — CS_CASEID alone is NOT unique.
+CREATE TABLE dbo.AO_CS (
+  CS_CASEID   VARCHAR(9)   NOT NULL,
+  COURT_ID    VARCHAR(4)   NOT NULL,
+  CASE_ID     VARCHAR(10)  NULL, -- public court case number, e.g. "26-99999"
+  CS_DIV      VARCHAR(3)   NOT NULL,
+  CS_CHAPTER  VARCHAR(3)   NULL,
+  PRIMARY KEY (CS_CASEID, COURT_ID)
+);
+GO
+
+-- Party information. PY_ROLE='tr' rows are the case trustee read by both queries.
+CREATE TABLE dbo.AO_PY (
+  CS_CASEID      VARCHAR(9)  NOT NULL,
+  COURT_ID       VARCHAR(4)  NOT NULL,
+  PY_ROLE        VARCHAR(2)  NOT NULL,
+  PY_FIRST_NAME  VARCHAR(30) NULL,
+  PY_MIDDLE_NAME VARCHAR(25) NULL,
+  PY_LAST_NAME   VARCHAR(200) NULL,
+  PY_GENERATION  VARCHAR(9)  NULL,
+  PY_ADDRESS1    VARCHAR(60) NULL,
+  PY_ADDRESS2    VARCHAR(60) NULL,
+  PY_ADDRESS3    VARCHAR(60) NULL,
+  PY_CITY        VARCHAR(30) NULL,
+  PY_STATE       VARCHAR(2)  NULL,
+  PY_ZIP         VARCHAR(13) NULL,
+  PY_COUNTRY     VARCHAR(40) NULL,
+  PY_PHONENO     VARCHAR(30) NULL,
+  PY_FAX_PHONE   VARCHAR(20) NULL,
+  PY_E_MAIL      VARCHAR(60) NULL,
+  PRIMARY KEY (CS_CASEID, COURT_ID, PY_ROLE)
+);
+GO
+
+-- Transaction records. REC is a fixed-width (237 char) legacy record; the aptDate and
+-- profCode fields the gateway reads are packed at different SUBSTRING offsets depending
+-- on TX_TYPE/TX_CODE:
+--   TR appointment (TX_TYPE='A', TX_CODE='TR'): profCode at REC[17..21], aptDate at REC[24..29]
+--   Petition       (TX_TYPE='1', TX_CODE='1'):  profCode at REC[86..90], aptDate at REC[91..96]
+-- TX_ID is a BIGINT identity serving as the primary key.
+CREATE TABLE dbo.AO_TX (
+  TX_ID     BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+  CS_CASEID VARCHAR(9)   NOT NULL,
+  COURT_ID  VARCHAR(4)   NOT NULL,
+  TX_TYPE   CHAR(1)      NOT NULL,
+  TX_CODE   VARCHAR(3)   NOT NULL,
+  TX_DATE   DATETIME2    NOT NULL,
+  REC       VARCHAR(237) NOT NULL
+);
+GO

--- a/test/integration/trustee-petition-match/seed/01-seed-dxtr-data.sql
+++ b/test/integration/trustee-petition-match/seed/01-seed-dxtr-data.sql
@@ -1,0 +1,61 @@
+-- Fixture rows for the trustee-petition-match integration test. Idempotent: safe to re-run.
+-- One test case with a trustee party, plus one 'A'/'TR' appointment transaction and one
+-- '1'/'1' petition transaction — the two event types SyncTrusteeCaseAppointmentsUseCase
+-- reads via getTrusteeAppointments() and getTrusteePetitionEvents().
+--
+-- Division: CS_DIV='081', GRP_DES='NY', COURT_ID='0208', CS_DIV_ACMS='081'
+--   → courtDivisionCode "081" (Manhattan), matches the real AO_CS_DIV row for div 081.
+-- Case: CS_CASEID='999999001', CASE_ID='26-99999' → caseId "081-26-99999"
+-- Trustee professional id: GROUP_DESIGNATOR='NY' + PROF_CODE='00063' → "NY-00063"
+
+DELETE FROM dbo.AO_TX WHERE CS_CASEID = '999999001' AND COURT_ID = '0208';
+GO
+
+DELETE FROM dbo.AO_PY WHERE CS_CASEID = '999999001' AND COURT_ID = '0208';
+GO
+
+DELETE FROM dbo.AO_CS WHERE CS_CASEID = '999999001' AND COURT_ID = '0208';
+GO
+
+DELETE FROM dbo.AO_CS_DIV WHERE CS_DIV = '081' AND GRP_DES = 'NY';
+GO
+
+INSERT INTO dbo.AO_CS_DIV (CS_DIV, GRP_DES, COURT_ID, CS_DIV_ACMS)
+VALUES ('081', 'NY', '0208', '081');
+GO
+
+INSERT INTO dbo.AO_CS (CS_CASEID, COURT_ID, CASE_ID, CS_DIV, CS_CHAPTER)
+VALUES ('999999001', '0208', '26-99999', '081', '7');
+GO
+
+INSERT INTO dbo.AO_PY (
+  CS_CASEID, COURT_ID, PY_ROLE,
+  PY_FIRST_NAME, PY_MIDDLE_NAME, PY_LAST_NAME, PY_GENERATION,
+  PY_ADDRESS1, PY_ADDRESS2, PY_ADDRESS3, PY_CITY, PY_STATE, PY_ZIP, PY_COUNTRY,
+  PY_PHONENO, PY_FAX_PHONE, PY_E_MAIL
+)
+VALUES (
+  '999999001', '0208', 'tr',
+  'Integration', '', 'Trustee', '',
+  '100 Integration Ave', '', '', 'Washington', 'DC', '20001', 'USA',
+  '202-555-0199', '', 'integration.trustee@example.com'
+);
+GO
+
+-- Appointment transaction: TX_TYPE='A', TX_CODE='TR'. REC packs profCode at
+-- position 17-21 and aptDate (YYMMDD) at position 24-29.
+INSERT INTO dbo.AO_TX (CS_CASEID, COURT_ID, TX_TYPE, TX_CODE, TX_DATE, REC)
+VALUES (
+  '999999001', '0208', 'A', 'TR', '2026-06-01T00:00:00',
+  STUFF(STUFF(REPLICATE(' ', 237), 17, 5, '00063'), 24, 6, '260601')
+);
+GO
+
+-- Petition transaction: TX_TYPE='1', TX_CODE='1'. REC packs profCode at
+-- position 86-90 and aptDate (YYMMDD) at position 91-96.
+INSERT INTO dbo.AO_TX (CS_CASEID, COURT_ID, TX_TYPE, TX_CODE, TX_DATE, REC)
+VALUES (
+  '999999001', '0208', '1', '1', '2026-03-01T00:00:00',
+  STUFF(STUFF(REPLICATE(' ', 237), 86, 5, '00063'), 91, 6, '260301')
+);
+GO


### PR DESCRIPTION
# Purpose

Add a real-database integration test for `SyncTrusteeCaseAppointmentsUseCase`, covering the DXTR read path (`getTrusteeAppointments` / `getTrusteePetitionEvents`) and the professional-id match + case-appointment write path, none of which any existing integration test in this repo actually exercises against a real DXTR instance.

# Major Changes

* Added `test/integration/trustee-petition-match/`, scaffolded on the `migrate-trustees` pattern: hand-crafted DXTR DDL (`AO_CS_DIV`/`AO_CS`/`AO_PY`/`AO_TX` — no DXTR DDL existed anywhere in this repo before) covering only the columns the two gateway queries actually use, fixture seed data for one case with both an appointment and a petition transaction, and a harness with `seed-schema`/`seed-sql`/`seed-cosmos`/`run`/`clean` commands
* Fixed two production bugs found while getting the test to actually run against a real database:
  * `CasesDxtrGateway` used `FORMAT(...)` and `AT TIME ZONE`, both of which require CLR support unavailable on some SQL Server editions (e.g. Azure SQL Edge, the only arm64-native SQL image, used by every other local integration test in this repo); replaced with `CONVERT(..., 126)` and dropped the no-op `AT TIME ZONE` annotations (both sides were already naive UTC values, so this is behavior-neutral)
  * `TrusteeCaseAppointmentsMongoRepository.getActiveByCaseId` threw instead of returning `null` when no active appointment exists — contradicting its own declared `Promise<CaseAppointment | null>` type and breaking every first-time trustee-case appointment in production. Unit tests never caught this because they mock this method directly (`mockResolvedValue(null)`), bypassing the real adapter's throw-on-not-found behavior

# Testing/Validation

* Full pipeline verified end-to-end locally against a real Azure SQL Edge + MongoDB container: schema creation, fixture seeding, DXTR read (both event types), professional-id fast-path matching, case-appointment write, and cleanup all pass
* `cases.dxtr.gateway.test.ts` (85 tests) and `trustee-case-appointments.mongo.repository.test.ts` (62 tests) pass after the production fixes; full `npm test` across `common`/`backend`/`user-interface` (3343 + 3250 tests) passes
* Ran `/cams-spec-review` on the one modified test file — the change on this branch (an assertion updated to match the new SQL) is correctly aligned; other findings reported are pre-existing and out of scope for this PR
* `npm run typecheck`, `npm run lint` (scoped), `npm run coverage:backend`, `npm audit`, and `npm run knip` all pass

# Notes

The two production fixes are in a separate commit (`e77192ca4`) from the test scaffolding (`942ff5c58`) so they can be reviewed/reverted independently — they were found by, but are logically distinct from, the new test.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Introduce a new trustee petition match integration harness that seeds minimal DXTR schema and Cosmos fixtures to validate SyncTrusteeCaseAppointmentsUseCase end-to-end, while fixing DXTR gateway SQL compatibility issues and correcting trustee appointment repository not-found handling.

New Features:
- Add a DXTR-backed integration test harness for SyncTrusteeCaseAppointmentsUseCase that exercises trustee appointment and petition events end-to-end against real SQL and Cosmos.

Bug Fixes:
- Adjust CasesDxtrGateway datetime formatting and comparison to avoid CLR-only SQL functions and ensure compatibility with Azure SQL Edge.
- Update TrusteeCaseAppointmentsMongoRepository.getActiveByCaseId to return null on not-found errors instead of throwing, aligning behavior with its declared return type.

Enhancements:
- Extend DXTR gateway tests to assert the updated SQL predicate used for transaction recency filtering.

Build:
- Add npm scripts to run the new trustee-petition-match integration harness in local and Azure environments.