### PR TITLE
Remove unused HTTP triggers from dataflows

### DIFF
--- a/backend/function-apps/dataflows/import/sync-cases.ts
+++ b/backend/function-apps/dataflows/import/sync-cases.ts
@@ -4,7 +4,6 @@ import ContextCreator from '../../azure/application-context-creator';
 import {
   buildFunctionName,
   buildQueueName,
-  buildStartQueueHttpTrigger,
   buildStartQueueTimerTrigger,
   StartMessage,
 } from '../dataflows-common';
@@ -53,7 +52,6 @@ const FIX = output.storageQueue({
 const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
 const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
 const HANDLE_PAGE_POISON = buildFunctionName(MODULE_NAME, 'handlePagePoison');
-const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 const TIMER_TRIGGER = buildFunctionName(MODULE_NAME, 'timerTrigger');
 
 /**
@@ -266,13 +264,6 @@ function setup() {
     schedule: '0 30 9 * * *',
     extraOutputs: [START],
     handler: buildStartQueueTimerTrigger(MODULE_NAME, START),
-  });
-
-  app.http(HTTP_TRIGGER, {
-    route: 'sync-cases',
-    methods: ['POST'],
-    extraOutputs: [START],
-    handler: buildStartQueueHttpTrigger(MODULE_NAME, START),
   });
 }
 

--- a/backend/function-apps/dataflows/import/sync-orders.ts
+++ b/backend/function-apps/dataflows/import/sync-orders.ts
@@ -1,8 +1,8 @@
-import { app, HttpRequest, InvocationContext, Timer } from '@azure/functions';
+import { app, InvocationContext, Timer } from '@azure/functions';
 import ContextCreator from '../../azure/application-context-creator';
 import { OrdersController } from '../../../lib/controllers/orders/orders.controller';
 import { toAzureError } from '../../azure/functions';
-import { buildFunctionName, buildHttpTrigger } from '../dataflows-common';
+import { buildFunctionName } from '@common/queues';
 import { completeDataflowTrace } from '../../../lib/use-cases/dataflows/dataflow-telemetry';
 
 const MODULE_NAME = 'SYNC-ORDERS';
@@ -43,40 +43,10 @@ async function timerTrigger(_ignore: Timer, invocationContext: InvocationContext
   }
 }
 
-/**
- * Used to invoke the orders sync process between DXTR and CAMS CosmosDB from an accessable HTTP endpoint.
- *
- * This endpoint can be invoked from the CLI with the following cURL command. Modify the `txIdOverride` to a
- * specific AO_TX.TX_ID to start the sync from or omit it from the request body to use the last runtime state
- * stored in CosmosDB.
- *
- * curl -v -d '{"txIdOverride": "0"}' -H "Content-Type: application/json" http://localhost:7071/api/sync-orders
- *
- */
-
-const httpTrigger = buildHttpTrigger(
-  MODULE_NAME,
-  async (invocationContext: InvocationContext, request: HttpRequest) => {
-    const context = await ContextCreator.getApplicationContext({
-      invocationContext,
-      request,
-    });
-
-    const ordersController = new OrdersController(context);
-    return ordersController.handleRequest(context);
-  },
-);
-
 function setup() {
   app.timer(buildFunctionName(MODULE_NAME, 'timerTrigger'), {
     schedule: '0 30 9 * * *',
     handler: timerTrigger,
-  });
-
-  app.http(buildFunctionName(MODULE_NAME, 'httpTrigger'), {
-    route: 'sync-orders',
-    methods: ['POST'],
-    handler: httpTrigger,
   });
 }
 

--- a/backend/function-apps/dataflows/migrations/backfill-phonetic-tokens.ts
+++ b/backend/function-apps/dataflows/migrations/backfill-phonetic-tokens.ts
@@ -4,7 +4,6 @@ import ApplicationContextCreator from '../../azure/application-context-creator';
 import {
   buildFunctionName,
   buildQueueName,
-  buildStartQueueHttpTrigger,
   CursorMessage,
   StartMessage,
 } from '../dataflows-common';
@@ -50,7 +49,6 @@ const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
 const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
 const HANDLE_ERROR = buildFunctionName(MODULE_NAME, 'handleError');
 const HANDLE_RETRY = buildFunctionName(MODULE_NAME, 'handleRetry');
-const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 
 type BackfillEvent = BackfillCase & {
   retryCount?: number;
@@ -61,7 +59,7 @@ type BackfillEvent = BackfillCase & {
  * handleStart
  *
  * Initialize the backfill migration by reading existing state for resumability.
- * If already completed, skip. Otherwise, queue first/next CursorMessage with lastId from state.
+ * If already completed, skip. Otherwise, queue the first/next CursorMessage with the lastId from the state.
  * No counting - uses cursor-based pagination for efficiency.
  */
 async function handleStart(_ignore: StartMessage, invocationContext: InvocationContext) {
@@ -111,8 +109,8 @@ async function handleStart(_ignore: StartMessage, invocationContext: InvocationC
  * handlePage
  *
  * Process a page of cases using cursor-based pagination.
- * Fetches page using cursor, processes batch, updates state with new cursor position.
- * If hasMore, queues next CursorMessage. If no more results, sets status to COMPLETED.
+ * Fetches page using cursor, processes batch, updates state with the new cursor position.
+ * If hasMore, queues next CursorMessage. If no more results, sets the status to "COMPLETED".
  */
 async function handlePage(cursor: CursorMessage, invocationContext: InvocationContext) {
   const context = await ApplicationContextCreator.getApplicationContext({ invocationContext });
@@ -243,7 +241,7 @@ async function handlePage(cursor: CursorMessage, invocationContext: InvocationCo
 /**
  * handleError
  *
- * Route failed events to retry queue for another attempt.
+ * Route failed events to the retry queue for another attempt.
  */
 async function handleError(event: BackfillEvent, invocationContext: InvocationContext) {
   const logger = ApplicationContextCreator.getLogger(invocationContext);
@@ -325,13 +323,6 @@ function setup() {
     queueName: RETRY.queueName,
     handler: handleRetry,
     extraOutputs: [DLQ, HARD_STOP],
-  });
-
-  app.http(HTTP_TRIGGER, {
-    route: 'backfill-phonetic-tokens',
-    methods: ['POST'],
-    extraOutputs: [START],
-    handler: buildStartQueueHttpTrigger(MODULE_NAME, START),
   });
 }
 

--- a/backend/function-apps/dataflows/migrations/backfill-trustee-phonetic-tokens.ts
+++ b/backend/function-apps/dataflows/migrations/backfill-trustee-phonetic-tokens.ts
@@ -1,12 +1,7 @@
 import { app, InvocationContext, output } from '@azure/functions';
 
 import ApplicationContextCreator from '../../azure/application-context-creator';
-import {
-  buildFunctionName,
-  buildQueueName,
-  buildStartQueueHttpTrigger,
-  StartMessage,
-} from '../dataflows-common';
+import { buildFunctionName, buildQueueName, StartMessage } from '../dataflows-common';
 import BackfillTrusteePhoneticTokensUseCase from '../../../lib/use-cases/dataflows/backfill-trustee-phonetic-tokens';
 import { buildQueueError } from '../../../lib/use-cases/dataflows/queue-types';
 import { STORAGE_QUEUE_CONNECTION } from '../../../lib/storage-queues';
@@ -27,7 +22,6 @@ const DLQ = output.storageQueue({
 
 // Registered function names
 const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
-const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 
 /**
  * handleStart
@@ -101,13 +95,6 @@ function setup() {
     queueName: START.queueName,
     handler: handleStart,
     extraOutputs: [DLQ],
-  });
-
-  app.http(HTTP_TRIGGER, {
-    route: 'backfill-trustee-phonetic-tokens',
-    methods: ['POST'],
-    extraOutputs: [START],
-    handler: buildStartQueueHttpTrigger(MODULE_NAME, START),
   });
 }
 

--- a/backend/function-apps/dataflows/migrations/handle-missed-division-changes.ts
+++ b/backend/function-apps/dataflows/migrations/handle-missed-division-changes.ts
@@ -1,7 +1,7 @@
 import { app, InvocationContext, output } from '@azure/functions';
 
 import ApplicationContextCreator from '../../azure/application-context-creator';
-import { buildFunctionName, buildQueueName, buildStartQueueHttpTrigger } from '../dataflows-common';
+import { buildFunctionName, buildQueueName } from '@common/queues';
 import { handleRateLimitRetry } from '../dataflows-rate-limit';
 import { STORAGE_QUEUE_CONNECTION } from '../../../lib/storage-queues';
 import { getCamsError } from '../../../lib/common-errors/error-utilities';
@@ -43,7 +43,6 @@ const DLQ = output.storageQueue({
 const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
 const HANDLE_CHECK = buildFunctionName(MODULE_NAME, 'handleCheck');
 const HANDLE_CHECK_POISON = buildFunctionName(MODULE_NAME, 'handleCheckPoison');
-const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 
 const BLOB_NAME = 'missed-division-change-case-ids.json';
 
@@ -212,13 +211,6 @@ async function handleCheckPoison(
 }
 
 function setup() {
-  app.http(HTTP_TRIGGER, {
-    route: 'handle-missed-division-changes',
-    methods: ['POST'],
-    handler: buildStartQueueHttpTrigger(MODULE_NAME, START),
-    extraOutputs: [START],
-  });
-
   app.storageQueue(HANDLE_START, {
     connection: STORAGE_QUEUE_CONNECTION,
     queueName: START.queueName,

--- a/backend/function-apps/dataflows/migrations/migrate-cases.ts
+++ b/backend/function-apps/dataflows/migrations/migrate-cases.ts
@@ -1,14 +1,7 @@
 import { app, InvocationContext, output } from '@azure/functions';
 import { CaseSyncEvent } from '@common/cams/dataflow-events';
 
-import ContextCreator from '../../azure/application-context-creator';
-import {
-  buildFunctionName,
-  buildQueueName,
-  buildStartQueueHttpTrigger,
-  RangeMessage,
-  StartMessage,
-} from '../dataflows-common';
+import { buildFunctionName, buildQueueName, RangeMessage, StartMessage } from '../dataflows-common';
 import MigrateCases from '../../../lib/use-cases/dataflows/migrate-cases';
 import { buildQueueError } from '../../../lib/use-cases/dataflows/queue-types';
 import CasesRuntimeState from '../../../lib/use-cases/dataflows/cases-runtime-state';
@@ -55,7 +48,6 @@ const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
 const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
 const HANDLE_ERROR = buildFunctionName(MODULE_NAME, 'handleError');
 const HANDLE_RETRY = buildFunctionName(MODULE_NAME, 'handleRetry');
-const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 const GET_CASEIDS_TO_MIGRATE = buildFunctionName(MODULE_NAME, 'getCaseIdsToMigrate');
 const LOAD_MIGRATION_TABLE = buildFunctionName(MODULE_NAME, 'loadMigrationTable');
 const EMPTY_MIGRATION_TABLE = buildFunctionName(MODULE_NAME, 'emptyMigrationTable');
@@ -63,16 +55,16 @@ const EMPTY_MIGRATION_TABLE = buildFunctionName(MODULE_NAME, 'emptyMigrationTabl
 /**
  * handleStart
  *
- * Get case Ids from ACMS identifying cases to migrate then export and load the cases from DXTR into CAMS.
+ * Get case Ids from ACMS identifying cases to migrate, then export, then load the cases from DXTR into CAMS.
  *
- * @param {object} message
+ * @param _ignore
  * @param {InvocationContext} invocationContext
  */
 async function handleStart(_ignore: StartMessage, invocationContext: InvocationContext) {
   const logger = ApplicationContextCreator.getLogger(invocationContext);
 
   try {
-    const appContext = await ContextCreator.getApplicationContext({
+    const appContext = await ApplicationContextCreator.getApplicationContext({
       invocationContext,
       logger,
     });
@@ -155,7 +147,7 @@ async function handleStart(_ignore: StartMessage, invocationContext: InvocationC
 /**
  * handlePage
  *
- * Get case Ids from ACMS identifying cases to migrate then export and load the cases from DXTR into CAMS.
+ * Get case Ids from ACMS identifying cases to then migrate, then export, then load the cases from DXTR into CAMS.
  *
  * @param range
  * @param invocationContext
@@ -164,7 +156,7 @@ async function handlePage(range: RangeMessage, invocationContext: InvocationCont
   const logger = ApplicationContextCreator.getLogger(invocationContext);
 
   try {
-    const appContext = await ContextCreator.getApplicationContext({
+    const appContext = await ApplicationContextCreator.getApplicationContext({
       invocationContext,
       logger,
     });
@@ -200,7 +192,7 @@ async function handleError(event: CaseSyncEvent, invocationContext: InvocationCo
   const logger = ApplicationContextCreator.getLogger(invocationContext);
 
   try {
-    const appContext = await ContextCreator.getApplicationContext({
+    const appContext = await ApplicationContextCreator.getApplicationContext({
       invocationContext,
       logger,
     });
@@ -255,7 +247,7 @@ async function handleRetry(event: CaseSyncEvent, invocationContext: InvocationCo
   const logger = ApplicationContextCreator.getLogger(invocationContext);
 
   try {
-    const appContext = await ContextCreator.getApplicationContext({
+    const appContext = await ApplicationContextCreator.getApplicationContext({
       invocationContext,
       logger,
     });
@@ -461,13 +453,6 @@ function setup() {
     queueName: RETRY.queueName,
     handler: handleRetry,
     extraOutputs: [DLQ, HARD_STOP],
-  });
-
-  app.http(HTTP_TRIGGER, {
-    route: 'migrate-cases',
-    methods: ['POST'],
-    extraOutputs: [START],
-    handler: buildStartQueueHttpTrigger(MODULE_NAME, START),
   });
 }
 

--- a/backend/function-apps/dataflows/migrations/resync-terminal-transaction-cases.ts
+++ b/backend/function-apps/dataflows/migrations/resync-terminal-transaction-cases.ts
@@ -2,12 +2,7 @@ import { app, InvocationContext, output } from '@azure/functions';
 import { CaseSyncEvent } from '@common/cams/dataflow-events';
 
 import ApplicationContextCreator from '../../azure/application-context-creator';
-import {
-  buildFunctionName,
-  buildQueueName,
-  buildStartQueueHttpTrigger,
-  StartMessage,
-} from '../dataflows-common';
+import { buildFunctionName, buildQueueName, StartMessage } from '../dataflows-common';
 import ResyncTerminalTransactionCases from '../../../lib/use-cases/dataflows/resync-terminal-transaction-cases';
 import ExportAndLoadCase from '../../../lib/use-cases/dataflows/export-and-load-case';
 import { isNotFoundError } from '../../../lib/common-errors/not-found-error';
@@ -54,7 +49,6 @@ const HANDLE_START = buildFunctionName(MODULE_NAME, 'handleStart');
 const HANDLE_PAGE = buildFunctionName(MODULE_NAME, 'handlePage');
 const HANDLE_ERROR = buildFunctionName(MODULE_NAME, 'handleError');
 const HANDLE_RETRY = buildFunctionName(MODULE_NAME, 'handleRetry');
-const HTTP_TRIGGER = buildFunctionName(MODULE_NAME, 'httpTrigger');
 
 /**
  * handleStart
@@ -236,13 +230,6 @@ function setup() {
     queueName: RETRY.queueName,
     handler: handleRetry,
     extraOutputs: [DLQ, HARD_STOP],
-  });
-
-  app.http(HTTP_TRIGGER, {
-    route: 'resync-terminal-transaction-cases',
-    methods: ['POST'],
-    extraOutputs: [START],
-    handler: buildStartQueueHttpTrigger(MODULE_NAME, START),
   });
 }
 


### PR DESCRIPTION
# Purpose

Several dataflows registered an `app.http(...)` trigger alongside their normal queue/timer triggers, exposing an HTTP endpoint whose only purpose was manually kicking off a run from the CLI (e.g. via `curl`). These endpoints are unused in practice and add unnecessary attack surface and maintenance overhead — dataflows should be started via their queue/timer triggers, not an ad hoc HTTP route.

# Major Changes

* Removed the `app.http(...)` registration and its associated `HTTP_TRIGGER` function-name constant from 7 dataflow handlers: `sync-cases`, `sync-orders`, `backfill-phonetic-tokens`, `backfill-trustee-phonetic-tokens`, `handle-missed-division-changes`, `migrate-cases`, and `resync-terminal-transaction-cases`.
* Removed the now-unused `buildStartQueueHttpTrigger`/`buildHttpTrigger` imports (and, in `sync-orders.ts`, the standalone `httpTrigger` handler function and its `HttpRequest` import) that only existed to support the removed HTTP triggers.
* `migrate-cases.ts` also picks up an incidental consistency fix: several handlers were still calling the module-level `ContextCreator` alias instead of `ApplicationContextCreator`, now made consistent.

# Testing/Validation

No test files were affected by this change (the HTTP triggers had no dedicated tests). Verified via typecheck and lint that the removed imports/constants are fully unused elsewhere in each file.

# Notes

No Jira ticket for this cleanup. Purely a removal of unused surface area — no behavioral change to any dataflow's queue/timer-triggered execution path.

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Remove unused HTTP triggers from several dataflow handlers to reduce attack surface and rely solely on queue/timer triggers for execution.

Enhancements:
- Clean up HTTP trigger routes and related handler code from sync-cases, sync-orders, migrate-cases, backfill-phonetic-tokens, backfill-trustee-phonetic-tokens, handle-missed-division-changes, and resync-terminal-transaction-cases dataflows.
- Align migrate-cases handlers to consistently use ApplicationContextCreator for application context and logger access.
- Clarify and slightly refine documentation comments for backfill and migration handlers without changing behavior.