### PR TITLE
CAMS-760 Co-locate branch app/network into shared RGs

### DIFF
--- a/.github/workflows/azure-remove-branch.yml
+++ b/.github/workflows/azure-remove-branch.yml
@@ -31,12 +31,19 @@ jobs:
           environment: ${{ vars.AZURE_ENVIRONMENT }}
       - name: List existing tagged Azure branch resources
         run: |
-          echo "List Azure resource groups tagged as branch deployment resources"
-          az group list --query "[?tags.isBranchDeployment == 'true'].{ Name:name Branch:tags.branchName HashId:tags.branchHashId }" -o table
+          # CAMS-760, Option E / Slice 2: branches no longer create their own
+          # tagged resource group — discover them via their network Deployment
+          # Stack in the shared network RG instead (still carries the same
+          # isBranchDeployment/branchName/branchHashId tags from Slice 1).
+          networkRgBase=$(az keyvault secret show --vault-name kv-ustp-cams-dev --name AZ-NETWORK-RG --query value -o tsv)
+          echo "List Azure network deployment stacks tagged as branch deployment resources"
+          az stack group list -g "${networkRgBase}" --query "[?tags.isBranchDeployment == 'true'].{ Name:name Branch:tags.branchName HashId:tags.branchHashId }" -o table
 
   check:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.hashId != '') || github.event.ref_type == 'branch' }}
+    if:
+      ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' &&
+      inputs.hashId != '') || github.event.ref_type == 'branch' }}
     environment: 'remove-branch'
     permissions:
       contents: read
@@ -76,6 +83,16 @@ jobs:
         run: |
           set -euo pipefail
 
+          # CAMS-760, Option E / Slice 2: branches no longer create their own
+          # tagged resource group — discover them via their network Deployment
+          # Stack in the shared network RG instead (still carries the same
+          # isBranchDeployment/branchName/branchHashId tags from Slice 1). Stack
+          # names are "<stackName>-network" where stackName already carries the
+          # hash (e.g. "ustp-cams-dev-<hash>-network"), so the defensive
+          # name/tag consistency check matches on that suffix instead of the
+          # old "<rg-base>-<hash>" resource-group-name suffix.
+          networkRgBase=$(az keyvault secret show --vault-name kv-ustp-cams-dev --name AZ-NETWORK-RG --query value -o tsv)
+
           if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
             localHour=$(TZ=America/Los_Angeles date +%H)
             if [[ "${localHour}" != "21" ]]; then
@@ -85,14 +102,14 @@ jobs:
               exit 0
             fi
 
-            branchResources=$(az group list --query "[?tags.isBranchDeployment == 'true' && tags.branchHashId != null].{name:name, branchName:tags.branchName, branchHashId:tags.branchHashId}" -o json)
-            targets=$(echo "${branchResources}" | jq -c '
+            branchStacks=$(az stack group list -g "${networkRgBase}" --query "[?tags.isBranchDeployment == 'true' && tags.branchHashId != null].{name:name, branchName:tags.branchName, branchHashId:tags.branchHashId}" -o json)
+            targets=$(echo "${branchStacks}" | jq -c '
               [
                 .[]
                 | select(.branchHashId | test("^[0-9a-f]{6}$"))
                 | select((.branchName // "") as $branch | $branch != "main" and $branch != "refs/heads/main")
                 | .branchHashId as $branchHashId
-                | select(.name | endswith("-" + $branchHashId))
+                | select(.name | test("-" + $branchHashId + "-network$"))
                 | .branchHashId
               ]
               | unique
@@ -117,14 +134,14 @@ jobs:
             fi
 
             echo "Do existing Azure branch resources with hash $target exist?"
-            branchResources=$(az group list --query "[?tags.isBranchDeployment == 'true' && tags.branchHashId == '$target'].{name:name, branchName:tags.branchName, branchHashId:tags.branchHashId}" -o json)
-            count=$(echo "${branchResources}" | jq '
+            branchStacks=$(az stack group list -g "${networkRgBase}" --query "[?tags.isBranchDeployment == 'true' && tags.branchHashId == '$target'].{name:name, branchName:tags.branchName, branchHashId:tags.branchHashId}" -o json)
+            count=$(echo "${branchStacks}" | jq '
               [
                 .[]
                 | select(.branchHashId | test("^[0-9a-f]{6}$"))
                 | select((.branchName // "") as $branch | $branch != "main" and $branch != "refs/heads/main")
                 | .branchHashId as $branchHashId
-                | select(.name | endswith("-" + $branchHashId))
+                | select(.name | test("-" + $branchHashId + "-network$"))
               ]
               | length
             ')
@@ -217,4 +234,5 @@ jobs:
             --network-resource-group="${AZ_NETWORK_RG_BASE}" \
             --analytics-resource-group="${AZ_ANALYTICS_RG}" \
             --stack-name="${STACK_NAME}" \
-            --short-hash="${SHORT_HASH}"
+            --short-hash="${SHORT_HASH}" \
+            --unmanage-action=deleteResources

--- a/.github/workflows/reusable-build-info.yml
+++ b/.github/workflows/reusable-build-info.yml
@@ -142,16 +142,10 @@ jobs:
           ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set -euo pipefail
-          AZ_APP_RG_BASE="${{ env.AZ_APP_RG_BASE }}"
-          AZ_NETWORK_RG_BASE="${{ env.AZ_NETWORK_RG_BASE }}"
-
-          if [[ "${ENVIRONMENT}" == "Main-Gov" ]]; then
-            AZ_APP_RG="${AZ_APP_RG_BASE}"
-            AZ_NETWORK_RG="${AZ_NETWORK_RG_BASE}"
-          else
-            AZ_APP_RG="${AZ_APP_RG_BASE}-${{ steps.check-env.outputs.environmentHash }}"
-            AZ_NETWORK_RG="${AZ_NETWORK_RG_BASE}-${{ steps.check-env.outputs.environmentHash }}"
-          fi
+          # CAMS-760, Option E / Slice 2: branches deploy into the SAME stable
+          # app/network RGs main uses, not a per-branch "-<hash>" RG.
+          AZ_APP_RG="${{ env.AZ_APP_RG_BASE }}"
+          AZ_NETWORK_RG="${{ env.AZ_NETWORK_RG_BASE }}"
           echo "AZ_APP_RG=${AZ_APP_RG}" >> "$GITHUB_ENV"
           echo "AZ_NETWORK_RG=${AZ_NETWORK_RG}" >> "$GITHUB_ENV"
 
@@ -159,6 +153,16 @@ jobs:
           echo "initialDeployment=${initialDeployment}" >> $GITHUB_OUTPUT
           echo "Initial Deployment: ${initialDeployment}"
 
-          deployVnet=$(./ops/scripts/pipeline/check-for-network.sh --resource-group "${AZ_NETWORK_RG}" --vnet-name "${{ env.AZ_NETWORK_VNET_NAME }}" --is-initial-deployment "${initialDeployment}")
+          # Each branch owns its own uniquely-named VNet (vnet-<stackName>, matching
+          # bicep's own default) now that it's co-located in the shared network RG —
+          # main keeps the fixed KV-sourced name. Checking existence under the wrong
+          # (main's) name would report "doesn't exist" for every branch and force an
+          # unnecessary (harmless but wasteful) vnet redeploy every time.
+          if [[ "${ENVIRONMENT}" == "Main-Gov" ]]; then
+            vnetNameToCheck="${{ env.AZ_NETWORK_VNET_NAME }}"
+          else
+            vnetNameToCheck="vnet-${{ steps.build-info.outputs.stackName }}"
+          fi
+          deployVnet=$(./ops/scripts/pipeline/check-for-network.sh --resource-group "${AZ_NETWORK_RG}" --vnet-name "${vnetNameToCheck}" --is-initial-deployment "${initialDeployment}")
           echo "deployVnet=${deployVnet}" >> $GITHUB_OUTPUT
           echo "Deploy Vnet: ${deployVnet}"

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Fetch config from Key Vault
         env:
           GHA_ENVIRONMENT: ${{ inputs.ghaEnvironment }}
-          ENVIRONMENT_HASH: ${{ inputs.environmentHash }}
+          STACK_NAME: ${{ inputs.stackName }}
         run: |
           set -euo pipefail
           if [[ "${GHA_ENVIRONMENT}" == "Main-Gov" ]]; then
@@ -72,13 +72,13 @@ jobs:
           _val=$(az keyvault secret show --vault-name "$KV" --name AZ-NETWORK-RG --query value -o tsv)
           echo "::add-mask::${_val}"
           AZ_NETWORK_RG_BASE="${_val}"
-          if [[ "${GHA_ENVIRONMENT}" == "Main-Gov" ]]; then
-            AZ_APP_RG="${AZ_APP_RG_BASE}"
-            AZ_NETWORK_RG="${AZ_NETWORK_RG_BASE}"
-          else
-            AZ_APP_RG="${AZ_APP_RG_BASE}-${ENVIRONMENT_HASH}"
-            AZ_NETWORK_RG="${AZ_NETWORK_RG_BASE}-${ENVIRONMENT_HASH}"
-          fi
+          # CAMS-760, Option E / Slice 2: branches deploy into the SAME stable
+          # app/network RGs main uses, distinguished by per-branch-unique resource
+          # names, rather than creating a per-branch RG (which forced
+          # subscription-scope Contributor on the branch deploy identity — Azure
+          # RBAC has no wildcard scoping over dynamically-named RGs).
+          AZ_APP_RG="${AZ_APP_RG_BASE}"
+          AZ_NETWORK_RG="${AZ_NETWORK_RG_BASE}"
           echo "AZ_APP_RG=${AZ_APP_RG}" >> "$GITHUB_ENV"
           echo "AZ_NETWORK_RG=${AZ_NETWORK_RG}" >> "$GITHUB_ENV"
           _val=$(az keyvault secret show --vault-name "$KV" --name AZURE-RG --query value -o tsv)
@@ -104,7 +104,18 @@ jobs:
           echo "SLOT_NAME=${_val}" >> "$GITHUB_ENV"
           _val=$(az keyvault secret show --vault-name "$KV" --name AZ-NETWORK-VNET-NAME --query value -o tsv)
           echo "::add-mask::${_val}"
-          echo "AZ_NETWORK_VNET_NAME=${_val}" >> "$GITHUB_ENV"
+          # CAMS-760, Option E / Slice 2: each branch owns its own uniquely-named
+          # VNet (vnet-<stackName>, matching bicep's own default) so it can safely
+          # coexist with main's and every other branch's VNet in the now-shared
+          # network RG. Main keeps the fixed KV-sourced name. (Branches already
+          # each created their own VNet before this change; only the identical
+          # forced name was the bug — see the Slice 2 design notes.)
+          if [[ "${GHA_ENVIRONMENT}" == "Main-Gov" ]]; then
+            AZ_NETWORK_VNET_NAME="${_val}"
+          else
+            AZ_NETWORK_VNET_NAME="vnet-${STACK_NAME}"
+          fi
+          echo "AZ_NETWORK_VNET_NAME=${AZ_NETWORK_VNET_NAME}" >> "$GITHUB_ENV"
           _val=$(az keyvault secret show --vault-name "$KV" --name AZ-PLAN-TYPE --query value -o tsv)
           echo "::add-mask::${_val}"
           echo "AZ_PLAN_TYPE=${_val}" >> "$GITHUB_ENV"
@@ -186,12 +197,19 @@ jobs:
           DEPLOY_VNET: ${{ inputs.deployVnet }}
           AZ_LOCATION: ${{ secrets.AZ_LOCATION }} # pragma: allowlist secret
         run: |
+          # CAMS-760, Option E / Slice 2: the Private DNS Zone is a genuinely
+          # shared resource (one zone, many VNet links) — only main ever
+          # creates/manages it. A branch declaring it too would let that
+          # branch's stack delete DNS resolution for everyone on teardown, the
+          # same bug shape as the shared Key Vault incident (GH #2749).
+          deployDns=$([[ "${IS_BRANCH_DEPLOYMENT}" == "true" ]] && echo false || echo true)
           ./ops/scripts/pipeline/azure-deploy-network.sh \
             --file ./ops/cloud-deployment/network.bicep \
             --stackName "${STACK_NAME}" \
             --networkResourceGroupName ${{ env.AZ_NETWORK_RG }} \
             --virtualNetworkName ${{ env.AZ_NETWORK_VNET_NAME }} \
             --deployVnet "${DEPLOY_VNET}" \
+            --deployDns "${deployDns}" \
             --isBranchDeployment "${IS_BRANCH_DEPLOYMENT}" \
             --branchName "${BRANCH_NAME}" \
             --branchHashId "${ENVIRONMENT_HASH}" \
@@ -201,14 +219,19 @@ jobs:
         id: azure-app-shared-setup-deploy
         env:
           STACK_NAME: ${{ inputs.stackName }}
+          IS_BRANCH_DEPLOYMENT: ${{ github.ref != 'refs/heads/main' && 'true' || 'false' }}
           AZ_SQL_SERVER_NAME: ${{ secrets.AZ_SQL_SERVER_NAME }} # pragma: allowlist secret
           AZ_SQL_IDENTITY_NAME: ${{ secrets.AZ_SQL_IDENTITY_NAME }} # pragma: allowlist secret
           AZ_LOCATION: ${{ secrets.AZ_LOCATION }} # pragma: allowlist secret
         run: |
+          # Same rationale as the network step above — only main creates/manages
+          # the KV's own Private DNS Zone (privatelink.vaultcore.usgovcloudapi.net).
+          deployDns=$([[ "${IS_BRANCH_DEPLOYMENT}" == "true" ]] && echo false || echo true)
           ./ops/scripts/pipeline/azure-deploy-app-shared-setup.sh \
             --file ./ops/cloud-deployment/app-shared-setup.bicep \
             --resource-group "${AZURE_RG}" \
             --stackName "${STACK_NAME}" \
+            --deployDns "${deployDns}" \
             --networkResourceGroupName ${{ env.AZ_NETWORK_RG }} \
             --virtualNetworkName ${{ env.AZ_NETWORK_VNET_NAME }} \
             --kvAppConfigResourceGroupName "${AZURE_RG}" \

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -197,11 +197,35 @@ jobs:
             --branchHashId "${ENVIRONMENT_HASH}" \
             -l "${AZ_LOCATION}"
 
+      - name: Deploy Azure app shared-setup resources
+        id: azure-app-shared-setup-deploy
+        env:
+          STACK_NAME: ${{ inputs.stackName }}
+          AZ_SQL_SERVER_NAME: ${{ secrets.AZ_SQL_SERVER_NAME }} # pragma: allowlist secret
+          AZ_SQL_IDENTITY_NAME: ${{ secrets.AZ_SQL_IDENTITY_NAME }} # pragma: allowlist secret
+          AZ_LOCATION: ${{ secrets.AZ_LOCATION }} # pragma: allowlist secret
+        run: |
+          ./ops/scripts/pipeline/azure-deploy-app-shared-setup.sh \
+            --file ./ops/cloud-deployment/app-shared-setup.bicep \
+            --resource-group "${AZURE_RG}" \
+            --stackName "${STACK_NAME}" \
+            --networkResourceGroupName ${{ env.AZ_NETWORK_RG }} \
+            --virtualNetworkName ${{ env.AZ_NETWORK_VNET_NAME }} \
+            --kvAppConfigResourceGroupName "${AZURE_RG}" \
+            --kvAppConfigName ${{ env.AZ_KV_APP_CONFIG_NAME }} \
+            --idKeyvaultAppConfiguration ${{ env.AZ_KV_APP_CONFIG_MANAGED_ID }} \
+            --sqlServerName "${AZ_SQL_SERVER_NAME}" \
+            --sqlServerResourceGroupName "${AZURE_RG}" \
+            --sqlServerIdentityName "${AZ_SQL_IDENTITY_NAME}" \
+            -l "${AZ_LOCATION}"
+
       - name: Deploy Azure resources
         id: azure-deploy
         env:
           STACK_NAME: ${{ inputs.stackName }}
+          BRANCH_NAME: ${{ github.ref_name }}
           ENVIRONMENT_HASH: ${{ inputs.environmentHash }}
+          IS_BRANCH_DEPLOYMENT: ${{ github.ref != 'refs/heads/main' && 'true' || 'false' }}
           DEPLOY_VNET: ${{ inputs.deployVnet }}
           CREATE_ALERTS: ${{ inputs.ghaEnvironment == 'Main-Gov' }}
           LOGIN_PROVIDER_CONFIG: ${{ vars.CAMS_LOGIN_PROVIDER_CONFIG }}
@@ -219,6 +243,9 @@ jobs:
             --resource-group ${{ env.AZ_APP_RG }} \
             --file ./ops/cloud-deployment/main.bicep \
             --stackName "${STACK_NAME}" \
+            --isBranchDeployment "${IS_BRANCH_DEPLOYMENT}" \
+            --branchName "${BRANCH_NAME}" \
+            --branchHashId "${ENVIRONMENT_HASH}" \
             --slotName ${{ env.SLOT_NAME }} \
             --networkResourceGroupName ${{ env.AZ_NETWORK_RG }} \
             --virtualNetworkName ${{ env.AZ_NETWORK_VNET_NAME }} \

--- a/ops/cloud-deployment/app-shared-setup.bicep
+++ b/ops/cloud-deployment/app-shared-setup.bicep
@@ -1,0 +1,115 @@
+// Shared cross-scope resources for the app tier (CAMS-760, Option E / Slice 2).
+//
+// Deploys resources that are genuinely SHARED across main and every branch: the
+// app-config Key Vault (+ its managed identity, its own private DNS zone, and
+// per-secret role assignments) and the read-only SQL managed identity used by
+// the API and dataflows function apps. Always a plain (non-stack) deployment
+// for both main and branches — these resources must never be managed by a
+// branch's Deployment Stack. An earlier version wrapped the whole app deploy
+// (including these cross-scope resources) in a stack, and a branch teardown
+// deleted the shared Key Vault + ~15 role assignments (GH #2749). This template
+// must be deployed before main.bicep (which references the KV identity and SQL
+// identity by name/id, not by bicep dependency, since they now live in a
+// separate deployment).
+targetScope = 'resourceGroup'
+
+param stackName string
+
+param location string = resourceGroup().location
+
+param isUstpDeployment bool = false
+
+@description('Flag: determines the setup of DNS Zone, Link virtual networks to zone.')
+param deployDns bool = true
+
+param networkResourceGroupName string
+
+param virtualNetworkName string = 'vnet-${stackName}'
+
+param privateEndpointSubnetName string = 'snet-${stackName}-private-endpoints'
+
+param privateDnsZoneResourceGroup string = resourceGroup().name
+
+@description('DNS Zone Subscription ID. USTP uses a different subscription for prod deployment.')
+param privateDnsZoneSubscriptionId string = subscription().subscriptionId
+
+@description('Resource group containing the app-config Key Vault')
+param kvAppConfigResourceGroupName string
+
+@description('Name of the app-config Key Vault')
+param kvAppConfigName string = 'kv-${stackName}'
+
+@description('Name of the managed identity with read access to the keyvault storing application configurations.')
+@secure()
+param idKeyvaultAppConfiguration string
+
+param sqlServerName string = ''
+
+param sqlServerResourceGroupName string = ''
+
+@description('Name for managed identity of database server.')
+param sqlServerIdentityName string = ''
+
+param sqlServerIdentityResourceGroupName string = ''
+
+param deployedAt string = utcNow()
+
+var tags = {
+  app: 'cams'
+  component: 'shared-setup'
+  'deployed-at': deployedAt
+}
+
+// The virtual network and its subnets are deployed separately by network.bicep
+// (its own Deployment Stack for branches). This template only needs the
+// private-endpoint subnet, for the Key Vault's private endpoint.
+resource ustpVirtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
+  name: virtualNetworkName
+  scope: resourceGroup(networkResourceGroupName)
+}
+
+resource privateEndpointSubnetExisting 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: privateEndpointSubnetName
+  parent: ustpVirtualNetwork
+}
+
+module kvSetup './ustp-cams-kv-app-config-setup.bicep' = {
+  name: '${stackName}-kv-setup-module'
+  params: {
+    stackName: stackName
+    location: location
+    deployDns: deployDns
+    kvResourceGroup: kvAppConfigResourceGroupName
+    kvName: kvAppConfigName
+    networkResourceGroup: networkResourceGroupName
+    virtualNetworkName: virtualNetworkName
+    privateEndpointSubnetId: privateEndpointSubnetExisting.id
+    privateDnsZoneResourceGroup: privateDnsZoneResourceGroup
+    privateDnsZoneSubscriptionId: privateDnsZoneSubscriptionId
+    managedIdentityName: idKeyvaultAppConfiguration
+    makeRoleAssignment: !isUstpDeployment
+  }
+}
+
+// The read-only SQL managed identity used by both the API and dataflows
+// function apps to authenticate to the SQL server. Its name comes from a
+// fixed value (the AZ_SQL_IDENTITY_NAME secret) shared by main and every
+// branch, so it is created exactly once here rather than per-function-app.
+// Creating it inside a branch's app stack would let that branch's teardown
+// delete the identity every other branch and main depend on — the same bug
+// shape as the shared Key Vault incident above.
+var sqlIdentityName = !empty(sqlServerIdentityName) ? sqlServerIdentityName : 'id-sql-${stackName}-readonly'
+var sqlIdentityRG = !empty(sqlServerIdentityResourceGroupName)
+  ? sqlServerIdentityResourceGroupName
+  : sqlServerResourceGroupName
+var createSqlIdentity = !empty(sqlServerResourceGroupName) && !empty(sqlServerName) && !isUstpDeployment
+
+module sqlManagedIdentity './lib/identity/managed-identity.bicep' = if (createSqlIdentity) {
+  scope: resourceGroup(sqlIdentityRG)
+  name: '${stackName}-sql-identity-module'
+  params: {
+    managedIdentityName: sqlIdentityName
+    location: location
+    tags: tags
+  }
+}

--- a/ops/cloud-deployment/backend-api-deploy.bicep
+++ b/ops/cloud-deployment/backend-api-deploy.bicep
@@ -471,20 +471,14 @@ module setApiFunctionSqlServerVnetRule './lib/network/sql-vnet-rule.bicep' = if 
   }
 }
 
+// The identity itself is created once, in app-shared-setup.bicep (CAMS-760,
+// Option E / Slice 2) — its name is a fixed value shared by main and every
+// branch, so it must never be created/managed inside a branch's app stack.
+// Referenced here as `existing` only.
 var sqlIdentityName = !empty(sqlServerIdentityName) ? sqlServerIdentityName : 'id-sql-${apiFunctionName}-readonly'
 var sqlIdentityRG = !empty(sqlServerIdentityResourceGroupName)
   ? sqlServerIdentityResourceGroupName
   : sqlServerResourceGroupName
-
-module sqlManagedIdentity './lib/identity/managed-identity.bicep' = if (createSqlServerVnetRule) {
-  scope: resourceGroup(sqlIdentityRG)
-  name: '${apiFunctionName}-sql-identity-module'
-  params: {
-    managedIdentityName: sqlIdentityName
-    location: location
-    tags: tags
-  }
-}
 
 resource sqlIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: sqlIdentityName

--- a/ops/cloud-deployment/dataflows-resource-deploy.bicep
+++ b/ops/cloud-deployment/dataflows-resource-deploy.bicep
@@ -736,21 +736,14 @@ module setDataflowFunctionSqlServerVnetRule './lib/network/sql-vnet-rule.bicep' 
   }
 }
 
-// Creates a managed identity that would be used to grant access to function instance
+// The identity itself is created once, in app-shared-setup.bicep (CAMS-760,
+// Option E / Slice 2) — its name is a fixed value shared by main and every
+// branch, so it must never be created/managed inside a branch's app stack.
+// Referenced here as `existing` only.
 var sqlIdentityName = !empty(sqlServerIdentityName) ? sqlServerIdentityName : 'id-sql-${apiFunctionName}-readonly'
 var sqlIdentityRG = !empty(sqlServerIdentityResourceGroupName)
   ? sqlServerIdentityResourceGroupName
   : sqlServerResourceGroupName
-
-module sqlManagedIdentity './lib/identity/managed-identity.bicep' = if (createSqlServerVnetRule) {
-  scope: resourceGroup(sqlIdentityRG)
-  name: '${dataflowsFunctionName}-sql-identity-module'
-  params: {
-    managedIdentityName: sqlIdentityName
-    location: location
-    tags: tags
-  }
-}
 
 resource sqlIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: sqlIdentityName

--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -10,9 +10,6 @@ param virtualNetworkName string = 'vnet-${stackName}'
 
 param networkResourceGroupName string
 
-@description('Flag: determines the setup of DNS Zone, Link virtual networks to zone.')
-param deployDns bool = true
-
 param privateDnsZoneName string = 'privatelink.azurewebsites.us'
 
 param privateDnsZoneResourceGroup string = networkResourceGroupName
@@ -176,23 +173,12 @@ resource dataflowsFunctionSubnetExisting 'Microsoft.Network/virtualNetworks/subn
   parent: ustpVirtualNetwork
 }
 
-module kvSetup './ustp-cams-kv-app-config-setup.bicep' = {
-  name: '${stackName}-kv-setup-module'
-  params: {
-    stackName: stackName
-    location: location
-    deployDns: deployDns
-    kvResourceGroup: kvAppConfigResourceGroupName
-    kvName: kvAppConfigName
-    networkResourceGroup: networkResourceGroupName
-    virtualNetworkName: virtualNetworkName
-    privateEndpointSubnetId: privateEndpointSubnetExisting.id
-    privateDnsZoneResourceGroup: privateDnsZoneResourceGroup
-    privateDnsZoneSubscriptionId: privateDnsZoneSubscriptionId
-    managedIdentityName: idKeyvaultAppConfiguration
-    makeRoleAssignment: !isUstpDeployment
-  }
-}
+// The app-config Key Vault (+ its managed identity, DNS zone, and secret role
+// assignments) and the SQL managed identity are deployed separately by
+// app-shared-setup.bicep — always a plain (non-stack) deployment, before this
+// template runs, because they are genuinely shared across main and every
+// branch (CAMS-760, Option E / Slice 2; see app-shared-setup.bicep for why).
+// This template references them by the name/id strings passed in as params.
 
 module ustpWebapp 'frontend-webapp-deploy.bicep' = {
     name: '${stackName}-webapp-module'
@@ -227,7 +213,6 @@ module ustpWebapp 'frontend-webapp-deploy.bicep' = {
 
 module acsEmail './lib/email/acs-email.bicep' = {
   name: '${stackName}-acs-email-module'
-  dependsOn: [kvSetup]
   params: {
     stackName: stackName
     kvAppConfigName: kvAppConfigName
@@ -244,7 +229,7 @@ module acsEmail './lib/email/acs-email.bicep' = {
 module ustpApiFunction 'backend-api-deploy.bicep' = {
     name: '${stackName}-function-module'
     scope: resourceGroup(appResourceGroup)
-    dependsOn: [kvSetup, acsEmail]
+    dependsOn: [acsEmail]
     params: {
       deployAppInsights: deployAppInsights
       analyticsWorkspaceId: deployAppInsights ? analyticsWorkspaceId : ''
@@ -290,7 +275,6 @@ module ustpApiFunction 'backend-api-deploy.bicep' = {
 module ustpDataflowsFunction 'dataflows-resource-deploy.bicep' = {
   name: '${stackName}-dataflows-module'
   scope: resourceGroup(appResourceGroup)
-  dependsOn: [kvSetup]
   params: {
     deployAppInsights: deployAppInsights
     analyticsWorkspaceId: deployAppInsights ? analyticsWorkspaceId : ''

--- a/ops/scripts/pipeline/azure-deploy-app-shared-setup.sh
+++ b/ops/scripts/pipeline/azure-deploy-app-shared-setup.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+# Title:        azure-deploy-app-shared-setup.sh
+# Description:  Deploy the USTP CAMS app-tier shared setup resources (the
+#               app-config Key Vault + its managed identity/role assignments,
+#               and the read-only SQL managed identity) into the shared
+#               AZURE_RG. Always a plain resource-group deployment for both
+#               main and branches (CAMS-760, Option E) — these resources are
+#               genuinely shared and must never be managed by a branch's
+#               Deployment Stack.
+#
+# Exitcodes
+# ==========
+# 0   No error
+# 1   Script interrupted
+# 2   Unknown flag or switch passed as parameter to script
+# 10+ Validation check errors
+
+set -euo pipefail # ensure job step fails in CI pipeline when error occurs
+
+deployment_file=''
+resource_group=''
+stack_name=''
+network_rg=''
+vnet_name=''
+kv_app_config_rg=''
+kv_app_config_name=''
+id_keyvault_app_config=''
+sql_server_name=''
+sql_server_rg=''
+sql_server_identity_name=''
+sql_server_identity_rg=''
+is_ustp_deployment=false
+deploy_dns=true
+location=''
+extra_parameters=''
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -f | --file)
+        deployment_file="${2}"
+        shift 2
+        ;;
+    --resource-group)
+        resource_group="${2}"
+        shift 2
+        ;;
+    --stackName)
+        stack_name="${2}"
+        shift 2
+        ;;
+    --networkResourceGroupName)
+        network_rg="${2}"
+        shift 2
+        ;;
+    --virtualNetworkName)
+        vnet_name="${2}"
+        shift 2
+        ;;
+    --kvAppConfigResourceGroupName)
+        kv_app_config_rg="${2}"
+        shift 2
+        ;;
+    --kvAppConfigName)
+        kv_app_config_name="${2}"
+        shift 2
+        ;;
+    --idKeyvaultAppConfiguration)
+        id_keyvault_app_config="${2}"
+        shift 2
+        ;;
+    --sqlServerName)
+        sql_server_name="${2}"
+        shift 2
+        ;;
+    --sqlServerResourceGroupName)
+        sql_server_rg="${2}"
+        shift 2
+        ;;
+    --sqlServerIdentityName)
+        sql_server_identity_name="${2}"
+        shift 2
+        ;;
+    --sqlServerIdentityResourceGroupName)
+        sql_server_identity_rg="${2}"
+        shift 2
+        ;;
+    --isUstpDeployment)
+        is_ustp_deployment="${2}"
+        shift 2
+        ;;
+    --deployDns)
+        deploy_dns="${2}"
+        shift 2
+        ;;
+    -l | --location)
+        location="${2}"
+        shift 2
+        ;;
+    # Space-delimited "key=value" bicep parameters passed straight through
+    -p | --parameters)
+        extra_parameters="${2}"
+        shift 2
+        ;;
+    *)
+        echo "Exit on param: ${1}"
+        exit 2
+        ;;
+    esac
+done
+
+if [[ -z "${deployment_file}" || -z "${resource_group}" || -z "${stack_name}" || -z "${network_rg}" || -z "${vnet_name}" || -z "${kv_app_config_rg}" || -z "${location}" ]]; then
+    echo "Error: --file, --resource-group, --stackName, --networkResourceGroupName, --virtualNetworkName, --kvAppConfigResourceGroupName and --location are required"
+    exit 10
+fi
+
+deployment_parameters="stackName=${stack_name} location=${location} networkResourceGroupName=${network_rg} virtualNetworkName=${vnet_name} kvAppConfigResourceGroupName=${kv_app_config_rg} isUstpDeployment=${is_ustp_deployment} deployDns=${deploy_dns}"
+[[ -n "${kv_app_config_name}" ]] && deployment_parameters="${deployment_parameters} kvAppConfigName=${kv_app_config_name}"
+[[ -n "${id_keyvault_app_config}" ]] && deployment_parameters="${deployment_parameters} idKeyvaultAppConfiguration=${id_keyvault_app_config}"
+[[ -n "${sql_server_name}" ]] && deployment_parameters="${deployment_parameters} sqlServerName=${sql_server_name}"
+[[ -n "${sql_server_rg}" ]] && deployment_parameters="${deployment_parameters} sqlServerResourceGroupName=${sql_server_rg}"
+[[ -n "${sql_server_identity_name}" ]] && deployment_parameters="${deployment_parameters} sqlServerIdentityName=${sql_server_identity_name}"
+[[ -n "${sql_server_identity_rg}" ]] && deployment_parameters="${deployment_parameters} sqlServerIdentityResourceGroupName=${sql_server_identity_rg}"
+if [[ -n "${extra_parameters}" ]]; then
+    deployment_parameters="${deployment_parameters} ${extra_parameters}"
+fi
+
+echo "Deploying app shared-setup resources to ${resource_group} (plain resource-group deployment; always non-stack — see app-shared-setup.bicep)"
+# shellcheck disable=SC2086 # REASON: intentional word-splitting of --parameter
+az deployment group create -w -g "${resource_group}" --template-file "${deployment_file}" --parameter ${deployment_parameters}
+# shellcheck disable=SC2086 # REASON: intentional word-splitting of --parameter
+az deployment group create -g "${resource_group}" --template-file "${deployment_file}" --parameter ${deployment_parameters}

--- a/ops/scripts/pipeline/azure-deploy-network.sh
+++ b/ops/scripts/pipeline/azure-deploy-network.sh
@@ -22,6 +22,7 @@ network_rg=''
 stack_name=''
 vnet_name=''
 deploy_vnet=false
+deploy_dns=true
 location=''
 is_branch_deployment=false
 branch_name=''
@@ -61,6 +62,10 @@ while [[ $# -gt 0 ]]; do
         deploy_vnet="${2}"
         shift 2
         ;;
+    --deployDns)
+        deploy_dns="${2}"
+        shift 2
+        ;;
     -l | --location)
         location="${2}"
         shift 2
@@ -94,7 +99,7 @@ if [[ -z "${deployment_file}" || -z "${network_rg}" || -z "${stack_name}" || -z 
     exit 10
 fi
 
-deployment_parameters="stackName=${stack_name} networkResourceGroupName=${network_rg} virtualNetworkName=${vnet_name} location=${location}"
+deployment_parameters="stackName=${stack_name} networkResourceGroupName=${network_rg} virtualNetworkName=${vnet_name} location=${location} deployDns=${deploy_dns}"
 if [[ -n "${extra_parameters}" ]]; then
     deployment_parameters="${deployment_parameters} ${extra_parameters}"
 fi

--- a/ops/scripts/pipeline/azure-deploy.sh
+++ b/ops/scripts/pipeline/azure-deploy.sh
@@ -58,6 +58,24 @@ function az_deploy_func() {
     az deployment group create -g ${rg} --template-file ${templateFile} --parameter $deploymentParameter -o json --query properties.outputs | tee outputs.json
 }
 
+function az_stack_deploy_func() {
+    local rg=$1
+    local templateFile=$2
+    local deploymentParameter=$3
+    echo "Deploying Azure app resources as deployment stack ${stack_name}-app in ${rg}"
+    # shellcheck disable=SC2086 # REASON: Adds unwanted quotes after --parameters
+    az stack group create \
+        --name "${stack_name}-app" \
+        --resource-group "${rg}" \
+        --template-file "${templateFile}" \
+        --parameters ${deploymentParameter} \
+        --action-on-unmanage deleteResources \
+        --deny-settings-mode none \
+        --tag isBranchDeployment=true branchName="${branch_name}" branchHashId="${branch_hash_id}" \
+        --yes \
+        -o json --query properties.outputs | tee outputs.json
+}
+
 while [[ $# -gt 0 ]]; do
     case $1 in
     # default resource group name
@@ -77,15 +95,24 @@ while [[ $# -gt 0 ]]; do
     #Core app name -- stack name
     --stackName)
         inputParams+=("${1}")
+        stack_name="${2}"
         stack_name_param="stackName=${2}"
         deployment_parameters="${deployment_parameters} ${stack_name_param}"
         shift 2
         ;;
-    # Branch-deployment flags accepted for backward compatibility but no longer used
-    # by the app deploy (app resources are deployed as a plain resource-group
-    # deployment, not a stack — see the note at the deploy call below).
-    --isBranchDeployment | --branchName | --branchHashId)
+    --isBranchDeployment)
         inputParams+=("${1}")
+        is_branch_deployment="${2}"
+        shift 2
+        ;;
+    --branchName)
+        inputParams+=("${1}")
+        branch_name="${2}"
+        shift 2
+        ;;
+    --branchHashId)
+        inputParams+=("${1}")
+        branch_hash_id="${2}"
         shift 2
         ;;
     --slotName)
@@ -125,10 +152,13 @@ while [[ $# -gt 0 ]]; do
         deployment_parameters="${deployment_parameters} ${vnet_name_param}"
         shift 2
         ;;
+    # deployDns is handled by azure-deploy-network.sh and
+    # azure-deploy-app-shared-setup.sh (the KV private DNS zone moved out of
+    # main.bicep into app-shared-setup.bicep for CAMS-760). Accepted here for
+    # backward compatibility but not forwarded — main.bicep no longer declares
+    # this parameter.
     --deployDns)
         inputParams+=("${1}")
-        deploy_dns_param="deployDns=${2}"
-        deployment_parameters="${deployment_parameters} ${deploy_dns_param}"
         shift 2
         ;;
     --privateDnsZoneName)
@@ -387,12 +417,19 @@ validateParameters
 # The virtual network is deployed separately by azure-deploy-network.sh before this
 # script runs (CAMS-760, Option E); vnet existence / deployVnet handling lives there.
 #
-# The app deploy is intentionally NOT an Azure Deployment Stack. main.bicep deploys
-# resources cross-scope into SHARED resource groups (the app-config Key Vault and its
-# role assignments + SQL vnet rules in AZURE_RG; the action group in the analytics RG).
-# A deployment stack manages every resource its template creates in ANY resource group,
-# so 'az stack group delete' on teardown would delete those shared resources — this is
-# what deleted the shared kv-ustp-cams-dev (GH #2749). App resources live in the
-# per-branch app RG and are torn down by deleting that RG; only the self-contained
-# per-branch network tier is managed as a stack (see azure-deploy-network.sh).
-az_deploy_func "${app_rg}" "${deployment_file}" "${deployment_parameters}"
+# The cross-scope SHARED resources main.bicep used to deploy (the app-config Key
+# Vault + its managed identity/role assignments, and the read-only SQL managed
+# identity) are now deployed separately, always as a plain deployment, by
+# azure-deploy-app-shared-setup.sh / app-shared-setup.bicep — BEFORE this script
+# runs. That split is what makes it safe to stack the resources left in
+# main.bicep: they no longer reach into shared resource groups. (An earlier
+# version wrapped the whole app deploy, cross-scope resources included, in a
+# stack; a branch teardown then deleted the shared kv-ustp-cams-dev — GH #2749.)
+#
+# For branches, deploy main.bicep as an Azure Deployment Stack so it can be torn
+# down as a unit, same as the network tier. Main keeps the plain deployment.
+if [[ "${is_branch_deployment:-false}" == "true" ]]; then
+    az_stack_deploy_func "${app_rg}" "${deployment_file}" "${deployment_parameters}"
+else
+    az_deploy_func "${app_rg}" "${deployment_file}" "${deployment_parameters}"
+fi

--- a/ops/scripts/utility/az-delete-branch-resources.sh
+++ b/ops/scripts/utility/az-delete-branch-resources.sh
@@ -201,24 +201,30 @@ fi
 
 # Tear down the branch's app and network tiers (CAMS-760, Option E).
 #
-# APP tier: NOT a deployment stack. main.bicep deploys resources cross-scope into
-# SHARED resource groups (the app-config Key Vault + its role assignments and SQL
-# vnet rules in AZURE_RG; the action group in the analytics RG). A deployment stack
-# manages every resource its template creates in ANY resource group, so deleting an
-# app stack would delete those shared resources — this is what deleted the shared
-# kv-ustp-cams-dev (GH #2749). The app resources live in the per-branch app RG, so
-# we tear them down by deleting that resource group directly. Deleting the per-branch
-# app RG cannot touch shared resources, which live in other (shared) RGs.
+# APP tier: a self-contained per-branch deployment stack. The genuinely shared
+# cross-scope resources (the app-config Key Vault + its role assignments, and the
+# SQL managed identity) are deployed separately by app-shared-setup.bicep, always
+# as a plain (non-stack) deployment, so the app stack itself only ever manages
+# app-RG-scoped resources (webapp, functions, app insights, plans, comms/email).
+# An earlier version wrapped those cross-scope resources into the branch's own
+# app stack, and a teardown deleted the shared kv-ustp-cams-dev (GH #2749) — this
+# split is what makes stacking the app tier safe. For per-branch teardown we
+# delete the whole app RG directly rather than deleting the stack first, mirroring
+# the network tier's per-branch behavior below. Only when a shared app RG must be
+# preserved (Slice 2, unmanage_action=deleteResources) do we fall back to a scoped
+# stack delete.
 #
 # NETWORK tier: a self-contained per-branch deployment stack (network.bicep only
 # touches the per-branch network RG). For per-branch teardown we delete the whole
 # network RG directly rather than deleting the stack first: the branch's Key Vault
-# private endpoint (pep-kv-ustp-cams-dev) is created in the network RG by the app-side
-# kvSetup module and is NOT stack-managed, so a stack delete fails with
-# InUseSubnetCannotBeDeleted (the PE still occupies the private-endpoint subnet).
-# `az group delete` removes the PE, subnets, vnet, and stack in one shot regardless of
-# ordering. Only when a shared network RG must be preserved (Slice 2,
-# unmanage_action=deleteResources) do we fall back to a scoped stack delete.
+# private endpoint (pep-kv-ustp-cams-dev) is created in the network RG by
+# app-shared-setup.bicep's kvSetup module and is NOT stack-managed, so a stack
+# delete fails with InUseSubnetCannotBeDeleted (the PE still occupies the
+# private-endpoint subnet). `az group delete` removes the PE, subnets, vnet, and
+# stack in one shot regardless of ordering. Only when a shared network RG must be
+# preserved (Slice 2, unmanage_action=deleteResources) do we fall back to a scoped
+# stack delete.
+appStack="${stack_name}-app"
 networkStack="${stack_name}-network"
 
 function stack_exists() {
@@ -228,8 +234,17 @@ function stack_exists() {
 }
 
 if [[ "${rgAppExists}" == "true" ]]; then
-    echo "Deleting app resource group ${app_rg} (per-branch; contains only branch-owned app resources)"
-    az group delete -n "${app_rg}" --yes
+    if [[ "${unmanage_action}" != "deleteResources" ]]; then
+        # Per-branch app RG: delete the whole RG.
+        echo "Deleting app resource group ${app_rg} (per-branch; contains only branch-owned app resources)"
+        az group delete -n "${app_rg}" --yes
+    elif [[ -n "$(stack_exists "${appStack}" "${app_rg}")" ]]; then
+        # Shared app RG (Slice 2): preserve the RG, remove only this branch's stack.
+        echo "Start deleting app deployment stack ${appStack} (action-on-unmanage=${unmanage_action})"
+        az stack group delete --name "${appStack}" --resource-group "${app_rg}" --action-on-unmanage "${unmanage_action}" --yes
+    else
+        echo "No app deployment stack ${appStack} found; nothing to delete in shared app RG"
+    fi
 fi
 
 if [[ "${rgNetExists}" == "true" ]]; then
@@ -330,13 +345,20 @@ fi
 
 echo "Completed resource clean up operations."
 
-# Verify nothing was left behind. The per-branch app RG is always deleted outright.
-# The network tier's RG is deleted for per-branch RGs (unmanage_action != deleteResources);
-# for a preserved shared network RG (deleteResources, Slice 2) verify the stack is gone.
+# Verify nothing was left behind. Per-branch RGs (unmanage_action != deleteResources)
+# are deleted outright and verified gone; for a preserved shared RG (deleteResources,
+# Slice 2) verify each tier's stack is gone instead.
 failed=false
-if [[ $(az group exists -n "${app_rg}") == "true" ]]; then
-    echo "ERROR: App resource group ${app_rg} still exists after deletion attempt." >&2
-    failed=true
+if [[ "${unmanage_action}" != "deleteResources" ]]; then
+    if [[ $(az group exists -n "${app_rg}") == "true" ]]; then
+        echo "ERROR: App resource group ${app_rg} still exists after deletion attempt." >&2
+        failed=true
+    fi
+else
+    if [[ -n "$(stack_exists "${appStack}" "${app_rg}")" ]]; then
+        echo "ERROR: App deployment stack ${appStack} still exists after deletion attempt." >&2
+        failed=true
+    fi
 fi
 if [[ "${unmanage_action}" != "deleteResources" ]]; then
     if [[ $(az group exists -n "${network_rg}") == "true" ]]; then

--- a/ops/scripts/utility/az-delete-branch-resources.sh
+++ b/ops/scripts/utility/az-delete-branch-resources.sh
@@ -146,48 +146,78 @@ done
 fi
 
 # Check which resources exist (partial cleanup is normal if a previous run partially succeeded)
-app_rg="${app_rg}-${hash_id}"
-network_rg="${net_rg}-${hash_id}"
+#
+# Slice 2 (unmanage_action=deleteResources): app_rg/network_rg are ALREADY the
+# correct shared base names passed in by the caller — do NOT suffix them with
+# the branch hash, that would point at a per-branch RG that no longer exists.
+# Legacy per-branch mode (deleteAll): suffix with the branch hash, as before.
+if [[ "${unmanage_action}" == "deleteResources" ]]; then
+    network_rg="${net_rg}"
+else
+    app_rg="${app_rg}-${hash_id}"
+    network_rg="${net_rg}-${hash_id}"
+fi
 e2e_db="cams-e2e-${hash_id}"
 stack_name="${stack_name}-${hash_id}"
+appStack="${stack_name}-app"
+networkStack="${stack_name}-network"
 
-# Safety guard (CAMS-760, GH #2749): this script deletes the app and network resource
-# groups outright. Those MUST be the per-branch, hash-suffixed RGs — never a shared RG.
-# A misconfiguration that made app_rg/network_rg resolve to a shared RG (e.g. the KV/DB
-# RG AZURE_RG, the SQL RG, or the analytics RG) would delete shared infrastructure, as
-# happened when the shared dev Key Vault was deleted. Abort before touching anything if
-# a delete target is not hash-suffixed, or if it (or its base name) is a known shared RG.
-for rg_var in app_rg network_rg; do
-    rg_val="${!rg_var}"
-    if [[ "${rg_val}" != *"-${hash_id}" ]]; then
-        error "Refusing to delete ${rg_var}='${rg_val}': not suffixed with branch hash '-${hash_id}'. This must be a per-branch resource group." 20
-    fi
-    # Compare both the full name and the base (name without the '-<hash>' suffix)
-    # against every known shared RG, so neither form can slip through.
-    rg_base="${rg_val%-"${hash_id}"}"
-    for shared in "${db_rg}" "${sql_rg:-}" "${analytics_rg:-}"; do
-        if [[ -n "${shared}" && ( "${rg_val}" == "${shared}" || "${rg_base}" == "${shared}" ) ]]; then
-            error "Refusing to delete ${rg_var}='${rg_val}': it (or its base '${rg_base}') matches a SHARED resource group '${shared}'. Aborting to protect shared infrastructure (GH #2749)." 21
+function stack_exists() {
+    local name=$1
+    local rg=$2
+    az stack group show --name "${name}" --resource-group "${rg}" --query id -o tsv 2>/dev/null || echo ""
+}
+
+# Safety guard (CAMS-760, GH #2749): applies only to the legacy per-branch path,
+# where this script deletes the resource group outright — it MUST be the
+# per-branch, hash-suffixed RG, never a shared RG. The deleteResources path never
+# deletes a resource group at all (only this branch's stack), so a shared,
+# un-suffixed RG name is the CORRECT and expected input there, not a violation.
+if [[ "${unmanage_action}" != "deleteResources" ]]; then
+    for rg_var in app_rg network_rg; do
+        rg_val="${!rg_var}"
+        if [[ "${rg_val}" != *"-${hash_id}" ]]; then
+            error "Refusing to delete ${rg_var}='${rg_val}': not suffixed with branch hash '-${hash_id}'. This must be a per-branch resource group." 20
         fi
+        # Compare both the full name and the base (name without the '-<hash>' suffix)
+        # against every known shared RG, so neither form can slip through.
+        rg_base="${rg_val%-"${hash_id}"}"
+        for shared in "${db_rg}" "${sql_rg:-}" "${analytics_rg:-}"; do
+            if [[ -n "${shared}" && ( "${rg_val}" == "${shared}" || "${rg_base}" == "${shared}" ) ]]; then
+                error "Refusing to delete ${rg_var}='${rg_val}': it (or its base '${rg_base}') matches a SHARED resource group '${shared}'. Aborting to protect shared infrastructure (GH #2749)." 21
+            fi
+        done
     done
-done
+fi
 
 rgAppExists=$(az group exists -n "${app_rg}")
 rgNetExists=$(az group exists -n "${network_rg}")
 dbExists=$(az cosmosdb mongodb database exists -g "${db_rg}" -a "${db_account}" -n "${e2e_db}")
 
-if [[ ${rgAppExists} != "true" && ${rgNetExists} != "true" && ${dbExists} != "true" ]]; then
+# What indicates "this branch has something to tear down" differs by mode: for a
+# per-branch RG, RG existence IS the signal. For a shared RG (deleteResources)
+# the RG always exists (main and other branches live there too) — the real
+# signal is whether THIS branch's own stack exists.
+if [[ "${unmanage_action}" == "deleteResources" ]]; then
+    appExists=$([[ -n "$(stack_exists "${appStack}" "${app_rg}")" ]] && echo true || echo false)
+    netExists=$([[ -n "$(stack_exists "${networkStack}" "${network_rg}")" ]] && echo true || echo false)
+else
+    appExists="${rgAppExists}"
+    netExists="${rgNetExists}"
+fi
+
+if [[ "${appExists}" != "true" && "${netExists}" != "true" && "${dbExists}" != "true" ]]; then
     echo "No branch resources found for hash ${hash_id} — nothing to clean up."
     exit 0
 fi
 
-[[ ${rgAppExists} != "true" ]] && echo "WARNING: App resource group ${app_rg} not found — may have been deleted already."
-[[ ${rgNetExists} != "true" ]] && echo "WARNING: Network resource group ${network_rg} not found — may have been deleted already."
+[[ "${appExists}" != "true" ]] && echo "WARNING: App resources for hash ${hash_id} not found — may have been deleted already."
+[[ "${netExists}" != "true" ]] && echo "WARNING: Network resources for hash ${hash_id} not found — may have been deleted already."
 
 echo "Begin clean up of Azure resources for ${hash_id}."
 
 # Disconnect VNET integration from App Service components prior to deleting resources
-if [[ "${rgAppExists}" == "true" ]]; then
+if [[ "${appExists}" == "true" ]]; then
     echo "Start disconnecting VNET integration"
     webapp="${stack_name}-webapp"
     az webapp vnet-integration remove -g "${app_rg}" -n "${webapp}"
@@ -224,42 +254,44 @@ fi
 # stack in one shot regardless of ordering. Only when a shared network RG must be
 # preserved (Slice 2, unmanage_action=deleteResources) do we fall back to a scoped
 # stack delete.
-appStack="${stack_name}-app"
-networkStack="${stack_name}-network"
-
-function stack_exists() {
-    local name=$1
-    local rg=$2
-    az stack group show --name "${name}" --resource-group "${rg}" --query id -o tsv 2>/dev/null || echo ""
-}
-
-if [[ "${rgAppExists}" == "true" ]]; then
+if [[ "${appExists}" == "true" ]]; then
     if [[ "${unmanage_action}" != "deleteResources" ]]; then
         # Per-branch app RG: delete the whole RG.
         echo "Deleting app resource group ${app_rg} (per-branch; contains only branch-owned app resources)"
         az group delete -n "${app_rg}" --yes
-    elif [[ -n "$(stack_exists "${appStack}" "${app_rg}")" ]]; then
+    else
         # Shared app RG (Slice 2): preserve the RG, remove only this branch's stack.
         echo "Start deleting app deployment stack ${appStack} (action-on-unmanage=${unmanage_action})"
         az stack group delete --name "${appStack}" --resource-group "${app_rg}" --action-on-unmanage "${unmanage_action}" --yes
-    else
-        echo "No app deployment stack ${appStack} found; nothing to delete in shared app RG"
+
+        # Application Insights auto-creates Smart Detection alert rules that are
+        # never declared in bicep, so the stack never manages/deletes them. The
+        # per-branch path sweeps these up for free via the whole-RG delete above;
+        # the shared-RG path cannot do that, so clean them up by name instead.
+        echo "Checking for stack-unmanaged Smart Detection alert rules for ${stack_name}"
+        mapfile -t smartDetectorRuleIds < <(az resource list -g "${app_rg}" --resource-type microsoft.alertsmanagement/smartDetectorAlertRules --query "[?starts_with(name, 'Failure Anomalies - appi-${stack_name}')].id" -o tsv 2>/dev/null || true)
+        if [[ ${#smartDetectorRuleIds[@]} -gt 0 ]]; then
+            for ruleId in "${smartDetectorRuleIds[@]}"; do
+                echo "Deleting stack-unmanaged Smart Detection alert rule: ${ruleId}"
+                az resource delete --ids "${ruleId}"
+            done
+        else
+            echo "No stack-unmanaged Smart Detection alert rules found for ${stack_name}"
+        fi
     fi
 fi
 
-if [[ "${rgNetExists}" == "true" ]]; then
+if [[ "${netExists}" == "true" ]]; then
     if [[ "${unmanage_action}" != "deleteResources" ]]; then
         # Per-branch network RG: delete the whole RG. This removes the network stack,
         # the vnet/subnets, and any stack-unmanaged resources (the KV private endpoint)
         # without hitting subnet-in-use ordering failures.
         echo "Deleting network resource group ${network_rg} (per-branch; removes vnet, subnets, and the KV private endpoint)"
         az group delete -n "${network_rg}" --yes
-    elif [[ -n "$(stack_exists "${networkStack}" "${network_rg}")" ]]; then
+    else
         # Shared network RG (Slice 2): preserve the RG, remove only this branch's stack.
         echo "Start deleting network deployment stack ${networkStack} (action-on-unmanage=${unmanage_action})"
         az stack group delete --name "${networkStack}" --resource-group "${network_rg}" --action-on-unmanage "${unmanage_action}" --yes
-    else
-        echo "No network deployment stack ${networkStack} found; nothing to delete in shared network RG"
     fi
 fi
 


### PR DESCRIPTION
# Purpose

Slice 2 of CAMS-760 (Option E): stop branch deploys from creating their own per-branch `<base>-<hash>` app/network resource groups, and instead deploy into the same stable RGs `main` already uses — distinguished by per-branch-unique resource names. This removes the dynamic per-branch RG that today forces subscription-scope Contributor on the branch deploy identity (Azure RBAC has no wildcard scoping over dynamically-named RGs), setting up Slice 3's RBAC cutover to RG-scoped least privilege.

# Major Changes

* Split `main.bicep` so the app tier can deploy as its own RG-scoped Deployment Stack, symmetric with the network tier from Slice 1. New `app-shared-setup.bicep` holds the genuinely shared cross-scope resources (the app-config Key Vault + its role assignments, and a deduplicated SQL managed identity) as an always-plain (non-stack) deployment.
* Added `az_stack_deploy_func` to `azure-deploy.sh`; branches now deploy the app tier as a stack, main unchanged.
* Added stack-aware teardown for the app tier in `az-delete-branch-resources.sh`, mirroring the network tier's existing `deleteAll`/`deleteResources` conditional from Slice 1.
* The cutover: dropped the `-<hash>` RG-name suffix for branches; fixed the VNet naming override (branches already own their own VNet — they were just forced onto an identical name; now each gets `vnet-<stackName>` again); forced `deployDns=false` for branches on both Private DNS Zones (a newly discovered risk with the same shape as the GH #2749 shared-KV incident — every branch's stack would otherwise manage the same shared DNS zone); switched branch teardown to `deleteResources`; added by-name cleanup for stack-unmanaged Smart Detection alert rules; replaced the nightly-cleanup discovery mechanism (RG tags → network stack tags).

# Testing/Validation

Static gates pass: `az bicep build` clean on all new/changed bicep, `shellcheck` clean on all new/changed scripts, workflow YAML validates, and the repo's `check-kv-secret-parity` pre-commit hook passes (no new/undocumented KV secrets introduced). Full `npm test`/`typecheck`/`coverage:backend`/`knip` also pass (no JS/TS touched by this PR; run for completeness).

**Live Azure validation has NOT been run** — no Azure access during implementation. Before merge, the 8 scenarios listed in the Slice 2 implementation notes (`.ustp-cams-fdp/ai/specs/CAMS-760_branch-deploy-shared-rgs/branch-deploy-shared-rgs.slice-2-implementation-notes.md`) need a real `workflow_dispatch` run: single-branch deploy into the shared RGs, two-branch concurrency (no name/network collisions), shared-resource-untouched checks (KV, SQL identity, both DNS zones), teardown of one branch leaving the other + main intact, idempotent re-teardown, nightly-cleanup discovery, main-unaffected regression, and the slot-swap regression check.

# Notes

* Targets `CAMS-760-azure-resource-groups-for-dev` (Slice 1, PR #2757) as base rather than `main`, since Slice 1 hasn't merged yet. Should be retargeted to `main` if Slice 1 merges first.
* Design + implementation-prompts + implementation-notes docs live in the `.ustp-cams-fdp` submodule under `ai/specs/CAMS-760_branch-deploy-shared-rgs/`.
* Two bugs were found only by tracing the actual code (not anticipated by the design doc) and fixed as part of this PR: `az-delete-branch-resources.sh` was unconditionally suffixing the RG name with the branch hash and gating its idempotent-teardown fast path on raw RG existence — both silently wrong once the RG is shared. `reusable-build-info.yml` independently recomputed the same RG names and did its own VNet-existence check feeding `deployVnet`/`initialDeployment` (which gates the blue-green slot-swap flow) — left unfixed, every branch deploy would have permanently looked like a first-ever deploy.
* Out of scope, deferred separately: the `acsEmail` shared-KV-secret-clobbering issue discovered along the way (pre-existing, unrelated to RG co-location).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Co-locate branch deployments into the shared app and network resource groups used by main while isolating per-branch resources via deployment stacks and unique names, and adjust teardown and workflows to respect the new shared-RG model.

New Features:
- Introduce a dedicated app-shared-setup deployment that provisions shared Key Vault, DNS, and SQL managed identity resources outside of per-branch stacks.
- Deploy branch app-tier resources as Azure Deployment Stacks, parallel to the existing network stack approach, enabling stack-scoped lifecycle management.

Bug Fixes:
- Ensure branch teardown correctly handles shared resource groups by using stack existence instead of resource-group existence and by avoiding hash-based RG suffixing in shared-RG mode.
- Fix VNet naming and existence checks so each branch uses and validates its own uniquely named virtual network rather than reusing main’s name.
- Prevent branch deployments from managing shared Private DNS Zones, avoiding accidental deletion of shared DNS configuration on teardown.
- Remove duplicate and inconsistent computation of app and network resource group names between workflows, aligning them on shared, non-suffixed names.
- Ensure stack-unmanaged Smart Detection alert rules created by Application Insights are explicitly cleaned up in shared app resource groups.

Enhancements:
- Refine branch teardown logic to distinguish between legacy per-branch resource groups and shared-RG stack-based cleanup, including post-teardown verification of stacks vs. groups.
- Tag and parameterize deployment stacks and scripts with branch metadata to support discovery, idempotent cleanup, and future least-privilege RBAC scoping.
- Update nightly branch-cleanup workflow to discover orphaned branches via tagged network stacks instead of per-branch tagged resource groups.
- Externalize creation of the read-only SQL managed identity into a single shared deployment and consume it as an existing resource from app templates.
- Simplify app and network deployment workflows by centralizing shared-RG names and stack naming conventions across build and deploy steps.

CI:
- Adjust reusable deploy and build-info GitHub workflows to deploy into stable shared app/network resource groups, pass stack metadata, and control DNS and VNet behavior based on whether the run is for main or a branch.
- Update the branch-removal GitHub workflow to detect and clean up branch environments via deployment stacks in the shared network resource group and to use stack-based unmanage actions during teardown.

Deployment:
- Extend deployment scripts to support both plain and stack-based group deployments, including new helpers for app shared-setup and app-tier stack deployment, and to propagate DNS-related parameters to the appropriate templates.

Documentation:
- Document in code comments the shared-resource vs. per-branch stack design, including how DNS zones, Key Vault, and SQL identities are safely managed across main and branch environments.