### PR TITLE
Document default vs override dataflow selection

### DIFF
--- a/backend/function-apps/dataflows/dataflows.ts
+++ b/backend/function-apps/dataflows/dataflows.ts
@@ -51,7 +51,8 @@ function envVarToNames(envVar: string) {
     .toUpperCase()
     .replaceAll('_', '-')
     .split(',')
-    .map((name) => name.trim());
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
 }
 
 class DataflowSetupMap {
@@ -130,26 +131,24 @@ dataflows.register(
 const registeredDataflows = dataflows.list().join(', ').replaceAll('-', '_');
 logger.info(MODULE_NAME, 'Registered Dataflows', registeredDataflows);
 
+// Default dataflows started when CAMS_ENABLED_DATAFLOWS is unset. Mutually exclusive
+// with `override` below: if the env var is set, these defaults are not started.
+const DEFAULT_DATAFLOWS = [
+  AcmsDailySync.MODULE_NAME,
+  CaseAssignmentEvent.MODULE_NAME,
+  CaseClosedEvent.MODULE_NAME,
+  SyncCases.MODULE_NAME,
+  SyncDeletedCases.MODULE_NAME,
+  SyncOfficeStaff.MODULE_NAME,
+  SyncOrders.MODULE_NAME,
+  SyncTrusteeCaseAppointments.MODULE_NAME,
+  SyncTrusteeDueDateMetrics.MODULE_NAME,
+  SyncTrusteeNotesMetrics.MODULE_NAME,
+];
+
 // CAMS_ENABLED_DATAFLOWS, when set, is the exclusive list of dataflows to start.
 const override = envVarToNames(process.env.CAMS_ENABLED_DATAFLOWS ?? '');
-
-// Default dataflows started when CAMS_ENABLED_DATAFLOWS is unset. Mutually exclusive
-// with `override`: if the env var is set, these defaults are not started.
-const names =
-  override.length > 0
-    ? override
-    : [
-        AcmsDailySync.MODULE_NAME,
-        CaseAssignmentEvent.MODULE_NAME,
-        CaseClosedEvent.MODULE_NAME,
-        SyncCases.MODULE_NAME,
-        SyncDeletedCases.MODULE_NAME,
-        SyncOfficeStaff.MODULE_NAME,
-        SyncOrders.MODULE_NAME,
-        SyncTrusteeCaseAppointments.MODULE_NAME,
-        SyncTrusteeDueDateMetrics.MODULE_NAME,
-        SyncTrusteeNotesMetrics.MODULE_NAME,
-      ];
+const names = override.length > 0 ? override : DEFAULT_DATAFLOWS;
 const status = dataflows.setup(...names);
 
 status.forEach((s) => {

--- a/backend/function-apps/dataflows/dataflows.ts
+++ b/backend/function-apps/dataflows/dataflows.ts
@@ -43,7 +43,11 @@ type DataflowSetup = {
 
 const logger = new LoggerImpl('bootstrap');
 
-function envVarToNames(envVar: string) {
+function listDataflowNames(...dataflows: DataflowSetup[]): string[] {
+  return dataflows.map((dataflow) => dataflow.MODULE_NAME);
+}
+
+function envVarToNames(envVar: string | undefined) {
   if (!envVar) {
     return [];
   }
@@ -131,23 +135,20 @@ dataflows.register(
 const registeredDataflows = dataflows.list().join(', ').replaceAll('-', '_');
 logger.info(MODULE_NAME, 'Registered Dataflows', registeredDataflows);
 
-// Default dataflows started when CAMS_ENABLED_DATAFLOWS is unset. Mutually exclusive
-// with `override` below: if the env var is set, these defaults are not started.
-const DEFAULT_DATAFLOWS = [
-  AcmsDailySync.MODULE_NAME,
-  CaseAssignmentEvent.MODULE_NAME,
-  CaseClosedEvent.MODULE_NAME,
-  SyncCases.MODULE_NAME,
-  SyncDeletedCases.MODULE_NAME,
-  SyncOfficeStaff.MODULE_NAME,
-  SyncOrders.MODULE_NAME,
-  SyncTrusteeCaseAppointments.MODULE_NAME,
-  SyncTrusteeDueDateMetrics.MODULE_NAME,
-  SyncTrusteeNotesMetrics.MODULE_NAME,
-];
+const DEFAULT_DATAFLOWS = listDataflowNames(
+  AcmsDailySync,
+  CaseAssignmentEvent,
+  CaseClosedEvent,
+  SyncCases,
+  SyncDeletedCases,
+  SyncOfficeStaff,
+  SyncOrders,
+  SyncTrusteeCaseAppointments,
+  SyncTrusteeDueDateMetrics,
+  SyncTrusteeNotesMetrics,
+);
 
-// CAMS_ENABLED_DATAFLOWS, when set, is the exclusive list of dataflows to start.
-const override = envVarToNames(process.env.CAMS_ENABLED_DATAFLOWS ?? '');
+const override = envVarToNames(process.env.CAMS_ENABLED_DATAFLOWS);
 const names = override.length > 0 ? override : DEFAULT_DATAFLOWS;
 const status = dataflows.setup(...names);
 

--- a/backend/function-apps/dataflows/dataflows.ts
+++ b/backend/function-apps/dataflows/dataflows.ts
@@ -44,15 +44,18 @@ type DataflowSetup = {
 const logger = new LoggerImpl('bootstrap');
 
 function envVarToNames(envVar: string) {
+  if (!envVar) {
+    return [];
+  }
   return envVar
     .toUpperCase()
-    .replace(/_/g, '-')
+    .replaceAll('_', '-')
     .split(',')
     .map((name) => name.trim());
 }
 
 class DataflowSetupMap {
-  private map = new Map<string, () => void>();
+  private readonly map = new Map<string, () => void>();
 
   register(...dataflows: DataflowSetup[]) {
     for (const dataflow of dataflows) {
@@ -124,10 +127,29 @@ dataflows.register(
   BackfillTrusteeVerificationTaskDate,
 );
 
-const registeredDataflows = dataflows.list().join(', ').replace(/-/g, '_');
+const registeredDataflows = dataflows.list().join(', ').replaceAll('-', '_');
 logger.info(MODULE_NAME, 'Registered Dataflows', registeredDataflows);
 
-const names = envVarToNames(process.env.CAMS_ENABLED_DATAFLOWS ?? '');
+// CAMS_ENABLED_DATAFLOWS, when set, is the exclusive list of dataflows to start.
+const override = envVarToNames(process.env.CAMS_ENABLED_DATAFLOWS ?? '');
+
+// Default dataflows started when CAMS_ENABLED_DATAFLOWS is unset. Mutually exclusive
+// with `override`: if the env var is set, these defaults are not started.
+const names =
+  override.length > 0
+    ? override
+    : [
+        AcmsDailySync.MODULE_NAME,
+        CaseAssignmentEvent.MODULE_NAME,
+        CaseClosedEvent.MODULE_NAME,
+        SyncCases.MODULE_NAME,
+        SyncDeletedCases.MODULE_NAME,
+        SyncOfficeStaff.MODULE_NAME,
+        SyncOrders.MODULE_NAME,
+        SyncTrusteeCaseAppointments.MODULE_NAME,
+        SyncTrusteeDueDateMetrics.MODULE_NAME,
+        SyncTrusteeNotesMetrics.MODULE_NAME,
+      ];
 const status = dataflows.setup(...names);
 
 status.forEach((s) => {


### PR DESCRIPTION
# Purpose

Dataflows should start with a sensible default set out of the box, while still allowing operators to override exactly which dataflows run via configuration. Previously, `dataflows.ts` only started dataflows named in `CAMS_ENABLED_DATAFLOWS` — if that variable was unset or empty, no dataflows started at all.

# Major Changes

* `envVarToNames` now returns an empty list (instead of `['']`) when the env var is unset, so it no longer produces a bogus dataflow name
* Introduced a default list of dataflows (`AcmsDailySync`, `CaseAssignmentEvent`, `CaseClosedEvent`, `SyncCases`, `SyncDeletedCases`, `SyncOfficeStaff`, `SyncOrders`, `SyncTrusteeCaseAppointments`, `SyncTrusteeDueDateMetrics`, `SyncTrusteeNotesMetrics`) that start automatically when `CAMS_ENABLED_DATAFLOWS` is not set
* When `CAMS_ENABLED_DATAFLOWS` is set, it is used exclusively — the two lists are mutually exclusive, and this is now documented in comments above `override` and `names`
* Minor cleanup: `.replace(/_/g, '-')` / `.replace(/-/g, '_')` → `.replaceAll(...)`, and `map` field marked `readonly`

# Testing/Validation

Full validation checklist run: prettier, eslint, typecheck, unit tests (common/backend/user-interface), backend coverage, and knip all passed. `npm audit` shows pre-existing high-severity findings in transitive dependencies (`brace-expansion`, `fast-uri`, `immutable`), confirmed present on `main` prior to this branch and unrelated to it. No new automated tests were added for the default-list behavior; this should be considered before merging.

# Notes

No Jira ticket associated with this change.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application