### PR TITLE
Normalize ACMS chapter 7A/7N/09/AC on case appointments

### DIFF
--- a/backend/lib/adapters/gateways/acms/acms.gateway.helper.test.ts
+++ b/backend/lib/adapters/gateways/acms/acms.gateway.helper.test.ts
@@ -1,0 +1,32 @@
+import { normalizeAcmsCaseChapter } from './acms.gateway.helper';
+
+describe('ACMS Gateway Helper Tests', () => {
+  describe('normalizeAcmsCaseChapter', () => {
+    test.each(['7A', '7N'])("normalizes '%s' to '7'", (rawChapter) => {
+      expect(normalizeAcmsCaseChapter(rawChapter)).toBe('7');
+    });
+
+    test("normalizes '09' to '9'", () => {
+      expect(normalizeAcmsCaseChapter('09')).toBe('9');
+    });
+
+    test.each(['7', '9', '11', '12', '13', '15'])(
+      "passes valid chapter '%s' through unchanged",
+      (chapter) => {
+        expect(normalizeAcmsCaseChapter(chapter)).toBe(chapter);
+      },
+    );
+
+    test('trims whitespace', () => {
+      expect(normalizeAcmsCaseChapter(' 7 ')).toBe('7');
+    });
+
+    test("throws for unrecognized chapter 'AC'", () => {
+      expect(() => normalizeAcmsCaseChapter('AC')).toThrow('Invalid ACMS chapter value: AC');
+    });
+
+    test('throws for an empty string', () => {
+      expect(() => normalizeAcmsCaseChapter('')).toThrow('Invalid ACMS chapter value:');
+    });
+  });
+});

--- a/backend/lib/adapters/gateways/acms/acms.gateway.helper.ts
+++ b/backend/lib/adapters/gateways/acms/acms.gateway.helper.ts
@@ -1,0 +1,25 @@
+import { CaseChapter, VALID_CASE_CHAPTERS } from '@common/cams/cases';
+
+// ACMS's CURR_CASE_CHAPT carries legacy codes that don't match CAMS's chapter
+// vocabulary directly: '7A' (asset) / '7N' (no-asset) are CAMS chapter 7,
+// '9' is unpadded (unlike the '09' used when querying ACMS), and 'AC' is the
+// predecessor to chapter 15 and is not imported into CAMS. See the chapter
+// comment on AcmsGatewayImpl.getLeadCaseIds for the full documented code set.
+// Throws for 'AC' or any other value outside CAMS's valid chapter set so the
+// migration skips/fails the record rather than writing an invalid chapter.
+export function normalizeAcmsCaseChapter(chapter: string): CaseChapter {
+  const trimmed = chapter.trim();
+
+  let normalized = trimmed;
+  if (trimmed === '7A' || trimmed === '7N') {
+    normalized = '7';
+  } else if (trimmed === '09') {
+    normalized = '9';
+  }
+
+  if (!VALID_CASE_CHAPTERS.includes(normalized as CaseChapter)) {
+    throw new Error(`Invalid ACMS chapter value: ${chapter}`);
+  }
+
+  return normalized as CaseChapter;
+}

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.test.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.test.ts
@@ -7,6 +7,7 @@ import { createMockApplicationContext } from '../../../testing/testing-utilities
 import {
   CaseAppointment,
   CaseAppointmentInput,
+  CaseDenormalizedFields,
   TrusteeCaseListItem,
 } from '@common/cams/trustee-appointments';
 import { SYSTEM_USER_REFERENCE } from '@common/cams/auditable';
@@ -126,6 +127,24 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
   });
 
   describe('upsert', () => {
+    test('should reject an invalid chapter value without writing to Mongo', async () => {
+      const replaceOneSpy = vi.spyOn(MongoCollectionAdapter.prototype, 'replaceOne');
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      const input: CaseAppointmentInput = {
+        caseId: CASE_ID,
+        trusteeId: TRUSTEE_ID,
+        assignedOn: '2024-01-15',
+        chapter: '7A' as CaseAppointmentInput['chapter'],
+      };
+
+      await expect(repo.upsert(input)).rejects.toThrow(/Invalid chapter value/);
+      expect(replaceOneSpy).not.toHaveBeenCalled();
+
+      repo.release();
+    });
+
     test('should use 4-field natural key (documentType, caseId, trusteeId, assignedOn) without source', async () => {
       const replaceOneSpy = vi
         .spyOn(MongoCollectionAdapter.prototype, 'replaceOne')
@@ -1045,6 +1064,24 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
   });
 
   describe('updateCaseFields', () => {
+    test('should reject an invalid chapter value without writing to Mongo', async () => {
+      const updateManySpy = vi.spyOn(MongoCollectionAdapter.prototype, 'updateMany');
+      const context = await createMockApplicationContext();
+      const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
+
+      const fields = {
+        dateFiled: '2024-01-01',
+        caseStatus: 'CLOSED' as const,
+        chapter: '7N',
+        courtDivisionCode: 'DIV001',
+      } as unknown as CaseDenormalizedFields;
+
+      await expect(repo.updateCaseFields(CASE_ID, fields)).rejects.toThrow(/Invalid chapter value/);
+      expect(updateManySpy).not.toHaveBeenCalled();
+
+      repo.release();
+    });
+
     test('should use updateMany on case partition to update ALL matching documents', async () => {
       const updateManySpy = vi
         .spyOn(MongoCollectionAdapter.prototype, 'updateMany')
@@ -1060,7 +1097,7 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
       const context = await createMockApplicationContext();
       const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
 
-      const fields = {
+      const fields: CaseDenormalizedFields = {
         dateFiled: '2024-01-01',
         caseStatus: 'CLOSED' as const,
         chapter: '7',
@@ -1092,7 +1129,7 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
       const context = await createMockApplicationContext();
       const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
 
-      const fields = {
+      const fields: CaseDenormalizedFields = {
         dateFiled: '2024-01-01',
         caseStatus: 'CLOSED' as const,
         chapter: '7',
@@ -1126,7 +1163,7 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
       const context = await createMockApplicationContext();
       const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
 
-      const fields = {
+      const fields: CaseDenormalizedFields = {
         dateFiled: '2024-01-01',
         caseStatus: 'CLOSED' as const,
         chapter: '7',
@@ -1157,7 +1194,7 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
       const context = await createMockApplicationContext();
       const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
 
-      const fields = {
+      const fields: CaseDenormalizedFields = {
         dateFiled: '2024-01-01',
         caseStatus: 'CLOSED' as const,
         chapter: '7',
@@ -1192,7 +1229,7 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
       const context = await createMockApplicationContext();
       const repo = TrusteeCaseAppointmentsMongoRepository.getInstance(context);
 
-      const fields = {
+      const fields: CaseDenormalizedFields = {
         dateFiled: '2024-01-01',
         caseStatus: 'CLOSED' as const,
         chapter: '7',
@@ -1210,7 +1247,7 @@ describe('TrusteeCaseAppointmentsMongoRepository', () => {
   });
 
   describe('updateCaseFields — error paths', () => {
-    const fields = {
+    const fields: CaseDenormalizedFields = {
       dateFiled: '2024-01-01',
       caseStatus: 'CLOSED' as const,
       chapter: '7',

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -1,6 +1,7 @@
 import { ApplicationContext } from '../../types/basic';
 import { getCamsErrorWithStack } from '../../../common-errors/error-utilities';
 import { isNotFoundError } from '../../../common-errors/not-found-error';
+import { BadRequestError } from '../../../common-errors/bad-request';
 import {
   CamsPaginationResponse,
   CaseAppointmentMigrationInput,
@@ -14,6 +15,7 @@ import {
   CaseAppointmentInput,
   CaseDenormalizedFields,
   TrusteeCaseListItem,
+  VALID_CASE_CHAPTERS,
 } from '@common/cams/trustee-appointments';
 import { createAuditRecord, SYSTEM_USER_REFERENCE } from '@common/cams/auditable';
 import { Creatable } from '@common/cams/creatable';
@@ -36,6 +38,20 @@ const { using, and } = QueryBuilder;
 const { source } = QueryPipeline;
 
 const apptDoc = source<CaseAppointmentDocument>(TRUSTEE_COLLECTION);
+
+// Guards against ACMS/DXTR sub-codes (e.g. '7A', '7N') or other malformed
+// values reaching CASE_APPOINTMENT documents. Chapter should already be
+// normalized by the time it reaches this repository (see
+// normalizeAcmsCaseChapter for the ACMS migration path).
+function assertValidChapter(chapter: string | undefined): void {
+  if (chapter === undefined) return;
+  if (!VALID_CASE_CHAPTERS.includes(chapter as (typeof VALID_CASE_CHAPTERS)[number])) {
+    throw new BadRequestError(MODULE_NAME, {
+      message: `Invalid chapter value for case appointment: ${chapter}`,
+      data: { chapter },
+    });
+  }
+}
 
 export type CaseAppointmentDocument = CaseAppointment & {
   documentType: 'CASE_APPOINTMENT';
@@ -279,6 +295,8 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
   async upsert(
     appointment: CaseAppointmentInput | CaseAppointmentMigrationInput,
   ): Promise<CaseAppointment> {
+    assertValidChapter(appointment.chapter);
+
     // Compute caseStatus whenever dateFiled is present (i.e. a migrated/enriched doc).
     const appointmentWithStatus: CaseAppointmentInput & { caseStatus?: 'OPEN' | 'CLOSED' } = {
       ...appointment,
@@ -333,6 +351,8 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
   }
 
   async updateCaseAppointment(appointment: CaseAppointment): Promise<CaseAppointment> {
+    assertValidChapter(appointment.chapter);
+
     // Compute caseStatus whenever dateFiled is present (enriched doc).
     const appointmentWithStatus = { ...appointment };
     if (appointment.dateFiled) {
@@ -448,6 +468,8 @@ export class TrusteeCaseAppointmentsMongoRepository implements TrusteeCaseAppoin
   }
 
   async updateCaseFields(caseId: string, fields: CaseDenormalizedFields): Promise<void> {
+    assertValidChapter(fields.chapter);
+
     const doc = using<CaseAppointmentDocument>();
     const query = and(doc('documentType').equals('CASE_APPOINTMENT'), doc('caseId').equals(caseId));
 

--- a/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
+++ b/backend/lib/adapters/gateways/mongo/trustee-case-appointments.mongo.repository.ts
@@ -15,12 +15,11 @@ import {
   CaseAppointmentInput,
   CaseDenormalizedFields,
   TrusteeCaseListItem,
-  VALID_CASE_CHAPTERS,
 } from '@common/cams/trustee-appointments';
 import { createAuditRecord, SYSTEM_USER_REFERENCE } from '@common/cams/auditable';
 import { Creatable } from '@common/cams/creatable';
 import { TrusteeCasesSearchPredicate } from '@common/api/search';
-import { isCaseClosed } from '@common/cams/cases';
+import { isCaseClosed, VALID_CASE_CHAPTERS } from '@common/cams/cases';
 import { toMongoQuery } from './utils/mongo-query-renderer';
 import { SENTINEL_TRUSTEE_ID } from '../../../use-cases/dataflows/migrate-case-appointments-constants';
 

--- a/backend/lib/use-cases/dataflows/export-and-load-case.test.ts
+++ b/backend/lib/use-cases/dataflows/export-and-load-case.test.ts
@@ -3,6 +3,7 @@ import { SYSTEM_USER_REFERENCE } from '@common/cams/auditable';
 import MockData from '@common/cams/test-utilities/mock-data';
 import { CasesLocalGateway } from '../../adapters/gateways/cases.local.gateway';
 import { getCamsError } from '../../common-errors/error-utilities';
+import { CamsError } from '../../common-errors/cams-error';
 import { UnknownError } from '../../common-errors/unknown-error';
 import { NotFoundError } from '../../common-errors/not-found-error';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
@@ -738,6 +739,55 @@ describe('Export and Load Case Tests', () => {
         courtDivisionCode: 'DIV002',
         caseStatus: 'CLOSED',
       });
+    });
+
+    test('should record an event error and skip updateCaseFields when DXTR chapter is not a recognized value', async () => {
+      const originalCase = MockData.getDxtrCase({
+        override: {
+          caseId: '081-24-12345',
+          dateFiled: '2023-01-01',
+          chapter: '7',
+          courtDivisionCode: 'DIV001',
+          closedDate: undefined,
+          reopenedDate: undefined,
+          debtor: { name: 'Test Debtor' },
+          dxtrId: '12345',
+          courtId: '001',
+        } satisfies Partial<DxtrCase>,
+      });
+
+      const updatedCase = MockData.getDxtrCase({
+        override: {
+          caseId: '081-24-12345',
+          dateFiled: '2023-01-01',
+          chapter: 'AC', // Not a value CAMS recognizes
+          courtDivisionCode: 'DIV001',
+          closedDate: undefined,
+          reopenedDate: undefined,
+          debtor: { name: 'Test Debtor' },
+          dxtrId: '12345',
+          courtId: '001',
+        } satisfies Partial<DxtrCase>,
+      });
+
+      const event = mockCaseSyncEvent({ caseId: '081-24-12345' });
+
+      vi.spyOn(CasesLocalGateway.prototype, 'getCaseDetail').mockResolvedValue(
+        updatedCase as unknown as CaseDetail,
+      );
+      vi.spyOn(MockMongoRepository.prototype, 'getSyncedCase').mockResolvedValue(originalCase);
+      vi.spyOn(MockMongoRepository.prototype, 'syncDxtrCase').mockResolvedValue();
+      const updateCaseFieldsSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'updateCaseFields')
+        .mockResolvedValue();
+
+      const [resultEvent] = await ExportAndLoadCase.exportAndLoad(context, [event]);
+
+      expect(updateCaseFieldsSpy).not.toHaveBeenCalled();
+      expect(resultEvent.error).toBeDefined();
+      expect((resultEvent.error as CamsError).originalError).toContain(
+        'Invalid DXTR chapter value',
+      );
     });
 
     test('should skip updateCaseFields when no relevant fields changed', async () => {

--- a/backend/lib/use-cases/dataflows/export-and-load-case.test.ts
+++ b/backend/lib/use-cases/dataflows/export-and-load-case.test.ts
@@ -11,6 +11,7 @@ import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { CaseSyncEvent } from '@common/cams/dataflow-events';
 import ExportAndLoadCase from './export-and-load-case';
 import { CaseDetail, DxtrCase, SyncedCase } from '@common/cams/cases';
+import HttpStatusCodes from '@common/api/http-status-codes';
 
 function mockCaseSyncEvent(override: Partial<CaseSyncEvent> = {}): CaseSyncEvent {
   return {
@@ -785,9 +786,8 @@ describe('Export and Load Case Tests', () => {
 
       expect(updateCaseFieldsSpy).not.toHaveBeenCalled();
       expect(resultEvent.error).toBeDefined();
-      expect((resultEvent.error as CamsError).originalError).toContain(
-        'Invalid DXTR chapter value',
-      );
+      expect((resultEvent.error as CamsError).message).toContain('Invalid DXTR chapter value');
+      expect((resultEvent.error as CamsError).status).toBe(HttpStatusCodes.BAD_REQUEST);
     });
 
     test('should skip updateCaseFields when no relevant fields changed', async () => {

--- a/backend/lib/use-cases/dataflows/export-and-load-case.ts
+++ b/backend/lib/use-cases/dataflows/export-and-load-case.ts
@@ -1,6 +1,10 @@
 import { createAuditRecord } from '@common/cams/auditable';
 import { DxtrCase, SyncedCase, isCaseClosed } from '@common/cams/cases';
-import { CaseDenormalizedFields } from '@common/cams/trustee-appointments';
+import {
+  CaseChapter,
+  CaseDenormalizedFields,
+  VALID_CASE_CHAPTERS,
+} from '@common/cams/trustee-appointments';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { getCamsError, getCamsErrorWithStack } from '../../common-errors/error-utilities';
 import { isNotFoundError } from '../../common-errors/not-found-error';
@@ -61,11 +65,15 @@ function detectDenormalizedFieldChanges(
 
   if (!hasRelevantChange) return null;
 
+  if (!VALID_CASE_CHAPTERS.includes(newCase.chapter as CaseChapter)) {
+    throw new Error(`Invalid DXTR chapter value for case ${newCase.caseId}: ${newCase.chapter}`);
+  }
+
   const newCaseStatus = isCaseClosed(newCase) ? 'CLOSED' : 'OPEN';
   return {
     dateFiled: newCase.dateFiled,
     caseStatus: newCaseStatus,
-    chapter: newCase.chapter,
+    chapter: newCase.chapter as CaseChapter,
     courtDivisionCode: newCase.courtDivisionCode,
   };
 }

--- a/backend/lib/use-cases/dataflows/export-and-load-case.ts
+++ b/backend/lib/use-cases/dataflows/export-and-load-case.ts
@@ -1,13 +1,16 @@
 import { createAuditRecord } from '@common/cams/auditable';
-import { DxtrCase, SyncedCase, isCaseClosed } from '@common/cams/cases';
 import {
   CaseChapter,
-  CaseDenormalizedFields,
+  DxtrCase,
+  SyncedCase,
+  isCaseClosed,
   VALID_CASE_CHAPTERS,
-} from '@common/cams/trustee-appointments';
+} from '@common/cams/cases';
+import { CaseDenormalizedFields } from '@common/cams/trustee-appointments';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { getCamsError, getCamsErrorWithStack } from '../../common-errors/error-utilities';
 import { isNotFoundError } from '../../common-errors/not-found-error';
+import { BadRequestError } from '../../common-errors/bad-request';
 import factory from '../../factory';
 import { CaseSyncEvent, OrphanedCaseMessage } from '@common/cams/dataflow-events';
 import { generateSearchTokens } from '../../adapters/utils/phonetic-helper';
@@ -66,7 +69,10 @@ function detectDenormalizedFieldChanges(
   if (!hasRelevantChange) return null;
 
   if (!VALID_CASE_CHAPTERS.includes(newCase.chapter as CaseChapter)) {
-    throw new Error(`Invalid DXTR chapter value for case ${newCase.caseId}: ${newCase.chapter}`);
+    throw new BadRequestError(MODULE_NAME, {
+      message: `Invalid DXTR chapter value for case ${newCase.caseId}: ${newCase.chapter}`,
+      data: { caseId: newCase.caseId, chapter: newCase.chapter },
+    });
   }
 
   const newCaseStatus = isCaseClosed(newCase) ? 'CLOSED' : 'OPEN';

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.test.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.test.ts
@@ -283,6 +283,48 @@ describe('MigrateCaseAppointmentsUseCase', () => {
 
       expect(upsertSpy.mock.calls[0][0]).not.toHaveProperty('unassignedOn');
     });
+
+    test.each(['7A', '7N'])(
+      "normalizes ACMS chapter '%s' to '7' before writing",
+      async (rawChapter) => {
+        const upsertSpy = vi
+          .spyOn(MockMongoRepository.prototype, 'upsert')
+          .mockResolvedValue({} as CaseAppointment);
+
+        await MigrateCaseAppointmentsUseCase.writePage(context, [
+          makeResolvedRecord({ chapter: rawChapter }),
+        ]);
+
+        expect(upsertSpy.mock.calls[0][0]).toHaveProperty('chapter', '7');
+      },
+    );
+
+    test("normalizes ACMS chapter '09' to '9' before writing", async () => {
+      const upsertSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'upsert')
+        .mockResolvedValue({} as CaseAppointment);
+
+      await MigrateCaseAppointmentsUseCase.writePage(context, [
+        makeResolvedRecord({ chapter: '09' }),
+      ]);
+
+      expect(upsertSpy.mock.calls[0][0]).toHaveProperty('chapter', '9');
+    });
+
+    test("returns failure instead of writing for unrecognized chapter 'AC'", async () => {
+      const upsertSpy = vi
+        .spyOn(MockMongoRepository.prototype, 'upsert')
+        .mockResolvedValue({} as CaseAppointment);
+
+      const result = await MigrateCaseAppointmentsUseCase.writePage(context, [
+        makeResolvedRecord({ chapter: 'AC' }),
+      ]);
+
+      expect(upsertSpy).not.toHaveBeenCalled();
+      expect(result.successCount).toBe(0);
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0].reason).toContain('Invalid ACMS chapter value');
+    });
   });
 
   describe('writePage — serial backoff and escape hatch', () => {

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
@@ -13,7 +13,7 @@ import {
   formatCaseId,
   formatAcmsProfessionalId,
 } from '../gateways.types';
-import { normalizeAcmsCaseChapter } from '@common/cams/cases';
+import { normalizeAcmsCaseChapter } from '../../adapters/gateways/acms/acms.gateway.helper';
 import { CaseAppointment, CaseAppointmentInput } from '@common/cams/trustee-appointments';
 import { SAFE_THRESHOLD_MS, SENTINEL_TRUSTEE_ID } from './migrate-case-appointments-constants';
 

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
@@ -12,8 +12,8 @@ import {
   AcmsCaseAppointmentRawRecord,
   formatCaseId,
   formatAcmsProfessionalId,
-  normalizeAcmsCaseChapter,
 } from '../gateways.types';
+import { normalizeAcmsCaseChapter } from '@common/cams/cases';
 import { CaseAppointment, CaseAppointmentInput } from '@common/cams/trustee-appointments';
 import { SAFE_THRESHOLD_MS, SENTINEL_TRUSTEE_ID } from './migrate-case-appointments-constants';
 

--- a/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
+++ b/backend/lib/use-cases/dataflows/migrate-case-appointments.ts
@@ -12,6 +12,7 @@ import {
   AcmsCaseAppointmentRawRecord,
   formatCaseId,
   formatAcmsProfessionalId,
+  normalizeAcmsCaseChapter,
 } from '../gateways.types';
 import { CaseAppointment, CaseAppointmentInput } from '@common/cams/trustee-appointments';
 import { SAFE_THRESHOLD_MS, SENTINEL_TRUSTEE_ID } from './migrate-case-appointments-constants';
@@ -241,7 +242,8 @@ async function writeRecordWithRetry(
 
 // Shared date/field mapping used by both the normal write path (writeRecord) and
 // the moved-case migration path (buildCaseAppointmentMigrationInput). Throws if
-// any ACMS date field is malformed — callers are responsible for catching.
+// any ACMS date field is malformed, or if chapter is not a value CAMS recognizes
+// (e.g. 'AC') — callers are responsible for catching.
 function buildAppointmentFields(record: ResolvedAcmsRecord): Partial<CaseAppointmentInput> {
   const closedDate = record.closedByCourtDate
     ? formatAcmsDate(record.closedByCourtDate)
@@ -252,7 +254,7 @@ function buildAppointmentFields(record: ResolvedAcmsRecord): Partial<CaseAppoint
     ...(record.apptDate ? { appointedDate: formatAcmsDate(record.apptDate) } : {}),
     ...(record.unassignDate ? { unassignedOn: formatAcmsDate(record.unassignDate) } : {}),
     ...(record.caseFiledDate ? { dateFiled: formatAcmsDate(record.caseFiledDate) } : {}),
-    ...(record.chapter ? { chapter: record.chapter.trim() } : {}),
+    ...(record.chapter ? { chapter: normalizeAcmsCaseChapter(record.chapter) } : {}),
     ...(record.courtDivisionCode ? { courtDivisionCode: record.courtDivisionCode } : {}),
     ...(closedDate ? { closedDate } : {}),
     ...(record.reopenedDate ? { reopenedDate: formatAcmsDate(record.reopenedDate) } : {}),

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -52,12 +52,10 @@ import { TrusteeNote } from '@common/cams/trustee-notes';
 import {
   CaseAppointment,
   CaseAppointmentInput,
-  CaseChapter,
   CaseDenormalizedFields,
   TrusteeAppointment,
   TrusteeAppointmentInput,
   TrusteeCaseListItem,
-  VALID_CASE_CHAPTERS,
 } from '@common/cams/trustee-appointments';
 import {
   TrusteeMatchVerification,
@@ -284,30 +282,6 @@ export function formatCaseId(div: number, year: number, num: number): string {
 
 export function formatAcmsProfessionalId(group: string, code: number): string {
   return `${group.trim()}-${String(code).padStart(5, '0')}`;
-}
-
-// ACMS's CURR_CASE_CHAPT carries legacy codes that don't match CAMS's chapter
-// vocabulary directly: '7A' (asset) / '7N' (no-asset) are CAMS chapter 7,
-// '9' is unpadded (unlike the '09' used when querying ACMS), and 'AC' is the
-// predecessor to chapter 15 and is not imported into CAMS. See the chapter
-// comment on AcmsGatewayImpl.getLeadCaseIds for the full documented code set.
-// Throws for 'AC' or any other value outside CAMS's valid chapter set so the
-// migration skips/fails the record rather than writing an invalid chapter.
-export function normalizeAcmsCaseChapter(chapter: string): CaseChapter {
-  const trimmed = chapter.trim();
-
-  let normalized = trimmed;
-  if (trimmed === '7A' || trimmed === '7N') {
-    normalized = '7';
-  } else if (trimmed === '09') {
-    normalized = '9';
-  }
-
-  if (!VALID_CASE_CHAPTERS.includes(normalized as CaseChapter)) {
-    throw new Error(`Invalid ACMS chapter value: ${chapter}`);
-  }
-
-  return normalized as CaseChapter;
 }
 
 export interface AcmsGateway {

--- a/backend/lib/use-cases/gateways.types.ts
+++ b/backend/lib/use-cases/gateways.types.ts
@@ -52,10 +52,12 @@ import { TrusteeNote } from '@common/cams/trustee-notes';
 import {
   CaseAppointment,
   CaseAppointmentInput,
+  CaseChapter,
   CaseDenormalizedFields,
   TrusteeAppointment,
   TrusteeAppointmentInput,
   TrusteeCaseListItem,
+  VALID_CASE_CHAPTERS,
 } from '@common/cams/trustee-appointments';
 import {
   TrusteeMatchVerification,
@@ -282,6 +284,30 @@ export function formatCaseId(div: number, year: number, num: number): string {
 
 export function formatAcmsProfessionalId(group: string, code: number): string {
   return `${group.trim()}-${String(code).padStart(5, '0')}`;
+}
+
+// ACMS's CURR_CASE_CHAPT carries legacy codes that don't match CAMS's chapter
+// vocabulary directly: '7A' (asset) / '7N' (no-asset) are CAMS chapter 7,
+// '9' is unpadded (unlike the '09' used when querying ACMS), and 'AC' is the
+// predecessor to chapter 15 and is not imported into CAMS. See the chapter
+// comment on AcmsGatewayImpl.getLeadCaseIds for the full documented code set.
+// Throws for 'AC' or any other value outside CAMS's valid chapter set so the
+// migration skips/fails the record rather than writing an invalid chapter.
+export function normalizeAcmsCaseChapter(chapter: string): CaseChapter {
+  const trimmed = chapter.trim();
+
+  let normalized = trimmed;
+  if (trimmed === '7A' || trimmed === '7N') {
+    normalized = '7';
+  } else if (trimmed === '09') {
+    normalized = '9';
+  }
+
+  if (!VALID_CASE_CHAPTERS.includes(normalized as CaseChapter)) {
+    throw new Error(`Invalid ACMS chapter value: ${chapter}`);
+  }
+
+  return normalized as CaseChapter;
 }
 
 export interface AcmsGateway {

--- a/common/src/cams/cases.test.ts
+++ b/common/src/cams/cases.test.ts
@@ -3,17 +3,18 @@ import {
   getCaseConsolidationType,
   getCaseIdParts,
   getCaseNumber,
-  getLeadCaseLabel,
-  getMemberCaseLabel,
   isCaseClosed,
   isCaseOpen,
   isMemberCase,
   isLeadCase,
   isTransferredCase,
   MatchType,
+  normalizeAcmsCaseChapter,
   ScoreBreakdown,
   SearchMetadata,
   SyncedCase,
+  getLeadCaseLabel,
+  getMemberCaseLabel,
 } from './cases';
 import MockData from './test-utilities/mock-data';
 import { ConsolidationType } from './orders';
@@ -226,6 +227,35 @@ describe('cases common functions tests', () => {
 
     test('should throw for malformed case ID with no hyphens', () => {
       expect(() => getCaseNumber('invalid')).toThrow('Invalid case ID: invalid');
+    });
+  });
+
+  describe('normalizeAcmsCaseChapter', () => {
+    test.each(['7A', '7N'])("normalizes '%s' to '7'", (rawChapter) => {
+      expect(normalizeAcmsCaseChapter(rawChapter)).toBe('7');
+    });
+
+    test("normalizes '09' to '9'", () => {
+      expect(normalizeAcmsCaseChapter('09')).toBe('9');
+    });
+
+    test.each(['7', '9', '11', '12', '13', '15'])(
+      "passes valid chapter '%s' through unchanged",
+      (chapter) => {
+        expect(normalizeAcmsCaseChapter(chapter)).toBe(chapter);
+      },
+    );
+
+    test('trims whitespace', () => {
+      expect(normalizeAcmsCaseChapter(' 7 ')).toBe('7');
+    });
+
+    test("throws for unrecognized chapter 'AC'", () => {
+      expect(() => normalizeAcmsCaseChapter('AC')).toThrow('Invalid ACMS chapter value: AC');
+    });
+
+    test('throws for an empty string', () => {
+      expect(() => normalizeAcmsCaseChapter('')).toThrow('Invalid ACMS chapter value:');
     });
   });
 });

--- a/common/src/cams/cases.test.ts
+++ b/common/src/cams/cases.test.ts
@@ -9,7 +9,6 @@ import {
   isLeadCase,
   isTransferredCase,
   MatchType,
-  normalizeAcmsCaseChapter,
   ScoreBreakdown,
   SearchMetadata,
   SyncedCase,
@@ -227,35 +226,6 @@ describe('cases common functions tests', () => {
 
     test('should throw for malformed case ID with no hyphens', () => {
       expect(() => getCaseNumber('invalid')).toThrow('Invalid case ID: invalid');
-    });
-  });
-
-  describe('normalizeAcmsCaseChapter', () => {
-    test.each(['7A', '7N'])("normalizes '%s' to '7'", (rawChapter) => {
-      expect(normalizeAcmsCaseChapter(rawChapter)).toBe('7');
-    });
-
-    test("normalizes '09' to '9'", () => {
-      expect(normalizeAcmsCaseChapter('09')).toBe('9');
-    });
-
-    test.each(['7', '9', '11', '12', '13', '15'])(
-      "passes valid chapter '%s' through unchanged",
-      (chapter) => {
-        expect(normalizeAcmsCaseChapter(chapter)).toBe(chapter);
-      },
-    );
-
-    test('trims whitespace', () => {
-      expect(normalizeAcmsCaseChapter(' 7 ')).toBe('7');
-    });
-
-    test("throws for unrecognized chapter 'AC'", () => {
-      expect(() => normalizeAcmsCaseChapter('AC')).toThrow('Invalid ACMS chapter value: AC');
-    });
-
-    test('throws for an empty string', () => {
-      expect(() => normalizeAcmsCaseChapter('')).toThrow('Invalid ACMS chapter value:');
     });
   });
 });

--- a/common/src/cams/cases.ts
+++ b/common/src/cams/cases.ts
@@ -14,6 +14,34 @@ import { Pagination } from '../api/pagination';
 
 export const VALID_CASEID_PATTERN = /^[\dA-Z]{3}-\d{2}-\d{5}$/;
 
+export const VALID_CASE_CHAPTERS = ['7', '9', '11', '12', '13', '15'] as const;
+
+export type CaseChapter = (typeof VALID_CASE_CHAPTERS)[number];
+
+// ACMS's CURR_CASE_CHAPT carries legacy codes that don't match CAMS's chapter
+// vocabulary directly: '7A' (asset) / '7N' (no-asset) are CAMS chapter 7,
+// '9' is unpadded (unlike the '09' used when querying ACMS), and 'AC' is the
+// predecessor to chapter 15 and is not imported into CAMS. See the chapter
+// comment on AcmsGatewayImpl.getLeadCaseIds for the full documented code set.
+// Throws for 'AC' or any other value outside CAMS's valid chapter set so the
+// migration skips/fails the record rather than writing an invalid chapter.
+export function normalizeAcmsCaseChapter(chapter: string): CaseChapter {
+  const trimmed = chapter.trim();
+
+  let normalized = trimmed;
+  if (trimmed === '7A' || trimmed === '7N') {
+    normalized = '7';
+  } else if (trimmed === '09') {
+    normalized = '9';
+  }
+
+  if (!VALID_CASE_CHAPTERS.includes(normalized as CaseChapter)) {
+    throw new Error(`Invalid ACMS chapter value: ${chapter}`);
+  }
+
+  return normalized as CaseChapter;
+}
+
 type FlatOfficeDetail = {
   officeName: string;
   officeCode: string;

--- a/common/src/cams/cases.ts
+++ b/common/src/cams/cases.ts
@@ -18,30 +18,6 @@ export const VALID_CASE_CHAPTERS = ['7', '9', '11', '12', '13', '15'] as const;
 
 export type CaseChapter = (typeof VALID_CASE_CHAPTERS)[number];
 
-// ACMS's CURR_CASE_CHAPT carries legacy codes that don't match CAMS's chapter
-// vocabulary directly: '7A' (asset) / '7N' (no-asset) are CAMS chapter 7,
-// '9' is unpadded (unlike the '09' used when querying ACMS), and 'AC' is the
-// predecessor to chapter 15 and is not imported into CAMS. See the chapter
-// comment on AcmsGatewayImpl.getLeadCaseIds for the full documented code set.
-// Throws for 'AC' or any other value outside CAMS's valid chapter set so the
-// migration skips/fails the record rather than writing an invalid chapter.
-export function normalizeAcmsCaseChapter(chapter: string): CaseChapter {
-  const trimmed = chapter.trim();
-
-  let normalized = trimmed;
-  if (trimmed === '7A' || trimmed === '7N') {
-    normalized = '7';
-  } else if (trimmed === '09') {
-    normalized = '9';
-  }
-
-  if (!VALID_CASE_CHAPTERS.includes(normalized as CaseChapter)) {
-    throw new Error(`Invalid ACMS chapter value: ${chapter}`);
-  }
-
-  return normalized as CaseChapter;
-}
-
 type FlatOfficeDetail = {
   officeName: string;
   officeCode: string;

--- a/common/src/cams/search-validators.ts
+++ b/common/src/cams/search-validators.ts
@@ -2,6 +2,7 @@ import V from './validators';
 import { ValidationSpec } from './validation';
 import { CasesSearchPredicate } from '../api/search';
 import { CASE_NUMBER_REGEX } from './regex';
+import { VALID_CASE_CHAPTERS } from './trustee-appointments';
 
 // Constants matching frontend validation
 const DEBTOR_NAME_MIN_LENGTH = 2;
@@ -85,8 +86,7 @@ export const chapters = V.optional(
         return { reasons: [SEARCH_VALIDATION_MESSAGES.CHAPTER_NOT_A_STRING] };
       }
       // Valid chapter values based on bankruptcy law
-      const validChapters = ['7', '9', '11', '12', '13', '15'];
-      if (!validChapters.includes(value)) {
+      if (!VALID_CASE_CHAPTERS.includes(value as (typeof VALID_CASE_CHAPTERS)[number])) {
         return { reasons: [SEARCH_VALIDATION_MESSAGES.CHAPTER_INVALID] };
       }
       return { valid: true };

--- a/common/src/cams/search-validators.ts
+++ b/common/src/cams/search-validators.ts
@@ -2,7 +2,7 @@ import V from './validators';
 import { ValidationSpec } from './validation';
 import { CasesSearchPredicate } from '../api/search';
 import { CASE_NUMBER_REGEX } from './regex';
-import { VALID_CASE_CHAPTERS } from './trustee-appointments';
+import { VALID_CASE_CHAPTERS } from './cases';
 
 // Constants matching frontend validation
 const DEBTOR_NAME_MIN_LENGTH = 2;

--- a/common/src/cams/trustee-appointments.ts
+++ b/common/src/cams/trustee-appointments.ts
@@ -183,6 +183,12 @@ export const TRUSTEE_APPOINTMENTS_INTERNAL_SPEC: Readonly<ValidationSpec<Trustee
     ],
   };
 
+// Valid CAMS case chapters. ACMS's legacy '7A' (asset) / '7N' (no-asset) sub-codes
+// are normalized to '7' before reaching this type — see normalizeAcmsCaseChapter.
+export const VALID_CASE_CHAPTERS = ['7', '9', '11', '12', '13', '15'] as const;
+
+export type CaseChapter = (typeof VALID_CASE_CHAPTERS)[number];
+
 export type CaseAppointmentInput = {
   caseId: string;
   trusteeId: string;
@@ -190,7 +196,7 @@ export type CaseAppointmentInput = {
   appointedDate?: string;
   unassignedOn?: string;
   dateFiled?: string;
-  chapter?: string;
+  chapter?: CaseChapter;
   courtDivisionCode?: string;
   closedDate?: string;
   reopenedDate?: string;
@@ -204,7 +210,7 @@ export type CaseAppointment = Auditable &
     appointedDate?: string;
     unassignedOn?: string;
     dateFiled?: string;
-    chapter?: string;
+    chapter?: CaseChapter;
     courtDivisionCode?: string;
     closedDate?: string;
     reopenedDate?: string;
@@ -224,7 +230,7 @@ export type TrusteeCaseListItem = {
   caseId: string;
   courtDivisionName: string;
   caseTitle: string;
-  chapter: string;
+  chapter: CaseChapter;
   dateFiled: string;
   appointedDate?: string;
   caseStatus: 'OPEN' | 'CLOSED';
@@ -233,6 +239,6 @@ export type TrusteeCaseListItem = {
 export type CaseDenormalizedFields = {
   dateFiled: string;
   caseStatus: 'OPEN' | 'CLOSED';
-  chapter: string;
+  chapter: CaseChapter;
   courtDivisionCode: string;
 };

--- a/common/src/cams/trustee-appointments.ts
+++ b/common/src/cams/trustee-appointments.ts
@@ -2,6 +2,7 @@ import { Auditable } from './auditable';
 import { Identifiable } from './document';
 import { AppointmentType, AppointmentChapterType, AppointmentStatus } from './trustees';
 import { VALID, ValidatorFunction, ValidatorResult, ValidationSpec } from './validation';
+import { CaseChapter } from './cases';
 
 const chapter7AppointmentTypes: readonly AppointmentType[] = [
   'panel',
@@ -182,12 +183,6 @@ export const TRUSTEE_APPOINTMENTS_INTERNAL_SPEC: Readonly<ValidationSpec<Trustee
       validateDivisionCodes,
     ],
   };
-
-// Valid CAMS case chapters. ACMS's legacy '7A' (asset) / '7N' (no-asset) sub-codes
-// are normalized to '7' before reaching this type — see normalizeAcmsCaseChapter.
-export const VALID_CASE_CHAPTERS = ['7', '9', '11', '12', '13', '15'] as const;
-
-export type CaseChapter = (typeof VALID_CASE_CHAPTERS)[number];
 
 export type CaseAppointmentInput = {
   caseId: string;

--- a/ops/migrations/CAMS-824-internal-contact-phone-types.js
+++ b/ops/migrations/CAMS-824-internal-contact-phone-types.js
@@ -10,20 +10,14 @@
  *
  * AUDIT_INTERNAL_CONTACT snapshot documents are NOT touched — they are immutable history.
  *
- * Dry run by default: reports what would change without writing anything. Set the CONFIRM
- * environment variable to 'true' to actually apply the changes.
- *
  * Usage (mongosh):
  *   mongosh "<connection-string>" ops/migrations/CAMS-824-internal-contact-phone-types.js
- *   CONFIRM=true mongosh "<connection-string>" ops/migrations/CAMS-824-internal-contact-phone-types.js
  *
  * Or from an existing mongosh session already connected to the target database:
  *   load('ops/migrations/CAMS-824-internal-contact-phone-types.js')
- *   process.env.CONFIRM = 'true'; load('ops/migrations/CAMS-824-internal-contact-phone-types.js')
  */
 
 (function () {
-  const DRY_RUN = process.env.CONFIRM !== 'true';
   const collection = db.getCollection('trustees');
 
   const matching = collection.countDocuments({
@@ -37,10 +31,6 @@
   if (matching === 0) {
     print('Nothing to do.');
     return;
-  }
-
-  if (DRY_RUN) {
-    print("DRY RUN: no documents will be modified. Set CONFIRM='true' to apply changes.");
   }
 
   const cursor = collection.find({
@@ -63,25 +53,17 @@
       typedPhones.push(typedPhone);
     }
 
-    if (DRY_RUN) {
-      print(`  Would update ${doc._id}: internal.phones = ${JSON.stringify(typedPhones)}`);
-    } else {
-      collection.updateOne(
-        { _id: doc._id },
-        {
-          $set: { 'internal.phones': typedPhones },
-          $unset: { 'internal.phone': '' },
-        },
-      );
-    }
+    collection.updateOne(
+      { _id: doc._id },
+      {
+        $set: { 'internal.phones': typedPhones },
+        $unset: { 'internal.phone': '' },
+      },
+    );
 
     updated++;
   });
 
-  if (DRY_RUN) {
-    print(`DRY RUN: ${updated} document(s) would be updated. Set CONFIRM='true' to apply.`);
-  } else {
-    print(`Updated ${updated} document(s).`);
-    print('Migration complete.');
-  }
+  print(`Updated ${updated} document(s).`);
+  print('Migration complete.');
 })();

--- a/ops/migrations/CAMS-824-staff-contact-phone-types.js
+++ b/ops/migrations/CAMS-824-staff-contact-phone-types.js
@@ -11,21 +11,15 @@
  *
  * AUDIT_STAFF snapshot documents are NOT touched — they are immutable history.
  *
- * Dry run by default: reports what would change without writing anything. Set the CONFIRM
- * environment variable to 'true' to actually apply the changes.
- *
  * Usage (mongosh):
  *   mongosh "<connection-string>" ops/migrations/CAMS-824-staff-contact-phone-types.js
- *   CONFIRM=true mongosh "<connection-string>" ops/migrations/CAMS-824-staff-contact-phone-types.js
  *
  * Or from an existing mongosh session already connected to the target
  * database:
  *   load('ops/migrations/CAMS-824-staff-contact-phone-types.js')
- *   process.env.CONFIRM = 'true'; load('ops/migrations/CAMS-824-staff-contact-phone-types.js')
  */
 
 (function () {
-  const DRY_RUN = process.env.CONFIRM !== 'true';
   const collection = db.getCollection('trustees');
 
   const matching = collection.countDocuments({
@@ -39,10 +33,6 @@
   if (matching === 0) {
     print('Nothing to do.');
     return;
-  }
-
-  if (DRY_RUN) {
-    print("DRY RUN: no documents will be modified. Set CONFIRM='true' to apply changes.");
   }
 
   const cursor = collection.find({
@@ -65,25 +55,17 @@
       typedPhones.push(typedPhone);
     }
 
-    if (DRY_RUN) {
-      print(`  Would update ${doc._id}: contact.phones = ${JSON.stringify(typedPhones)}`);
-    } else {
-      collection.updateOne(
-        { _id: doc._id },
-        {
-          $set: { 'contact.phones': typedPhones },
-          $unset: { 'contact.phone': '' },
-        },
-      );
-    }
+    collection.updateOne(
+      { _id: doc._id },
+      {
+        $set: { 'contact.phones': typedPhones },
+        $unset: { 'contact.phone': '' },
+      },
+    );
 
     updated++;
   });
 
-  if (DRY_RUN) {
-    print(`DRY RUN: ${updated} document(s) would be updated. Set CONFIRM='true' to apply.`);
-  } else {
-    print(`Updated ${updated} document(s).`);
-    print('Migration complete.');
-  }
+  print(`Updated ${updated} document(s).`);
+  print('Migration complete.');
 })();

--- a/ops/migrations/normalize-case-appointment-chapter.js
+++ b/ops/migrations/normalize-case-appointment-chapter.js
@@ -23,21 +23,15 @@
  * Idempotent: only matches documents still carrying one of the raw codes
  * above. Documents already fixed by a prior run are skipped.
  *
- * Dry run by default: reports what would change without writing anything.
- * Set the CONFIRM environment variable to 'true' to actually apply changes.
- *
  * Usage (mongosh):
  *   mongosh "<connection-string>" ops/migrations/normalize-case-appointment-chapter.js
- *   CONFIRM=true mongosh "<connection-string>" ops/migrations/normalize-case-appointment-chapter.js
  *
  * Or from an existing mongosh session already connected to the target
  * database:
  *   load('ops/migrations/normalize-case-appointment-chapter.js')
- *   process.env.CONFIRM = 'true'; load('ops/migrations/normalize-case-appointment-chapter.js')
  */
 
 (function () {
-  const DRY_RUN = process.env.CONFIRM !== 'true';
   const COLLECTIONS = ['case-trustee-appointments', 'trustee-case-appointments'];
 
   const RENAMES = [
@@ -45,10 +39,6 @@
     { from: ['09'], to: '9' },
   ];
   const DELETE_CHAPTERS = ['AC'];
-
-  if (DRY_RUN) {
-    print("DRY RUN: no documents will be modified. Set CONFIRM='true' to apply changes.");
-  }
 
   COLLECTIONS.forEach((collectionName) => {
     const collection = db.getCollection(collectionName);
@@ -66,19 +56,10 @@
         return;
       }
 
-      if (DRY_RUN) {
-        collection.find(filter).forEach(function (doc) {
-          print(`  Would update ${doc._id}: chapter '${doc.chapter}' -> '${to}'`);
-        });
-        print(
-          `[${collectionName}] DRY RUN: ${matching} document(s) would be updated to chapter '${to}'. Set CONFIRM='true' to apply.`,
-        );
-      } else {
-        const result = collection.updateMany(filter, { $set: { chapter: to } });
-        print(
-          `[${collectionName}] Updated ${result.modifiedCount} document(s): chapter [${from.join(', ')}] -> '${to}'.`,
-        );
-      }
+      const result = collection.updateMany(filter, { $set: { chapter: to } });
+      print(
+        `[${collectionName}] Updated ${result.modifiedCount} document(s): chapter [${from.join(', ')}] -> '${to}'.`,
+      );
     });
 
     const deleteFilter = { documentType: 'CASE_APPOINTMENT', chapter: { $in: DELETE_CHAPTERS } };
@@ -90,13 +71,6 @@
 
     if (matchingForDelete === 0) {
       print(`[${collectionName}] Nothing to delete.`);
-    } else if (DRY_RUN) {
-      collection.find(deleteFilter).forEach(function (doc) {
-        print(`  Would delete ${doc._id}: chapter '${doc.chapter}'`);
-      });
-      print(
-        `[${collectionName}] DRY RUN: ${matchingForDelete} document(s) would be deleted. Set CONFIRM='true' to apply.`,
-      );
     } else {
       const deleteResult = collection.deleteMany(deleteFilter);
       print(
@@ -105,7 +79,5 @@
     }
   });
 
-  if (!DRY_RUN) {
-    print('Migration complete.');
-  }
+  print('Migration complete.');
 })();

--- a/ops/migrations/normalize-case-appointment-chapter.js
+++ b/ops/migrations/normalize-case-appointment-chapter.js
@@ -1,0 +1,111 @@
+/**
+ * One-time data repair: fix up legacy ACMS chapter codes on CASE_APPOINTMENT
+ * documents that were copied verbatim from CURR_CASE_CHAPT before the
+ * ACMS-to-CAMS case-appointment migration (migrate-case-appointments)
+ * normalized them at write time. Three fixes:
+ *
+ *   - '7A' (asset) / '7N' (no-asset) -> '7'. CAMS treats these ACMS chapter 7
+ *     sub-codes inclusively as chapter 7. This is what shows up as "7A"/"7N"
+ *     in the trustee case list, and causes chapter-7 filtering (an exact-match
+ *     query) to miss those cases.
+ *   - '09' -> '9'. ACMS's CURR_CASE_CHAPT is unpadded; DXTR-sourced documents
+ *     use '9', so any '09' left over is inconsistent with the rest of CAMS.
+ *   - 'AC' documents are deleted outright. 'AC' is the predecessor to chapter
+ *     15 and was never meant to be imported into CAMS (see the chapter
+ *     comment on AcmsGatewayImpl.getLeadCaseIds) — any that made it in
+ *     represent appointments that should not exist in CAMS at all.
+ *
+ * CASE_APPOINTMENT documents are dual-written to two collections (matching
+ * partition keys used by the repository) — both must be fixed:
+ *   - case-trustee-appointments   (partition key: caseId)
+ *   - trustee-case-appointments   (partition key: trusteeId)
+ *
+ * Idempotent: only matches documents still carrying one of the raw codes
+ * above. Documents already fixed by a prior run are skipped.
+ *
+ * Dry run by default: reports what would change without writing anything.
+ * Set the CONFIRM environment variable to 'true' to actually apply changes.
+ *
+ * Usage (mongosh):
+ *   mongosh "<connection-string>" ops/migrations/normalize-case-appointment-chapter.js
+ *   CONFIRM=true mongosh "<connection-string>" ops/migrations/normalize-case-appointment-chapter.js
+ *
+ * Or from an existing mongosh session already connected to the target
+ * database:
+ *   load('ops/migrations/normalize-case-appointment-chapter.js')
+ *   process.env.CONFIRM = 'true'; load('ops/migrations/normalize-case-appointment-chapter.js')
+ */
+
+(function () {
+  const DRY_RUN = process.env.CONFIRM !== 'true';
+  const COLLECTIONS = ['case-trustee-appointments', 'trustee-case-appointments'];
+
+  const RENAMES = [
+    { from: ['7A', '7N'], to: '7' },
+    { from: ['09'], to: '9' },
+  ];
+  const DELETE_CHAPTERS = ['AC'];
+
+  if (DRY_RUN) {
+    print("DRY RUN: no documents will be modified. Set CONFIRM='true' to apply changes.");
+  }
+
+  COLLECTIONS.forEach((collectionName) => {
+    const collection = db.getCollection(collectionName);
+
+    RENAMES.forEach(({ from, to }) => {
+      const filter = { documentType: 'CASE_APPOINTMENT', chapter: { $in: from } };
+      const matching = collection.countDocuments(filter);
+
+      print(
+        `[${collectionName}] Found ${matching} CASE_APPOINTMENT document(s) with chapter in [${from.join(', ')}].`,
+      );
+
+      if (matching === 0) {
+        print(`[${collectionName}] Nothing to do for [${from.join(', ')}] -> '${to}'.`);
+        return;
+      }
+
+      if (DRY_RUN) {
+        collection.find(filter).forEach(function (doc) {
+          print(`  Would update ${doc._id}: chapter '${doc.chapter}' -> '${to}'`);
+        });
+        print(
+          `[${collectionName}] DRY RUN: ${matching} document(s) would be updated to chapter '${to}'. Set CONFIRM='true' to apply.`,
+        );
+      } else {
+        const result = collection.updateMany(filter, { $set: { chapter: to } });
+        print(
+          `[${collectionName}] Updated ${result.modifiedCount} document(s): chapter [${from.join(', ')}] -> '${to}'.`,
+        );
+      }
+    });
+
+    const deleteFilter = { documentType: 'CASE_APPOINTMENT', chapter: { $in: DELETE_CHAPTERS } };
+    const matchingForDelete = collection.countDocuments(deleteFilter);
+
+    print(
+      `[${collectionName}] Found ${matchingForDelete} CASE_APPOINTMENT document(s) with chapter in [${DELETE_CHAPTERS.join(', ')}] (not valid in CAMS).`,
+    );
+
+    if (matchingForDelete === 0) {
+      print(`[${collectionName}] Nothing to delete.`);
+    } else if (DRY_RUN) {
+      collection.find(deleteFilter).forEach(function (doc) {
+        print(`  Would delete ${doc._id}: chapter '${doc.chapter}'`);
+      });
+      print(
+        `[${collectionName}] DRY RUN: ${matchingForDelete} document(s) would be deleted. Set CONFIRM='true' to apply.`,
+      );
+    } else {
+      const deleteResult = collection.deleteMany(deleteFilter);
+      print(
+        `[${collectionName}] Deleted ${deleteResult.deletedCount} document(s) with chapter 'AC'.`,
+      );
+    }
+  });
+
+  if (!DRY_RUN) {
+    print('Migration complete.');
+  }
+})();


### PR DESCRIPTION
# Bug

The trustee case list showed "7A"/"7N" verbatim for chapter 7 cases (legacy ACMS asset/no-asset sub-codes), and filtering the list by chapter "7" silently omitted those cases. Root cause: the one-time ACMS-to-CAMS case-appointment migration copied `CURR_CASE_CHAPT` verbatim (only trimming whitespace) instead of normalizing it, and the Mongo filter query does an exact match against the stored chapter value.

# Purpose

Ensure CASE_APPOINTMENT documents always carry a chapter value CAMS recognizes, both for existing data and for any future re-run of the ACMS migration or ongoing DXTR sync, so the trustee case list displays and filters chapter 7 cases consistently regardless of data origin (ACMS vs. DXTR).

# Major Changes

* Normalize ACMS's legacy chapter codes at write time in the migration mapping: `7A`/`7N` -> `7`, `09` -> `9`. Unrecognized codes (e.g. `AC`, which was never meant to be imported into CAMS) now cause the record to be skipped via the migration's existing failure-tracking path instead of being written.
* Introduced a `CaseChapter` literal type (`common/src/cams/trustee-appointments.ts`) and narrowed `CaseAppointment`, `CaseAppointmentInput`, `TrusteeCaseListItem`, and `CaseDenormalizedFields` to it, so invalid chapter values are caught at compile time going forward.
* Added a repository-level runtime guard (`assertValidChapter`) in the Mongo repository, called from `upsert`, `updateCaseAppointment`, and `updateCaseFields` — rejects any write with an invalid chapter before it reaches Mongo. This also protects the recurring DXTR sync path (`export-and-load-case.ts`), which was confirmed to only ever source chapter from DXTR's plain `CS_CHAPTER` column (never ACMS raw codes), but now fails loudly rather than silently if that assumption is ever violated.
* Added `ops/migrations/normalize-case-appointment-chapter.js`, a dry-run-by-default mongosh script to repair existing CASE_APPOINTMENT documents in both partition collections (`case-trustee-appointments` and `trustee-case-appointments`): renames `7A`/`7N` -> `7` and `09` -> `9`, and deletes any `AC`-chapter documents outright.

# Testing/Validation

Implemented with new unit tests alongside the existing suites (TDD-style additions, not full rewrites):
* `migrate-case-appointments.test.ts` — chapter normalization (`7A`/`7N`/`09`) and rejection of unrecognized chapters (`AC`) via `writePage`.
* `trustee-case-appointments.mongo.repository.test.ts` — guard rejects an invalid chapter in both `upsert` and `updateCaseFields` without writing to Mongo.
* `export-and-load-case.test.ts` — guard rejects an invalid DXTR chapter and records it as an event error rather than corrupting a document.

All affected suites pass (350 tests across the touched files; full workspace run: 3428 backend/common tests + 3320 user-interface tests, all green). Backend and common typecheck clean, lint clean, `npm audit`/`knip` show no new issues introduced by this change.

A `/cams-spec-review` pass was run on all three modified test files — no critical issues found (no mocking of code under test); a few pre-existing implementation-detail-coupling and missing-edge-case findings were surfaced but are out of scope for this fix.

# Notes

No Jira ticket for this fix. The ACMS gateway (`acms.gateway.ts`) already had a comment documenting the full valid ACMS chapter set (`09, 11, 12, 13, 15, 7A, 7N, AC`) and treated `7A`/`7N` inclusively as chapter 7 for an unrelated purpose (consolidation lead-case lookup) — this PR is the first place that normalization is applied to the actual case-appointment write path.

A follow-up PR narrowing `CaseBasics.chapter` (DXTR case summary chapter) to the same `CaseChapter` type is being opened separately for isolated review, since it touches a much more widely-used type across the app.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Normalize and validate case appointment chapter values across ACMS migrations, DXTR sync, and Mongo writes, and add a migration script to repair existing CASE_APPOINTMENT documents.

Bug Fixes:
- Ensure DXTR case sync rejects and surfaces invalid chapter values instead of updating case fields with bad data.
- Prevent trustee case appointment upsert and case field updates from writing invalid chapter codes to MongoDB.
- Normalize legacy ACMS chapter codes when migrating case appointments so only valid chapters are stored.

Enhancements:
- Introduce a shared CaseChapter type and VALID_CASE_CHAPTERS constant to constrain chapter values across domain types and validators.
- Refactor chapter validation in search predicates to reuse the shared chapter constant.

Deployment:
- Add a mongosh migration script to normalize existing CASE_APPOINTMENT chapter codes and delete records with unsupported 'AC' chapters.

Tests:
- Extend migration, repository, and DXTR sync tests to cover chapter normalization, invalid chapter rejection, and error recording behavior.