### PR TITLE
CAMS-824 Default phone migration scripts to dry run

### DIFF
--- a/ops/migrations/CAMS-824-internal-contact-phone-types.js
+++ b/ops/migrations/CAMS-824-internal-contact-phone-types.js
@@ -10,14 +10,20 @@
  *
  * AUDIT_INTERNAL_CONTACT snapshot documents are NOT touched — they are immutable history.
  *
+ * Dry run by default: reports what would change without writing anything. Set the CONFIRM
+ * environment variable to 'true' to actually apply the changes.
+ *
  * Usage (mongosh):
  *   mongosh "<connection-string>" ops/migrations/CAMS-824-internal-contact-phone-types.js
+ *   CONFIRM=true mongosh "<connection-string>" ops/migrations/CAMS-824-internal-contact-phone-types.js
  *
  * Or from an existing mongosh session already connected to the target database:
  *   load('ops/migrations/CAMS-824-internal-contact-phone-types.js')
+ *   process.env.CONFIRM = 'true'; load('ops/migrations/CAMS-824-internal-contact-phone-types.js')
  */
 
 (function () {
+  const DRY_RUN = process.env.CONFIRM !== 'true';
   const collection = db.getCollection('trustees');
 
   const matching = collection.countDocuments({
@@ -31,6 +37,10 @@
   if (matching === 0) {
     print('Nothing to do.');
     return;
+  }
+
+  if (DRY_RUN) {
+    print("DRY RUN: no documents will be modified. Set CONFIRM='true' to apply changes.");
   }
 
   const cursor = collection.find({
@@ -53,17 +63,25 @@
       typedPhones.push(typedPhone);
     }
 
-    collection.updateOne(
-      { _id: doc._id },
-      {
-        $set: { 'internal.phones': typedPhones },
-        $unset: { 'internal.phone': '' },
-      },
-    );
+    if (DRY_RUN) {
+      print(`  Would update ${doc._id}: internal.phones = ${JSON.stringify(typedPhones)}`);
+    } else {
+      collection.updateOne(
+        { _id: doc._id },
+        {
+          $set: { 'internal.phones': typedPhones },
+          $unset: { 'internal.phone': '' },
+        },
+      );
+    }
 
     updated++;
   });
 
-  print(`Updated ${updated} document(s).`);
-  print('Migration complete.');
+  if (DRY_RUN) {
+    print(`DRY RUN: ${updated} document(s) would be updated. Set CONFIRM='true' to apply.`);
+  } else {
+    print(`Updated ${updated} document(s).`);
+    print('Migration complete.');
+  }
 })();

--- a/ops/migrations/CAMS-824-staff-contact-phone-types.js
+++ b/ops/migrations/CAMS-824-staff-contact-phone-types.js
@@ -11,14 +11,21 @@
  *
  * AUDIT_STAFF snapshot documents are NOT touched — they are immutable history.
  *
+ * Dry run by default: reports what would change without writing anything. Set the CONFIRM
+ * environment variable to 'true' to actually apply the changes.
+ *
  * Usage (mongosh):
  *   mongosh "<connection-string>" ops/migrations/CAMS-824-staff-contact-phone-types.js
+ *   CONFIRM=true mongosh "<connection-string>" ops/migrations/CAMS-824-staff-contact-phone-types.js
  *
- * Or from an existing mongosh session already connected to the target database:
+ * Or from an existing mongosh session already connected to the target
+ * database:
  *   load('ops/migrations/CAMS-824-staff-contact-phone-types.js')
+ *   process.env.CONFIRM = 'true'; load('ops/migrations/CAMS-824-staff-contact-phone-types.js')
  */
 
 (function () {
+  const DRY_RUN = process.env.CONFIRM !== 'true';
   const collection = db.getCollection('trustees');
 
   const matching = collection.countDocuments({
@@ -32,6 +39,10 @@
   if (matching === 0) {
     print('Nothing to do.');
     return;
+  }
+
+  if (DRY_RUN) {
+    print("DRY RUN: no documents will be modified. Set CONFIRM='true' to apply changes.");
   }
 
   const cursor = collection.find({
@@ -54,17 +65,25 @@
       typedPhones.push(typedPhone);
     }
 
-    collection.updateOne(
-      { _id: doc._id },
-      {
-        $set: { 'contact.phones': typedPhones },
-        $unset: { 'contact.phone': '' },
-      },
-    );
+    if (DRY_RUN) {
+      print(`  Would update ${doc._id}: contact.phones = ${JSON.stringify(typedPhones)}`);
+    } else {
+      collection.updateOne(
+        { _id: doc._id },
+        {
+          $set: { 'contact.phones': typedPhones },
+          $unset: { 'contact.phone': '' },
+        },
+      );
+    }
 
     updated++;
   });
 
-  print(`Updated ${updated} document(s).`);
-  print('Migration complete.');
+  if (DRY_RUN) {
+    print(`DRY RUN: ${updated} document(s) would be updated. Set CONFIRM='true' to apply.`);
+  } else {
+    print(`Updated ${updated} document(s).`);
+    print('Migration complete.');
+  }
 })();


### PR DESCRIPTION
# Purpose

The two CAMS-824 phone-type migration scripts (`ops/migrations/CAMS-824-internal-contact-phone-types.js` and `ops/migrations/CAMS-824-staff-contact-phone-types.js`) wrote to the database on first invocation with no way to preview the change, risking an accidental or premature write against a live environment.

# Major Changes

* Both scripts now default to a dry run: they report per-document what would change (document id and the resulting `phones`/`internal.phones` array) without writing anything
* Set `CONFIRM=true` in the environment (or `process.env.CONFIRM = 'true'` before `load()` in an interactive mongosh session) to actually apply the changes
* Updated each script's header usage comment to document both modes

# Testing/Validation

These are mongosh scripts with no existing project test harness. Verified behavior by:
* Simulating the script logic in Node with a mock `db`/`collection`/`print`, confirming dry run leaves the in-memory store untouched and prints the expected preview, while `CONFIRM=true` applies the update
* Confirming directly with mongosh that `process.env` reflects the shell environment and is settable interactively within a session, so both usage patterns documented in the header comment work as described
* `prettier --check` and `eslint` pass on both files (eslint ignores `ops/migrations/**`, consistent with the rest of that directory)

# Notes

Base branch is `CAMS-824-multiple-phones`, not `main` — this PR stacks the dry-run safeguard on top of the in-progress multiple-phones work before that branch merges.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Default the CAMS-824 staff and internal contact phone-type migration scripts to dry-run mode with optional confirmation to apply changes.

Enhancements:
- Add environment-driven DRY_RUN/CONFIRM switch to control whether migrations preview or persist changes.
- Improve migration script output to clearly report which documents would be updated and with what phone arrays.
- Update migration script usage comments to document dry-run behavior and how to enable real updates from mongosh.