### PR TITLE
CAMS-824 Limit trustee/staff phones to 20, track additions

### DIFF
--- a/backend/lib/use-cases/trustee-staff/trustee-staff.test.ts
+++ b/backend/lib/use-cases/trustee-staff/trustee-staff.test.ts
@@ -179,6 +179,27 @@ describe('TrusteeStaffUseCase', () => {
         }),
       );
     });
+
+    test('should track a Phone Number Added event for each phone on the new staff member', async () => {
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createStaffMember').mockResolvedValue(
+        createdStaffMember,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue(undefined);
+      const completeTraceSpy = vi.spyOn(context.observability, 'completeTrace');
+
+      await trusteeStaffUseCase.createStaffMember(context, trusteeId, validInput);
+
+      const phoneAddedCalls = completeTraceSpy.mock.calls.filter(
+        (call) => call[1] === 'Phone Number Added',
+      );
+      expect(phoneAddedCalls).toHaveLength(validInput.contact!.phones!.length);
+      phoneAddedCalls.forEach((call) => {
+        expect(call[2]).toEqual(
+          expect.objectContaining({ success: true, properties: { contactType: 'staff' } }),
+        );
+      });
+    });
   });
 
   describe('getStaffMember', () => {
@@ -334,6 +355,47 @@ describe('TrusteeStaffUseCase', () => {
           after: updatedStaffMember,
         }),
       );
+    });
+
+    test('should track a Phone Number Added event for each phone added to the staff member', async () => {
+      const mockTrustee = { id: trusteeId, name: 'Test Trustee' };
+      const staffWithOnePhone = MockData.getTrusteeStaff({
+        id: staffId,
+        trusteeId,
+        contact: { phones: [{ type: 'direct', number: '555-000-0001' }] },
+      });
+      const staffWithThreePhones = {
+        ...staffWithOnePhone,
+        contact: {
+          ...staffWithOnePhone.contact,
+          phones: [
+            { type: 'direct' as const, number: '555-000-0001' },
+            { type: 'home' as const, number: '555-000-0002' },
+            { type: 'fax' as const, number: '555-000-0003' },
+          ],
+        },
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'readStaffMember').mockResolvedValue(
+        staffWithOnePhone,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'updateStaffMember').mockResolvedValue(
+        staffWithThreePhones,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue(undefined);
+      const completeTraceSpy = vi.spyOn(context.observability, 'completeTrace');
+
+      await trusteeStaffUseCase.updateStaffMember(context, trusteeId, staffId, updateInput);
+
+      const phoneAddedCalls = completeTraceSpy.mock.calls.filter(
+        (call) => call[1] === 'Phone Number Added',
+      );
+      expect(phoneAddedCalls).toHaveLength(2);
+      phoneAddedCalls.forEach((call) => {
+        expect(call[2]).toEqual(
+          expect.objectContaining({ success: true, properties: { contactType: 'staff' } }),
+        );
+      });
     });
   });
 

--- a/backend/lib/use-cases/trustee-staff/trustee-staff.test.ts
+++ b/backend/lib/use-cases/trustee-staff/trustee-staff.test.ts
@@ -397,6 +397,43 @@ describe('TrusteeStaffUseCase', () => {
         );
       });
     });
+
+    test('should not track a Phone Number Added event when phones are removed', async () => {
+      const mockTrustee = { id: trusteeId, name: 'Test Trustee' };
+      const staffWithTwoPhones = MockData.getTrusteeStaff({
+        id: staffId,
+        trusteeId,
+        contact: {
+          phones: [
+            { type: 'direct' as const, number: '555-000-0001' },
+            { type: 'home' as const, number: '555-000-0002' },
+          ],
+        },
+      });
+      const staffWithOnePhone = {
+        ...staffWithTwoPhones,
+        contact: {
+          ...staffWithTwoPhones.contact,
+          phones: [{ type: 'direct' as const, number: '555-000-0001' }],
+        },
+      };
+      vi.spyOn(MockMongoRepository.prototype, 'read').mockResolvedValue(mockTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'readStaffMember').mockResolvedValue(
+        staffWithTwoPhones,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'updateStaffMember').mockResolvedValue(
+        staffWithOnePhone,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue(undefined);
+      const completeTraceSpy = vi.spyOn(context.observability, 'completeTrace');
+
+      await trusteeStaffUseCase.updateStaffMember(context, trusteeId, staffId, updateInput);
+
+      const phoneAddedCalls = completeTraceSpy.mock.calls.filter(
+        (call) => call[1] === 'Phone Number Added',
+      );
+      expect(phoneAddedCalls).toHaveLength(0);
+    });
   });
 
   describe('deleteStaffMember', () => {

--- a/backend/lib/use-cases/trustee-staff/trustee-staff.ts
+++ b/backend/lib/use-cases/trustee-staff/trustee-staff.ts
@@ -102,6 +102,8 @@ export class TrusteeStaffUseCase {
         createAuditRecord(historyRecord, userReference),
       );
 
+      this.trackPhoneNumbersAdded(context, 0, staffMember.contact?.phones?.length ?? 0);
+
       context.logger.info(
         MODULE_NAME,
         `Created staff member ${staffMember.id} for trustee ${trusteeId}`,
@@ -158,6 +160,12 @@ export class TrusteeStaffUseCase {
         createAuditRecord(historyRecord, userReference),
       );
 
+      this.trackPhoneNumbersAdded(
+        context,
+        existingStaffMember.contact?.phones?.length ?? 0,
+        updatedStaffMember.contact?.phones?.length ?? 0,
+      );
+
       context.logger.info(MODULE_NAME, `Updated staff member ${staffId} for trustee ${trusteeId}`);
       return updatedStaffMember;
     } catch (originalError) {
@@ -203,6 +211,24 @@ export class TrusteeStaffUseCase {
           message: `Failed to delete staff member with ID ${staffId} for trustee ${trusteeId}.`,
         },
       });
+    }
+  }
+
+  private trackPhoneNumbersAdded(
+    context: ApplicationContext,
+    phoneCountBefore: number,
+    phoneCountAfter: number,
+  ): void {
+    const phonesAdded = phoneCountAfter - phoneCountBefore;
+    for (let i = 0; i < phonesAdded; i++) {
+      const trace = context.observability.startTrace(context.invocationId);
+      context.observability.completeTrace(
+        trace,
+        'Phone Number Added',
+        { success: true, properties: { contactType: 'staff' }, measurements: {} },
+        undefined,
+        context.logger,
+      );
     }
   }
 }

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -12,7 +12,7 @@ import { FIELD_VALIDATION_MESSAGES } from '@common/cams/validation-messages';
 import { CourtsUseCase } from '../courts/courts';
 import { CourtDivisionDetails } from '@common/cams/courts';
 import { MockNotificationGateway } from '../../testing/mock-gateways/mock-notification.gateway';
-import { AppointmentChapterType } from '@common/cams/trustees';
+import { AppointmentChapterType, TypedPhoneNumber } from '@common/cams/trustees';
 import { ContactInformation } from '@common/cams/contact';
 import { BankruptcySoftwareProfile } from '@common/cams/bankruptcy-software';
 
@@ -646,6 +646,60 @@ describe('TrusteesUseCase tests', () => {
           after: newPublicContact,
         }),
       );
+    });
+
+    test('should track a Phone Number Added event for each phone added to internal contact', async () => {
+      existingTrustee.internal = {
+        phones: [{ type: 'direct', number: '555-000-0001' }],
+      };
+      const updatedInternal: { phones: TypedPhoneNumber[] } = {
+        phones: [
+          { type: 'direct', number: '555-000-0001' },
+          { type: 'home', number: '555-000-0002' },
+          { type: 'fax', number: '555-000-0003' },
+        ],
+      };
+      const updateData = { internal: updatedInternal };
+      const updatedTrustee = { ...existingTrustee, internal: updatedInternal };
+
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+      const completeTraceSpy = vi.spyOn(context.observability, 'completeTrace');
+
+      await trusteesUseCase.updateTrustee(context, trusteeId, updateData);
+
+      const phoneAddedCalls = completeTraceSpy.mock.calls.filter(
+        (call) => call[1] === 'Phone Number Added',
+      );
+      expect(phoneAddedCalls).toHaveLength(2);
+      phoneAddedCalls.forEach((call) => {
+        expect(call[2]).toEqual(
+          expect.objectContaining({ success: true, properties: { contactType: 'internal' } }),
+        );
+      });
+    });
+
+    test('should not track a Phone Number Added event when phones are removed', async () => {
+      existingTrustee.internal = {
+        phones: [
+          { type: 'direct', number: '555-000-0001' },
+          { type: 'home', number: '555-000-0002' },
+        ],
+      };
+      const updatedInternal = { phones: [{ type: 'direct' as const, number: '555-000-0001' }] };
+      const updateData = { internal: updatedInternal };
+      const updatedTrustee = { ...existingTrustee, internal: updatedInternal };
+
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+      vi.spyOn(MockMongoRepository.prototype, 'createTrusteeHistory').mockResolvedValue();
+      const completeTraceSpy = vi.spyOn(context.observability, 'completeTrace');
+
+      await trusteesUseCase.updateTrustee(context, trusteeId, updateData);
+
+      const phoneAddedCalls = completeTraceSpy.mock.calls.filter(
+        (call) => call[1] === 'Phone Number Added',
+      );
+      expect(phoneAddedCalls).toHaveLength(0);
     });
 
     test('should update trustee public contact with company name', async () => {

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -552,6 +552,13 @@ export class TrusteesUseCase {
       );
     }
 
+    this.trackPhoneNumbersAdded(
+      context,
+      before.internal?.phones?.length ?? 0,
+      after.internal?.phones?.length ?? 0,
+      'internal',
+    );
+
     const bankNames = this.buildBankNameMap(software, after.softwareId || before.softwareId);
     const beforeNames = before.banks?.map((id) => bankNames.get(id) ?? id);
     const afterNames = after.banks?.map((id) => bankNames.get(id) ?? id);
@@ -600,6 +607,25 @@ export class TrusteesUseCase {
       trusteeName: after.name,
       fields,
     };
+  }
+
+  private trackPhoneNumbersAdded(
+    context: ApplicationContext,
+    phoneCountBefore: number,
+    phoneCountAfter: number,
+    contactType: 'internal' | 'staff',
+  ): void {
+    const phonesAdded = phoneCountAfter - phoneCountBefore;
+    for (let i = 0; i < phonesAdded; i++) {
+      const trace = context.observability.startTrace(context.invocationId);
+      context.observability.completeTrace(
+        trace,
+        'Phone Number Added',
+        { success: true, properties: { contactType }, measurements: {} },
+        undefined,
+        context.logger,
+      );
+    }
   }
 
   private async resolveChapters(trusteeId: string): Promise<TrusteeChangeSet['chapters']> {

--- a/common/src/cams/trustees-validators.test.ts
+++ b/common/src/cams/trustees-validators.test.ts
@@ -845,9 +845,7 @@ describe('trustees-validators', () => {
       };
 
       const result = validateObject(TV.trusteeContactSpec, contact);
-      expect(result.reasonMap?.phones?.reasons).toContain(
-        `No more than ${MAX_PHONE_NUMBERS} phone numbers are allowed.`,
-      );
+      expect(result.reasonMap?.phones?.reasons).toContain(TV.MAX_PHONE_NUMBERS_MESSAGE);
     });
 
     test('should accept missing phones (phones is optional)', () => {

--- a/common/src/cams/trustees-validators.test.ts
+++ b/common/src/cams/trustees-validators.test.ts
@@ -823,6 +823,32 @@ describe('trustees-validators', () => {
       expect(result.reasonMap?.phones).toBeDefined();
     });
 
+    test('should accept exactly the maximum number of phones', () => {
+      const contact = {
+        phones: Array.from({ length: 20 }, (_, i) => ({
+          number: `555-000-${String(i).padStart(4, '0')}`,
+          type: 'direct',
+        })),
+      };
+
+      const result = validateObject(TV.trusteeContactSpec, contact);
+      expect(result.reasonMap?.phones).toBeUndefined();
+    });
+
+    test('should reject more than the maximum number of phones', () => {
+      const contact = {
+        phones: Array.from({ length: 21 }, (_, i) => ({
+          number: `555-000-${String(i).padStart(4, '0')}`,
+          type: 'direct',
+        })),
+      };
+
+      const result = validateObject(TV.trusteeContactSpec, contact);
+      expect(result.reasonMap?.phones?.reasons).toContain(
+        'No more than 20 phone numbers are allowed.',
+      );
+    });
+
     test('should accept missing phones (phones is optional)', () => {
       const contact = {
         email: 'staff@example.com',

--- a/common/src/cams/trustees-validators.test.ts
+++ b/common/src/cams/trustees-validators.test.ts
@@ -3,6 +3,7 @@ import { validateObject, VALID } from './validation';
 import * as TV from './trustees-validators';
 import { FIELD_VALIDATION_MESSAGES } from './validation-messages';
 import MockData from './test-utilities/mock-data';
+import { MAX_PHONE_NUMBERS } from './trustees';
 
 describe('trustees-validators', () => {
   describe('trusteeName', () => {
@@ -825,7 +826,7 @@ describe('trustees-validators', () => {
 
     test('should accept exactly the maximum number of phones', () => {
       const contact = {
-        phones: Array.from({ length: 20 }, (_, i) => ({
+        phones: Array.from({ length: MAX_PHONE_NUMBERS }, (_, i) => ({
           number: `555-000-${String(i).padStart(4, '0')}`,
           type: 'direct',
         })),
@@ -837,7 +838,7 @@ describe('trustees-validators', () => {
 
     test('should reject more than the maximum number of phones', () => {
       const contact = {
-        phones: Array.from({ length: 21 }, (_, i) => ({
+        phones: Array.from({ length: MAX_PHONE_NUMBERS + 1 }, (_, i) => ({
           number: `555-000-${String(i).padStart(4, '0')}`,
           type: 'direct',
         })),
@@ -845,7 +846,7 @@ describe('trustees-validators', () => {
 
       const result = validateObject(TV.trusteeContactSpec, contact);
       expect(result.reasonMap?.phones?.reasons).toContain(
-        'No more than 20 phone numbers are allowed.',
+        `No more than ${MAX_PHONE_NUMBERS} phone numbers are allowed.`,
       );
     });
 

--- a/common/src/cams/trustees-validators.ts
+++ b/common/src/cams/trustees-validators.ts
@@ -8,7 +8,7 @@ import {
 } from './regex';
 import { FIELD_VALIDATION_MESSAGES } from './validation-messages';
 import { ValidationSpec } from './validation';
-import { ZoomInfo, TypedPhoneNumber, TrusteeContact } from './trustees';
+import { ZoomInfo, TypedPhoneNumber, TrusteeContact, MAX_PHONE_NUMBERS } from './trustees';
 import { Address, ContactInformation, PhoneNumber } from './contact';
 import { TrusteeStaffInput } from './trustee-staff';
 
@@ -119,7 +119,15 @@ export const typedPhoneNumberSpec: ValidationSpec<TypedPhoneNumber> = {
 
 export const trusteeContactSpec: ValidationSpec<TrusteeContact> = {
   address: [V.optional(V.nullable(V.spec(addressSpec)))],
-  phones: [V.optional(V.arrayOf(V.spec(typedPhoneNumberSpec)))],
+  phones: [
+    V.optional(V.arrayOf(V.spec(typedPhoneNumberSpec))),
+    V.optional(
+      V.maxLength(
+        MAX_PHONE_NUMBERS,
+        `No more than ${MAX_PHONE_NUMBERS} phone numbers are allowed.`,
+      ),
+    ),
+  ],
   email: [V.optional(V.nullable(email))],
 };
 

--- a/common/src/cams/trustees-validators.ts
+++ b/common/src/cams/trustees-validators.ts
@@ -117,16 +117,13 @@ export const typedPhoneNumberSpec: ValidationSpec<TypedPhoneNumber> = {
   type: [V.checkFirst(V.minLength(1, 'Phone type is required'))],
 };
 
+export const MAX_PHONE_NUMBERS_MESSAGE = `No more than ${MAX_PHONE_NUMBERS} phone numbers are allowed.`;
+
 export const trusteeContactSpec: ValidationSpec<TrusteeContact> = {
   address: [V.optional(V.nullable(V.spec(addressSpec)))],
   phones: [
     V.optional(V.arrayOf(V.spec(typedPhoneNumberSpec))),
-    V.optional(
-      V.maxLength(
-        MAX_PHONE_NUMBERS,
-        `No more than ${MAX_PHONE_NUMBERS} phone numbers are allowed.`,
-      ),
-    ),
+    V.optional(V.maxLength(MAX_PHONE_NUMBERS, MAX_PHONE_NUMBERS_MESSAGE)),
   ],
   email: [V.optional(V.nullable(email))],
 };

--- a/common/src/cams/trustees.ts
+++ b/common/src/cams/trustees.ts
@@ -13,6 +13,8 @@ import type { TrusteeAppointment } from './trustee-appointments';
 export type PhoneType = 'direct' | 'fax' | 'home' | 'office' | 'personalMobile' | 'workMobile';
 export type TypedPhoneNumber = PhoneNumber & { type: PhoneType };
 
+export const MAX_PHONE_NUMBERS = 20;
+
 export const PHONE_TYPES = [
   'direct',
   'fax',

--- a/user-interface/src/lib/components/cams/PhoneEntryList/PhoneEntryList.test.tsx
+++ b/user-interface/src/lib/components/cams/PhoneEntryList/PhoneEntryList.test.tsx
@@ -156,6 +156,26 @@ describe('PhoneEntryList', () => {
     ]);
   });
 
+  test('shows the add button below the maximum of 20 phones', () => {
+    const phones: TypedPhoneNumber[] = Array.from({ length: 19 }, (_, i) => ({
+      type: 'direct' as const,
+      number: `555-000-${String(i).padStart(4, '0')}`,
+    }));
+    setup(phones);
+
+    expect(getAddButton()).toBeInTheDocument();
+  });
+
+  test('hides the add button once the maximum of 20 phones is reached', () => {
+    const phones: TypedPhoneNumber[] = Array.from({ length: 20 }, (_, i) => ({
+      type: 'direct' as const,
+      number: `555-000-${String(i).padStart(4, '0')}`,
+    }));
+    setup(phones);
+
+    expect(screen.queryByRole('button', { name: /add another phone/i })).not.toBeInTheDocument();
+  });
+
   test('renders per-row type, number, and extension errors', () => {
     setup([{ type: 'direct', number: 'bad' }], {
       errors: {

--- a/user-interface/src/lib/components/cams/PhoneEntryList/PhoneEntryList.test.tsx
+++ b/user-interface/src/lib/components/cams/PhoneEntryList/PhoneEntryList.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PhoneEntryList, { PhoneRowErrors } from './PhoneEntryList';
-import { PHONE_TYPES, PHONE_TYPE_LABELS, TypedPhoneNumber } from '@common/cams/trustees';
+import {
+  PHONE_TYPES,
+  PHONE_TYPE_LABELS,
+  TypedPhoneNumber,
+  MAX_PHONE_NUMBERS,
+} from '@common/cams/trustees';
 
 function getTypeSelect(index: number): HTMLSelectElement {
   return document.querySelector(`[data-testid$="-phone-${index}-type"]`) as HTMLSelectElement;
@@ -157,7 +162,7 @@ describe('PhoneEntryList', () => {
   });
 
   test('shows the add button below the maximum of 20 phones', () => {
-    const phones: TypedPhoneNumber[] = Array.from({ length: 19 }, (_, i) => ({
+    const phones: TypedPhoneNumber[] = Array.from({ length: MAX_PHONE_NUMBERS - 1 }, (_, i) => ({
       type: 'direct' as const,
       number: `555-000-${String(i).padStart(4, '0')}`,
     }));
@@ -167,7 +172,7 @@ describe('PhoneEntryList', () => {
   });
 
   test('hides the add button once the maximum of 20 phones is reached', () => {
-    const phones: TypedPhoneNumber[] = Array.from({ length: 20 }, (_, i) => ({
+    const phones: TypedPhoneNumber[] = Array.from({ length: MAX_PHONE_NUMBERS }, (_, i) => ({
       type: 'direct' as const,
       number: `555-000-${String(i).padStart(4, '0')}`,
     }));

--- a/user-interface/src/lib/components/cams/PhoneEntryList/PhoneEntryList.tsx
+++ b/user-interface/src/lib/components/cams/PhoneEntryList/PhoneEntryList.tsx
@@ -4,7 +4,13 @@ import Input from '@/lib/components/uswds/Input';
 import Button, { UswdsButtonStyle } from '@/lib/components/uswds/Button';
 import Icon from '@/lib/components/uswds/Icon';
 import PhoneNumberInput from '@/lib/components/PhoneNumberInput';
-import { PhoneType, PHONE_TYPES, PHONE_TYPE_LABELS, TypedPhoneNumber } from '@common/cams/trustees';
+import {
+  PhoneType,
+  PHONE_TYPES,
+  PHONE_TYPE_LABELS,
+  TypedPhoneNumber,
+  MAX_PHONE_NUMBERS,
+} from '@common/cams/trustees';
 
 export type PhoneRowErrors = {
   type?: string[];
@@ -43,6 +49,7 @@ export default function PhoneEntryList(props: Readonly<PhoneEntryListProps>) {
   }
 
   const showRemove = phones.length > 1;
+  const showAdd = phones.length < MAX_PHONE_NUMBERS;
 
   return (
     <div className="phone-entry-list">
@@ -125,16 +132,18 @@ export default function PhoneEntryList(props: Readonly<PhoneEntryListProps>) {
         );
       })}
 
-      <Button
-        id={`${baseId}-add-phone`}
-        className="phone-entry-list__add-button"
-        uswdsStyle={UswdsButtonStyle.Unstyled}
-        type="button"
-        onClick={handleAdd}
-      >
-        <Icon name="add" decorative={true} />
-        Add Another Phone
-      </Button>
+      {showAdd && (
+        <Button
+          id={`${baseId}-add-phone`}
+          className="phone-entry-list__add-button"
+          uswdsStyle={UswdsButtonStyle.Unstyled}
+          type="button"
+          onClick={handleAdd}
+        >
+          <Icon name="add" decorative={true} />
+          Add Another Phone
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# Purpose

Cap the number of phone numbers a trustee (or a single staff member) can accumulate, and give the team visibility into how often phone numbers are actually being added, without silently letting an unbounded list grow in either the UI or the API.

# Major Changes

* Added `MAX_PHONE_NUMBERS = 20` to `common/src/cams/trustees.ts` as the single source of truth for the limit
* `trusteeContactSpec.phones` now rejects arrays over 20 entries server-side — since `staffInputSpec.contact` wraps this same spec, one change enforces the limit on both the trustee internal-contact PATCH and the staff POST/PUT paths
* `PhoneEntryList` hides the "Add Another Phone" button once a contact reaches 20 phone entries
* Backend now fires an App Insights `'Phone Number Added'` custom event (via the existing `context.observability` trace pattern, matching `'Trustee Name Edited'`) whenever an update actually persists a net-new phone number — once per phone added, tagged with `contactType: 'internal' | 'staff'`
* No running total is computed or sent — existing App Insights workbooks already tally custom events via `customEvents | summarize count()`, so the workbook does the aggregation, consistent with every other custom event in this codebase

# Testing/Validation

* Added unit tests for the 20-phone validation limit in `common` (validator) and `user-interface` (button visibility)
* Added unit tests for the telemetry in `backend`, covering: trustee internal-contact updates that add phones, staff member creation (all phones counted as new), staff member updates (before/after diff), and confirming no event fires when phones are only removed
* Full `common`/`backend`/`user-interface` suite passes; the only failures present (~79-81 Okta/MSW-related tests, count varies by run) were confirmed pre-existing on the clean baseline before this branch, unrelated to this work

# Notes

Deliberately did not touch the Azure Application Insights workbook (Bicep/JSON under `ops/cloud-deployment/lib/workbooks/`) to add a panel visualizing the new event — that's deployed shared infrastructure, so filed `cams-w5lz` to track it as separate follow-up work rather than bundling an infra change into this PR. The pattern to extend is already established in `trustee-name-management-metrics.json`, which queries a backend-only event (`'Trustee Name Edited'`) the same way.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Limit trustee and staff contacts to a maximum of 20 phone numbers and add telemetry for phone number additions.

New Features:
- Enforce a shared 20-phone maximum for trustee internal contacts and staff member contacts via common validation.
- Hide the "Add Another Phone" button in the phone entry UI once a contact reaches 20 phone numbers.
- Emit a "Phone Number Added" App Insights event for each newly added phone number on trustee internal contacts and staff members, tagged by contact type.

Enhancements:
- Introduce a central MAX_PHONE_NUMBERS constant in the shared trustees model for consistent limits across backend and UI.

Tests:
- Add validator tests to ensure the 20-phone limit is accepted at the boundary and rejected when exceeded.
- Add UI tests to verify visibility of the add-phone button below and at the 20-phone threshold.
- Add backend tests to confirm phone addition telemetry fires for staff creation, staff updates, trustee internal-contact updates, and does not fire when phones are only removed.