### PR TITLE
CAMS-831 Remove aria-live from Main Content Wrapper

### DIFF
--- a/user-interface/src/lib/components/cams/MainContent/MainContent.tsx
+++ b/user-interface/src/lib/components/cams/MainContent/MainContent.tsx
@@ -5,7 +5,7 @@ export function MainContent(props: MainContentProps) {
   const { children, ...otherProps } = props;
 
   return (
-    <main {...otherProps} id="main" role="main" aria-live="polite">
+    <main {...otherProps} id="main" role="main">
       {children}
     </main>
   );


### PR DESCRIPTION
# Bug

`MainContent.tsx` set `aria-live="polite"` on the `<main>` element, making the entire main content area a live region. Every DOM mutation across the page — route changes, component re-renders, lazy-loaded content — was being announced to screen readers, creating excessive noise and potentially breaking virtual cursor navigation.

# Purpose

Prevent screen readers from announcing unrelated DOM changes across the whole app by removing the overly broad live region on `<main>`.

# Major Changes

* Removed `aria-live="polite"` from the `<main>` element in `MainContent.tsx`

# Testing/Validation

* Full unit test suite (common, backend, user-interface) passes
* Playwright accessibility test suite (72 tests across chromium and Edge) passes with no regressions
* Existing targeted live regions in individual components are unaffected — they don't rely on the removed attribute

# Notes

Individual components that need to announce changes to screen readers already implement their own targeted live regions, so no replacement live regions were needed.

Closes #2717

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Bug Fixes:
- Stop the main content area from announcing all DOM mutations to screen readers by removing the broad aria-live attribute on the <main> element.