### PR TITLE
CAMS-817 heal re-resolves sentinel case appointments

### DIFF
--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@common/cams/trustee-appointments';
 import { SYSTEM_USER_REFERENCE } from '@common/cams/auditable';
 import { TrusteeCasesSearchPredicate } from '@common/api/search';
+import { NotFoundError } from '../../../common-errors/not-found-error';
 
 describe('TrusteeCaseAppointmentsMongoRepository', () => {
   const CASE_ID = '081-24-12345';
@@ -1224,6 +1225,127 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
 
       await expect(repo.replaceOneInTrusteePartition(query, document)).rejects.toThrow(
         `Failed to write to trustee partition for case ${CASE_ID}`,
+      );
+      repo.release();
+    });
+  });
+
+  describe('resolveSentinelTrusteeId', () => {
+    const sentinelKey = { caseId: CASE_ID, assignedOn: '2024-01-15' };
+    const resolvedDocument = {
+      ...baseAppointment,
+      trusteeId: 'RESOLVED-TRUSTEE',
+      documentType: 'CASE_APPOINTMENT' as const,
+    };
+
+    const SENTINEL_TRUSTEE_ID = '00000000-0000-0000-0000-000000000000';
+
+    test('deletes the sentinel row, moves it to the resolved trustee partition, and replaces it in place in the case partition', async () => {
+      const replaceOneSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')
+        .mockResolvedValue({ id: 'appt-001', modifiedCount: 1, upsertedCount: 0 });
+      const deleteOneSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'deleteOne')
+        .mockResolvedValue(1);
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      await repo.resolveSentinelTrusteeId(sentinelKey, resolvedDocument);
+
+      expect(deleteOneSpy).toHaveBeenCalledTimes(1);
+      expect(replaceOneSpy).toHaveBeenCalledTimes(2);
+
+      // Trustee partition delete targets the SENTINEL row for this case/assignedOn.
+      const deleteQuery = JSON.stringify(deleteOneSpy.mock.calls[0][0]);
+      expect(deleteQuery).toContain(SENTINEL_TRUSTEE_ID);
+      expect(deleteQuery).toContain(CASE_ID);
+      expect(deleteQuery).toContain('2024-01-15');
+
+      // First replace = trustee partition (new partition), keyed on the RESOLVED trustee.
+      const trusteeReplaceQuery = JSON.stringify(replaceOneSpy.mock.calls[0][0]);
+      expect(trusteeReplaceQuery).toContain('RESOLVED-TRUSTEE');
+      expect(trusteeReplaceQuery).not.toContain(SENTINEL_TRUSTEE_ID);
+
+      // Second replace = case partition (in place), still matched on the SENTINEL row.
+      const caseReplaceQuery = JSON.stringify(replaceOneSpy.mock.calls[1][0]);
+      expect(caseReplaceQuery).toContain(SENTINEL_TRUSTEE_ID);
+
+      // Both writes persist the resolved document.
+      expect((replaceOneSpy.mock.calls[0][1] as CaseAppointment).trusteeId).toBe(
+        'RESOLVED-TRUSTEE',
+      );
+      expect((replaceOneSpy.mock.calls[1][1] as CaseAppointment).trusteeId).toBe(
+        'RESOLVED-TRUSTEE',
+      );
+      repo.release();
+    });
+
+    test('writes the trustee partition before the case partition (crash-safe ordering)', async () => {
+      const deleteOneSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'deleteOne')
+        .mockResolvedValue(1);
+      const replaceOneSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')
+        .mockResolvedValue({ id: 'appt-001', modifiedCount: 1, upsertedCount: 0 });
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      await repo.resolveSentinelTrusteeId(sentinelKey, resolvedDocument);
+
+      // delete (trustee) → replace (trustee) both precede the case-partition replace.
+      expect(deleteOneSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        replaceOneSpy.mock.invocationCallOrder[0],
+      );
+      expect(replaceOneSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        replaceOneSpy.mock.invocationCallOrder[1],
+      );
+      repo.release();
+    });
+
+    test('tolerates a missing sentinel row in the trustee partition and still completes the move', async () => {
+      const replaceOneSpy = vi
+        .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')
+        .mockResolvedValue({ id: 'appt-001', modifiedCount: 1, upsertedCount: 0 });
+      vi.spyOn(MongoCollectionAdapter.prototype, 'deleteOne').mockRejectedValue(
+        new NotFoundError('TEST'),
+      );
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      await expect(
+        repo.resolveSentinelTrusteeId(sentinelKey, resolvedDocument),
+      ).resolves.toBeUndefined();
+
+      // The swallowed NotFoundError must not short-circuit the two partition writes.
+      expect(replaceOneSpy).toHaveBeenCalledTimes(2);
+      repo.release();
+    });
+
+    test('throws with case context when a non-NotFound delete error occurs', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'deleteOne').mockRejectedValue(
+        new Error('delete failed'),
+      );
+      const replaceOneSpy = vi.spyOn(MongoCollectionAdapter.prototype, 'replaceOne');
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      await expect(repo.resolveSentinelTrusteeId(sentinelKey, resolvedDocument)).rejects.toThrow(
+        `Failed to resolve sentinel appointment for case ${CASE_ID}`,
+      );
+      expect(replaceOneSpy).not.toHaveBeenCalled();
+      repo.release();
+    });
+
+    test('throws with case context when a write fails', async () => {
+      vi.spyOn(MongoCollectionAdapter.prototype, 'deleteOne').mockResolvedValue(1);
+      vi.spyOn(MongoCollectionAdapter.prototype, 'replaceOne').mockRejectedValue(
+        new Error('write failed'),
+      );
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      await expect(repo.resolveSentinelTrusteeId(sentinelKey, resolvedDocument)).rejects.toThrow(
+        `Failed to resolve sentinel appointment for case ${CASE_ID}`,
       );
       repo.release();
     });

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -519,6 +519,75 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     }
   }
 
+  /**
+   * resolveSentinelTrusteeId — rewrites a sentinel appointment (trusteeId ===
+   * SENTINEL_TRUSTEE_ID) to a now-resolved trustee across both partitions.
+   *
+   * The trustee partition is keyed by trusteeId, so a resolved doc belongs in a
+   * different partition than the sentinel — this is a move, not an in-place
+   * replace. We delete the sentinel-partition row and upsert the resolved doc.
+   * The case partition is keyed by caseId, so the resolved doc replaces the
+   * sentinel row in place (its _id is preserved by the natural-key match).
+   *
+   * Trustee partition is written FIRST: if the process crashes before the case
+   * partition replace, the sentinel remains visible to heal's scan (which reads
+   * the case partition) and a re-run resolves it again idempotently. A missing
+   * sentinel row in the trustee partition (already deleted by a prior partial
+   * run) is tolerated.
+   */
+  async resolveSentinelTrusteeId(
+    sentinelKey: { caseId: string; assignedOn: string },
+    resolvedDocument: CaseAppointmentDocument,
+  ): Promise<void> {
+    const doc = using<CaseAppointmentDocument>();
+    try {
+      // 1. Trustee partition: remove the stale sentinel-partition row.
+      const sentinelTrusteeQuery = and(
+        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('caseId').equals(sentinelKey.caseId),
+        doc('trusteeId').equals(SENTINEL_TRUSTEE_ID),
+        doc('assignedOn').equals(sentinelKey.assignedOn),
+      );
+      try {
+        await this.trusteePartition
+          .adapter<CaseAppointmentDocument>()
+          .deleteOne(sentinelTrusteeQuery);
+      } catch (deleteError) {
+        // Idempotent: a prior partial run may have already removed it.
+        if (!isNotFoundError(deleteError)) {
+          throw deleteError;
+        }
+      }
+
+      // 2. Trustee partition: upsert the resolved doc into its new partition.
+      const resolvedNaturalKey = and(
+        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('caseId').equals(resolvedDocument.caseId),
+        doc('trusteeId').equals(resolvedDocument.trusteeId),
+        doc('assignedOn').equals(resolvedDocument.assignedOn),
+      );
+      await this.trusteePartition
+        .adapter<CaseAppointmentDocument>()
+        .replaceOne(resolvedNaturalKey, resolvedDocument, true);
+
+      // 3. Case partition: replace the sentinel row in place (caseId partition is
+      // stable, so the existing _id is preserved by the natural-key match).
+      const sentinelCaseQuery = and(
+        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('caseId').equals(sentinelKey.caseId),
+        doc('trusteeId').equals(SENTINEL_TRUSTEE_ID),
+        doc('assignedOn').equals(sentinelKey.assignedOn),
+      );
+      await this.casePartition
+        .adapter<CaseAppointmentDocument>()
+        .replaceOne(sentinelCaseQuery, resolvedDocument, true);
+    } catch (originalError) {
+      throw getCamsErrorWithStack(originalError, MODULE_NAME, {
+        message: `Failed to resolve sentinel appointment for case ${sentinelKey.caseId}.`,
+      });
+    }
+  }
+
   private async findByCursor<T>(
     query: ConditionOrConjunction<T>,
     options: { limit: number; sortField: keyof T; sortDirection: 'ASCENDING' | 'DESCENDING' },

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -32,6 +32,9 @@ const TRUSTEE_COLLECTION = 'trustee-case-appointments';
 
 const CASES_COLLECTION = 'cases';
 
+// documentType discriminator for appointment docs in both partitions.
+const CASE_APPOINTMENT_DOC_TYPE = 'CASE_APPOINTMENT' as const;
+
 const { using, and } = QueryBuilder;
 const { source } = QueryPipeline;
 
@@ -108,7 +111,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     try {
       const doc = using<CaseAppointmentDocument>();
       const query = and(
-        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
         doc('caseId').equals(caseId),
       );
       return await this.casePartition.adapter<CaseAppointmentDocument>().find(query);
@@ -123,7 +126,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     try {
       const doc = using<CaseAppointmentDocument>();
       const query = and(
-        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
         doc('caseId').equals(caseId),
         doc('unassignedOn').notExists(),
         doc('trusteeId').notEqual(SENTINEL_TRUSTEE_ID),
@@ -266,14 +269,14 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     }
 
     const document = createAuditRecord<Creatable<CaseAppointmentDocument>>(
-      { ...appointmentWithStatus, documentType: 'CASE_APPOINTMENT' },
+      { ...appointmentWithStatus, documentType: CASE_APPOINTMENT_DOC_TYPE },
       SYSTEM_USER_REFERENCE,
     );
 
     // Natural key for idempotent upsert — safe to replay on retry
     const doc = using<CaseAppointmentDocument>();
     const naturalKeyQuery = and(
-      doc('documentType').equals('CASE_APPOINTMENT'),
+      doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
       doc('caseId').equals(appointment.caseId),
       doc('trusteeId').equals(appointment.trusteeId),
       doc('assignedOn').equals(appointment.assignedOn),
@@ -319,7 +322,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
 
     const updatedDocument: CaseAppointmentDocument = {
       ...appointmentWithStatus,
-      documentType: 'CASE_APPOINTMENT',
+      documentType: CASE_APPOINTMENT_DOC_TYPE,
       updatedBy: SYSTEM_USER_REFERENCE,
       updatedOn: new Date().toISOString(),
     };
@@ -327,7 +330,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     try {
       const doc = using<CaseAppointmentDocument>();
       const query = and(
-        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
         doc('id').equals(appointment.id),
       );
       await this.casePartition
@@ -342,7 +345,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     try {
       const doc = using<CaseAppointmentDocument>();
       const query = and(
-        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
         doc('id').equals(appointment.id),
       );
       await this.trusteePartition
@@ -396,7 +399,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     type CaseAppointmentQueryable = CaseAppointmentDocument & { _id: string };
     const doc = using<CaseAppointmentQueryable>();
     const conditions = [
-      doc('documentType').equals('CASE_APPOINTMENT'),
+      doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
       doc('unassignedOn').notExists(),
       doc('appointedDate').notExists(),
     ];
@@ -415,7 +418,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
   ): Promise<Array<CaseAppointment & { _id: string }>> {
     type CaseAppointmentQueryable = CaseAppointmentDocument & { _id: string };
     const doc = using<CaseAppointmentQueryable>();
-    const conditions = [doc('documentType').equals('CASE_APPOINTMENT')];
+    const conditions = [doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE)];
     if (lastId) conditions.push(doc('_id').greaterThan(lastId));
     const query = and(...conditions);
     return this.findByCursor<CaseAppointmentQueryable>(query, {
@@ -427,7 +430,10 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
 
   async updateCaseFields(caseId: string, fields: CaseDenormalizedFields): Promise<void> {
     const doc = using<CaseAppointmentDocument>();
-    const query = and(doc('documentType').equals('CASE_APPOINTMENT'), doc('caseId').equals(caseId));
+    const query = and(
+      doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
+      doc('caseId').equals(caseId),
+    );
 
     // Update fields: do NOT include source (being removed in follow-up)
     const updateFields = {
@@ -465,7 +471,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     for (const trusteeId of uniqueTrusteeIds) {
       try {
         const trusteeQuery = and(
-          doc('documentType').equals('CASE_APPOINTMENT'),
+          doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
           doc('caseId').equals(caseId),
           doc('trusteeId').equals(trusteeId),
         );
@@ -490,7 +496,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
   ): Promise<Array<CaseAppointment>> {
     const doc = using<CaseAppointmentDocument>();
     const query = and(
-      doc('documentType').equals('CASE_APPOINTMENT'),
+      doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
       doc('trusteeId').equals(trusteeId),
       doc('unassignedOn').notExists(),
     );
@@ -504,7 +510,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     try {
       const doc = using<CaseAppointmentDocument>();
       const naturalKeyQuery = and(
-        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
         doc('caseId').equals(query.caseId),
         doc('trusteeId').equals(query.trusteeId),
         doc('assignedOn').equals(query.assignedOn),
@@ -543,7 +549,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
     try {
       // 1. Trustee partition: remove the stale sentinel-partition row.
       const sentinelTrusteeQuery = and(
-        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
         doc('caseId').equals(sentinelKey.caseId),
         doc('trusteeId').equals(SENTINEL_TRUSTEE_ID),
         doc('assignedOn').equals(sentinelKey.assignedOn),
@@ -561,7 +567,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
 
       // 2. Trustee partition: upsert the resolved doc into its new partition.
       const resolvedNaturalKey = and(
-        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
         doc('caseId').equals(resolvedDocument.caseId),
         doc('trusteeId').equals(resolvedDocument.trusteeId),
         doc('assignedOn').equals(resolvedDocument.assignedOn),
@@ -573,7 +579,7 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
       // 3. Case partition: replace the sentinel row in place (caseId partition is
       // stable, so the existing _id is preserved by the natural-key match).
       const sentinelCaseQuery = and(
-        doc('documentType').equals('CASE_APPOINTMENT'),
+        doc('documentType').equals(CASE_APPOINTMENT_DOC_TYPE),
         doc('caseId').equals(sentinelKey.caseId),
         doc('trusteeId').equals(SENTINEL_TRUSTEE_ID),
         doc('assignedOn').equals(sentinelKey.assignedOn),

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -775,4 +775,9 @@ export class MockMongoRepository
   async replaceOneInTrusteePartition(_query: any, _document: any): Promise<void> {
     // Mock does nothing — test spies will override
   }
+
+  // Mock implementation for resolveSentinelTrusteeId
+  async resolveSentinelTrusteeId(_sentinelKey: any, _resolvedDocument: any): Promise<void> {
+    // Mock does nothing — test spies will override
+  }
 }

--- a/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
+++ b/backend/lib/testing/mock-gateways/mock-mongo.repository.ts
@@ -777,7 +777,10 @@ export class MockMongoRepository
   }
 
   // Mock implementation for resolveSentinelTrusteeId
-  async resolveSentinelTrusteeId(_sentinelKey: any, _resolvedDocument: any): Promise<void> {
+  async resolveSentinelTrusteeId(
+    _sentinelKey: { caseId: string; assignedOn: string },
+    _resolvedDocument: CaseAppointment & { documentType: 'CASE_APPOINTMENT' },
+  ): Promise<void> {
     // Mock does nothing — test spies will override
   }
 }

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.test.ts
@@ -1147,6 +1147,22 @@ describe('MigrateCaseAppointmentsUseCase', () => {
       expect(result.resolvedIds.has('sentinel-1')).toBe(true);
     });
 
+    test('looks up each acmsProfessionalId once per batch and reuses the result', async () => {
+      // Two sentinels for the same unmapped trustee (same acmsProfessionalId).
+      const sentinelA = makeSentinelDoc({ _id: 'a', id: 'a', caseId: '081-24-00001' });
+      const sentinelB = makeSentinelDoc({ _id: 'b', id: 'b', caseId: '081-24-00002' });
+      const { resolveSpy, findByAcmsSpy } = setupRepos({
+        matches: [makeProfessionalId({ camsTrusteeId: 'T1' })],
+      });
+
+      const result = await resolveSentinelDocs(context, [sentinelA, sentinelB]);
+
+      // One lookup shared across both docs; both still resolved.
+      expect(findByAcmsSpy).toHaveBeenCalledTimes(1);
+      expect(resolveSpy).toHaveBeenCalledTimes(2);
+      expect(result.resolved).toBe(2);
+    });
+
     test('drops the sentinel reason and Mongo _id from the resolved document', async () => {
       const sentinel = makeSentinelDoc({ reason: 'trustee-not-found' });
       const { resolveSpy } = setupRepos({

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.test.ts
@@ -1231,6 +1231,28 @@ describe('MigrateCaseAppointmentsUseCase', () => {
       expect(resolveSpy).toHaveBeenCalledTimes(1);
       expect(result.resolved).toBe(1);
     });
+
+    test('isolates a per-doc write failure: counts it unresolved and resolves the rest', async () => {
+      const failing = makeSentinelDoc({ _id: 'bad', id: 'bad', caseId: '081-24-00001' });
+      const succeeding = makeSentinelDoc({ _id: 'good', id: 'good', caseId: '081-24-00002' });
+      const resolveSpy = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('cosmos write failed'))
+        .mockResolvedValue(undefined);
+      setupRepos({
+        matches: [makeProfessionalId({ camsTrusteeId: 'T1' })],
+        resolveSpy,
+      });
+
+      const result = await resolveSentinelDocs(context, [failing, succeeding]);
+
+      // The failure did not abort the loop — the second doc still resolved.
+      expect(resolveSpy).toHaveBeenCalledTimes(2);
+      expect(result.resolved).toBe(1);
+      expect(result.unresolved).toBe(1);
+      expect(result.resolvedIds.has('good')).toBe(true);
+      expect(result.resolvedIds.has('bad')).toBe(false);
+    });
   });
 
   describe('heal — sentinel resolution integration', () => {
@@ -1334,6 +1356,64 @@ describe('MigrateCaseAppointmentsUseCase', () => {
       const finalState = upsertHealStateSpy.mock.calls.at(-1)![0];
       expect(finalState.sentinelResolvedCount).toBe(1);
       expect(finalState.sentinelUnresolvedCount).toBe(1);
+    });
+
+    test('isolates a partition-parity repair failure and completes the batch', async () => {
+      // Two active, diverged (missing from trustee partition) docs; the first
+      // repair write fails. heal must not abort — it should repair the second
+      // and still mark the run COMPLETED.
+      const docA: CaseAppointment & { _id: string } = {
+        _id: 'a',
+        id: 'a',
+        caseId: '081-24-00001',
+        trusteeId: 'T1',
+        assignedOn: '2020-01-15',
+        createdOn: '2020-01-15T00:00:00Z',
+        updatedOn: '2020-01-15T00:00:00Z',
+        createdBy: { id: 'system', name: 'system' },
+        updatedBy: { id: 'system', name: 'system' },
+      };
+      const docB: CaseAppointment & { _id: string } = {
+        ...docA,
+        _id: 'b',
+        id: 'b',
+        caseId: '081-24-00002',
+        trusteeId: 'T2',
+      };
+      const replaceOneSpy = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('cosmos write failed'))
+        .mockResolvedValue(undefined);
+      const upsertHealStateSpy = vi.fn().mockResolvedValue({});
+
+      vi.spyOn(factory, 'getTrusteeCaseAppointmentsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          getAllCaseAppointments: vi.fn().mockResolvedValueOnce([docA, docB]).mockResolvedValue([]),
+          getActiveByTrusteeIdFromTrusteePartition: vi.fn().mockResolvedValue([]),
+          replaceOneInTrusteePartition: replaceOneSpy,
+          resolveSentinelTrusteeId: vi.fn(),
+        }) as never,
+      );
+      vi.spyOn(factory, 'getTrusteeProfessionalIdsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          findByAcmsProfessionalId: vi.fn().mockResolvedValue([]),
+        }) as never,
+      );
+      vi.spyOn(factory, 'getRuntimeStateRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          read: vi.fn().mockRejectedValue(new NotFoundError('test')),
+          upsert: upsertHealStateSpy,
+        }) as never,
+      );
+
+      await expect(MigrateCaseAppointmentsUseCase.heal(context)).resolves.toBeUndefined();
+
+      // Both repairs attempted despite the first throwing; run completed.
+      expect(replaceOneSpy).toHaveBeenCalledTimes(2);
+      const finalState = upsertHealStateSpy.mock.calls.at(-1)![0];
+      expect(finalState.status).toBe('COMPLETED');
+      // Only the successful repair is counted.
+      expect(finalState.repairedCount).toBe(1);
     });
   });
 });

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.test.ts
@@ -3,7 +3,9 @@ import { ApplicationContext } from '../../adapters/types/basic';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import MigrateCaseAppointmentsUseCase, {
   ResolvedAcmsRecord,
+  ScannedCaseAppointment,
   clearProfessionalIdMapCache,
+  resolveSentinelDocs,
 } from './migrate-case-appointments';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import factory from '../../factory';
@@ -13,6 +15,7 @@ import { TrusteeProfessionalId } from '@common/cams/trustee-professional-ids';
 import { NotFoundError } from '../../common-errors/not-found-error';
 import { TooManyRequestsError } from '../../common-errors/too-many-requests-error';
 import { SyncedCase } from '@common/cams/cases';
+import { SENTINEL_TRUSTEE_ID } from './migrate-case-appointments-constants';
 
 function makeRawRecord(
   override: Partial<AcmsCaseAppointmentRawRecord> = {},
@@ -1084,6 +1087,237 @@ describe('MigrateCaseAppointmentsUseCase', () => {
       await MigrateCaseAppointmentsUseCase.heal(context);
 
       expect(replaceOneSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveSentinelDocs', () => {
+    function makeSentinelDoc(
+      override: Partial<ScannedCaseAppointment> = {},
+    ): ScannedCaseAppointment {
+      return {
+        _id: 'sentinel-1',
+        id: 'sentinel-1',
+        caseId: '081-24-12345',
+        trusteeId: SENTINEL_TRUSTEE_ID,
+        assignedOn: '2020-01-15',
+        acmsProfessionalId: 'NY-00063',
+        createdOn: '2020-01-15T00:00:00Z',
+        updatedOn: '2020-01-15T00:00:00Z',
+        createdBy: { id: 'system', name: 'system' },
+        updatedBy: { id: 'system', name: 'system' },
+        ...override,
+      };
+    }
+
+    function setupRepos(opts: {
+      matches?: TrusteeProfessionalId[];
+      resolveSpy?: ReturnType<typeof vi.fn>;
+      findByAcmsSpy?: ReturnType<typeof vi.fn>;
+    }) {
+      const resolveSpy = opts.resolveSpy ?? vi.fn().mockResolvedValue(undefined);
+      const findByAcmsSpy = opts.findByAcmsSpy ?? vi.fn().mockResolvedValue(opts.matches ?? []);
+      vi.spyOn(factory, 'getTrusteeCaseAppointmentsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          resolveSentinelTrusteeId: resolveSpy,
+        }) as never,
+      );
+      vi.spyOn(factory, 'getTrusteeProfessionalIdsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          findByAcmsProfessionalId: findByAcmsSpy,
+        }) as never,
+      );
+      return { resolveSpy, findByAcmsSpy };
+    }
+
+    test('rewrites trusteeId in both partitions when exactly one trustee matches', async () => {
+      const sentinel = makeSentinelDoc();
+      const { resolveSpy, findByAcmsSpy } = setupRepos({
+        matches: [makeProfessionalId({ camsTrusteeId: 'T1' })],
+      });
+
+      const result = await resolveSentinelDocs(context, [sentinel]);
+
+      expect(findByAcmsSpy).toHaveBeenCalledWith('NY-00063');
+      expect(resolveSpy).toHaveBeenCalledWith(
+        { caseId: sentinel.caseId, assignedOn: sentinel.assignedOn },
+        expect.objectContaining({ trusteeId: 'T1', documentType: 'CASE_APPOINTMENT' }),
+      );
+      expect(result.resolved).toBe(1);
+      expect(result.unresolved).toBe(0);
+      expect(result.resolvedIds.has('sentinel-1')).toBe(true);
+    });
+
+    test('drops the sentinel reason and Mongo _id from the resolved document', async () => {
+      const sentinel = makeSentinelDoc({ reason: 'trustee-not-found' });
+      const { resolveSpy } = setupRepos({
+        matches: [makeProfessionalId({ camsTrusteeId: 'T1' })],
+      });
+
+      // Guard: the input genuinely carried a reason, so the assertion below is meaningful.
+      expect(sentinel.reason).toBe('trustee-not-found');
+
+      await resolveSentinelDocs(context, [sentinel]);
+
+      const resolvedDoc = resolveSpy.mock.calls[0][1];
+      expect('reason' in resolvedDoc).toBe(false);
+      expect('_id' in resolvedDoc).toBe(false);
+    });
+
+    test.each([
+      ['no', [] as TrusteeProfessionalId[]],
+      [
+        'multiple',
+        [makeProfessionalId({ camsTrusteeId: 'T1' }), makeProfessionalId({ camsTrusteeId: 'T2' })],
+      ],
+    ])('leaves the sentinel untouched when %s trustees match', async (_label, matches) => {
+      const sentinel = makeSentinelDoc();
+      const { resolveSpy } = setupRepos({ matches });
+
+      const result = await resolveSentinelDocs(context, [sentinel]);
+
+      expect(resolveSpy).not.toHaveBeenCalled();
+      expect(result.resolved).toBe(0);
+      expect(result.unresolved).toBe(1);
+      expect(result.resolvedIds.size).toBe(0);
+    });
+
+    test('does not look up a sentinel doc that lacks an acmsProfessionalId', async () => {
+      const sentinel = makeSentinelDoc({ acmsProfessionalId: undefined });
+      const { resolveSpy, findByAcmsSpy } = setupRepos({});
+
+      const result = await resolveSentinelDocs(context, [sentinel]);
+
+      expect(findByAcmsSpy).not.toHaveBeenCalled();
+      expect(resolveSpy).not.toHaveBeenCalled();
+      expect(result.unresolved).toBe(1);
+    });
+
+    test('is a no-op for already-resolved (non-sentinel) documents', async () => {
+      const resolved = makeSentinelDoc({ _id: 'id1', id: 'id1', trusteeId: 'T1' });
+      const { resolveSpy, findByAcmsSpy } = setupRepos({});
+
+      const result = await resolveSentinelDocs(context, [resolved]);
+
+      expect(findByAcmsSpy).not.toHaveBeenCalled();
+      expect(resolveSpy).not.toHaveBeenCalled();
+      expect(result.resolved).toBe(0);
+      expect(result.unresolved).toBe(0);
+    });
+
+    test('resolves historical (unassignedOn) sentinel docs, not just active ones', async () => {
+      const historicalSentinel = makeSentinelDoc({ unassignedOn: '2021-06-01' });
+      const { resolveSpy } = setupRepos({
+        matches: [makeProfessionalId({ camsTrusteeId: 'T1' })],
+      });
+
+      const result = await resolveSentinelDocs(context, [historicalSentinel]);
+
+      expect(resolveSpy).toHaveBeenCalledTimes(1);
+      expect(result.resolved).toBe(1);
+    });
+  });
+
+  describe('heal — sentinel resolution integration', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    function makeSentinelDoc(
+      override: Partial<ScannedCaseAppointment> = {},
+    ): ScannedCaseAppointment {
+      return {
+        _id: 'sentinel-1',
+        id: 'sentinel-1',
+        caseId: '081-24-12345',
+        trusteeId: SENTINEL_TRUSTEE_ID,
+        assignedOn: '2020-01-15',
+        acmsProfessionalId: 'NY-00063',
+        createdOn: '2020-01-15T00:00:00Z',
+        updatedOn: '2020-01-15T00:00:00Z',
+        createdBy: { id: 'system', name: 'system' },
+        updatedBy: { id: 'system', name: 'system' },
+        ...override,
+      };
+    }
+
+    test('does not run partition-parity repair for a doc it just resolved', async () => {
+      // A sentinel doc has SENTINEL_TRUSTEE_ID; if the parity pass ran on it after
+      // resolution, it would re-create a sentinel row in the trustee partition.
+      const sentinel = makeSentinelDoc();
+      const replaceOneSpy = vi.fn();
+      const resolveSpy = vi.fn().mockResolvedValue(undefined);
+
+      vi.spyOn(factory, 'getTrusteeCaseAppointmentsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          getAllCaseAppointments: vi.fn().mockResolvedValueOnce([sentinel]).mockResolvedValue([]),
+          getActiveByTrusteeIdFromTrusteePartition: vi.fn().mockResolvedValue([]),
+          replaceOneInTrusteePartition: replaceOneSpy,
+          resolveSentinelTrusteeId: resolveSpy,
+        }) as never,
+      );
+      vi.spyOn(factory, 'getTrusteeProfessionalIdsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          findByAcmsProfessionalId: vi
+            .fn()
+            .mockResolvedValue([makeProfessionalId({ camsTrusteeId: 'T1' })]),
+        }) as never,
+      );
+      vi.spyOn(factory, 'getRuntimeStateRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          read: vi.fn().mockRejectedValue(new NotFoundError('test')),
+          upsert: vi.fn().mockResolvedValue({}),
+        }) as never,
+      );
+
+      await MigrateCaseAppointmentsUseCase.heal(context);
+
+      expect(resolveSpy).toHaveBeenCalledTimes(1);
+      expect(replaceOneSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ trusteeId: SENTINEL_TRUSTEE_ID }),
+        expect.anything(),
+      );
+    });
+
+    test('persists sentinel resolution counts to heal state', async () => {
+      const resolvable = makeSentinelDoc({ _id: 'sentinel-1', id: 'sentinel-1' });
+      const unresolvable = makeSentinelDoc({
+        _id: 'sentinel-2',
+        id: 'sentinel-2',
+        caseId: '081-24-99999',
+        acmsProfessionalId: 'CA-00007',
+      });
+      const upsertHealStateSpy = vi.fn().mockResolvedValue({});
+
+      vi.spyOn(factory, 'getTrusteeCaseAppointmentsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          getAllCaseAppointments: vi
+            .fn()
+            .mockResolvedValueOnce([resolvable, unresolvable])
+            .mockResolvedValue([]),
+          getActiveByTrusteeIdFromTrusteePartition: vi.fn().mockResolvedValue([]),
+          replaceOneInTrusteePartition: vi.fn(),
+          resolveSentinelTrusteeId: vi.fn().mockResolvedValue(undefined),
+        }) as never,
+      );
+      vi.spyOn(factory, 'getTrusteeProfessionalIdsRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          findByAcmsProfessionalId: vi.fn(async (acmsProfessionalId: string) =>
+            acmsProfessionalId === 'NY-00063' ? [makeProfessionalId({ camsTrusteeId: 'T1' })] : [],
+          ),
+        }) as never,
+      );
+      vi.spyOn(factory, 'getRuntimeStateRepository').mockReturnValue(
+        Object.assign(new MockMongoRepository(), {
+          read: vi.fn().mockRejectedValue(new NotFoundError('test')),
+          upsert: upsertHealStateSpy,
+        }) as never,
+      );
+
+      await MigrateCaseAppointmentsUseCase.heal(context);
+
+      const finalState = upsertHealStateSpy.mock.calls.at(-1)![0];
+      expect(finalState.sentinelResolvedCount).toBe(1);
+      expect(finalState.sentinelUnresolvedCount).toBe(1);
     });
   });
 });

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
@@ -593,6 +593,16 @@ export async function resolveSentinelDocs(
   let resolved = 0;
   let unresolved = 0;
 
+  // Per-batch memo of professional-ID lookups. Sentinels for the same unmapped
+  // trustee cluster (one trustee → many cases), so the same acmsProfessionalId
+  // repeats within a batch — reuse the result to avoid redundant Cosmos reads.
+  const lookupCache = new Map<string, number>();
+  // For uniquely-matched acmsProfessionalIds, remember the resolved trusteeId so
+  // repeated docs reuse it without a second lookup.
+  const resolvedTrusteeByAcmsId = new Map<string, string>();
+  // Accumulate unresolved detail and log once per batch to avoid per-doc log spam.
+  const unresolvedDetails: string[] = [];
+
   const sentinelDocs = batch.filter((doc) => doc.trusteeId === SENTINEL_TRUSTEE_ID);
 
   for (const doc of sentinelDocs) {
@@ -600,20 +610,26 @@ export async function resolveSentinelDocs(
     // legacy/externally-written docs of unknown provenance — not the normal path.
     if (!doc.acmsProfessionalId) {
       unresolved++;
-      logger.info(
-        MODULE_NAME,
-        `heal: sentinel doc ${doc._id} (case ${doc.caseId}) has no acmsProfessionalId — leaving unresolved.`,
-      );
+      unresolvedDetails.push(`${doc._id} (case ${doc.caseId}): no acmsProfessionalId`);
       continue;
     }
 
-    const matches = await professionalIdsRepo.findByAcmsProfessionalId(doc.acmsProfessionalId);
+    let matchCount = lookupCache.get(doc.acmsProfessionalId);
+    if (matchCount === undefined) {
+      const matches = await professionalIdsRepo.findByAcmsProfessionalId(doc.acmsProfessionalId);
+      matchCount = matches.length;
+      lookupCache.set(doc.acmsProfessionalId, matchCount);
 
-    if (matches.length !== 1) {
+      if (matchCount === 1) {
+        // Cache the resolved trusteeId alongside the count for reuse below.
+        resolvedTrusteeByAcmsId.set(doc.acmsProfessionalId, matches[0].camsTrusteeId);
+      }
+    }
+
+    if (matchCount !== 1) {
       unresolved++;
-      logger.info(
-        MODULE_NAME,
-        `heal: sentinel doc ${doc._id} (case ${doc.caseId}, acmsProfessionalId ${doc.acmsProfessionalId}) matched ${matches.length} trustees — leaving unresolved.`,
+      unresolvedDetails.push(
+        `${doc._id} (case ${doc.caseId}, acmsProfessionalId ${doc.acmsProfessionalId}): matched ${matchCount} trustees`,
       );
       continue;
     }
@@ -622,7 +638,7 @@ export async function resolveSentinelDocs(
     // sentinel reason and Mongo _id. Everything else on the original doc is preserved.
     const resolvedDocument = {
       ...doc,
-      trusteeId: matches[0].camsTrusteeId,
+      trusteeId: resolvedTrusteeByAcmsId.get(doc.acmsProfessionalId)!,
       documentType: 'CASE_APPOINTMENT',
     } as CaseAppointmentDocument & { _id?: string };
     delete resolvedDocument._id;
@@ -634,6 +650,13 @@ export async function resolveSentinelDocs(
     );
     resolvedIds.add(doc._id);
     resolved++;
+  }
+
+  if (unresolvedDetails.length > 0) {
+    logger.info(
+      MODULE_NAME,
+      `heal: left ${unresolvedDetails.length} sentinel doc(s) unresolved this batch — ${unresolvedDetails.join('; ')}`,
+    );
   }
 
   return { resolvedIds, resolved, unresolved };

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
@@ -558,11 +558,97 @@ async function updateHealState(
 }
 
 /**
- * heal — repairs partition divergence and flags legacy documents.
+ * Sentinel documents (trusteeId === SENTINEL_TRUSTEE_ID) carry an
+ * acmsProfessionalId so they can be healed once a professional-ID mapping
+ * exists. This shape exposes those extra fields on the scanned document.
+ */
+export type ScannedCaseAppointment = CaseAppointment & {
+  _id: string;
+  acmsProfessionalId?: string;
+  reason?: string;
+};
+
+/**
+ * resolveSentinelDocs — re-resolves sentinel appointments in a heal batch.
+ *
+ * For each doc still stamped with SENTINEL_TRUSTEE_ID, looks up its
+ * acmsProfessionalId against trustee-professional-ids. When exactly one CAMS
+ * trustee matches, rewrites the trusteeId across both partitions (clearing the
+ * sentinel reason). Zero, multiple, or missing-id cases are left untouched and
+ * counted for visibility. Runs over the full batch (active and historical).
+ *
+ * Returns the _ids it resolved so the caller's partition-parity pass can skip
+ * them — a just-resolved doc no longer belongs in the sentinel partition, and
+ * re-running parity repair on it would recreate a stale sentinel row.
+ */
+export async function resolveSentinelDocs(
+  context: ApplicationContext,
+  batch: ScannedCaseAppointment[],
+): Promise<{ resolvedIds: Set<string>; resolved: number; unresolved: number }> {
+  const { logger } = context;
+  const appointmentsRepo = factory.getTrusteeCaseAppointmentsRepository(context);
+  const professionalIdsRepo = factory.getTrusteeProfessionalIdsRepository(context);
+
+  const resolvedIds = new Set<string>();
+  let resolved = 0;
+  let unresolved = 0;
+
+  const sentinelDocs = batch.filter((doc) => doc.trusteeId === SENTINEL_TRUSTEE_ID);
+
+  for (const doc of sentinelDocs) {
+    // writeRecord always stamps acmsProfessionalId on sentinels, so this guards
+    // legacy/externally-written docs of unknown provenance — not the normal path.
+    if (!doc.acmsProfessionalId) {
+      unresolved++;
+      logger.info(
+        MODULE_NAME,
+        `heal: sentinel doc ${doc._id} (case ${doc.caseId}) has no acmsProfessionalId — leaving unresolved.`,
+      );
+      continue;
+    }
+
+    const matches = await professionalIdsRepo.findByAcmsProfessionalId(doc.acmsProfessionalId);
+
+    if (matches.length !== 1) {
+      unresolved++;
+      logger.info(
+        MODULE_NAME,
+        `heal: sentinel doc ${doc._id} (case ${doc.caseId}, acmsProfessionalId ${doc.acmsProfessionalId}) matched ${matches.length} trustees — leaving unresolved.`,
+      );
+      continue;
+    }
+
+    // Build the resolved document: adopt the matched trusteeId and drop the
+    // sentinel reason and Mongo _id. Everything else on the original doc is preserved.
+    const resolvedDocument = {
+      ...doc,
+      trusteeId: matches[0].camsTrusteeId,
+      documentType: 'CASE_APPOINTMENT',
+    } as CaseAppointmentDocument & { _id?: string };
+    delete resolvedDocument._id;
+    delete resolvedDocument.reason;
+
+    await appointmentsRepo.resolveSentinelTrusteeId(
+      { caseId: doc.caseId, assignedOn: doc.assignedOn },
+      resolvedDocument,
+    );
+    resolvedIds.add(doc._id);
+    resolved++;
+  }
+
+  return { resolvedIds, resolved, unresolved };
+}
+
+/**
+ * heal — repairs partition divergence, re-resolves sentinel documents, and
+ * flags legacy documents.
  *
  * Processes documents in batches, resuming from cursor across invocations.
- * Filters to active (no unassignedOn) docs when comparing partitions.
- * Repairs by writing only to trustee partition, preserving existing case-partition ids.
+ * Per batch it first re-resolves sentinel docs (trusteeId === SENTINEL_TRUSTEE_ID)
+ * whose professional-ID mapping now exists, then repairs partition divergence for
+ * the remaining active docs (skipping any it just resolved). Partition-parity
+ * comparison filters to active (no unassignedOn) docs; repairs write only to the
+ * trustee partition, preserving existing case-partition ids.
  * Exits early if approaching SAFE_THRESHOLD_MS to stay within Function budget.
  */
 async function heal(context: ApplicationContext): Promise<void> {
@@ -575,8 +661,29 @@ async function heal(context: ApplicationContext): Promise<void> {
   let lastId = healState?.lastId ?? null;
   let totalRepaired = healState?.repairedCount ?? 0;
   let totalChecked = healState?.checkedCount ?? 0;
+  let totalSentinelResolved = healState?.sentinelResolvedCount ?? 0;
+  let totalSentinelUnresolved = healState?.sentinelUnresolvedCount ?? 0;
 
   const BATCH_SIZE = 200;
+
+  const buildState = (
+    status: HealCaseAppointmentsState['status'],
+    cursor: string | null,
+  ): HealCaseAppointmentsState => ({
+    id: healState?.id,
+    documentType: 'HEAL_CASE_APPOINTMENTS_STATE',
+    lastId: cursor,
+    status,
+    startedAt: healState?.startedAt ?? new Date().toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    repairedCount: totalRepaired,
+    checkedCount: totalChecked,
+    sentinelResolvedCount: totalSentinelResolved,
+    sentinelUnresolvedCount: totalSentinelUnresolved,
+  });
+
+  const completionLog = () =>
+    `heal: completed. checked ${totalChecked} docs, repaired ${totalRepaired} missing from trustee partition, resolved ${totalSentinelResolved} sentinels (${totalSentinelUnresolved} still unresolved)`;
 
   // Main loop: fetch batches and process
   while (true) {
@@ -584,51 +691,39 @@ async function heal(context: ApplicationContext): Promise<void> {
     if (Date.now() - healStartedAt >= SAFE_THRESHOLD_MS) {
       logger.warn(
         MODULE_NAME,
-        `heal: approaching timeout — stopping early. checked=${totalChecked} repaired=${totalRepaired} lastId=${lastId}`,
+        `heal: approaching timeout — stopping early. checked=${totalChecked} repaired=${totalRepaired} sentinelResolved=${totalSentinelResolved} lastId=${lastId}`,
       );
       // Update state before exiting
-      healState = {
-        id: healState?.id,
-        documentType: 'HEAL_CASE_APPOINTMENTS_STATE',
-        lastId,
-        status: 'IN_PROGRESS',
-        startedAt: healState?.startedAt ?? new Date().toISOString(),
-        lastUpdatedAt: new Date().toISOString(),
-        repairedCount: totalRepaired,
-        checkedCount: totalChecked,
-      };
+      healState = buildState('IN_PROGRESS', lastId);
       await updateHealState(context, healState);
       return;
     }
 
-    const batch = (await appointmentsRepo.getAllCaseAppointments(lastId, BATCH_SIZE)) as Array<
-      CaseAppointment & { _id: string }
-    >;
+    const batch = (await appointmentsRepo.getAllCaseAppointments(
+      lastId,
+      BATCH_SIZE,
+    )) as ScannedCaseAppointment[];
 
     if (batch.length === 0) {
       // Done — mark state completed
-      healState = {
-        id: healState?.id,
-        documentType: 'HEAL_CASE_APPOINTMENTS_STATE',
-        lastId: null,
-        status: 'COMPLETED',
-        startedAt: healState?.startedAt ?? new Date().toISOString(),
-        lastUpdatedAt: new Date().toISOString(),
-        repairedCount: totalRepaired,
-        checkedCount: totalChecked,
-      };
+      healState = buildState('COMPLETED', null);
       await updateHealState(context, healState);
-      logger.info(
-        MODULE_NAME,
-        `heal: completed. checked ${totalChecked} docs, repaired ${totalRepaired} missing from trustee partition`,
-      );
+      logger.info(MODULE_NAME, completionLog());
       return;
     }
 
     lastId = batch[batch.length - 1]._id;
 
-    // Bug Fix 1: Filter to active (no unassignedOn) documents only
-    const activeDocs = batch.filter((doc) => !doc.unassignedOn);
+    // Sentinel re-resolution pass — runs over the full batch (active + historical).
+    const sentinelResult = await resolveSentinelDocs(context, batch);
+    totalSentinelResolved += sentinelResult.resolved;
+    totalSentinelUnresolved += sentinelResult.unresolved;
+
+    // Bug Fix 1: Filter to active (no unassignedOn) documents only.
+    // Skip docs we just resolved — they no longer belong in the sentinel partition.
+    const activeDocs = batch.filter(
+      (doc) => !doc.unassignedOn && !sentinelResult.resolvedIds.has(doc._id),
+    );
 
     // Group by trusteeId
     const byTrustee = new Map<string, Array<CaseAppointment & { _id: string }>>();
@@ -671,16 +766,7 @@ async function heal(context: ApplicationContext): Promise<void> {
     }
 
     // Update state after each batch
-    healState = {
-      id: healState?.id,
-      documentType: 'HEAL_CASE_APPOINTMENTS_STATE',
-      lastId,
-      status: 'IN_PROGRESS',
-      startedAt: healState?.startedAt ?? new Date().toISOString(),
-      lastUpdatedAt: new Date().toISOString(),
-      repairedCount: totalRepaired,
-      checkedCount: totalChecked,
-    };
+    healState = buildState('IN_PROGRESS', lastId);
     await updateHealState(context, healState);
 
     if (batch.length < BATCH_SIZE) {
@@ -688,10 +774,7 @@ async function heal(context: ApplicationContext): Promise<void> {
       healState.status = 'COMPLETED';
       healState.lastId = null;
       await updateHealState(context, healState);
-      logger.info(
-        MODULE_NAME,
-        `heal: completed. checked ${totalChecked} docs, repaired ${totalRepaired} missing from trustee partition`,
-      );
+      logger.info(MODULE_NAME, completionLog());
       return;
     }
   }
@@ -700,6 +783,8 @@ async function heal(context: ApplicationContext): Promise<void> {
 // Type needed for heal — CaseAppointmentDocument
 type CaseAppointmentDocument = CaseAppointment & {
   documentType: 'CASE_APPOINTMENT';
+  acmsProfessionalId?: string;
+  reason?: string;
 };
 
 const MigrateCaseAppointmentsUseCase = {

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
@@ -644,12 +644,22 @@ export async function resolveSentinelDocs(
     delete resolvedDocument._id;
     delete resolvedDocument.reason;
 
-    await appointmentsRepo.resolveSentinelTrusteeId(
-      { caseId: doc.caseId, assignedOn: doc.assignedOn },
-      resolvedDocument,
-    );
-    resolvedIds.add(doc._id);
-    resolved++;
+    // Isolate per-doc write failures: a single bad doc must not abort the whole
+    // heal invocation and strand the resolutions already completed in this batch.
+    // The doc keeps its sentinel and is retried on a later run (heal is idempotent).
+    try {
+      await appointmentsRepo.resolveSentinelTrusteeId(
+        { caseId: doc.caseId, assignedOn: doc.assignedOn },
+        resolvedDocument,
+      );
+      resolvedIds.add(doc._id);
+      resolved++;
+    } catch (error) {
+      unresolved++;
+      unresolvedDetails.push(
+        `${doc._id} (case ${doc.caseId}): resolve failed — ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   if (unresolvedDetails.length > 0) {
@@ -775,15 +785,25 @@ async function heal(context: ApplicationContext): Promise<void> {
             ...doc,
             documentType: 'CASE_APPOINTMENT',
           } as CaseAppointmentDocument;
-          await appointmentsRepo.replaceOneInTrusteePartition(
-            {
-              caseId: doc.caseId,
-              trusteeId: doc.trusteeId,
-              assignedOn: doc.assignedOn,
-            },
-            docWithType,
-          );
-          totalRepaired++;
+          // Isolate per-doc write failures so one bad doc can't abort the whole
+          // heal invocation and strand progress already made in this batch. The
+          // doc is left diverged and repaired on a later run (heal is idempotent).
+          try {
+            await appointmentsRepo.replaceOneInTrusteePartition(
+              {
+                caseId: doc.caseId,
+                trusteeId: doc.trusteeId,
+                assignedOn: doc.assignedOn,
+              },
+              docWithType,
+            );
+            totalRepaired++;
+          } catch (error) {
+            logger.warn(
+              MODULE_NAME,
+              `heal: partition-parity repair failed for ${doc._id} (case ${doc.caseId}) — ${error instanceof Error ? error.message : String(error)}. Leaving diverged for a later run.`,
+            );
+          }
         }
       }
     }

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -570,6 +570,10 @@ export interface TrusteeCaseAppointmentsRepository extends Releasable {
     query: { caseId: string; trusteeId: string; assignedOn: string },
     document: CaseAppointment & { documentType: 'CASE_APPOINTMENT' },
   ): Promise<void>;
+  resolveSentinelTrusteeId(
+    sentinelKey: { caseId: string; assignedOn: string },
+    resolvedDocument: CaseAppointment & { documentType: 'CASE_APPOINTMENT' },
+  ): Promise<void>;
 }
 
 export interface TrusteeAppointmentsRepository extends Releasable {
@@ -712,6 +716,10 @@ export type HealCaseAppointmentsState = RuntimeState & {
   lastUpdatedAt: string;
   repairedCount: number;
   checkedCount: number;
+  // Sentinel re-resolution counters (issue #2688). Optional for backward
+  // compatibility with state documents written before sentinel healing existed.
+  sentinelResolvedCount?: number;
+  sentinelUnresolvedCount?: number;
 };
 
 export type TrusteeAppointmentsSyncState = RuntimeState & {


### PR DESCRIPTION
# Purpose

Sentinel `CASE_APPOINTMENT` documents (stamped with `SENTINEL_TRUSTEE_ID` when an ACMS appointment's `acmsProfessionalId` didn't resolve to a CAMS trustee at migration time) were stuck with the placeholder `trusteeId` indefinitely. As professional-ID gaps get backfilled (#2687), these docs need a healing step to become real appointments.

# Major Changes

* Extended `heal()` so that, in addition to its existing partition-parity repair, it re-resolves sentinel documents against `trustee-professional-ids`:
  * Scans each batch for docs with `trusteeId === SENTINEL_TRUSTEE_ID`
  * Looks up `acmsProfessionalId` via `findByAcmsProfessionalId`
  * **Exactly one** match → rewrites `trusteeId` in both partitions and clears the sentinel `reason`
  * **Zero / multiple / missing-id** → left untouched and counted for visibility
* Added a new repository method `resolveSentinelTrusteeId` on `TrusteeCaseAppointmentsRepository`. Because `trusteeId` is the trustee-partition key, resolution is a cross-partition *move* (delete sentinel row + upsert resolved doc), not an in-place replace. The case partition is replaced in place, preserving `_id`.
* Added optional `sentinelResolvedCount` / `sentinelUnresolvedCount` counters to `HealCaseAppointmentsState`, persisted per batch and surfaced in the completion log.

# Testing/Validation

Implemented using TDD (RED → GREEN → REFACTOR). `resolveSentinelDocs` is exported and unit-tested directly across the resolve / no-match / multiple-match / missing-id / historical paths, with assertions on the returned counts and resolved-id set. Repository tests cover the cross-partition move (delete targets sentinel, resolved doc written to both partitions), the crash-safe write ordering (trustee before case), `NotFoundError` tolerance, and the non-`NotFoundError` failure branch. `heal`-level integration tests verify the parity pass skips just-resolved docs and that counts persist to state. Verified the new count assertions bite via a mutation check. Full backend suite: 3402 tests pass; typecheck, lint, and knip clean; coverage 96.29%.

# Notes

* **Idempotency & resumability:** resolution runs inside `heal()`'s existing paginated, cursor-resumable loop and respects `SAFE_THRESHOLD_MS`. Resolved docs no longer carry the sentinel, so re-runs skip them. The trustee partition is written *before* the case partition, so an interrupted run leaves the sentinel visible to the case-partition scan and re-resolves cleanly without double-writing.
* Docs resolved within a batch are excluded from the parity-repair pass to avoid recreating a stale sentinel row in the trustee partition.
* Depends on #2687 (already merged to main) for there to be meaningfully more mappings to heal against.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Add healing of sentinel CASE_APPOINTMENT documents during the migrate-case-appointments heal process and track resolution metrics.

New Features:
- Introduce resolveSentinelDocs to re-resolve sentinel case appointments using trustee-professional-id mappings within heal batches.

Bug Fixes:
- Ensure partition-parity repair skips just-resolved sentinel documents to avoid recreating stale sentinel rows in the trustee partition.

Enhancements:
- Extend the heal workflow to process sentinel documents before partition parity checks and persist per-batch sentinel resolution counts in HealCaseAppointmentsState.
- Add ScannedCaseAppointment and CaseAppointmentDocument shapes to surface sentinel-specific fields while keeping the public API type constrained.

Tests:
- Add unit and integration tests for resolveSentinelDocs, heal sentinel integration, and the new resolveSentinelTrusteeId repository behavior, including crash-safety and error handling scenarios.

Chores:
- Update TrusteeCaseAppointmentsRepository, its Mongo implementation, and the mock repository to support resolveSentinelTrusteeId with backward-compatible heal state changes.