### PR TITLE
CAMS-813 Add mongosh migration to purge trustee-match-verification collection

### DIFF
--- a/ops/migrations/CAMS-809-purge-trustee-match-verification.js
+++ b/ops/migrations/CAMS-809-purge-trustee-match-verification.js
@@ -15,15 +15,14 @@
 (function () {
   const collection = db.getCollection('trustee-match-verification');
 
-  const total = collection.countDocuments({});
-  print(`Found ${total} document(s) in 'trustee-match-verification'.`);
-
-  if (total === 0) {
-    print('Collection is already empty. Nothing to do.');
-    return;
-  }
+  print("Purging all documents from 'trustee-match-verification' collection...");
 
   const result = collection.deleteMany({});
-  print(`Deleted ${result.deletedCount} document(s).`);
-  print('Purge complete. Run the backfill to repopulate.');
+
+  if (result.deletedCount === 0) {
+    print('Collection was already empty. Nothing to do.');
+  } else {
+    print(`Deleted ${result.deletedCount} document(s).`);
+    print('Purge complete. Run the backfill to repopulate.');
+  }
 })();

--- a/ops/migrations/CAMS-809-purge-trustee-match-verification.js
+++ b/ops/migrations/CAMS-809-purge-trustee-match-verification.js
@@ -1,0 +1,29 @@
+/**
+ * One-time migration: delete all documents from the `trustee-match-verification`
+ * collection so the backfill process can repopulate it cleanly.
+ *
+ * This is intentionally destructive and should only be run when the team has
+ * confirmed the backfill will immediately follow.
+ *
+ * Usage (mongosh):
+ *   mongosh "<connection-string>" ops/migrations/CAMS-809-purge-trustee-match-verification.js
+ *
+ * Or from an existing mongosh session already connected to the target database:
+ *   load('ops/migrations/CAMS-809-purge-trustee-match-verification.js')
+ */
+
+(function () {
+  const collection = db.getCollection('trustee-match-verification');
+
+  const total = collection.countDocuments({});
+  print(`Found ${total} document(s) in 'trustee-match-verification'.`);
+
+  if (total === 0) {
+    print('Collection is already empty. Nothing to do.');
+    return;
+  }
+
+  const result = collection.deleteMany({});
+  print(`Deleted ${result.deletedCount} document(s).`);
+  print('Purge complete. Run the backfill to repopulate.');
+})();


### PR DESCRIPTION
# Purpose

Purge all existing `trustee-match-verification` records from the database so the backfill process can repopulate the collection cleanly, eliminating any legacy records that may be missing `taskDate` due to predating timestamp tracking.

# Major Changes

* Added `ops/migrations/CAMS-809-purge-trustee-match-verification.js` — a one-time mongosh script that deletes all documents from the `trustee-match-verification` collection
* Script reports document count before deletion and exits early if the collection is already empty

# Testing/Validation

Manual review of the script logic. The operation uses a single `deleteMany({})` call for optimal performance, preserving collection indexes for the subsequent backfill.

# Notes

This script is intentionally destructive and should only be run immediately before the backfill is triggered. The backfill will repopulate the collection with all records having a proper `taskDate`.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

New Features:
- Introduce a mongosh migration script that counts and conditionally deletes all documents from the trustee-match-verification collection, preserving indexes for backfill use.