### PR TITLE
CAMS-810 Pass authenticated user context to LaunchDarkly

### DIFF
--- a/backend/express/application-context-creator.test.ts
+++ b/backend/express/application-context-creator.test.ts
@@ -1,24 +1,38 @@
 import { vi } from 'vitest';
 import { Request } from 'express';
 import MockData from '@common/cams/test-utilities/mock-data';
+import { ApplicationContext } from '../lib/adapters/types/basic';
 import * as FeatureFlags from '../lib/adapters/utils/feature-flag';
+import { testFeatureFlags } from '@common/feature-flags';
+import { createMockApplicationContext } from '../lib/testing/testing-utilities';
 import ContextCreator from './application-context-creator';
 
-function createMockExpressRequest(headers: Record<string, string> = {}): Request {
+type MockExpressRequestOverrides = {
+  method?: string;
+  secure?: boolean;
+  host?: string;
+  query?: Record<string, string>;
+  params?: Record<string, string>;
+  body?: unknown;
+  headers?: Record<string, string | string[]>;
+};
+
+function createMockExpressRequest(overrides: MockExpressRequestOverrides = {}): Request {
+  const host = overrides.host ?? 'localhost:7071';
   return {
-    method: 'GET',
+    method: overrides.method ?? 'GET',
     url: '/cases',
-    secure: false,
-    get: (field: string): string | undefined => (field === 'host' ? 'localhost:7071' : undefined),
-    query: {},
-    params: {},
-    body: undefined,
-    headers: { authorization: 'Bearer ' + MockData.getJwt(), ...headers },
+    secure: overrides.secure ?? false,
+    get: (field: string): string | undefined => (field === 'host' ? host : undefined),
+    query: overrides.query ?? {},
+    params: overrides.params ?? {},
+    body: overrides.body,
+    headers: { authorization: 'Bearer ' + MockData.getJwt(), ...overrides.headers },
   } as Partial<Request> as Request;
 }
 
 describe('Express Application Context Creator', () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.restoreAllMocks();
   });
 
@@ -30,6 +44,7 @@ describe('Express Application Context Creator', () => {
 
     expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
     expect(featureFlagsSpy).toHaveBeenCalledWith(context.config, context.session.user);
+    expect(context.featureFlags).toEqual(testFeatureFlags);
   });
 
   test('should eagerly fetch anonymous feature flags when getApplicationContext is called directly with no opts', async () => {
@@ -41,6 +56,93 @@ describe('Express Application Context Creator', () => {
 
     expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
     expect(featureFlagsSpy).toHaveBeenCalledWith(context.config);
-    expect(context.featureFlags).toBeInstanceOf(Object);
+    expect(context.featureFlags).toEqual(testFeatureFlags);
+  });
+
+  test('should skip the eager feature-flag fetch when skipFeatureFlags is true', async () => {
+    const featureFlagsSpy = vi.spyOn(FeatureFlags, 'getFeatureFlags');
+    const request = createMockExpressRequest();
+    const logger = ContextCreator.getLogger('test-request-id');
+
+    const context = await ContextCreator.getApplicationContext(request, logger, 'test-request-id', {
+      skipFeatureFlags: true,
+    });
+
+    expect(featureFlagsSpy).not.toHaveBeenCalled();
+    expect(context.featureFlags).toEqual({});
+  });
+
+  describe('expressToCamsHttpRequest', () => {
+    test('joins array-valued headers and builds a secure URL', () => {
+      const request = createMockExpressRequest({
+        method: 'POST',
+        secure: true,
+        host: 'example.com',
+        query: { foo: 'bar' },
+        params: { id: '123' },
+        body: { some: 'body' },
+        headers: { 'x-multi': ['a', 'b'], authorization: 'Bearer token' },
+      });
+
+      const camsRequest = ContextCreator.expressToCamsHttpRequest(request);
+
+      expect(camsRequest).toEqual({
+        method: 'POST',
+        url: 'https://example.com/cases',
+        headers: { 'x-multi': 'a, b', authorization: 'Bearer token' },
+        query: { foo: 'bar' },
+        params: { id: '123' },
+        body: { some: 'body' },
+      });
+    });
+
+    test('falls back to localhost:7071 when no host header is present', () => {
+      const request = createMockExpressRequest({ headers: { authorization: 'Bearer token' } });
+
+      const camsRequest = ContextCreator.expressToCamsHttpRequest(request);
+
+      expect(camsRequest.url).toEqual('http://localhost:7071/cases');
+    });
+
+    test('wraps an unexpected error via getCamsError', () => {
+      const request = {
+        get headers(): Request['headers'] {
+          throw new Error('boom');
+        },
+      } as Partial<Request> as Request;
+
+      expect(() => ContextCreator.expressToCamsHttpRequest(request)).toThrow();
+    });
+  });
+
+  describe('getApplicationContextSession', () => {
+    let context: ApplicationContext;
+
+    beforeEach(async () => {
+      context = await createMockApplicationContext();
+    });
+
+    test('should throw an UnauthorizedError if authorization header is missing', async () => {
+      delete context.request.headers.authorization;
+      await expect(ContextCreator.getApplicationContextSession(context)).rejects.toThrow(
+        'Authorization header missing.',
+      );
+    });
+
+    test('should throw an UnauthorizedError if authorization header is not a bearer token', async () => {
+      context.request.headers.authorization = 'shouldthrowError';
+
+      await expect(ContextCreator.getApplicationContextSession(context)).rejects.toThrow(
+        'Bearer token not found in authorization header',
+      );
+    });
+
+    test('should throw an UnauthorizedError if authorization header contains Bearer with malformed token', async () => {
+      context.request.headers.authorization = 'Bearer some-text-that-is-not-possibly-a-valid-jwt';
+
+      await expect(ContextCreator.getApplicationContextSession(context)).rejects.toThrow(
+        'Malformed Bearer token in authorization header',
+      );
+    });
   });
 });

--- a/backend/express/application-context-creator.test.ts
+++ b/backend/express/application-context-creator.test.ts
@@ -1,0 +1,46 @@
+import { vi } from 'vitest';
+import { Request } from 'express';
+import MockData from '@common/cams/test-utilities/mock-data';
+import * as FeatureFlags from '../lib/adapters/utils/feature-flag';
+import ContextCreator from './application-context-creator';
+
+function createMockExpressRequest(headers: Record<string, string> = {}): Request {
+  return {
+    method: 'GET',
+    url: '/cases',
+    secure: false,
+    get: (field: string): string | undefined => (field === 'host' ? 'localhost:7071' : undefined),
+    query: {},
+    params: {},
+    body: undefined,
+    headers: { authorization: 'Bearer ' + MockData.getJwt(), ...headers },
+  } as Partial<Request> as Request;
+}
+
+describe('Express Application Context Creator', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should call getFeatureFlags exactly once with the resolved session user', async () => {
+    const featureFlagsSpy = vi.spyOn(FeatureFlags, 'getFeatureFlags');
+    const request = createMockExpressRequest();
+
+    const context = await ContextCreator.applicationContextCreator(request);
+
+    expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
+    expect(featureFlagsSpy).toHaveBeenCalledWith(context.config, context.session.user);
+  });
+
+  test('should eagerly fetch anonymous feature flags when getApplicationContext is called directly with no opts', async () => {
+    const featureFlagsSpy = vi.spyOn(FeatureFlags, 'getFeatureFlags');
+    const request = createMockExpressRequest();
+    const logger = ContextCreator.getLogger('test-request-id');
+
+    const context = await ContextCreator.getApplicationContext(request, logger, 'test-request-id');
+
+    expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
+    expect(featureFlagsSpy).toHaveBeenCalledWith(context.config);
+    expect(context.featureFlags).toBeInstanceOf(Object);
+  });
+});

--- a/backend/express/application-context-creator.test.ts
+++ b/backend/express/application-context-creator.test.ts
@@ -5,6 +5,7 @@ import { ApplicationContext } from '../lib/adapters/types/basic';
 import * as FeatureFlags from '../lib/adapters/utils/feature-flag';
 import { testFeatureFlags } from '@common/feature-flags';
 import { createMockApplicationContext } from '../lib/testing/testing-utilities';
+import { CamsError } from '../lib/common-errors/cams-error';
 import ContextCreator from './application-context-creator';
 
 type MockExpressRequestOverrides = {
@@ -111,7 +112,7 @@ describe('Express Application Context Creator', () => {
         },
       } as Partial<Request> as Request;
 
-      expect(() => ContextCreator.expressToCamsHttpRequest(request)).toThrow();
+      expect(() => ContextCreator.expressToCamsHttpRequest(request)).toThrow(expect.any(CamsError));
     });
   });
 
@@ -142,6 +143,20 @@ describe('Express Application Context Creator', () => {
 
       await expect(ContextCreator.getApplicationContextSession(context)).rejects.toThrow(
         'Malformed Bearer token in authorization header',
+      );
+    });
+  });
+
+  describe('getLogger', () => {
+    test('forwards log calls to console.log, prefixed with the request id', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const logger = ContextCreator.getLogger('test-request-id');
+      logger.info('MODULE', 'a log message');
+
+      expect(logSpy).toHaveBeenCalledWith(
+        '[test-request-id]',
+        '[INFO] [MODULE] [INVOCATION test-request-id] a log message',
       );
     });
   });

--- a/backend/express/application-context-creator.ts
+++ b/backend/express/application-context-creator.ts
@@ -60,9 +60,10 @@ async function getApplicationContext<B = unknown>(
   request: Request,
   logger: LoggerImpl,
   requestId: string,
+  opts?: { skipFeatureFlags?: boolean },
 ): Promise<ApplicationContext<B>> {
   const config = new ApplicationConfiguration();
-  const featureFlags = await getFeatureFlags(config);
+  const featureFlags = opts?.skipFeatureFlags ? {} : await getFeatureFlags(config);
 
   return {
     config,
@@ -115,10 +116,13 @@ async function applicationContextCreator<B = unknown>(
   const requestId = getRequestId();
   const logger = getLogger(requestId);
 
-  const context = await getApplicationContext<B>(request, logger, requestId);
+  const context = await getApplicationContext<B>(request, logger, requestId, {
+    skipFeatureFlags: true,
+  });
   context.request = sanitizeDeep(context.request, MODULE_NAME, context.logger);
 
   context.session = await getApplicationContextSession(context);
+  context.featureFlags = await getFeatureFlags(context.config, context.session.user);
 
   return context;
 }

--- a/backend/express/application-context-creator.ts
+++ b/backend/express/application-context-creator.ts
@@ -131,6 +131,7 @@ const ContextCreator = {
   applicationContextCreator,
   expressToCamsHttpRequest,
   getApplicationContext,
+  getApplicationContextSession,
   getLogger,
 };
 

--- a/backend/function-apps/azure/application-context-creator.test.ts
+++ b/backend/function-apps/azure/application-context-creator.test.ts
@@ -2,7 +2,9 @@ import { vi } from 'vitest';
 import MockData from '@common/cams/test-utilities/mock-data';
 import { ApplicationContext } from '../../lib/adapters/types/basic';
 import * as FeatureFlags from '../../lib/adapters/utils/feature-flag';
+import { testFeatureFlags } from '@common/feature-flags';
 import { ApplicationConfiguration } from '../../lib/configs/application-configuration';
+import { LoggerImpl } from '../../lib/adapters/services/logger.service';
 import { MockUserSessionUseCase } from '../../lib/testing/mock-gateways/mock-user-session-use-case';
 import {
   createMockApplicationContext,
@@ -14,8 +16,12 @@ import { azureToCamsHttpRequest } from './functions';
 import { BadRequestError } from '../../lib/common-errors/bad-request';
 
 describe('Application Context Creator', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('applicationContextCreator', () => {
-    test('should create an application context', async () => {
+    test('should create an application context and call getFeatureFlags exactly once with the resolved session user', async () => {
       const invocationContext = createMockAzureFunctionContext();
       const featureFlagsSpy = vi.spyOn(FeatureFlags, 'getFeatureFlags');
       const request = createMockAzureFunctionRequest();
@@ -26,22 +32,10 @@ describe('Application Context Creator', () => {
       });
       expect(context.logger instanceof Object && 'camsError' in context.logger).toBeTruthy();
       expect(context.config instanceof ApplicationConfiguration).toBeTruthy();
-      expect(context.featureFlags instanceof Object).toBeTruthy();
-      expect(featureFlagsSpy).toHaveBeenCalled();
       expect(context.request).toEqual(await azureToCamsHttpRequest(request));
-    });
-
-    test('should call getFeatureFlags exactly once with the resolved session user', async () => {
-      const invocationContext = createMockAzureFunctionContext();
-      const featureFlagsSpy = vi.spyOn(FeatureFlags, 'getFeatureFlags');
-      const request = createMockAzureFunctionRequest();
-      const context = await ContextCreator.applicationContextCreator({
-        invocationContext,
-        observability: mockObservability,
-        request,
-      });
       expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
       expect(featureFlagsSpy).toHaveBeenCalledWith(context.config, context.session.user);
+      expect(context.featureFlags).toEqual(testFeatureFlags);
     });
 
     test('should throw an error when attempting to create context with no request', async () => {
@@ -88,13 +82,29 @@ describe('Application Context Creator', () => {
 
       expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
       expect(featureFlagsSpy).toHaveBeenCalledWith(context.config);
-      expect(context.featureFlags).toBeInstanceOf(Object);
+      expect(context.featureFlags).toEqual(testFeatureFlags);
+    });
+
+    test('should reuse an explicitly injected logger instead of building one', async () => {
+      const invocationContext = createMockAzureFunctionContext();
+      const request = createMockAzureFunctionRequest();
+      const injectedLogger = new LoggerImpl('injected-invocation-id');
+      const getLoggerSpy = vi.spyOn(ContextCreator, 'getLogger');
+
+      const context = await ContextCreator.getApplicationContext({
+        invocationContext,
+        observability: mockObservability,
+        request,
+        logger: injectedLogger,
+      });
+
+      expect(context.logger).toBe(injectedLogger);
+      expect(getLoggerSpy).not.toHaveBeenCalled();
     });
 
     test('should resolve observability via the factory singleton when none is injected', async () => {
       vi.resetModules();
       const FreshContextCreator = (await import('./application-context-creator')).default;
-      const freshFactory = (await import('../../lib/factory')).default;
       const { NoOpObservability } = await import('../../lib/adapters/services/observability');
 
       const invocationContext = createMockAzureFunctionContext();
@@ -106,10 +116,8 @@ describe('Application Context Creator', () => {
       });
 
       // DATABASE_MOCK is true in the test environment, so the no-op resolves
-      // (applicationinsights is never required) and the instance is the one
-      // and only process-wide singleton the factory hands out.
+      // (applicationinsights is never required).
       expect(context.observability).toBeInstanceOf(NoOpObservability);
-      expect(context.observability).toBe(freshFactory.getObservability());
     });
 
     test('should scrub unicode characters', async () => {
@@ -181,6 +189,20 @@ describe('Application Context Creator', () => {
         .mockResolvedValue(MockData.getCamsSession());
       await ContextCreator.getApplicationContextSession(mockContext);
       expect(lookupSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('getLogger', () => {
+    test('forwards log calls to the invocation context, wrapped in an array', () => {
+      const invocationContext = createMockAzureFunctionContext();
+      const logSpy = vi.spyOn(invocationContext, 'log');
+
+      const logger = ContextCreator.getLogger(invocationContext);
+      logger.info('MODULE', 'a log message');
+
+      expect(logSpy).toHaveBeenCalledWith([
+        `[INFO] [MODULE] [INVOCATION ${invocationContext.invocationId}] a log message`,
+      ]);
     });
   });
 });

--- a/backend/function-apps/azure/application-context-creator.test.ts
+++ b/backend/function-apps/azure/application-context-creator.test.ts
@@ -31,6 +31,19 @@ describe('Application Context Creator', () => {
       expect(context.request).toEqual(await azureToCamsHttpRequest(request));
     });
 
+    test('should call getFeatureFlags exactly once with the resolved session user', async () => {
+      const invocationContext = createMockAzureFunctionContext();
+      const featureFlagsSpy = vi.spyOn(FeatureFlags, 'getFeatureFlags');
+      const request = createMockAzureFunctionRequest();
+      const context = await ContextCreator.applicationContextCreator({
+        invocationContext,
+        observability: mockObservability,
+        request,
+      });
+      expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
+      expect(featureFlagsSpy).toHaveBeenCalledWith(context.config, context.session.user);
+    });
+
     test('should throw an error when attempting to create context with no request', async () => {
       const invocationContext = createMockAzureFunctionContext();
       await expect(
@@ -60,6 +73,22 @@ describe('Application Context Creator', () => {
       ).rejects.toThrow(
         new BadRequestError(expect.any(String), { message: 'Invalid user input.' }),
       );
+    });
+
+    test('should eagerly fetch anonymous feature flags when called directly with no opts', async () => {
+      const invocationContext = createMockAzureFunctionContext();
+      const featureFlagsSpy = vi.spyOn(FeatureFlags, 'getFeatureFlags');
+      const request = createMockAzureFunctionRequest();
+
+      const context = await ContextCreator.getApplicationContext({
+        invocationContext,
+        observability: mockObservability,
+        request,
+      });
+
+      expect(featureFlagsSpy).toHaveBeenCalledTimes(1);
+      expect(featureFlagsSpy).toHaveBeenCalledWith(context.config);
+      expect(context.featureFlags).toBeInstanceOf(Object);
     });
 
     test('should resolve observability via the factory singleton when none is injected', async () => {

--- a/backend/function-apps/azure/application-context-creator.ts
+++ b/backend/function-apps/azure/application-context-creator.ts
@@ -32,24 +32,29 @@ async function applicationContextCreator<B = unknown>(
 ): Promise<ApplicationContext<B>> {
   const { invocationContext, logger, request } = args;
 
-  const context = await getApplicationContext<B>({
-    invocationContext,
-    logger,
-    request,
-  });
+  const context = await getApplicationContext<B>(
+    {
+      invocationContext,
+      logger,
+      request,
+    },
+    { skipFeatureFlags: true },
+  );
   context.request = sanitizeDeep(context.request, MODULE_NAME, context.logger);
 
   context.session = await getApplicationContextSession(context);
+  context.featureFlags = await getFeatureFlags(context.config, context.session.user);
 
   return context;
 }
 
 async function getApplicationContext<B = unknown>(
   args: ContextCreatorArgs,
+  opts?: { skipFeatureFlags?: boolean },
 ): Promise<ApplicationContext<B>> {
   const { invocationContext, logger, observability, request } = args;
   const config = new ApplicationConfiguration();
-  const featureFlags = await getFeatureFlags(config);
+  const featureFlags = opts?.skipFeatureFlags ? {} : await getFeatureFlags(config);
   const contextLogger = logger ?? ContextCreator.getLogger(invocationContext);
 
   return {

--- a/backend/lib/adapters/utils/feature-flag.test.ts
+++ b/backend/lib/adapters/utils/feature-flag.test.ts
@@ -1,15 +1,23 @@
 import { vi } from 'vitest';
 import { getFeatureFlags } from './feature-flag';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
+import { buildLaunchDarklyContext } from '@common/feature-flags';
+import MockData from '@common/cams/test-utilities/mock-data';
+
+const { allFlagsState } = vi.hoisted(() => {
+  return {
+    allFlagsState: vi.fn().mockReturnValue({
+      allValues: vi.fn().mockReturnValue({
+        'chapter-twelve-enabled': true,
+      }),
+    }),
+  };
+});
 
 vi.mock('@launchdarkly/node-server-sdk', () => {
   return {
     init: vi.fn().mockReturnValue({
-      allFlagsState: vi.fn().mockReturnValue({
-        allValues: vi.fn().mockReturnValue({
-          'chapter-twelve-enabled': true,
-        }),
-      }),
+      allFlagsState,
       flush: vi.fn(),
       close: vi.fn(),
       waitForInitialization: vi.fn(),
@@ -25,5 +33,30 @@ describe('Tests for feature flags', () => {
 
     const flags = await getFeatureFlags(context.config);
     expect(flags['chapter-twelve-enabled']).toEqual(true);
+  });
+
+  test('calls allFlagsState with the anonymous context when no user is provided', async () => {
+    const context = await createMockApplicationContext({
+      env: { FEATURE_FLAG_SDK_KEY: 'fake-key' },
+    });
+
+    await getFeatureFlags(context.config);
+
+    expect(allFlagsState).toHaveBeenCalledWith({
+      kind: 'user',
+      key: 'feature-flag-migration',
+      anonymous: true,
+    });
+  });
+
+  test('calls allFlagsState with the real user context when a user is provided', async () => {
+    const context = await createMockApplicationContext({
+      env: { FEATURE_FLAG_SDK_KEY: 'fake-key' },
+    });
+    const user = MockData.getCamsUser();
+
+    await getFeatureFlags(context.config, user);
+
+    expect(allFlagsState).toHaveBeenCalledWith(buildLaunchDarklyContext(user));
   });
 });

--- a/backend/lib/adapters/utils/feature-flag.test.ts
+++ b/backend/lib/adapters/utils/feature-flag.test.ts
@@ -1,31 +1,30 @@
 import { vi } from 'vitest';
+import * as ld from '@launchdarkly/node-server-sdk';
 import { getFeatureFlags } from './feature-flag';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
-import { buildLaunchDarklyContext } from '@common/feature-flags';
+import { buildLaunchDarklyContext, testFeatureFlags } from '@common/feature-flags';
 import MockData from '@common/cams/test-utilities/mock-data';
 
-const { allFlagsState } = vi.hoisted(() => {
-  return {
-    allFlagsState: vi.fn().mockReturnValue({
+type MockLDClient = ReturnType<typeof ld.init>;
+
+describe('Tests for feature flags', () => {
+  let allFlagsState: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    allFlagsState = vi.fn().mockReturnValue({
       allValues: vi.fn().mockReturnValue({
         'chapter-twelve-enabled': true,
       }),
-    }),
-  };
-});
-
-vi.mock('@launchdarkly/node-server-sdk', () => {
-  return {
-    init: vi.fn().mockReturnValue({
+    });
+    vi.spyOn(ld, 'init').mockReturnValue({
       allFlagsState,
       flush: vi.fn(),
       close: vi.fn(),
       waitForInitialization: vi.fn(),
-    }),
-  };
-});
+    } as Partial<MockLDClient> as MockLDClient);
+  });
 
-describe('Tests for feature flags', () => {
   test('Should test a known feature flag with known set value', async () => {
     const context = await createMockApplicationContext({
       env: { FEATURE_FLAG_SDK_KEY: 'fake-key' },
@@ -58,5 +57,16 @@ describe('Tests for feature flags', () => {
     await getFeatureFlags(context.config, user);
 
     expect(allFlagsState).toHaveBeenCalledWith(buildLaunchDarklyContext(user));
+  });
+
+  test('returns testFeatureFlags without contacting LaunchDarkly when no feature flag key is configured', async () => {
+    const context = await createMockApplicationContext({
+      env: { FEATURE_FLAG_SDK_KEY: '' },
+    });
+
+    const flags = await getFeatureFlags(context.config);
+
+    expect(flags).toEqual(testFeatureFlags);
+    expect(ld.init).not.toHaveBeenCalled();
   });
 });

--- a/backend/lib/adapters/utils/feature-flag.test.ts
+++ b/backend/lib/adapters/utils/feature-flag.test.ts
@@ -2,7 +2,9 @@ import { vi } from 'vitest';
 import * as ld from '@launchdarkly/node-server-sdk';
 import { getFeatureFlags } from './feature-flag';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
-import { buildLaunchDarklyContext, testFeatureFlags } from '@common/feature-flags';
+import { ANONYMOUS_FEATURE_FLAG_CONTEXT, testFeatureFlags } from '@common/feature-flags';
+import { getGroupDesignators } from '@common/cams/users';
+import { CamsRole } from '@common/cams/roles';
 import MockData from '@common/cams/test-utilities/mock-data';
 
 type MockLDClient = ReturnType<typeof ld.init>;
@@ -41,22 +43,28 @@ describe('Tests for feature flags', () => {
 
     await getFeatureFlags(context.config);
 
-    expect(allFlagsState).toHaveBeenCalledWith({
-      kind: 'user',
-      key: 'feature-flag-migration',
-      anonymous: true,
-    });
+    expect(allFlagsState).toHaveBeenCalledWith(ANONYMOUS_FEATURE_FLAG_CONTEXT);
   });
 
   test('calls allFlagsState with the real user context when a user is provided', async () => {
     const context = await createMockApplicationContext({
       env: { FEATURE_FLAG_SDK_KEY: 'fake-key' },
     });
-    const user = MockData.getCamsUser();
+    const user = MockData.getCamsUser({
+      email: 'jane.doe@example.com',
+      roles: [CamsRole.TrialAttorney],
+    });
 
     await getFeatureFlags(context.config, user);
 
-    expect(allFlagsState).toHaveBeenCalledWith(buildLaunchDarklyContext(user));
+    expect(allFlagsState).toHaveBeenCalledWith({
+      kind: 'user',
+      key: user.id,
+      name: user.name,
+      email: user.email,
+      roles: user.roles,
+      officeGroupDesignators: getGroupDesignators(user),
+    });
   });
 
   test('returns testFeatureFlags without contacting LaunchDarkly when no feature flag key is configured', async () => {

--- a/backend/lib/adapters/utils/feature-flag.ts
+++ b/backend/lib/adapters/utils/feature-flag.ts
@@ -1,9 +1,13 @@
 import * as ld from '@launchdarkly/node-server-sdk';
 import { ApplicationConfiguration } from '../../configs/application-configuration';
-import { testFeatureFlags } from '@common/feature-flags';
+import { buildLaunchDarklyContext, testFeatureFlags } from '@common/feature-flags';
+import { CamsUser } from '@common/cams/users';
 import { FeatureFlagSet } from '../types/basic';
 
-export async function getFeatureFlags(config: ApplicationConfiguration): Promise<FeatureFlagSet> {
+export async function getFeatureFlags(
+  config: ApplicationConfiguration,
+  user?: CamsUser,
+): Promise<FeatureFlagSet> {
   if (!config.featureFlagKey) return testFeatureFlags;
 
   const client = ld.init(config.featureFlagKey, {
@@ -12,11 +16,10 @@ export async function getFeatureFlags(config: ApplicationConfiguration): Promise
     eventsUri: 'https://events.launchdarkly.us',
   });
   await client.waitForInitialization();
-  const state = await client.allFlagsState({
-    kind: 'user',
-    key: 'feature-flag-migration',
-    anonymous: true,
-  });
+  const context = user
+    ? buildLaunchDarklyContext(user)
+    : { kind: 'user' as const, key: 'feature-flag-migration', anonymous: true };
+  const state = await client.allFlagsState(context);
   await client.flush();
   client.close();
   return state.allValues();

--- a/backend/lib/adapters/utils/feature-flag.ts
+++ b/backend/lib/adapters/utils/feature-flag.ts
@@ -1,6 +1,10 @@
 import * as ld from '@launchdarkly/node-server-sdk';
 import { ApplicationConfiguration } from '../../configs/application-configuration';
-import { buildLaunchDarklyContext, testFeatureFlags } from '@common/feature-flags';
+import {
+  ANONYMOUS_FEATURE_FLAG_CONTEXT,
+  buildLaunchDarklyContext,
+  testFeatureFlags,
+} from '@common/feature-flags';
 import { CamsUser } from '@common/cams/users';
 import { FeatureFlagSet } from '../types/basic';
 
@@ -16,9 +20,7 @@ export async function getFeatureFlags(
     eventsUri: 'https://events.launchdarkly.us',
   });
   await client.waitForInitialization();
-  const context = user
-    ? buildLaunchDarklyContext(user)
-    : { kind: 'user' as const, key: 'feature-flag-migration', anonymous: true };
+  const context = user ? buildLaunchDarklyContext(user) : ANONYMOUS_FEATURE_FLAG_CONTEXT;
   const state = await client.allFlagsState(context);
   await client.flush();
   client.close();

--- a/common/src/feature-flags.test.ts
+++ b/common/src/feature-flags.test.ts
@@ -1,9 +1,56 @@
-import { testFeatureFlags } from './feature-flags';
+import { UstpOfficeDetails } from './cams/offices';
+import MockData from './cams/test-utilities/mock-data';
+import { buildLaunchDarklyContext, testFeatureFlags } from './feature-flags';
 
 describe('feature flag tests', () => {
   test('all testFeatureFlags are enabled for testing', () => {
     const values = Object.values(testFeatureFlags);
     expect(values.length).toBeGreaterThan(0);
     expect(values.every((v) => v === true)).toBe(true);
+  });
+});
+
+describe('buildLaunchDarklyContext', () => {
+  test('maps a full CamsUser to a LaunchDarklyContext', () => {
+    const office = (officeCode: string, groupDesignator: string): UstpOfficeDetails => ({
+      officeCode,
+      officeName: officeCode,
+      idpGroupName: officeCode,
+      regionId: '1',
+      regionName: 'Region 1',
+      groups: [{ groupDesignator, divisions: [] }],
+    });
+    const offices = [office('OFFICE_A', 'A'), office('OFFICE_B', 'B')];
+    const user = MockData.getCamsUser({
+      email: 'jane.doe@example.com',
+      roles: [],
+      offices,
+    });
+
+    const context = buildLaunchDarklyContext(user);
+
+    expect(context).toEqual({
+      kind: 'user',
+      key: user.id,
+      name: user.name,
+      email: user.email,
+      roles: user.roles,
+      officeGroupDesignators: ['A', 'B'],
+    });
+  });
+
+  test('maps a minimal CamsUser with no email, offices, or roles', () => {
+    const user = MockData.getCamsUser({ email: undefined, offices: undefined, roles: undefined });
+
+    const context = buildLaunchDarklyContext(user);
+
+    expect(context).toEqual({
+      kind: 'user',
+      key: user.id,
+      name: user.name,
+      email: undefined,
+      roles: undefined,
+      officeGroupDesignators: [],
+    });
   });
 });

--- a/common/src/feature-flags.test.ts
+++ b/common/src/feature-flags.test.ts
@@ -12,15 +12,15 @@ describe('feature flag tests', () => {
 
 describe('buildLaunchDarklyContext', () => {
   test('maps a full CamsUser to a LaunchDarklyContext', () => {
-    const office = (officeCode: string, groupDesignator: string): UstpOfficeDetails => ({
+    const office = (officeCode: string, groupDesignators: string[]): UstpOfficeDetails => ({
       officeCode,
       officeName: officeCode,
       idpGroupName: officeCode,
       regionId: '1',
       regionName: 'Region 1',
-      groups: [{ groupDesignator, divisions: [] }],
+      groups: groupDesignators.map((groupDesignator) => ({ groupDesignator, divisions: [] })),
     });
-    const offices = [office('OFFICE_A', 'A'), office('OFFICE_B', 'B')];
+    const offices = [office('OFFICE_A', ['A', 'B']), office('OFFICE_C', ['C'])];
     const user = MockData.getCamsUser({
       email: 'jane.doe@example.com',
       roles: [],
@@ -35,7 +35,7 @@ describe('buildLaunchDarklyContext', () => {
       name: user.name,
       email: user.email,
       roles: user.roles,
-      officeGroupDesignators: ['A', 'B'],
+      officeGroupDesignators: ['A', 'B', 'C'],
     });
   });
 

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -1,4 +1,5 @@
 import { CamsUser, getGroupDesignators } from './cams/users';
+import { CamsRoleType } from './cams/roles';
 
 // This internal interface aligns with the LaunchDarkly LDFlagSet interface that
 // types the return of the useFlags hook. It is more restrictive than the `any` type
@@ -37,7 +38,7 @@ export type LaunchDarklyContext = {
   key: string;
   name?: string;
   email?: string;
-  roles?: string[];
+  roles?: CamsRoleType[];
   officeGroupDesignators?: string[];
 };
 
@@ -51,3 +52,9 @@ export function buildLaunchDarklyContext(user: CamsUser): LaunchDarklyContext {
     officeGroupDesignators: getGroupDesignators(user),
   };
 }
+
+export const ANONYMOUS_FEATURE_FLAG_CONTEXT = {
+  kind: 'user',
+  key: 'feature-flag-migration',
+  anonymous: true,
+} as const;

--- a/common/src/feature-flags.ts
+++ b/common/src/feature-flags.ts
@@ -1,3 +1,5 @@
+import { CamsUser, getGroupDesignators } from './cams/users';
+
 // This internal interface aligns with the LaunchDarkly LDFlagSet interface that
 // types the return of the useFlags hook. It is more restrictive than the `any` type
 // used for the value which could include JSON / object literal payloads. If we were
@@ -29,3 +31,23 @@ export const testFeatureFlags: FeatureFlagSet = {
   'trustee-change-notification-enabled': true,
   'trustee-typed-phones': true,
 };
+
+export type LaunchDarklyContext = {
+  kind: 'user';
+  key: string;
+  name?: string;
+  email?: string;
+  roles?: string[];
+  officeGroupDesignators?: string[];
+};
+
+export function buildLaunchDarklyContext(user: CamsUser): LaunchDarklyContext {
+  return {
+    kind: 'user',
+    key: user.id,
+    name: user.name,
+    email: user.email,
+    roles: user.roles,
+    officeGroupDesignators: getGroupDesignators(user),
+  };
+}

--- a/docs/contributing/feature-flags.md
+++ b/docs/contributing/feature-flags.md
@@ -11,3 +11,63 @@ settings > Client-side SDK availability
 and check the box labeled "SDKs using Client-side ID".
 
 If you do not check this box, the flag will not be available to the front end.
+
+## User Context
+
+Both the backend (Node server SDK) and frontend (React client SDK) evaluate flags using a
+LaunchDarkly ["user" context](https://docs.launchdarkly.com/sdk/features/user-context) built from
+the authenticated user's `CamsUser`. The context shape is identical on both sides because both SDKs
+consume the same mapping function, `buildLaunchDarklyContext(user: CamsUser)`, defined once in
+`common/src/feature-flags.ts` (see the `LaunchDarklyContext` type there for the exact shape).
+
+| Attribute                | Source                                                          | Notes                                                                                                                               |
+| ------------------------ | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `kind`                   | always `'user'`                                                 |                                                                                                                                     |
+| `key`                    | `CamsUser.id`                                                   | Equals the Okta `sub` claim — this is what LaunchDarkly targeting rules and segments match against.                                 |
+| `name`                   | `CamsUser.name`                                                 |                                                                                                                                     |
+| `email`                  | `CamsUser.email`                                                | May be `undefined`.                                                                                                                 |
+| `roles`                  | `CamsUser.roles`                                                | e.g. `TrialAttorney`, `TrusteeAdmin`, `SuperUser` — see `common/src/cams/roles.ts` for the full `CamsRole` set. May be `undefined`. |
+| `officeGroupDesignators` | `getGroupDesignators(user)` (flattened from `CamsUser.offices`) | Always an array; empty if the user has no offices.                                                                                  |
+
+**Backend:** `getFeatureFlags(config, user?)` in `backend/lib/adapters/utils/feature-flag.ts` sends
+`buildLaunchDarklyContext(user)` when a resolved `CamsUser` is available (i.e. for authenticated API
+requests, via `applicationContextCreator()`). Dataflow, healthcheck, and mock-oauth2 invocations
+have no user session, so they call `getFeatureFlags(config)` with no user and get today's hardcoded
+anonymous context (`{ kind: 'user', key: 'feature-flag-migration', anonymous: true }`) — this keeps
+their behavior unchanged.
+
+**Frontend:** `App.tsx` calls the LaunchDarkly client SDK's `identify()` once, on mount, with
+`buildLaunchDarklyContext(session.user)`, once a session is available in `LocalStorage`.
+
+### Adding a new targeting rule
+
+Because `key` is the Okta `sub` claim, a targeting rule or segment can be built around specific
+users by adding their `key` to a list-based segment. To target by role or office instead of by
+individual user, write a targeting rule against the `roles` or `officeGroupDesignators` custom
+attributes — no code changes are required to add a new rule for an attribute that's already part of
+the context above. If you need a new attribute, add it to `LaunchDarklyContext` and
+`buildLaunchDarklyContext()` in `common/src/feature-flags.ts` — that single change is picked up by
+both the backend and frontend since they share the same mapping function.
+
+### Detailees pilot: dashboard configuration
+
+To pilot a flag with a manually-maintained list of users ahead of that feature's broader rollout,
+set up a list-based segment and a targeting rule in the LaunchDarkly **GovCloud US** environment:
+
+1. **Create the segment** — Dashboard > your project > GovCloud US environment > Segments > New
+   Segment.
+   - Name: `Detailees`
+   - Type: **List** (a manually-maintained list of context keys, not a rule-based segment)
+   - Add each pilot user's context `key` (their Okta `sub` claim — see the User Context table above)
+     to the segment's list.
+2. **Add a targeting rule to the pilot flag** (e.g. `trustee-management`) — Flag > Targeting tab >
+   Add rule.
+   - Condition: "context is in segment" > `Detailees`
+   - Serve: the `true` (or "on") variation
+   - **Ordering:** this rule must be placed _above_ the existing default/fallthrough rule, since
+     LaunchDarkly evaluates targeting rules top-to-bottom and stops at the first match — a rule
+     placed after the fallthrough would never be reached.
+3. **Verify:** a user whose `key` is in the `Detailees` segment list sees the flag's "on" variation;
+   a user not in the list falls through to the existing default behavior, unchanged.
+
+Repeat this for any other flag that needs a pilot rollout ahead of its general availability.

--- a/docs/contributing/feature-flags.md
+++ b/docs/contributing/feature-flags.md
@@ -33,8 +33,8 @@ consume the same mapping function, `buildLaunchDarklyContext(user: CamsUser)`, d
 `buildLaunchDarklyContext(user)` when a resolved `CamsUser` is available (i.e. for authenticated API
 requests, via `applicationContextCreator()`). Dataflow, healthcheck, and mock-oauth2 invocations
 have no user session, so they call `getFeatureFlags(config)` with no user and get today's hardcoded
-anonymous context (`{ kind: 'user', key: 'feature-flag-migration', anonymous: true }`) — this keeps
-their behavior unchanged.
+`ANONYMOUS_FEATURE_FLAG_CONTEXT` (also defined in `common/src/feature-flags.ts`) — this keeps their
+behavior unchanged.
 
 **Frontend:** `App.tsx` calls the LaunchDarkly client SDK's `identify()` once, on mount, with
 `buildLaunchDarklyContext(session.user)`, once a session is available in `LocalStorage`.

--- a/user-interface/src/App.test.tsx
+++ b/user-interface/src/App.test.tsx
@@ -1,14 +1,27 @@
+import { ComponentType } from 'react';
 import { act, render, waitFor, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
+import * as LaunchDarklyReactClientSdk from 'launchdarkly-react-client-sdk';
 import App from './App';
 import * as HeaderModule from './lib/components/Header';
 import * as UseLandingPageAnalyticsModule from './lib/hooks/UseLandingPageAnalytics';
 import { getAppInsights } from './lib/hooks/UseApplicationInsights';
 import useFeatureFlags from './lib/hooks/UseFeatureFlags';
+import LocalStorage from '@/lib/utils/local-storage';
+import { buildLaunchDarklyContext } from '@common/feature-flags';
+import MockData from '@common/cams/test-utilities/mock-data';
 
 vi.mock('./lib/hooks/UseLandingPageAnalytics');
 vi.mock('./lib/hooks/UseFeatureFlags');
 vi.mock('./lib/hooks/UseApplicationInsights');
+vi.mock('launchdarkly-react-client-sdk', () => {
+  return {
+    withLDProvider: () => (Component: ComponentType) => Component,
+    useLDClient: vi.fn(),
+  };
+});
+
+type MockLDClient = NonNullable<ReturnType<typeof LaunchDarklyReactClientSdk.useLDClient>>;
 
 describe('App', () => {
   function scrollTo(position: number) {
@@ -141,6 +154,44 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(scrollToTopBtn).not.toHaveClass('show');
+    });
+  });
+
+  describe('LaunchDarkly identify on mount', () => {
+    test('calls identify with the session user when a session and ldClient are present', async () => {
+      const session = MockData.getCamsSession();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
+      const identify = vi.fn();
+      vi.mocked(LaunchDarklyReactClientSdk.useLDClient).mockReturnValue({
+        identify,
+        waitForInitialization: vi.fn().mockResolvedValue(undefined),
+      } as Partial<MockLDClient> as MockLDClient);
+
+      renderWithoutProps();
+
+      await waitFor(() => {
+        expect(identify).toHaveBeenCalledWith(buildLaunchDarklyContext(session.user));
+      });
+    });
+
+    test('does not call identify or throw when there is no session', async () => {
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(null);
+      const identify = vi.fn();
+      vi.mocked(LaunchDarklyReactClientSdk.useLDClient).mockReturnValue({
+        identify,
+        waitForInitialization: vi.fn().mockResolvedValue(undefined),
+      } as Partial<MockLDClient> as MockLDClient);
+
+      expect(() => renderWithoutProps()).not.toThrow();
+      expect(identify).not.toHaveBeenCalled();
+    });
+
+    test('does not call identify or throw when useLDClient returns undefined', async () => {
+      const session = MockData.getCamsSession();
+      vi.spyOn(LocalStorage, 'getSession').mockReturnValue(session);
+      vi.mocked(LaunchDarklyReactClientSdk.useLDClient).mockReturnValue(undefined);
+
+      expect(() => renderWithoutProps()).not.toThrow();
     });
   });
 });

--- a/user-interface/src/App.test.tsx
+++ b/user-interface/src/App.test.tsx
@@ -16,7 +16,7 @@ vi.mock('./lib/hooks/UseFeatureFlags');
 vi.mock('./lib/hooks/UseApplicationInsights');
 vi.mock('launchdarkly-react-client-sdk', () => {
   return {
-    withLDProvider: () => (Component: ComponentType) => Component,
+    withLDProvider: vi.fn(() => (Component: ComponentType) => Component),
     useLDClient: vi.fn(),
   };
 });
@@ -39,6 +39,8 @@ describe('App', () => {
   }
 
   beforeEach(() => {
+    vi.restoreAllMocks();
+
     window.scrollTo = vi.fn(({ top }) => {
       if (typeof top === 'number') {
         scrollTo(top);
@@ -70,10 +72,6 @@ describe('App', () => {
       trackNavigation: vi.fn(),
       trackFirstSearch: vi.fn(),
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   test('should show message when error boundary catches an error', async () => {
@@ -125,8 +123,35 @@ describe('App', () => {
     vi.doMock('@/configuration/appConfiguration', () => ({
       default: () => ({ featureFlagClientId: undefined }),
     }));
+    vi.mocked(LaunchDarklyReactClientSdk.withLDProvider).mockClear();
 
     const { default: AppComponent } = await import('./App');
+
+    expect(AppComponent).toBeDefined();
+    expect(LaunchDarklyReactClientSdk.withLDProvider).not.toHaveBeenCalled();
+
+    vi.doUnmock('@/configuration/appConfiguration');
+    vi.resetModules();
+  });
+
+  test('should wrap App with withLDProvider when featureFlagClientId is configured', async () => {
+    vi.resetModules();
+    vi.doMock('@/configuration/appConfiguration', () => ({
+      default: () => ({ featureFlagClientId: 'test-client-id' }),
+    }));
+    vi.mocked(LaunchDarklyReactClientSdk.withLDProvider).mockClear();
+
+    const { default: AppComponent } = await import('./App');
+
+    expect(LaunchDarklyReactClientSdk.withLDProvider).toHaveBeenCalledWith({
+      clientSideID: 'test-client-id',
+      reactOptions: { useCamelCaseFlagKeys: false },
+      options: {
+        baseUrl: 'https://clientsdk.launchdarkly.us',
+        streamUrl: 'https://clientstream.launchdarkly.us',
+        eventsUrl: 'https://events.launchdarkly.us',
+      },
+    });
     expect(AppComponent).toBeDefined();
 
     vi.doUnmock('@/configuration/appConfiguration');

--- a/user-interface/src/App.test.tsx
+++ b/user-interface/src/App.test.tsx
@@ -8,7 +8,7 @@ import * as UseLandingPageAnalyticsModule from './lib/hooks/UseLandingPageAnalyt
 import { getAppInsights } from './lib/hooks/UseApplicationInsights';
 import useFeatureFlags from './lib/hooks/UseFeatureFlags';
 import LocalStorage from '@/lib/utils/local-storage';
-import { buildLaunchDarklyContext } from '@common/feature-flags';
+import { getGroupDesignators } from '@common/cams/users';
 import MockData from '@common/cams/test-utilities/mock-data';
 
 vi.mock('./lib/hooks/UseLandingPageAnalytics');
@@ -74,6 +74,11 @@ describe('App', () => {
     });
   });
 
+  afterEach(() => {
+    vi.doUnmock('@/configuration/appConfiguration');
+    vi.resetModules();
+  });
+
   test('should show message when error boundary catches an error', async () => {
     vi.spyOn(HeaderModule, 'Header').mockImplementation(() => {
       throw Error('mock error');
@@ -129,9 +134,6 @@ describe('App', () => {
 
     expect(AppComponent).toBeDefined();
     expect(LaunchDarklyReactClientSdk.withLDProvider).not.toHaveBeenCalled();
-
-    vi.doUnmock('@/configuration/appConfiguration');
-    vi.resetModules();
   });
 
   test('should wrap App with withLDProvider when featureFlagClientId is configured', async () => {
@@ -153,9 +155,6 @@ describe('App', () => {
       },
     });
     expect(AppComponent).toBeDefined();
-
-    vi.doUnmock('@/configuration/appConfiguration');
-    vi.resetModules();
   });
 
   test('should scroll to top when scroll-to-top button is clicked', async () => {
@@ -195,7 +194,14 @@ describe('App', () => {
       renderWithoutProps();
 
       await waitFor(() => {
-        expect(identify).toHaveBeenCalledWith(buildLaunchDarklyContext(session.user));
+        expect(identify).toHaveBeenCalledWith({
+          kind: 'user',
+          key: session.user.id,
+          name: session.user.name,
+          email: session.user.email,
+          roles: session.user.roles,
+          officeGroupDesignators: getGroupDesignators(session.user),
+        });
       });
     });
 

--- a/user-interface/src/App.tsx
+++ b/user-interface/src/App.tsx
@@ -2,9 +2,11 @@ import { Routes, Route } from 'react-router-dom';
 import { Header } from './lib/components/Header';
 import { AppInsightsErrorBoundary } from '@microsoft/applicationinsights-react-js';
 import { getAppInsights } from './lib/hooks/UseApplicationInsights';
-import { createContext, useRef } from 'react';
-import { withLDProvider } from 'launchdarkly-react-client-sdk';
+import { createContext, useEffect, useRef } from 'react';
+import { useLDClient, withLDProvider } from 'launchdarkly-react-client-sdk';
+import { buildLaunchDarklyContext } from '@common/feature-flags';
 import { getFeatureFlagConfiguration } from './configuration/featureFlagConfiguration';
+import LocalStorage from './lib/utils/local-storage';
 import CaseDetailScreen from './case-detail/CaseDetailScreen';
 import ScrollToTopButton from './lib/components/ScrollToTopButton';
 import DataVerificationScreen from './data-verification/DataVerificationScreen';
@@ -30,6 +32,14 @@ export const GlobalAlertContext = createContext<React.RefObject<GlobalAlertRef |
 function App() {
   const { reactPlugin } = getAppInsights();
   const globalAlertRef = useRef<GlobalAlertRef>(null);
+  const ldClient = useLDClient();
+
+  useEffect(() => {
+    const session = LocalStorage.getSession();
+    if (session?.user && ldClient) {
+      ldClient.identify(buildLaunchDarklyContext(session.user));
+    }
+  }, [ldClient]);
 
   return (
     <AppInsightsErrorBoundary

--- a/user-interface/src/App.tsx
+++ b/user-interface/src/App.tsx
@@ -34,6 +34,9 @@ function App() {
   const globalAlertRef = useRef<GlobalAlertRef>(null);
   const ldClient = useLDClient();
 
+  // Identifies once, on mount. `Session.tsx` blocks rendering `App` until the full
+  // session is resolved, so this always reflects the logged-in user. A re-login as
+  // a different user without a full remount would not re-identify.
   useEffect(() => {
     const session = LocalStorage.getSession();
     if (session?.user && ldClient) {


### PR DESCRIPTION
# Purpose

LaunchDarkly evaluated every flag with a single hardcoded, anonymous context on the backend and no context at all on the frontend, so segments and targeting rules couldn't distinguish one user from another. This slice makes both SDKs evaluate flags using the real authenticated user's identity, unblocking a phased pilot rollout (Detailees segment -> Working Group -> all users) for the trustee-management flag.

# Major Changes

* Added a shared `buildLaunchDarklyContext(user: CamsUser)` mapping function in `common/src/feature-flags.ts` so backend and frontend build an identical LaunchDarkly context (key, name, email, roles, office group designators) from one place.
* Restructured backend feature-flag fetching (`backend/lib/adapters/utils/feature-flag.ts`, both `application-context-creator.ts` files) so authenticated API requests get exactly one LD evaluation using the real resolved user, via a `skipFeatureFlags` option on `getApplicationContext()`. Dataflow, healthcheck, and mock-oauth2 call sites are untouched and keep today's anonymous-context behavior.
* Added a mount-time `identify()` call in `user-interface/src/App.tsx` so the frontend LD client also evaluates flags against the real session user.
* Documented the resulting context attributes and added a runbook for the Detailees pilot segment/targeting-rule setup in `docs/contributing/feature-flags.md`.

# Testing/Validation

Implemented using TDD (Red-Green-Refactor) across all three affected workspaces. Full test suites pass: backend (229 files / 3410 tests), user-interface (229 files / 3265 tests), common. Root-level lint, typecheck, and knip are clean. `cams-unit-test-reviewer` was run against all new/modified test files (`feature-flag.test.ts`, both `application-context-creator.test.ts` files, `feature-flags.test.ts`, `App.test.tsx`) and every finding (missing auth-failure-branch coverage, mock-lifecycle convention drift, tautological assertions, an untested `withLDProvider` branch, etc.) was fixed in a follow-up commit — no CRITICAL/HIGH issues remain.

# Notes

* `CamsUser.id` already equals the Okta `sub` claim (`backend/lib/adapters/gateways/okta/okta-gateway.ts`), so no separate key-mapping work was needed.
* The frontend `useEffect` depends on `[ldClient]` rather than `[]`, since `withLDProvider` initializes asynchronously and `ldClient` can be `undefined` on first render — this is more correct than suppressing the exhaustive-deps lint rule.
* This PR covers Slice 1 of a 2-slice feature. Slice 2 (creating the LaunchDarkly "Detailees" segment and a targeting rule on the `trustee-management` pilot flag) is manual dashboard configuration in the GovCloud US environment, documented as a runbook but out of scope for this PR.
* npm audit shows 4 pre-existing high/low vulnerabilities (brace-expansion, dompurify, fast-uri, immutable) — confirmed unrelated to this change (identical on `main`).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Update backend and frontend to evaluate LaunchDarkly feature flags using the authenticated user context while preserving existing anonymous behavior for non-user flows.

New Features:
- Introduce a shared buildLaunchDarklyContext helper and LaunchDarklyContext type to derive a consistent user context for feature flag evaluations across services.

Enhancements:
- Change backend feature-flag retrieval to accept an optional user and use the shared context mapping, wiring authenticated request contexts to pass the resolved user.
- Adjust Express and Azure application context creators to defer feature-flag evaluation until after session resolution and to support an option to skip eager flag fetching.
- Add a frontend mount-time identify call using the LaunchDarkly React client and the shared context mapping so flags are evaluated per logged-in user.
- Expand tests for backend context creation, feature-flag utilities, and the App component to cover user-aware LaunchDarkly behavior and configuration edge cases.
- Refine logging and observability behavior in the Azure context creator and logger helper.

Documentation:
- Document the shared LaunchDarkly user context shape and add a runbook for configuring user- and segment-based targeting in LaunchDarkly GovCloud.

Tests:
- Add comprehensive tests for Express application-context creation, including feature-flag wiring, request translation, and session error handling.
- Extend feature-flag tests in common and backend packages to validate context mapping, anonymous vs user-specific evaluation, and fallback behavior without an SDK key.
- Enhance App component tests to cover LaunchDarkly provider configuration and identify behavior for various session and client states.