### PR TITLE
CAMS-814 Constrain trustee case list division filter

### DIFF
--- a/backend/function-apps/api/trustee-cases/trustee-cases.function.ts
+++ b/backend/function-apps/api/trustee-cases/trustee-cases.function.ts
@@ -2,6 +2,7 @@ import { app, InvocationContext, HttpRequest, HttpResponseInit } from '@azure/fu
 import ContextCreator from '../../azure/application-context-creator';
 import { toAzureError, toAzureSuccess } from '../../azure/functions';
 import { TrusteeCasesController } from '../../../lib/controllers/trustee-cases/trustee-cases.controller';
+import { TrusteeCaseDivisionsController } from '../../../lib/controllers/trustee-cases/trustee-case-divisions.controller';
 
 const MODULE_NAME = 'TRUSTEE-CASES-FUNCTION';
 
@@ -32,4 +33,33 @@ app.http('trustee-cases', {
   authLevel: 'anonymous',
   handler,
   route: 'trustees/{trusteeId}/cases',
+});
+
+export async function divisionsHandler(
+  request: HttpRequest,
+  invocationContext: InvocationContext,
+): Promise<HttpResponseInit> {
+  const logger = ContextCreator.getLogger(invocationContext);
+
+  try {
+    const context = await ContextCreator.applicationContextCreator({
+      invocationContext,
+      request,
+      logger,
+    });
+
+    const controller = new TrusteeCaseDivisionsController(context);
+
+    const controllerResponse = await controller.handleRequest(context);
+    return toAzureSuccess(controllerResponse);
+  } catch (error) {
+    return toAzureError(logger, MODULE_NAME, error);
+  }
+}
+
+app.http('trustee-case-divisions', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  handler: divisionsHandler,
+  route: 'trustees/{trusteeId}/divisions',
 });

--- a/backend/function-apps/api/trustee-cases/trustee-cases.function.ts
+++ b/backend/function-apps/api/trustee-cases/trustee-cases.function.ts
@@ -35,6 +35,8 @@ app.http('trustee-cases', {
   route: 'trustees/{trusteeId}/cases',
 });
 
+const DIVISIONS_MODULE_NAME = 'TRUSTEE-CASE-DIVISIONS-FUNCTION';
+
 export async function divisionsHandler(
   request: HttpRequest,
   invocationContext: InvocationContext,
@@ -53,7 +55,7 @@ export async function divisionsHandler(
     const controllerResponse = await controller.handleRequest(context);
     return toAzureSuccess(controllerResponse);
   } catch (error) {
-    return toAzureError(logger, MODULE_NAME, error);
+    return toAzureError(logger, DIVISIONS_MODULE_NAME, error);
   }
 }
 

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.test.ts
@@ -950,6 +950,100 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
     });
   });
 
+  describe('getDistinctDivisionsForTrustee', () => {
+    function mockAggregateResult(divisions: string[]) {
+      const cursor = {
+        next: vi.fn().mockResolvedValue({ divisions }),
+        [Symbol.asyncIterator]: async function* () {
+          yield { divisions };
+        },
+      };
+      vi.spyOn(CollectionHumble.prototype, 'aggregate').mockResolvedValue(
+        cursor as unknown as AggregationCursor,
+      );
+    }
+
+    test('returns deduplicated division codes from the aggregate result', async () => {
+      mockAggregateResult(['081', '129']);
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      const result = await repo.getDistinctDivisionsForTrustee(TRUSTEE_ID);
+
+      expect(result).toEqual(['081', '129']);
+      repo.release();
+    });
+
+    test('returns [] when the trustee has no case appointments', async () => {
+      mockAggregateResult([]);
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      const result = await repo.getDistinctDivisionsForTrustee(TRUSTEE_ID);
+
+      expect(result).toEqual([]);
+      repo.release();
+    });
+
+    test('returns [] when the aggregate cursor yields no document at all', async () => {
+      const cursor = {
+        next: vi.fn().mockResolvedValue(null),
+        [Symbol.asyncIterator]: async function* () {},
+      };
+      vi.spyOn(CollectionHumble.prototype, 'aggregate').mockResolvedValue(
+        cursor as unknown as AggregationCursor,
+      );
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      const result = await repo.getDistinctDivisionsForTrustee(TRUSTEE_ID);
+
+      expect(result).toEqual([]);
+      repo.release();
+    });
+
+    test('the rendered pipeline does not filter by caseStatus', async () => {
+      mockAggregateResult(['081']);
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      await repo.getDistinctDivisionsForTrustee(TRUSTEE_ID);
+
+      const spy = vi.mocked(CollectionHumble.prototype.aggregate);
+      const pipeline = spy.mock.calls[0][0] as unknown as Record<string, unknown>[];
+      const pipelineStr = JSON.stringify(pipeline);
+      expect(pipelineStr).not.toContain('caseStatus');
+      repo.release();
+    });
+
+    test('the rendered pipeline matches on trusteeId', async () => {
+      mockAggregateResult(['081']);
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      await repo.getDistinctDivisionsForTrustee(TRUSTEE_ID);
+
+      const spy = vi.mocked(CollectionHumble.prototype.aggregate);
+      const pipeline = spy.mock.calls[0][0] as unknown as Record<string, unknown>[];
+      const pipelineStr = JSON.stringify(pipeline);
+      expect(pipelineStr).toContain(TRUSTEE_ID);
+      repo.release();
+    });
+
+    test('error thrown by aggregate — propagates to caller wrapped as CamsError', async () => {
+      vi.spyOn(CollectionHumble.prototype, 'aggregate').mockRejectedValue(
+        new Error('mongo connection failed'),
+      );
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      await expect(repo.getDistinctDivisionsForTrustee(TRUSTEE_ID)).rejects.toThrow(
+        `Failed to retrieve distinct divisions for trustee ${TRUSTEE_ID}`,
+      );
+      repo.release();
+    });
+  });
+
   describe('updateCaseFields', () => {
     test('should use updateMany on case partition to update ALL matching documents', async () => {
       const updateManySpy = vi

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -228,6 +228,28 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     }
   }
 
+  async getDistinctDivisionsForTrustee(trusteeId: string): Promise<string[]> {
+    try {
+      const doc = using<CaseAppointmentDocument>();
+      const match = toMongoQuery(and(doc('trusteeId').equals(trusteeId)));
+
+      const mongoAggregate = [
+        { $match: match },
+        { $group: { _id: null, divisions: { $addToSet: '$courtDivisionCode' } } },
+      ];
+
+      const collection = this.trusteePartition.collection<CaseAppointmentDocument>();
+      const cursor = await collection.aggregate(mongoAggregate);
+      const result = await cursor.next();
+
+      return (result?.divisions ?? []).filter((code: string | undefined) => !!code);
+    } catch (originalError) {
+      throw getCamsErrorWithStack(originalError, MODULE_NAME, {
+        message: `Failed to retrieve distinct divisions for trustee ${trusteeId}.`,
+      });
+    }
+  }
+
   private buildPrePaginateMatch(trusteeId: string, predicate: TrusteeCasesSearchPredicate) {
     const conditions: ConditionOrConjunction<CaseAppointmentDocument>[] = [
       apptDoc.field('trusteeId').equals(trusteeId),

--- a/backend/lib/controllers/trustee-cases/trustee-case-divisions.controller.test.ts
+++ b/backend/lib/controllers/trustee-cases/trustee-case-divisions.controller.test.ts
@@ -1,0 +1,94 @@
+import { vi } from 'vitest';
+import { ApplicationContext } from '../../adapters/types/basic';
+import { TrusteeCaseDivisionsController } from './trustee-case-divisions.controller';
+import { TrusteeCasesUseCase } from '../../use-cases/trustee-cases/trustee-cases.use-case';
+import { CamsRole } from '@common/cams/roles';
+import { createMockApplicationContext } from '../../testing/testing-utilities';
+
+describe('TrusteeCaseDivisionsController', () => {
+  let context: ApplicationContext;
+  let controller: TrusteeCaseDivisionsController;
+
+  beforeEach(async () => {
+    context = await createMockApplicationContext();
+    context.session.user = { id: 'user1', name: 'Test User', roles: [CamsRole.TrusteeAdmin] };
+    context.featureFlags = {
+      'trustee-management': true,
+      'trustee-case-list': true,
+    };
+    context.request.method = 'GET';
+    context.request.params = { trusteeId: 'trustee-123' };
+    context.request.query = {};
+
+    controller = new TrusteeCaseDivisionsController(context);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Feature flag protection', () => {
+    test('returns 404 when trustee-management flag is off', async () => {
+      context.featureFlags['trustee-management'] = false;
+      const result = await controller.handleRequest(context);
+      expect(result.statusCode).toBe(404);
+    });
+
+    test('returns 404 when trustee-case-list flag is off', async () => {
+      context.featureFlags['trustee-case-list'] = false;
+      const result = await controller.handleRequest(context);
+      expect(result.statusCode).toBe(404);
+    });
+  });
+
+  describe('Authorization', () => {
+    test('throws with status 401 when user lacks TrusteeAdmin role', async () => {
+      context.session.user.roles = [CamsRole.TrialAttorney];
+      await expect(controller.handleRequest(context)).rejects.toMatchObject({ status: 401 });
+    });
+
+    test('throws with status 401 when user has no roles', async () => {
+      context.session.user = { id: 'u1', name: 'No Roles', roles: undefined as unknown as [] };
+      await expect(controller.handleRequest(context)).rejects.toMatchObject({ status: 401 });
+    });
+  });
+
+  describe('GET /trustees/:trusteeId/divisions', () => {
+    test('returns 200 with division codes', async () => {
+      vi.spyOn(TrusteeCasesUseCase.prototype, 'getDistinctDivisionsForTrustee').mockResolvedValue([
+        '081',
+        '129',
+      ]);
+      const result = await controller.handleRequest(context);
+      expect(result.statusCode).toBe(200);
+      expect(result.body?.data).toEqual(['081', '129']);
+      expect(result.body?.meta).toBeDefined();
+    });
+
+    test('returns 200 with empty array when trustee has no case appointments', async () => {
+      vi.spyOn(TrusteeCasesUseCase.prototype, 'getDistinctDivisionsForTrustee').mockResolvedValue(
+        [],
+      );
+      const result = await controller.handleRequest(context);
+      expect(result.statusCode).toBe(200);
+      expect(result.body?.data).toEqual([]);
+    });
+
+    test('calls use case with trusteeId from route params', async () => {
+      const spy = vi
+        .spyOn(TrusteeCasesUseCase.prototype, 'getDistinctDivisionsForTrustee')
+        .mockResolvedValue([]);
+      await controller.handleRequest(context);
+      expect(spy).toHaveBeenCalledWith(context, 'trustee-123');
+    });
+
+    test('propagates use case errors as CamsErrors', async () => {
+      vi.spyOn(TrusteeCasesUseCase.prototype, 'getDistinctDivisionsForTrustee').mockRejectedValue(
+        new Error('db connection failed'),
+      );
+      await expect(controller.handleRequest(context)).rejects.toMatchObject({
+        isCamsError: true,
+      });
+    });
+  });
+});

--- a/backend/lib/controllers/trustee-cases/trustee-case-divisions.controller.ts
+++ b/backend/lib/controllers/trustee-cases/trustee-case-divisions.controller.ts
@@ -1,0 +1,56 @@
+import { ApplicationContext } from '../../adapters/types/basic';
+import { TrusteeCasesUseCase } from '../../use-cases/trustee-cases/trustee-cases.use-case';
+import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
+import { getCamsError } from '../../common-errors/error-utilities';
+import { CamsController } from '../controller';
+import { UnauthorizedError } from '../../common-errors/unauthorized-error';
+import { CamsRole } from '@common/cams/roles';
+
+const MODULE_NAME = 'TRUSTEE-CASE-DIVISIONS-CONTROLLER';
+
+export class TrusteeCaseDivisionsController implements CamsController {
+  private readonly useCase: TrusteeCasesUseCase;
+
+  constructor(_context: ApplicationContext) {
+    this.useCase = new TrusteeCasesUseCase();
+  }
+
+  public async handleRequest(context: ApplicationContext): Promise<CamsHttpResponseInit<string[]>> {
+    if (!context.featureFlags['trustee-management']) {
+      return { statusCode: 404 };
+    }
+
+    if (!context.featureFlags['trustee-case-list']) {
+      return { statusCode: 404 };
+    }
+
+    if (!this.hasRequiredRole(context)) {
+      throw getCamsError(
+        new UnauthorizedError(MODULE_NAME, {
+          message: 'User does not have permission to access trustee case divisions',
+        }),
+        MODULE_NAME,
+      );
+    }
+
+    try {
+      const trusteeId = context.request.params['trusteeId'];
+      const divisionCodes = await this.useCase.getDistinctDivisionsForTrustee(context, trusteeId);
+
+      return httpSuccess({
+        body: {
+          meta: { self: context.request.url },
+          data: divisionCodes,
+        },
+      });
+    } catch (originalError) {
+      throw getCamsError(originalError, MODULE_NAME);
+    }
+  }
+
+  private hasRequiredRole(context: ApplicationContext): boolean {
+    const user = context.session?.user;
+    if (!user?.roles) return false;
+    return user.roles.includes(CamsRole.TrusteeAdmin);
+  }
+}

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -591,6 +591,10 @@ export class MockMongoRepository
     return Promise.resolve({ data: [], metadata: { total: 0 } });
   }
 
+  getDistinctDivisionsForTrustee(..._ignore: any[]): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
   findTrusteeByLegacyTruId(_ignore: any): Promise<Trustee | null> {
     throw new Error('Method not implemented.');
   }

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -529,6 +529,7 @@ export interface TrusteeCaseAppointmentsRepository extends Releasable {
     trusteeId: string,
     predicate: TrusteeCasesSearchPredicate,
   ): Promise<CamsPaginationResponse<TrusteeCaseListItem>>;
+  getDistinctDivisionsForTrustee(trusteeId: string): Promise<string[]>;
   upsert(
     appointment: CaseAppointmentInput | CaseAppointmentMigrationInput,
   ): Promise<CaseAppointment>;

--- a/backend/lib/use-cases/trustee-cases/trustee-cases.use-case.test.ts
+++ b/backend/lib/use-cases/trustee-cases/trustee-cases.use-case.test.ts
@@ -49,4 +49,28 @@ describe('TrusteeCasesUseCase', () => {
       useCase.getCasesForTrustee(context, 'trustee-abc', { limit: 25, offset: 0 }),
     ).rejects.toThrow('repository failed');
   });
+
+  test('delegates to getDistinctDivisionsForTrustee and returns result unchanged', async () => {
+    const expected = ['081', '129'];
+    const spy = vi
+      .spyOn(MockMongoRepository.prototype, 'getDistinctDivisionsForTrustee')
+      .mockResolvedValue(expected);
+
+    const useCase = new TrusteeCasesUseCase();
+    const result = await useCase.getDistinctDivisionsForTrustee(context, 'trustee-abc');
+
+    expect(spy).toHaveBeenCalledWith('trustee-abc');
+    expect(result).toBe(expected);
+  });
+
+  test('errors from getDistinctDivisionsForTrustee propagate without being swallowed', async () => {
+    vi.spyOn(MockMongoRepository.prototype, 'getDistinctDivisionsForTrustee').mockRejectedValue(
+      new Error('repository failed'),
+    );
+
+    const useCase = new TrusteeCasesUseCase();
+    await expect(useCase.getDistinctDivisionsForTrustee(context, 'trustee-abc')).rejects.toThrow(
+      'repository failed',
+    );
+  });
 });

--- a/backend/lib/use-cases/trustee-cases/trustee-cases.use-case.ts
+++ b/backend/lib/use-cases/trustee-cases/trustee-cases.use-case.ts
@@ -13,4 +13,12 @@ export class TrusteeCasesUseCase {
     const apptRepo = factory.getTrusteeCaseAppointmentsRepository(context);
     return apptRepo.getCasesForTrustee(trusteeId, predicate);
   }
+
+  public async getDistinctDivisionsForTrustee(
+    context: ApplicationContext,
+    trusteeId: string,
+  ): Promise<string[]> {
+    const apptRepo = factory.getTrusteeCaseAppointmentsRepository(context);
+    return apptRepo.getDistinctDivisionsForTrustee(trusteeId);
+  }
 }

--- a/dev-tools/db_scripts/scenarios/trustee-case-list.ts
+++ b/dev-tools/db_scripts/scenarios/trustee-case-list.ts
@@ -27,6 +27,10 @@
  * so case detail links from the trustee case list render completely.
  *
  * NOTE: unassignedOn is omitted for active appointments — the repo queries { $exists: false }.
+ * NOTE: dateFiled, chapter, courtDivisionCode, and caseStatus are denormalized onto each
+ * CASE_APPOINTMENT doc (mirroring what the repo's upsert() computes in production) — the
+ * repo's getCasesForTrustee/getDistinctDivisionsForTrustee queries read these fields directly
+ * off the appointment doc, not the joined SYNCED_CASE.
  */
 
 import type { SeedContext, SeedOperation } from '../../runner.js';
@@ -406,6 +410,11 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
       trusteeId: PAGINATED_TRUSTEE_ID,
       assignedOn: `${dateFiled.slice(0, 7)}-15T00:00:00Z`,
       appointedDate: makeAppointedDate(i),
+      dateFiled,
+      chapter,
+      courtDivisionCode: div.divisionCode,
+      caseStatus: closedDate ? 'CLOSED' : 'OPEN',
+      ...(closedDate ? { closedDate } : {}),
       source: 'dxtr',
       createdOn: NOW,
       createdBy: SEEDER,
@@ -473,6 +482,10 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
       trusteeId: SINGLE_DIVISION_TRUSTEE_ID,
       assignedOn: `${dateFiled.slice(0, 7)}-15T00:00:00Z`,
       appointedDate: dateFiled,
+      dateFiled,
+      chapter: '7',
+      courtDivisionCode: singleDivision.divisionCode,
+      caseStatus: 'OPEN',
       source: 'dxtr',
       createdOn: NOW,
       createdBy: SEEDER,
@@ -541,6 +554,11 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
       trusteeId: DIVISION_CLOSED_TRUSTEE_ID,
       assignedOn: `${dateFiled.slice(0, 7)}-15T00:00:00Z`,
       appointedDate: dateFiled,
+      dateFiled,
+      chapter: '7',
+      courtDivisionCode: closedDivision.divisionCode,
+      caseStatus: 'CLOSED',
+      closedDate: '2022-12-31',
       source: 'dxtr',
       createdOn: NOW,
       createdBy: SEEDER,

--- a/dev-tools/db_scripts/scenarios/trustee-case-list.ts
+++ b/dev-tools/db_scripts/scenarios/trustee-case-list.ts
@@ -12,6 +12,17 @@
  *   - "Empty Trustee" (cams-593-empty) — no active CASE_APPOINTMENT docs.
  *     Used to test the empty state ("No case appointments found.").
  *
+ * Also seeds test data for the CAMS-814 District/Division filter constraint feature:
+ *
+ *   - "Single Division Trustee" (cams-814-single-division) — 3 case
+ *     appointments, all in the Manhattan (081) division, at least one open.
+ *     Used to verify the District/Division filter shows exactly one option.
+ *
+ *   - "Division Closed Trustee" (cams-814-division-closed) — 2 case
+ *     appointments, both in the Dallas (393) division, both closed.
+ *     Used to verify a division stays in the filter's option set even after
+ *     all of the trustee's cases there have closed.
+ *
  * Each case is seeded in both DXTR (AO_CS + AO_PY) and Cosmos (SYNCED_CASE)
  * so case detail links from the trustee case list render completely.
  *
@@ -24,6 +35,8 @@ import { createDebtor, createTrusteeBase } from '../lib/test-data-utils.js';
 
 const PAGINATED_TRUSTEE_ID = 'cams-593-paginated';
 const EMPTY_TRUSTEE_ID = 'cams-593-empty';
+const SINGLE_DIVISION_TRUSTEE_ID = 'cams-814-single-division';
+const DIVISION_CLOSED_TRUSTEE_ID = 'cams-814-division-closed';
 const SEEDER = { id: 'SEED', name: 'Test Data Seeder' };
 const NOW = '2026-01-01T00:00:00.000Z';
 
@@ -243,6 +256,38 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
         updatedOn: NOW,
         updatedBy: SEEDER,
       },
+      {
+        ...createTrusteeBase({
+          id: SINGLE_DIVISION_TRUSTEE_ID,
+          firstName: 'SingleDivision',
+          lastName: 'Trustee',
+          status: 'active',
+          address1: '300 Single St',
+          city: 'Buffalo',
+          state: 'NY',
+          zipCode: '14202',
+          phone: '716-555-0300',
+          email: 'single.division.trustee@example.com',
+        }),
+        updatedOn: NOW,
+        updatedBy: SEEDER,
+      },
+      {
+        ...createTrusteeBase({
+          id: DIVISION_CLOSED_TRUSTEE_ID,
+          firstName: 'DivisionClosed',
+          lastName: 'Trustee',
+          status: 'active',
+          address1: '400 Closed St',
+          city: 'Buffalo',
+          state: 'NY',
+          zipCode: '14202',
+          phone: '716-555-0400',
+          email: 'division.closed.trustee@example.com',
+        }),
+        updatedOn: NOW,
+        updatedBy: SEEDER,
+      },
     ],
   });
 
@@ -369,6 +414,141 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
     });
   }
 
+  // ── CAMS-814: single-division trustee (3 cases, one division, mostly open) ──
+  const singleDivision = DIVISIONS[0]; // Manhattan (081)
+  const singleDivisionResults = await Promise.all(
+    Array.from({ length: 3 }, (_, i) =>
+      ensureDxtrCase(ctx, {
+        divisionCode: singleDivision.divisionCode,
+        chapter: '7',
+        debtorName: `SingleDivision Debtor ${i + 1}`,
+        courtId: singleDivision.courtId,
+        groupDesignator: singleDivision.groupDesignator,
+      }).then((result) => ({ ...result, i })),
+    ),
+  );
+
+  for (const { operations: dxtrOps, caseInfo, i } of singleDivisionResults) {
+    const { caseId, caseNumber, csCaseId } = caseInfo;
+    const dateFiled = `2024-0${i + 1}-01`;
+    operations.push(...dxtrOps);
+
+    syncedCases.push({
+      id: caseId,
+      documentType: 'SYNCED_CASE',
+      dxtrId: csCaseId,
+      caseId,
+      caseNumber,
+      chapter: '7',
+      caseTitle: `SingleDivision Debtor ${i + 1}`,
+      dateFiled,
+      petitionLabel: 'Original petition',
+      debtorTypeCode: 'IC',
+      debtorTypeLabel: 'Individual Consumer',
+      officeName: singleDivision.officeName,
+      officeCode: singleDivision.officeCode,
+      courtId: singleDivision.courtId,
+      courtName: singleDivision.courtName,
+      courtDivisionCode: singleDivision.divisionCode,
+      courtDivisionName: singleDivision.courtDivisionName,
+      groupDesignator: singleDivision.groupDesignator,
+      regionId: singleDivision.regionId,
+      regionName: singleDivision.regionName,
+      consolidation: [],
+      debtor: createDebtor(`SingleDivision Debtor ${i + 1}`, {
+        address1: STREETS[i % STREETS.length],
+        city: singleDivision.city,
+        state: singleDivision.state,
+        zip: singleDivision.zip,
+        ssn: `***-**-${String(1000 + i).padStart(4, '0')}`,
+      }),
+      updatedOn: NOW,
+      updatedBy: SEEDER,
+    });
+
+    appointments.push({
+      id: `cams-814-single-appt-${String(i + 1).padStart(3, '0')}`,
+      documentType: 'CASE_APPOINTMENT',
+      caseId,
+      trusteeId: SINGLE_DIVISION_TRUSTEE_ID,
+      assignedOn: `${dateFiled.slice(0, 7)}-15T00:00:00Z`,
+      appointedDate: dateFiled,
+      source: 'dxtr',
+      createdOn: NOW,
+      createdBy: SEEDER,
+      updatedOn: NOW,
+      updatedBy: SEEDER,
+    });
+  }
+
+  // ── CAMS-814: division-closed trustee (2 cases, one division, all closed) ──
+  const closedDivision = DIVISIONS[2]; // Dallas (393)
+  const divisionClosedResults = await Promise.all(
+    Array.from({ length: 2 }, (_, i) =>
+      ensureDxtrCase(ctx, {
+        divisionCode: closedDivision.divisionCode,
+        chapter: '7',
+        debtorName: `DivisionClosed Debtor ${i + 1}`,
+        courtId: closedDivision.courtId,
+        groupDesignator: closedDivision.groupDesignator,
+      }).then((result) => ({ ...result, i })),
+    ),
+  );
+
+  for (const { operations: dxtrOps, caseInfo, i } of divisionClosedResults) {
+    const { caseId, caseNumber, csCaseId } = caseInfo;
+    const dateFiled = `2022-0${i + 1}-01`;
+    operations.push(...dxtrOps);
+
+    syncedCases.push({
+      id: caseId,
+      documentType: 'SYNCED_CASE',
+      dxtrId: csCaseId,
+      caseId,
+      caseNumber,
+      chapter: '7',
+      caseTitle: `DivisionClosed Debtor ${i + 1}`,
+      dateFiled,
+      closedDate: '2022-12-31',
+      petitionLabel: 'Original petition',
+      debtorTypeCode: 'IC',
+      debtorTypeLabel: 'Individual Consumer',
+      officeName: closedDivision.officeName,
+      officeCode: closedDivision.officeCode,
+      courtId: closedDivision.courtId,
+      courtName: closedDivision.courtName,
+      courtDivisionCode: closedDivision.divisionCode,
+      courtDivisionName: closedDivision.courtDivisionName,
+      groupDesignator: closedDivision.groupDesignator,
+      regionId: closedDivision.regionId,
+      regionName: closedDivision.regionName,
+      consolidation: [],
+      debtor: createDebtor(`DivisionClosed Debtor ${i + 1}`, {
+        address1: STREETS[i % STREETS.length],
+        city: closedDivision.city,
+        state: closedDivision.state,
+        zip: closedDivision.zip,
+        ssn: `***-**-${String(2000 + i).padStart(4, '0')}`,
+      }),
+      updatedOn: NOW,
+      updatedBy: SEEDER,
+    });
+
+    appointments.push({
+      id: `cams-814-closed-appt-${String(i + 1).padStart(3, '0')}`,
+      documentType: 'CASE_APPOINTMENT',
+      caseId,
+      trusteeId: DIVISION_CLOSED_TRUSTEE_ID,
+      assignedOn: `${dateFiled.slice(0, 7)}-15T00:00:00Z`,
+      appointedDate: dateFiled,
+      source: 'dxtr',
+      createdOn: NOW,
+      createdBy: SEEDER,
+      updatedOn: NOW,
+      updatedBy: SEEDER,
+    });
+  }
+
   operations.push({
     db: 'cams',
     collectionOrTable: 'cases',
@@ -387,8 +567,8 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
     data: appointments,
   });
 
-  // TRUSTEE_APPOINTMENT so Paginated Trustee appears active in the trustee list.
-  // (The 60 appointments above are CASE_APPOINTMENTs — a different document type.)
+  // TRUSTEE_APPOINTMENT so Paginated/SingleDivision/DivisionClosed Trustees appear
+  // active in the trustee list. (The CASE_APPOINTMENTs above are a different document type.)
   operations.push({
     db: 'cams',
     collectionOrTable: 'trustee-appointments',
@@ -409,6 +589,42 @@ export async function generate(ctx: SeedContext): Promise<SeedOperation[]> {
         createdOn: '2020-01-01T00:00:00.000Z',
         createdBy: SEEDER,
         updatedOn: '2020-01-01T00:00:00.000Z',
+        updatedBy: SEEDER,
+      },
+      {
+        id: 'cams-814-trustee-appt-single-division',
+        documentType: 'TRUSTEE_APPOINTMENT',
+        trusteeId: SINGLE_DIVISION_TRUSTEE_ID,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: singleDivision.courtId,
+        divisionCodes: [singleDivision.divisionCode],
+        appointedDate: '2024-01-01',
+        status: 'active',
+        effectiveDate: '2024-01-01',
+        courtName: singleDivision.courtName,
+        courtDivisionName: singleDivision.courtDivisionName,
+        createdOn: '2024-01-01T00:00:00.000Z',
+        createdBy: SEEDER,
+        updatedOn: '2024-01-01T00:00:00.000Z',
+        updatedBy: SEEDER,
+      },
+      {
+        id: 'cams-814-trustee-appt-division-closed',
+        documentType: 'TRUSTEE_APPOINTMENT',
+        trusteeId: DIVISION_CLOSED_TRUSTEE_ID,
+        chapter: '7',
+        appointmentType: 'panel',
+        courtId: closedDivision.courtId,
+        divisionCodes: [closedDivision.divisionCode],
+        appointedDate: '2022-01-01',
+        status: 'active',
+        effectiveDate: '2022-01-01',
+        courtName: closedDivision.courtName,
+        courtDivisionName: closedDivision.courtDivisionName,
+        createdOn: '2022-01-01T00:00:00.000Z',
+        createdBy: SEEDER,
+        updatedOn: '2022-01-01T00:00:00.000Z',
         updatedBy: SEEDER,
       },
     ],

--- a/user-interface/src/lib/components/DistrictDivisionComboBox.test.tsx
+++ b/user-interface/src/lib/components/DistrictDivisionComboBox.test.tsx
@@ -48,6 +48,7 @@ function renderComboBox(
   onDivisionCodesChange = vi.fn(),
   initialDivisionCodes?: string[],
   onSelectionsChange = vi.fn(),
+  divisionCodeAllowList?: string[],
 ) {
   return render(
     <DistrictDivisionComboBox
@@ -55,6 +56,7 @@ function renderComboBox(
       onDivisionCodesChange={onDivisionCodesChange}
       initialDivisionCodes={initialDivisionCodes}
       onSelectionsChange={onSelectionsChange}
+      divisionCodeAllowList={divisionCodeAllowList}
     />,
   );
 }
@@ -362,6 +364,111 @@ describe('DistrictDivisionComboBox', () => {
         expect(lastCall.find((s) => s.value === 'NYSB|087')).toBeUndefined();
         expect(lastCall.find((s) => s.value === 'NYSB|ALL')).toBeDefined();
       });
+    });
+  });
+
+  describe('divisionCodeAllowList (opt-in restriction)', () => {
+    test('restricts rendered options to only allow-listed divisions', async () => {
+      const user = userEvent.setup();
+      renderComboBox(vi.fn(), undefined, vi.fn(), ['081']);
+      const combo = await screen.findByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combo);
+      expect(
+        await screen.findByText('Southern District of New York (Manhattan)', {
+          selector: 'li span',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Southern District of New York (White Plains)', {
+          selector: 'li span',
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('District of Vermont (Rutland)', { selector: 'li span' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('excludes the district "All" option when the allow list does not cover every division in that district', async () => {
+      const user = userEvent.setup();
+      renderComboBox(vi.fn(), undefined, vi.fn(), ['081']);
+      const combo = await screen.findByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combo);
+      await screen.findByText('Southern District of New York (Manhattan)', {
+        selector: 'li span',
+      });
+      expect(
+        screen.queryByText('Southern District of New York (All)', { selector: 'li span' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('includes the district "All" option when the allow list covers every division in that district', async () => {
+      const user = userEvent.setup();
+      renderComboBox(vi.fn(), undefined, vi.fn(), ['081', '087']);
+      const combo = await screen.findByRole('combobox', { name: /district \(division\)/i });
+      await user.click(combo);
+      expect(
+        await screen.findByText('Southern District of New York (All)', { selector: 'li span' }),
+      ).toBeInTheDocument();
+    });
+
+    test('defaults selection to every allow-listed division when initialDivisionCodes is empty', async () => {
+      const onDivisionCodesChange = vi.fn();
+      renderComboBox(onDivisionCodesChange, undefined, vi.fn(), ['081', '088']);
+      await waitFor(() => {
+        expect(onDivisionCodesChange).toHaveBeenCalledWith(expect.arrayContaining(['081', '088']));
+      });
+    });
+
+    test('renders nothing (no error) when divisionCodeAllowList is an empty array', async () => {
+      renderComboBox(vi.fn(), undefined, vi.fn(), []);
+      await waitFor(() => {
+        expect(Api2.getCourts).toHaveBeenCalled();
+      });
+      expect(
+        screen.queryByRole('combobox', { name: /district \(division\)/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'Unable to load district filter options. Please try refreshing the page.',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    test('does not fall through to user-office defaults when divisionCodeAllowList is provided', async () => {
+      const session = {
+        ...MockData.getCamsSession(),
+        user: {
+          ...MockData.getCamsSession().user,
+          offices: [
+            {
+              officeCode: '088',
+              officeName: 'Rutland',
+              idpGroupName: 'Rutland',
+              regionId: '01',
+              regionName: 'Boston Region',
+              groups: [
+                {
+                  groupDesignator: 'VT',
+                  divisions: [
+                    {
+                      divisionCode: '088',
+                      court: { courtId: 'VTB', courtName: 'District of Vermont' },
+                      courtOffice: { courtOfficeCode: '088', courtOfficeName: 'Rutland' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
+      const onDivisionCodesChange = vi.fn();
+      renderComboBox(onDivisionCodesChange, undefined, vi.fn(), ['081']);
+      await waitFor(() => {
+        expect(onDivisionCodesChange).toHaveBeenCalledWith(expect.arrayContaining(['081']));
+      });
+      expect(onDivisionCodesChange).not.toHaveBeenCalledWith(expect.arrayContaining(['088']));
     });
   });
 

--- a/user-interface/src/lib/components/DistrictDivisionComboBox.tsx
+++ b/user-interface/src/lib/components/DistrictDivisionComboBox.tsx
@@ -108,31 +108,29 @@ const DistrictDivisionComboBox_ = (
             ) as ComboOption[])
           : nationalOptions;
 
+        const applyDefaults = (defaults: ComboOption[]) => {
+          if (defaults.length > 0) {
+            const codes = encodeDivisionCodes(defaults, allCourts);
+            setSelectedDivisions(defaults);
+            previousSelectionsRef.current = defaults;
+            onDivisionCodesChange?.(codes);
+            onSelectionsChange?.(defaults);
+          }
+        };
+
         let defaults: ComboOption[] = [];
         if (initialDivisionCodes?.length) {
           defaults = allOptions.filter((opt) => {
             const [, code] = opt.value.split('|');
             return code !== 'ALL' && initialDivisionCodes.includes(code);
           });
-          if (defaults.length > 0) {
-            const codes = encodeDivisionCodes(defaults, allCourts);
-            setSelectedDivisions(defaults);
-            previousSelectionsRef.current = defaults;
-            onDivisionCodesChange?.(codes);
-            onSelectionsChange?.(defaults);
-          }
+          applyDefaults(defaults);
         } else if (divisionCodeAllowList) {
           defaults = allOptions.filter((opt) => {
             const [, code] = opt.value.split('|');
             return code !== 'ALL';
           });
-          if (defaults.length > 0) {
-            const codes = encodeDivisionCodes(defaults, allCourts);
-            setSelectedDivisions(defaults);
-            previousSelectionsRef.current = defaults;
-            onDivisionCodesChange?.(codes);
-            onSelectionsChange?.(defaults);
-          }
+          applyDefaults(defaults);
         } else {
           const userCodes = getUserDivisionCodes(LocalStorage.getSession());
           if (userCodes.size > 0) {
@@ -140,13 +138,7 @@ const DistrictDivisionComboBox_ = (
               const [, code] = opt.value.split('|');
               return code !== 'ALL' && userCodes.has(code);
             });
-            if (defaults.length > 0) {
-              const codes = encodeDivisionCodes(defaults, allCourts);
-              setSelectedDivisions(defaults);
-              previousSelectionsRef.current = defaults;
-              onDivisionCodesChange?.(codes);
-              onSelectionsChange?.(defaults);
-            }
+            applyDefaults(defaults);
           }
         }
 

--- a/user-interface/src/lib/components/DistrictDivisionComboBox.tsx
+++ b/user-interface/src/lib/components/DistrictDivisionComboBox.tsx
@@ -35,6 +35,17 @@ type DistrictDivisionComboBoxProps = {
   divisionCodeAllowList?: string[];
 };
 
+type DivisionOptionMeta = {
+  courtId: string;
+  code: string;
+  isAll: boolean;
+};
+
+function parseDivisionOptionValue(value: string): DivisionOptionMeta {
+  const [courtId, code] = value.split('|');
+  return { courtId, code, isAll: code === 'ALL' };
+}
+
 function filterOptionsToAllowList(
   allOptions: { value: string; label: string; selectedLabel?: string }[],
   allCourts: CourtDivisionDetails[],
@@ -50,8 +61,8 @@ function filterOptionsToAllowList(
   }
 
   return allOptions.filter((opt) => {
-    const [courtId, code] = opt.value.split('|');
-    if (code === 'ALL') {
+    const { courtId, code, isAll } = parseDivisionOptionValue(opt.value);
+    if (isAll) {
       const allDivisionsForCourt = divisionsByCourtId.get(courtId);
       return (
         !!allDivisionsForCourt &&
@@ -60,6 +71,34 @@ function filterOptionsToAllowList(
       );
     }
     return allowSet.has(code);
+  });
+}
+
+function computeInitialDivisionDefaults(
+  allOptions: ComboOption[],
+  initialDivisionCodes: string[] | undefined,
+): ComboOption[] {
+  if (!initialDivisionCodes?.length) return [];
+  return allOptions.filter((opt) => {
+    const { code, isAll } = parseDivisionOptionValue(opt.value);
+    return !isAll && initialDivisionCodes.includes(code);
+  });
+}
+
+function computeAllowListDefaults(
+  allOptions: ComboOption[],
+  divisionCodeAllowList: string[] | undefined,
+): ComboOption[] {
+  if (!divisionCodeAllowList) return [];
+  return allOptions.filter((opt) => !parseDivisionOptionValue(opt.value).isAll);
+}
+
+function computeUserOfficeDefaults(allOptions: ComboOption[]): ComboOption[] {
+  const userCodes = getUserDivisionCodes(LocalStorage.getSession());
+  if (userCodes.size === 0) return [];
+  return allOptions.filter((opt) => {
+    const { code, isAll } = parseDivisionOptionValue(opt.value);
+    return !isAll && userCodes.has(code);
   });
 }
 
@@ -118,29 +157,15 @@ const DistrictDivisionComboBox_ = (
           }
         };
 
-        let defaults: ComboOption[] = [];
+        let defaults: ComboOption[];
         if (initialDivisionCodes?.length) {
-          defaults = allOptions.filter((opt) => {
-            const [, code] = opt.value.split('|');
-            return code !== 'ALL' && initialDivisionCodes.includes(code);
-          });
-          applyDefaults(defaults);
+          defaults = computeInitialDivisionDefaults(allOptions, initialDivisionCodes);
         } else if (divisionCodeAllowList) {
-          defaults = allOptions.filter((opt) => {
-            const [, code] = opt.value.split('|');
-            return code !== 'ALL';
-          });
-          applyDefaults(defaults);
+          defaults = computeAllowListDefaults(allOptions, divisionCodeAllowList);
         } else {
-          const userCodes = getUserDivisionCodes(LocalStorage.getSession());
-          if (userCodes.size > 0) {
-            defaults = allOptions.filter((opt) => {
-              const [, code] = opt.value.split('|');
-              return code !== 'ALL' && userCodes.has(code);
-            });
-            applyDefaults(defaults);
-          }
+          defaults = computeUserOfficeDefaults(allOptions);
         }
+        applyDefaults(defaults);
 
         const defaultOptionValues = new Set(defaults.map((d) => d.value));
         setDivisionComboOptions(

--- a/user-interface/src/lib/components/DistrictDivisionComboBox.tsx
+++ b/user-interface/src/lib/components/DistrictDivisionComboBox.tsx
@@ -28,7 +28,40 @@ type DistrictDivisionComboBoxProps = {
   onDefaultsApplied?: () => void;
   hideInternalLabel?: boolean;
   wrapPills?: boolean;
+  // Opt-in: when provided, restricts the option set to these division codes
+  // (and any per-district "All" option only when it covers every division in
+  // the allow list) instead of the full national court list, and defaults the
+  // selection to the full allow list rather than the user's own office divisions.
+  divisionCodeAllowList?: string[];
 };
+
+function filterOptionsToAllowList(
+  allOptions: { value: string; label: string; selectedLabel?: string }[],
+  allCourts: CourtDivisionDetails[],
+  allowList: string[],
+): { value: string; label: string; selectedLabel?: string }[] {
+  const allowSet = new Set(allowList);
+  const divisionsByCourtId = new Map<string, Set<string>>();
+  for (const court of allCourts) {
+    if (!divisionsByCourtId.has(court.courtId)) {
+      divisionsByCourtId.set(court.courtId, new Set());
+    }
+    divisionsByCourtId.get(court.courtId)!.add(court.courtDivisionCode);
+  }
+
+  return allOptions.filter((opt) => {
+    const [courtId, code] = opt.value.split('|');
+    if (code === 'ALL') {
+      const allDivisionsForCourt = divisionsByCourtId.get(courtId);
+      return (
+        !!allDivisionsForCourt &&
+        allDivisionsForCourt.size > 0 &&
+        [...allDivisionsForCourt].every((divisionCode) => allowSet.has(divisionCode))
+      );
+    }
+    return allowSet.has(code);
+  });
+}
 
 const DistrictDivisionComboBox_ = (
   {
@@ -40,6 +73,7 @@ const DistrictDivisionComboBox_ = (
     onDefaultsApplied,
     hideInternalLabel,
     wrapPills,
+    divisionCodeAllowList,
   }: DistrictDivisionComboBoxProps,
   ref: React.Ref<DistrictDivisionComboBoxRef>,
 ) => {
@@ -65,13 +99,32 @@ const DistrictDivisionComboBox_ = (
         const allCourts = r.data;
         setCourts(allCourts);
         onCourtsLoaded?.(allCourts);
-        const allOptions = getDistrictDivisionComboOptions(allCourts) as ComboOption[];
+        const nationalOptions = getDistrictDivisionComboOptions(allCourts) as ComboOption[];
+        const allOptions = divisionCodeAllowList
+          ? (filterOptionsToAllowList(
+              nationalOptions,
+              allCourts,
+              divisionCodeAllowList,
+            ) as ComboOption[])
+          : nationalOptions;
 
         let defaults: ComboOption[] = [];
         if (initialDivisionCodes?.length) {
           defaults = allOptions.filter((opt) => {
             const [, code] = opt.value.split('|');
             return code !== 'ALL' && initialDivisionCodes.includes(code);
+          });
+          if (defaults.length > 0) {
+            const codes = encodeDivisionCodes(defaults, allCourts);
+            setSelectedDivisions(defaults);
+            previousSelectionsRef.current = defaults;
+            onDivisionCodesChange?.(codes);
+            onSelectionsChange?.(defaults);
+          }
+        } else if (divisionCodeAllowList) {
+          defaults = allOptions.filter((opt) => {
+            const [, code] = opt.value.split('|');
+            return code !== 'ALL';
           });
           if (defaults.length > 0) {
             const codes = encodeDivisionCodes(defaults, allCourts);

--- a/user-interface/src/lib/models/api2.ts
+++ b/user-interface/src/lib/models/api2.ts
@@ -404,6 +404,10 @@ async function getTrusteeCases(trusteeId: string, predicate?: TrusteeCasesSearch
   return api().get<TrusteeCaseListItem[]>(`/trustees/${trusteeId}/cases`, params);
 }
 
+async function getTrusteeCaseDivisions(trusteeId: string) {
+  return api().get<string[]>(`/trustees/${trusteeId}/divisions`);
+}
+
 async function getTrusteeNotes(trusteeId: string) {
   return api().get<TrusteeNote[]>(`/trustees/${trusteeId}/notes`);
 }
@@ -745,6 +749,7 @@ export const _Api2 = {
   getCaseNotes,
   deleteCaseNote,
   getTrusteeCases,
+  getTrusteeCaseDivisions,
   getTrusteeNotes,
   postTrusteeNote,
   putTrusteeNote,

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -2505,6 +2505,10 @@ async function getTrusteeCases(
   };
 }
 
+async function getTrusteeCaseDivisions(_trusteeId: string): Promise<ResponseBody<string[]>> {
+  return { data: [] };
+}
+
 async function getTrusteeNotes(trusteeId: string): Promise<ResponseBody<TrusteeNote[]>> {
   return get<TrusteeNote[]>(`/trustees/${trusteeId}/notes`);
 }
@@ -3217,6 +3221,7 @@ const MockApi2 = {
   getCaseNotes,
   deleteCaseNote,
   getTrusteeCases,
+  getTrusteeCaseDivisions,
   getTrusteeNotes,
   postTrusteeNote,
   putTrusteeNote,

--- a/user-interface/src/trustees/panels/TrusteeCaseList.tsx
+++ b/user-interface/src/trustees/panels/TrusteeCaseList.tsx
@@ -92,7 +92,11 @@ export default function TrusteeCaseList({
   return (
     <div data-testid="trustee-case-list" className="right-side-screen-content">
       <h3 className="trustee-case-list-heading">Case List</h3>
-      <TrusteeCaseListFilter onFilterChange={onFilterChange} initialValue={filterPredicate} />
+      <TrusteeCaseListFilter
+        trusteeId={trusteeId}
+        onFilterChange={onFilterChange}
+        initialValue={filterPredicate}
+      />
       {isLoading && <LoadingSpinner caption="Loading case list..." />}
       {!isLoading && error && (
         <Alert type={UswdsAlertStyle.Error} show={true}>

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
@@ -515,6 +515,39 @@ describe('TrusteeCaseListFilter', () => {
       ).not.toBeInTheDocument();
     });
 
+    test('hides the district combo box again while divisions are refetched for a new trusteeId', async () => {
+      vi.spyOn(Api2, 'getTrusteeCaseDivisions').mockResolvedValueOnce({
+        data: ['0971'],
+        meta: { self: '' },
+      });
+      const view = render(<TrusteeCaseListFilter trusteeId="trustee-1" onFilterChange={vi.fn()} />);
+      await userEvent.click(screen.getByRole('button', { name: 'Filters' }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('combobox', { name: /district \(division\)/i }),
+        ).toBeInTheDocument();
+      });
+
+      let resolveDivisions: (value: { data: string[]; meta: { self: string } }) => void;
+      vi.spyOn(Api2, 'getTrusteeCaseDivisions').mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveDivisions = resolve;
+        }),
+      );
+      view.rerender(<TrusteeCaseListFilter trusteeId="trustee-2" onFilterChange={vi.fn()} />);
+
+      expect(
+        screen.queryByRole('combobox', { name: /district \(division\)/i }),
+      ).not.toBeInTheDocument();
+
+      resolveDivisions!({ data: ['0972'], meta: { self: '' } });
+      await waitFor(() => {
+        expect(
+          screen.getByRole('combobox', { name: /district \(division\)/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
     test('includes initialValue divisionCodes in onFilterChange when another filter changes', async () => {
       const onFilterChange = vi.fn();
       render(

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.test.tsx
@@ -35,11 +35,14 @@ describe('TrusteeCaseListFilter', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(Api2, 'getCourts').mockResolvedValue({ data: [], meta: { self: '' } });
+    vi.spyOn(Api2, 'getTrusteeCaseDivisions').mockResolvedValue({ data: [], meta: { self: '' } });
     vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
   });
 
   async function renderFilter(onFilterChange = vi.fn()) {
-    const view = render(<TrusteeCaseListFilter onFilterChange={onFilterChange} />);
+    const view = render(
+      <TrusteeCaseListFilter trusteeId="trustee-1" onFilterChange={onFilterChange} />,
+    );
     const accordionButton = screen.getByRole('button', { name: 'Filters' });
     await userEvent.click(accordionButton);
     return view;
@@ -159,6 +162,7 @@ describe('TrusteeCaseListFilter', () => {
   test('initializes status from initialValue prop', async () => {
     render(
       <TrusteeCaseListFilter
+        trusteeId="trustee-1"
         onFilterChange={vi.fn()}
         initialValue={{ caseStatus: 'CLOSED', chapters: [] }}
       />,
@@ -172,6 +176,7 @@ describe('TrusteeCaseListFilter', () => {
   test('initializes chapters from initialValue prop', async () => {
     render(
       <TrusteeCaseListFilter
+        trusteeId="trustee-1"
         onFilterChange={vi.fn()}
         initialValue={{ caseStatus: 'OPEN', chapters: ['7', '13'] }}
       />,
@@ -187,6 +192,7 @@ describe('TrusteeCaseListFilter', () => {
   test('initializes date fields from initialValue prop', async () => {
     render(
       <TrusteeCaseListFilter
+        trusteeId="trustee-1"
         onFilterChange={vi.fn()}
         initialValue={{
           caseStatus: 'ALL',
@@ -227,6 +233,7 @@ describe('TrusteeCaseListFilter', () => {
     const user = userEvent.setup();
     render(
       <TrusteeCaseListFilter
+        trusteeId="trustee-1"
         onFilterChange={onFilterChange}
         initialValue={{
           caseStatus: 'OPEN',
@@ -328,7 +335,7 @@ describe('TrusteeCaseListFilter', () => {
 
     test('announces chapter selection', async () => {
       const user = userEvent.setup();
-      render(<TrusteeCaseListFilter onFilterChange={vi.fn()} />);
+      render(<TrusteeCaseListFilter trusteeId="trustee-1" onFilterChange={vi.fn()} />);
       await user.click(screen.getByRole('button', { name: 'Filters' }));
       const comboInput = screen.getByRole('combobox', { name: /chapter/i });
       await user.click(comboInput);
@@ -342,7 +349,7 @@ describe('TrusteeCaseListFilter', () => {
 
     test('announces chapter filter cleared', async () => {
       const user = userEvent.setup();
-      render(<TrusteeCaseListFilter onFilterChange={vi.fn()} />);
+      render(<TrusteeCaseListFilter trusteeId="trustee-1" onFilterChange={vi.fn()} />);
       await user.click(screen.getByRole('button', { name: 'Filters' }));
       const comboInput = screen.getByRole('combobox', { name: /chapter/i });
       await user.click(comboInput);
@@ -405,6 +412,10 @@ describe('TrusteeCaseListFilter', () => {
         data: mockCourts,
         meta: { self: '' },
       });
+      vi.spyOn(Api2, 'getTrusteeCaseDivisions').mockResolvedValue({
+        data: ['0971', '0972'],
+        meta: { self: '' },
+      });
       vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
         cb(0);
         return 0;
@@ -413,7 +424,7 @@ describe('TrusteeCaseListFilter', () => {
 
     test('announces district filter selection', async () => {
       const user = userEvent.setup();
-      render(<TrusteeCaseListFilter onFilterChange={vi.fn()} />);
+      render(<TrusteeCaseListFilter trusteeId="trustee-1" onFilterChange={vi.fn()} />);
       await user.click(screen.getByRole('button', { name: 'Filters' }));
       expect(
         await screen.findByRole('combobox', { name: /district \(division\)/i }),
@@ -434,7 +445,7 @@ describe('TrusteeCaseListFilter', () => {
 
     test('announces district filter cleared', async () => {
       const user = userEvent.setup();
-      render(<TrusteeCaseListFilter onFilterChange={vi.fn()} />);
+      render(<TrusteeCaseListFilter trusteeId="trustee-1" onFilterChange={vi.fn()} />);
       await user.click(screen.getByRole('button', { name: 'Filters' }));
       expect(
         await screen.findByRole('combobox', { name: /district \(division\)/i }),
@@ -458,10 +469,57 @@ describe('TrusteeCaseListFilter', () => {
       });
     });
 
+    test('fetches trustee case divisions with the given trusteeId on mount', async () => {
+      const spy = vi.spyOn(Api2, 'getTrusteeCaseDivisions');
+      render(<TrusteeCaseListFilter trusteeId="trustee-42" onFilterChange={vi.fn()} />);
+      await waitFor(() => expect(spy).toHaveBeenCalledWith('trustee-42'));
+    });
+
+    test('does not render the district combo box until trustee divisions have loaded', async () => {
+      let resolveDivisions: (value: { data: string[]; meta: { self: string } }) => void;
+      vi.spyOn(Api2, 'getTrusteeCaseDivisions').mockReturnValue(
+        new Promise((resolve) => {
+          resolveDivisions = resolve;
+        }),
+      );
+      await renderFilter();
+      expect(
+        screen.queryByRole('combobox', { name: /district \(division\)/i }),
+      ).not.toBeInTheDocument();
+      resolveDivisions!({ data: ['0971'], meta: { self: '' } });
+      await waitFor(() => {
+        expect(
+          screen.getByRole('combobox', { name: /district \(division\)/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('renders no district combo box (no error) when trustee has zero case divisions', async () => {
+      vi.spyOn(Api2, 'getTrusteeCaseDivisions').mockResolvedValue({
+        data: [],
+        meta: { self: '' },
+      });
+      await renderFilter();
+      await waitFor(() => expect(Api2.getTrusteeCaseDivisions).toHaveBeenCalled());
+      expect(
+        screen.queryByRole('combobox', { name: /district \(division\)/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('falls back to no district combo box (no crash) when getTrusteeCaseDivisions rejects', async () => {
+      vi.spyOn(Api2, 'getTrusteeCaseDivisions').mockRejectedValue(new Error('network error'));
+      await renderFilter();
+      await waitFor(() => expect(Api2.getTrusteeCaseDivisions).toHaveBeenCalled());
+      expect(
+        screen.queryByRole('combobox', { name: /district \(division\)/i }),
+      ).not.toBeInTheDocument();
+    });
+
     test('includes initialValue divisionCodes in onFilterChange when another filter changes', async () => {
       const onFilterChange = vi.fn();
       render(
         <TrusteeCaseListFilter
+          trusteeId="trustee-1"
           onFilterChange={onFilterChange}
           initialValue={{ caseStatus: 'OPEN', chapters: [], divisionCodes: ['0971'] }}
         />,

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
@@ -38,6 +38,7 @@ export default function TrusteeCaseListFilter({
 
   useEffect(() => {
     let cancelled = false;
+    setDivisionCodeAllowList(undefined);
     Api2.getTrusteeCaseDivisions(trusteeId)
       .then((response) => {
         if (!cancelled) setDivisionCodeAllowList(response.data);

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ComboOption } from '@/lib/components/combobox/ComboBox';
 import TrusteeCaseListFilterView from './TrusteeCaseListFilterView';
 import trusteeCaseListFilterUseCase, { CASE_CHAPTER_OPTIONS } from './trusteeCaseListFilterUseCase';
@@ -8,8 +8,10 @@ import {
   TrusteeCaseStatus,
 } from './trusteeCaseListFilter.types';
 import { CourtDivisionDetails } from '@common/cams/courts';
+import Api2 from '@/lib/models/api2';
 
 export default function TrusteeCaseListFilter({
+  trusteeId,
   onFilterChange,
   initialValue,
 }: TrusteeCaseListFilterProps) {
@@ -30,6 +32,23 @@ export default function TrusteeCaseListFilter({
   const [resolvedDivisionCodes, setResolvedDivisionCodes] = useState<string[] | undefined>(
     initialValue?.divisionCodes,
   );
+  const [divisionCodeAllowList, setDivisionCodeAllowList] = useState<string[] | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    Api2.getTrusteeCaseDivisions(trusteeId)
+      .then((response) => {
+        if (!cancelled) setDivisionCodeAllowList(response.data);
+      })
+      .catch(() => {
+        if (!cancelled) setDivisionCodeAllowList([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [trusteeId]);
 
   const useCase = trusteeCaseListFilterUseCase(
     {
@@ -64,6 +83,7 @@ export default function TrusteeCaseListFilter({
     filterAnnouncement,
     selectedDivisions,
     initialDivisionCodes: initialValue?.divisionCodes,
+    divisionCodeAllowList,
     chaptersToComboOptions: useCase.chaptersToComboOptions,
     handleStatusChange: useCase.handleStatusChange,
     handleChapterChange: useCase.handleChapterChange,

--- a/user-interface/src/trustees/panels/filters/TrusteeCaseListFilterView.tsx
+++ b/user-interface/src/trustees/panels/filters/TrusteeCaseListFilterView.tsx
@@ -27,6 +27,7 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
     filterAnnouncement,
     selectedDivisions,
     initialDivisionCodes,
+    divisionCodeAllowList,
     onCourtsLoaded,
   } = viewModel;
 
@@ -144,14 +145,17 @@ function TrusteeCaseListFilterView({ viewModel }: TrusteeCaseListFilterViewProps
                 />
               </div>
               <div className="filter-control filter-control--district">
-                <DistrictDivisionComboBox
-                  ref={divisionRef}
-                  id="case-district-division-combobox"
-                  initialDivisionCodes={initialDivisionCodes}
-                  onSelectionsChange={viewModel.handleDivisionChange}
-                  onCourtsLoaded={onCourtsLoaded}
-                  wrapPills={true}
-                />
+                {divisionCodeAllowList !== undefined && (
+                  <DistrictDivisionComboBox
+                    ref={divisionRef}
+                    id="case-district-division-combobox"
+                    initialDivisionCodes={initialDivisionCodes}
+                    divisionCodeAllowList={divisionCodeAllowList}
+                    onSelectionsChange={viewModel.handleDivisionChange}
+                    onCourtsLoaded={onCourtsLoaded}
+                    wrapPills={true}
+                  />
+                )}
               </div>
             </div>
           </div>

--- a/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
+++ b/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
@@ -58,8 +58,6 @@ export interface TrusteeCaseListFilterViewModel extends TrusteeCaseListFilterHan
   filterAnnouncement: string;
   selectedDivisions: ComboOption[];
   initialDivisionCodes?: string[];
-  // undefined until the trustee's case divisions have been fetched; the district
-  // combo box is not rendered until this is resolved (possibly to an empty array).
   divisionCodeAllowList?: string[];
   onCourtsLoaded: (courts: CourtDivisionDetails[]) => void;
 }

--- a/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
+++ b/user-interface/src/trustees/panels/filters/trusteeCaseListFilter.types.ts
@@ -58,10 +58,14 @@ export interface TrusteeCaseListFilterViewModel extends TrusteeCaseListFilterHan
   filterAnnouncement: string;
   selectedDivisions: ComboOption[];
   initialDivisionCodes?: string[];
+  // undefined until the trustee's case divisions have been fetched; the district
+  // combo box is not rendered until this is resolved (possibly to an empty array).
+  divisionCodeAllowList?: string[];
   onCourtsLoaded: (courts: CourtDivisionDetails[]) => void;
 }
 
 export type TrusteeCaseListFilterProps = {
+  trusteeId: string;
   onFilterChange(filter: TrusteeCaseListFilterValue): void;
   initialValue?: TrusteeCaseListFilterValue;
 };


### PR DESCRIPTION
# Purpose

The Trustee Case List's District/Division filter defaulted its options and selection to the logged-in user's own office divisions, not the trustee's. A reviewer covering a trustee outside their own office divisions saw the wrong (or no) filter options.

# Major Changes

* Added `GET /trustees/{trusteeId}/divisions`, returning the distinct districts/divisions a trustee has case appointments in, across all case statuses (never filtered by open/closed) — new repository aggregate, use-case method, controller, and route.
* Added an opt-in `divisionCodeAllowList` prop on the shared `DistrictDivisionComboBox` that restricts its option set (including correct handling of the per-district "select all" pseudo-option) and defaults selection to the full allow list. The prop is additive only — the component's existing behavior is unchanged when it isn't passed, so the other two consumers (Trustee District Filter, Search Screen) are unaffected.
* Wired `TrusteeCaseList` → `TrusteeCaseListFilter` → `TrusteeCaseListFilterView` to fetch the trustee's divisions on mount and pass them through; the combo box is not rendered until the divisions have resolved (avoiding a flash of unfiltered options), and falls back to an empty (non-erroring) state if the trustee has no cases or the fetch fails.
* Added seed data (`cams-814-single-division`, `cams-814-division-closed`) for manual verification of a single-division trustee and a trustee whose one division has all cases closed.

# Testing/Validation

Implemented using TDD (tests written alongside each change, run continuously). Backend: 3359 tests passing, including new repository/use-case/controller test coverage for the distinct-divisions query (asserting no status filter is applied). Frontend: 3259 tests passing (+3 skipped), including new coverage for the allow-list filtering/defaulting logic, the per-district "All" edge case, the fetch-then-render gating, and the error-fallback path. Confirmed the two other `DistrictDivisionComboBox` consumers' existing tests pass unmodified (no regression). `npm run typecheck`, `npm run build` (backend + frontend), and `npm run lint` all pass repo-wide.

Ran `/cams-spec-review` against all 5 changed test files. No critical or high-severity issues found in the new test code; most flagged items were pre-existing conventions in these files (e.g. an established `{ selector: 'li span' }` pattern, existing pipeline-structure assertions) unrelated to this change. One genuine gap in new code was found and fixed: added a test for the `getTrusteeCaseDivisions` rejection path.

# Notes

Slice 1 of a 3-slice feature (see the linked spec). Remaining slices: zero-case trustee empty state (largely already covered by this slice's fetch-gating behavior, per implementation notes) and verifying the trustee-scoped default survives return navigation without clobbering a manual selection.

The seed data changes were not run against a live database in this session (no local DXTR/Mongo available) — worth a manual `npm run seed:local` check before merge.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Constrain the Trustee Case List district/division filter to the trustee’s own case divisions via a new backend divisions endpoint and updated filter wiring, ensuring correct options and defaults for cross-office reviewers.

New Features:
- Expose GET /trustees/{trusteeId}/divisions to return the trustee’s distinct case division codes.
- Add an opt-in divisionCodeAllowList capability to DistrictDivisionComboBox to limit options and default selections to a provided set.
- Wire TrusteeCaseListFilter to fetch trustee-specific case divisions by trusteeId and gate rendering of the district combo box on those results.

Enhancements:
- Extend TrusteeCasesUseCase and Mongo repository with a distinct-division query for trustees, without case-status filtering.
- Update TrusteeCaseListFilter types and view to support trustee-scoped division allow lists and non-rendered empty states.
- Add mock and API client support for trustee case divisions, consistent with existing trustee endpoints.

Tests:
- Add backend tests covering the distinct-division aggregate, error handling, and use-case delegation.
- Add frontend tests for divisionCodeAllowList behavior, trustee division fetching, gating/empty/error states, and rerendering on trusteeId changes.
- Extend trustee-case-list seed scenario data with single-division and all-closed-division trustees for manual and automated verification.