### PR TITLE
CAMS-845 Remove focusable property from Icon component

### DIFF
--- a/user-interface/src/lib/components/uswds/Icon.test.tsx
+++ b/user-interface/src/lib/components/uswds/Icon.test.tsx
@@ -53,13 +53,7 @@ describe('Test Icon component', async () => {
     expect(icon).toHaveAttribute('aria-label', 'warning icon');
   });
 
-  test('should be focusable when focusable prop is true', () => {
-    renderWithProps({ name: 'check', focusable: true });
-    const icon = screen.getByTestId('icon');
-    expect(icon).toHaveAttribute('focusable', 'true');
-  });
-
-  test('should not be focusable by default', () => {
+  test('should not be focusable', () => {
     renderWithProps({ name: 'check' });
     const icon = screen.getByTestId('icon');
     expect(icon).toHaveAttribute('focusable', 'false');

--- a/user-interface/src/lib/components/uswds/Icon.tsx
+++ b/user-interface/src/lib/components/uswds/Icon.tsx
@@ -6,19 +6,17 @@ export interface IconProps {
   name: string;
   tooltip?: string;
   className?: string;
-  focusable?: boolean;
   decorative?: boolean;
 }
 
 export default function Icon(props: IconProps) {
   const link = `/assets/styles/img/sprite.svg#${props.name}`;
-  const isFocusable = !!props.focusable;
   const isDecorative = props.decorative ?? true;
 
   return (
     <svg
       className={`usa-icon ${props.className ?? ''}`}
-      focusable={isFocusable}
+      focusable="false"
       role={isDecorative ? undefined : 'img'}
       aria-hidden={isDecorative ? 'true' : undefined}
       data-testid="icon"

--- a/user-interface/src/lib/components/uswds/Input.tsx
+++ b/user-interface/src/lib/components/uswds/Input.tsx
@@ -206,7 +206,7 @@ function Input_(props: InputProps, ref: React.Ref<InputRef>) {
         )}
         {!includeClearButton && props.icon && (
           <div className="usa-input-prefix" aria-hidden="true">
-            <Icon focusable={false} name={props.icon}></Icon>
+            <Icon name={props.icon}></Icon>
           </div>
         )}
       </div>


### PR DESCRIPTION
# Purpose and Overview

The Icon component has a focusable prop that has no legitimate use case in CAMS and adds unnecessary complexity to the component's public API. This was identified during a CAMS codebase audit conducted as part of creating the CAMS Brand Guidelines document.

# Previous Behavior

* Icon.tsx accepts a focusable prop (boolean, default false) that controls whether the SVG renders focusable="true" or focusable="false"
* focusable={true} is never used anywhere in the application — the only usage is in a unit test asserting attribute passthrough
* USWDS's own icon templates hardcode focusable="false" unconditionally — it is never a configurable value there
* In CAMS, icons are either purely decorative or wrapped in a <Button>/link that receives focus — the icon itself never needs to be a focus target

# Required Behavior

* The focusable prop is removed from Icon
* focusable="false" is always rendered on the SVG element
* The unit test asserting focusable passthrough is updated

# Major Changes

* focusable prop removed from Icon component
* focusable attribute in JSX is hardcoded to false
* Tests and updated, everything passes

# Acceptance Criteria

* [ ] focusable prop removed from Icon.tsx
* [ ] SVG always renders with focusable="false"
* [ ] Unit test updated to reflect the simplified component
* [ ] No regressions in icon rendering across the application

# Components to Review

* user-interface/src/lib/components/uswds/Icon.tsx
* user-interface/src/lib/components/uswds/Icon.test.tsx

# References

* Brand Guidelines Issue: https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/pull/51
* [CAMS Brand Guidelines](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/issues/docs/BRAND_GUIDELINES.md)
* [CAMS Brand Guidelines Issues](https://github.com/US-Trustee-Program/Bankruptcy-Oversight-Support-Systems/issues/docs/BRAND_GUIDELINES_ISSUES.md)

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn’t directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team’s latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove the Icon component's focusable prop and hardcode SVG icons as non-focusable.

Enhancements:
- Simplify the Icon component API by removing the unused focusable prop and always rendering SVGs with focusable="false".

Tests:
- Update Icon tests to assert that icons are never focusable and remove coverage for the deleted focusable prop.