### PR TITLE
CAMS-856 Fix silent trustee-notification delivery failures

### DIFF
--- a/backend/lib/controllers/admin/notification-routing.controller.test.ts
+++ b/backend/lib/controllers/admin/notification-routing.controller.test.ts
@@ -1,4 +1,5 @@
 import { vi, Mocked } from 'vitest';
+import * as dns from 'node:dns/promises';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { createMockApplicationContext } from '../../testing/testing-utilities';
 import { NotificationRoutingController } from './notification-routing.controller';
@@ -9,7 +10,20 @@ import { NotificationRoutingRecord } from '@common/cams/notifications';
 import HttpStatusCodes from '@common/api/http-status-codes';
 
 vi.mock('../../factory');
+vi.mock('node:dns/promises');
 const mockFactory = factory as Mocked<typeof factory>;
+
+function notFoundError(): NodeJS.ErrnoException {
+  const error = new Error('queryA ENOTFOUND') as NodeJS.ErrnoException;
+  error.code = 'ENOTFOUND';
+  return error;
+}
+
+function timeoutError(): NodeJS.ErrnoException {
+  const error = new Error('queryMx ETIMEOUT') as NodeJS.ErrnoException;
+  error.code = 'ETIMEOUT';
+  return error;
+}
 
 describe('NotificationRoutingController', () => {
   let context: ApplicationContext;
@@ -34,6 +48,11 @@ describe('NotificationRoutingController', () => {
     } as unknown as Mocked<NotificationRoutingRepository>;
 
     mockFactory.getNotificationRoutingRepository = vi.fn().mockReturnValue(mockRepo);
+
+    vi.mocked(dns.resolveMx)
+      .mockReset()
+      .mockResolvedValue([{ exchange: 'mail.example.com', priority: 10 }]);
+    vi.mocked(dns.resolve).mockReset().mockResolvedValue(['1.2.3.4']);
 
     context = await createMockApplicationContext();
     context.session.user.roles = [CamsRole.SuperUser];
@@ -241,6 +260,93 @@ describe('NotificationRoutingController', () => {
       await expect(controller.handleRequest(context)).rejects.toThrow(
         expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
       );
+    });
+  });
+
+  describe('handlePut domain validation', () => {
+    test('should throw BadRequestError when a domain has neither MX nor A records', async () => {
+      vi.mocked(dns.resolveMx).mockRejectedValue(notFoundError());
+      vi.mocked(dns.resolve).mockRejectedValue(notFoundError());
+      context.request.method = 'PUT';
+      context.request.params = { routingId: 'chapter-7-oversight' };
+      context.request.body = { recipientAddresses: ['someone@UST.DOJ.GOV'] };
+
+      await expect(controller.handleRequest(context)).rejects.toThrow(
+        expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
+      );
+      expect(mockRepo.updateRoutingRecord).not.toHaveBeenCalled();
+    });
+
+    test('should fall back to an A-record lookup when a domain has no MX records', async () => {
+      vi.mocked(dns.resolveMx).mockRejectedValue(notFoundError());
+      vi.mocked(dns.resolve).mockResolvedValue(['1.2.3.4']);
+      context.request.method = 'PUT';
+      context.request.params = { routingId: 'chapter-7-oversight' };
+      context.request.body = { recipientAddresses: ['someone@usdoj.gov'] };
+      mockRepo.updateRoutingRecord.mockResolvedValue({
+        ...mockRecord,
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(HttpStatusCodes.OK);
+      expect(mockRepo.updateRoutingRecord).toHaveBeenCalledWith('chapter-7-oversight', {
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
+    });
+
+    test('should save and return a warning when the DNS lookup is indeterminate rather than confirming the domain is missing', async () => {
+      vi.mocked(dns.resolveMx).mockRejectedValue(timeoutError());
+      vi.mocked(dns.resolve).mockRejectedValue(timeoutError());
+      context.request.method = 'PUT';
+      context.request.params = { routingId: 'chapter-7-oversight' };
+      context.request.body = { recipientAddresses: ['someone@usdoj.gov'] };
+      mockRepo.updateRoutingRecord.mockResolvedValue({
+        ...mockRecord,
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(HttpStatusCodes.OK);
+      expect(mockRepo.updateRoutingRecord).toHaveBeenCalledWith('chapter-7-oversight', {
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
+      expect(result.body.warnings).toEqual([expect.stringContaining("'usdoj.gov'")]);
+    });
+
+    test('should not include a warnings field on the response when domain validation succeeds cleanly', async () => {
+      context.request.method = 'PUT';
+      context.request.params = { routingId: 'chapter-7-oversight' };
+      context.request.body = { recipientAddresses: ['someone@usdoj.gov'] };
+      mockRepo.updateRoutingRecord.mockResolvedValue({
+        ...mockRecord,
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(HttpStatusCodes.OK);
+      expect(result.body.warnings).toBeUndefined();
+    });
+
+    test('should only check each unique domain once across multiple recipient addresses', async () => {
+      context.request.method = 'PUT';
+      context.request.params = { routingId: 'chapter-7-oversight' };
+      context.request.body = {
+        recipientAddresses: ['first@usdoj.gov', 'second@usdoj.gov'],
+      };
+      mockRepo.updateRoutingRecord.mockResolvedValue({
+        ...mockRecord,
+        recipientAddresses: ['first@usdoj.gov', 'second@usdoj.gov'],
+      });
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(HttpStatusCodes.OK);
+      expect(dns.resolveMx).toHaveBeenCalledTimes(1);
+      expect(dns.resolveMx).toHaveBeenCalledWith('usdoj.gov');
     });
   });
 });

--- a/backend/lib/controllers/admin/notification-routing.controller.test.ts
+++ b/backend/lib/controllers/admin/notification-routing.controller.test.ts
@@ -9,13 +9,17 @@ import factory from '../../factory';
 import { NotificationRoutingRecord } from '@common/cams/notifications';
 import HttpStatusCodes from '@common/api/http-status-codes';
 
-vi.mock('../../factory');
 vi.mock('node:dns/promises');
-const mockFactory = factory as Mocked<typeof factory>;
 
 function notFoundError(): NodeJS.ErrnoException {
   const error = new Error('queryA ENOTFOUND') as NodeJS.ErrnoException;
   error.code = 'ENOTFOUND';
+  return error;
+}
+
+function noDataError(): NodeJS.ErrnoException {
+  const error = new Error('queryMx ENODATA') as NodeJS.ErrnoException;
+  error.code = 'ENODATA';
   return error;
 }
 
@@ -39,6 +43,8 @@ describe('NotificationRoutingController', () => {
   };
 
   beforeEach(async () => {
+    vi.restoreAllMocks();
+
     mockRepo = {
       getAll: vi.fn(),
       updateRoutingRecord: vi.fn(),
@@ -47,7 +53,7 @@ describe('NotificationRoutingController', () => {
       release: vi.fn(),
     } as unknown as Mocked<NotificationRoutingRepository>;
 
-    mockFactory.getNotificationRoutingRepository = vi.fn().mockReturnValue(mockRepo);
+    vi.spyOn(factory, 'getNotificationRoutingRepository').mockReturnValue(mockRepo);
 
     vi.mocked(dns.resolveMx)
       .mockReset()
@@ -57,10 +63,6 @@ describe('NotificationRoutingController', () => {
     context = await createMockApplicationContext();
     context.session.user.roles = [CamsRole.SuperUser];
     controller = new NotificationRoutingController(context);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe('authorization', () => {
@@ -188,14 +190,50 @@ describe('NotificationRoutingController', () => {
       expect(result.statusCode).toBe(HttpStatusCodes.METHOD_NOT_ALLOWED);
     });
 
-    test('should throw BadRequestError when recipientAddresses is missing', async () => {
+    test.each([
+      { description: 'recipientAddresses is missing', body: {} },
+      {
+        description: 'recipientAddresses contains an invalid address',
+        body: { recipientAddresses: ['valid@example.com', 'not-an-email'] },
+      },
+      { description: 'body is null', body: null },
+      {
+        description: 'recipientAddresses is a non-array value',
+        body: { recipientAddresses: 'not-an-array' },
+      },
+      {
+        description: 'recipientAddresses contains non-string values',
+        body: { recipientAddresses: [1, null, {}] },
+      },
+      {
+        description: 'recipientAddresses mixes valid strings and non-strings',
+        body: { recipientAddresses: ['valid@example.com', 42] },
+      },
+    ])('should throw BadRequestError when $description', async ({ body }) => {
       context.request.method = 'PUT';
       context.request.params = { routingId: 'chapter-7-oversight' };
-      context.request.body = {};
+      context.request.body = body;
 
       await expect(controller.handleRequest(context)).rejects.toThrow(
         expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
       );
+    });
+
+    test('should trim leading/trailing whitespace from addresses before validating and saving', async () => {
+      context.request.method = 'PUT';
+      context.request.params = { routingId: 'chapter-7-oversight' };
+      context.request.body = { recipientAddresses: ['  someone@usdoj.gov  '] };
+      mockRepo.updateRoutingRecord.mockResolvedValue({
+        ...mockRecord,
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(HttpStatusCodes.OK);
+      expect(mockRepo.updateRoutingRecord).toHaveBeenCalledWith('chapter-7-oversight', {
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
     });
 
     test('should allow clearing all recipients by passing an empty array', async () => {
@@ -211,65 +249,53 @@ describe('NotificationRoutingController', () => {
         recipientAddresses: [],
       });
     });
-
-    test('should throw BadRequestError when any address in recipientAddresses is invalid', async () => {
-      context.request.method = 'PUT';
-      context.request.params = { routingId: 'chapter-7-oversight' };
-      context.request.body = { recipientAddresses: ['valid@example.com', 'not-an-email'] };
-
-      await expect(controller.handleRequest(context)).rejects.toThrow(
-        expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
-      );
-    });
-
-    test('should throw BadRequestError when body is null', async () => {
-      context.request.method = 'PUT';
-      context.request.params = { routingId: 'chapter-7-oversight' };
-      context.request.body = null;
-
-      await expect(controller.handleRequest(context)).rejects.toThrow(
-        expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
-      );
-    });
-
-    test('should throw BadRequestError when recipientAddresses is a non-array value', async () => {
-      context.request.method = 'PUT';
-      context.request.params = { routingId: 'chapter-7-oversight' };
-      context.request.body = { recipientAddresses: 'not-an-array' };
-
-      await expect(controller.handleRequest(context)).rejects.toThrow(
-        expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
-      );
-    });
-
-    test('should throw BadRequestError when recipientAddresses contains non-string values', async () => {
-      context.request.method = 'PUT';
-      context.request.params = { routingId: 'chapter-7-oversight' };
-      context.request.body = { recipientAddresses: [1, null, {}] };
-
-      await expect(controller.handleRequest(context)).rejects.toThrow(
-        expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
-      );
-    });
-
-    test('should throw BadRequestError when recipientAddresses mixes valid strings and non-strings', async () => {
-      context.request.method = 'PUT';
-      context.request.params = { routingId: 'chapter-7-oversight' };
-      context.request.body = { recipientAddresses: ['valid@example.com', 42] };
-
-      await expect(controller.handleRequest(context)).rejects.toThrow(
-        expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
-      );
-    });
   });
 
   describe('handlePut domain validation', () => {
-    test('should throw BadRequestError when a domain has neither MX nor A records', async () => {
-      vi.mocked(dns.resolveMx).mockRejectedValue(notFoundError());
-      vi.mocked(dns.resolve).mockRejectedValue(notFoundError());
+    test.each([
+      { description: 'ENOTFOUND', mxError: notFoundError(), aError: notFoundError() },
+      { description: 'ENODATA', mxError: noDataError(), aError: noDataError() },
+    ])(
+      'should throw BadRequestError when a domain has neither MX nor A records ($description)',
+      async ({ mxError, aError }) => {
+        vi.mocked(dns.resolveMx).mockRejectedValue(mxError);
+        vi.mocked(dns.resolve).mockRejectedValue(aError);
+        context.request.method = 'PUT';
+        context.request.params = { routingId: 'chapter-7-oversight' };
+        context.request.body = { recipientAddresses: ['someone@UST.DOJ.GOV'] };
+
+        await expect(controller.handleRequest(context)).rejects.toThrow(
+          expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),
+        );
+        expect(mockRepo.updateRoutingRecord).not.toHaveBeenCalled();
+      },
+    );
+
+    test('should fall back to an A-record lookup when the MX lookup resolves an empty list', async () => {
+      vi.mocked(dns.resolveMx).mockResolvedValue([]);
+      vi.mocked(dns.resolve).mockResolvedValue(['1.2.3.4']);
       context.request.method = 'PUT';
       context.request.params = { routingId: 'chapter-7-oversight' };
-      context.request.body = { recipientAddresses: ['someone@UST.DOJ.GOV'] };
+      context.request.body = { recipientAddresses: ['someone@usdoj.gov'] };
+      mockRepo.updateRoutingRecord.mockResolvedValue({
+        ...mockRecord,
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
+
+      const result = await controller.handleRequest(context);
+
+      expect(result.statusCode).toBe(HttpStatusCodes.OK);
+      expect(mockRepo.updateRoutingRecord).toHaveBeenCalledWith('chapter-7-oversight', {
+        recipientAddresses: ['someone@usdoj.gov'],
+      });
+    });
+
+    test('should reject a domain when the A-record lookup resolves an empty list', async () => {
+      vi.mocked(dns.resolveMx).mockRejectedValue(notFoundError());
+      vi.mocked(dns.resolve).mockResolvedValue([]);
+      context.request.method = 'PUT';
+      context.request.params = { routingId: 'chapter-7-oversight' };
+      context.request.body = { recipientAddresses: ['someone@usdoj.gov'] };
 
       await expect(controller.handleRequest(context)).rejects.toThrow(
         expect.objectContaining({ status: HttpStatusCodes.BAD_REQUEST }),

--- a/backend/lib/controllers/admin/notification-routing.controller.ts
+++ b/backend/lib/controllers/admin/notification-routing.controller.ts
@@ -1,3 +1,4 @@
+import * as dns from 'node:dns/promises';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { CamsHttpResponseInit, httpSuccess } from '../../adapters/utils/http-response';
 import { CamsController } from '../controller';
@@ -59,7 +60,7 @@ export class NotificationRoutingController implements CamsController {
         message: `Unknown routing ID: '${routingId}'. Must be one of: ${NOTIFICATION_ROUTING_DEFINITIONS.map((d) => d.id).join(', ')}`,
       });
     }
-    const input = this.validateUpdateInput(context.request.body);
+    const { input, warnings } = await this.validateUpdateInput(context, context.request.body);
     const definition = NOTIFICATION_ROUTING_DEFINITIONS.find((d) => d.id === routingId)!;
     const existing = await this.repository.findRecipientByRoutingKey(definition.covers[0]);
     const record = await this.repository.updateRoutingRecord(routingId, input);
@@ -73,11 +74,18 @@ export class NotificationRoutingController implements CamsController {
     });
     return httpSuccess({
       statusCode: HttpStatusCodes.OK,
-      body: { meta: { self: context.request.url }, data: record },
+      body: {
+        meta: { self: context.request.url },
+        data: record,
+        ...(warnings.length > 0 ? { warnings } : {}),
+      },
     });
   }
 
-  private validateUpdateInput(body: unknown): NotificationRoutingUpdateInput {
+  private async validateUpdateInput(
+    context: ApplicationContext,
+    body: unknown,
+  ): Promise<{ input: NotificationRoutingUpdateInput; warnings: string[] }> {
     const input = body as { recipientAddresses?: unknown } | null;
     if (!input) {
       throw new BadRequestError(MODULE_NAME, { message: 'Request body is required.' });
@@ -100,7 +108,60 @@ export class NotificationRoutingController implements CamsController {
         message: `Invalid email address(es): ${invalid.join(', ')}`,
       });
     }
-    return { recipientAddresses: trimmed };
+
+    const { invalidDomains, warnings } = await this.checkDomains(context, trimmed);
+    if (invalidDomains.length > 0) {
+      throw new BadRequestError(MODULE_NAME, {
+        message: `Domain(s) do not appear to accept email and were rejected: ${invalidDomains.join(', ')}`,
+      });
+    }
+
+    return { input: { recipientAddresses: trimmed }, warnings };
+  }
+
+  private async checkDomains(
+    context: ApplicationContext,
+    addresses: string[],
+  ): Promise<{ invalidDomains: string[]; warnings: string[] }> {
+    const domains = new Set(
+      addresses.map((address) => address.slice(address.lastIndexOf('@') + 1).toLowerCase()),
+    );
+    const invalidDomains: string[] = [];
+    const warnings: string[] = [];
+
+    for (const domain of domains) {
+      const result = await this.resolveDomain(domain);
+      if (result === 'not-found') {
+        invalidDomains.push(domain);
+      } else if (result === 'indeterminate') {
+        const message = `Could not verify that the domain '${domain}' accepts email; the DNS lookup failed rather than confirming the domain doesn't exist. Saved without domain verification for this address.`;
+        context.logger.warn(MODULE_NAME, message);
+        warnings.push(message);
+      }
+    }
+
+    return { invalidDomains, warnings };
+  }
+
+  private async resolveDomain(domain: string): Promise<'valid' | 'not-found' | 'indeterminate'> {
+    try {
+      const mxRecords = await dns.resolveMx(domain);
+      if (mxRecords.length > 0) return 'valid';
+    } catch (error) {
+      if (!this.isDomainNotFoundError(error)) return 'indeterminate';
+    }
+
+    try {
+      const addresses = await dns.resolve(domain);
+      return addresses.length > 0 ? 'valid' : 'not-found';
+    } catch (error) {
+      return this.isDomainNotFoundError(error) ? 'not-found' : 'indeterminate';
+    }
+  }
+
+  private isDomainNotFoundError(error: unknown): boolean {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    return code === 'ENOTFOUND' || code === 'ENODATA';
   }
 
   private requireSuperUser(context: ApplicationContext): void {

--- a/backend/lib/use-cases/notifications/trustee-change-notification.test.ts
+++ b/backend/lib/use-cases/notifications/trustee-change-notification.test.ts
@@ -290,6 +290,56 @@ describe('TrusteeChangeNotificationUseCase', () => {
     expect(recorded[0].replyTo).toBeUndefined();
   });
 
+  test('continues sending to addresses after a failed send, both within and across recipients', async () => {
+    seedRouting([
+      {
+        ...CHAPTER_OVERSIGHT_RECIPIENT,
+        recipientAddresses: ['primary@example.test', 'backup@example.test'],
+      },
+      ZOOM_341_RECIPIENT,
+    ]);
+    const originalSend = mockGateway.send.bind(mockGateway);
+    const sendSpy = vi.spyOn(mockGateway, 'send').mockImplementation(async (notification) => {
+      if (notification.to === 'primary@example.test') {
+        throw new Error('ACS rejected this address');
+      }
+      return originalSend(notification);
+    });
+    const errorSpy = vi.spyOn(context.logger, 'error');
+
+    await useCase.notify(
+      context,
+      buildChangeSet([
+        buildField({ category: 'profile', section: 'appointment' }),
+        buildField({
+          label: 'Zoom Info',
+          category: 'zoom-341',
+          section: 'meeting',
+          comparisons: [{ before: 'old', after: 'new' }],
+        }),
+      ]),
+    );
+
+    // 'primary@example.test' is the FIRST address attempted (first recipient, first address).
+    // Both the second address of that same recipient and the entirely separate zoom-341
+    // recipient are attempted afterward, so this proves the failure doesn't abort either
+    // the inner (same-recipient) or outer (cross-recipient) loop.
+    const recorded = mockGateway.getRecorded();
+    const addresses = recorded.map((n) => n.to).sort();
+    expect(addresses).toEqual(
+      ['backup@example.test', ZOOM_341_RECIPIENT.recipientAddresses[0]].sort(),
+    );
+    expect(
+      errorSpy.mock.calls.some(
+        (call) =>
+          typeof call[1] === 'string' &&
+          call[1].includes('primary@example.test') &&
+          call[1].includes('chapter:7'),
+      ),
+    ).toBe(true);
+    sendSpy.mockRestore();
+  });
+
   test('correlationId on each notification matches the context invocationId', async () => {
     seedRouting([CHAPTER_OVERSIGHT_RECIPIENT, ZOOM_341_RECIPIENT]);
 

--- a/backend/lib/use-cases/notifications/trustee-change-notification.test.ts
+++ b/backend/lib/use-cases/notifications/trustee-change-notification.test.ts
@@ -76,10 +76,6 @@ describe('TrusteeChangeNotificationUseCase', () => {
     useCase = new TrusteeChangeNotificationUseCase(context);
   });
 
-  afterEach(() => {
-    delete process.env.DEFAULT_NOTIFICATION_RECIPIENT;
-  });
-
   test('returns without dispatching when the change set is empty', async () => {
     seedRouting([CHAPTER_OVERSIGHT_RECIPIENT]);
 
@@ -179,6 +175,38 @@ describe('TrusteeChangeNotificationUseCase', () => {
     );
 
     expect(mockGateway.getRecorded()).toHaveLength(1);
+  });
+
+  test('dedupes only the overlapping address, keeping the unique one from a partially-overlapping recipient', async () => {
+    seedRouting([
+      CHAPTER_OVERSIGHT_RECIPIENT,
+      {
+        ...ZOOM_341_RECIPIENT,
+        recipientAddresses: [
+          CHAPTER_OVERSIGHT_RECIPIENT.recipientAddresses[0],
+          'unique@example.test',
+        ],
+      },
+    ]);
+
+    await useCase.notify(
+      context,
+      buildChangeSet([
+        buildField({ category: 'profile', section: 'appointment' }),
+        buildField({
+          label: 'Zoom Info',
+          category: 'zoom-341',
+          section: 'meeting',
+          comparisons: [{ before: 'old', after: 'new' }],
+        }),
+      ]),
+    );
+
+    const addresses = mockGateway.getRecorded().map((n) => n.to);
+    expect(addresses).toEqual([
+      CHAPTER_OVERSIGHT_RECIPIENT.recipientAddresses[0],
+      'unique@example.test',
+    ]);
   });
 
   test('drops the dispatch with an error log when no record or env var fallback exists', async () => {
@@ -338,28 +366,5 @@ describe('TrusteeChangeNotificationUseCase', () => {
       ),
     ).toBe(true);
     sendSpy.mockRestore();
-  });
-
-  test('correlationId on each notification matches the context invocationId', async () => {
-    seedRouting([CHAPTER_OVERSIGHT_RECIPIENT, ZOOM_341_RECIPIENT]);
-
-    await useCase.notify(
-      context,
-      buildChangeSet([
-        buildField({ category: 'profile', section: 'appointment' }),
-        buildField({
-          label: 'Zoom Info',
-          category: 'zoom-341',
-          section: 'meeting',
-          comparisons: [{ before: 'old', after: 'new' }],
-        }),
-      ]),
-    );
-
-    const recorded = mockGateway.getRecorded();
-    expect(recorded).toHaveLength(2);
-    for (const n of recorded) {
-      expect(n.correlationId).toBe(context.invocationId);
-    }
   });
 });

--- a/backend/lib/use-cases/notifications/trustee-change-notification.ts
+++ b/backend/lib/use-cases/notifications/trustee-change-notification.ts
@@ -23,39 +23,48 @@ export class TrusteeChangeNotificationUseCase {
   async notify(context: ApplicationContext, changeSet: TrusteeChangeSet): Promise<void> {
     if (changeSet.fields.length === 0) return;
 
-    const recipients = await this.resolveRecipients(context, changeSet);
-    if (recipients.length === 0) return;
+    const mailingLists = await this.resolveMailingLists(context, changeSet);
+    if (mailingLists.length === 0) return;
 
     const compiled = compileTrusteeChangeTemplate(changeSet);
     const replyTo = changeSet.author?.email
       ? { address: changeSet.author.email, displayName: changeSet.author.name }
       : undefined;
 
-    for (const recipient of recipients) {
-      for (const address of recipient.recipientAddresses) {
-        const notification: Notification = {
-          to: address,
-          toDisplayName: recipient.displayName,
-          subject: compiled.subject,
-          html: compiled.html,
-          text: compiled.text,
-          correlationId: context.invocationId,
-          replyTo,
-        };
-        try {
-          await this.notificationGateway.send(notification);
-        } catch (error) {
-          context.logger.error(
-            MODULE_NAME,
-            `Failed to send trustee change notification to '${address}' (covers: ${recipient.covers.join(', ')}).`,
-            error,
-          );
-        }
+    for (const mailingList of mailingLists) {
+      await this.sendToMailingList(context, mailingList, compiled, replyTo);
+    }
+  }
+
+  private async sendToMailingList(
+    context: ApplicationContext,
+    mailingList: NotificationRecipient,
+    compiled: { subject: string; html: string; text: string },
+    replyTo: Notification['replyTo'],
+  ): Promise<void> {
+    for (const address of mailingList.recipientAddresses) {
+      const notification: Notification = {
+        to: address,
+        toDisplayName: mailingList.displayName,
+        subject: compiled.subject,
+        html: compiled.html,
+        text: compiled.text,
+        correlationId: context.invocationId,
+        replyTo,
+      };
+      try {
+        await this.notificationGateway.send(notification);
+      } catch (error) {
+        context.logger.error(
+          MODULE_NAME,
+          `Failed to send trustee change notification to '${address}' (covers: ${mailingList.covers.join(', ')}).`,
+          error,
+        );
       }
     }
   }
 
-  private async resolveRecipients(
+  private async resolveMailingLists(
     context: ApplicationContext,
     changeSet: TrusteeChangeSet,
   ): Promise<NotificationRecipient[]> {
@@ -63,12 +72,12 @@ export class TrusteeChangeNotificationUseCase {
 
     const candidates: NotificationRecipient[] = [];
     for (const category of categories) {
-      const recipients = await this.resolveRecipientsForCategory(
+      const mailingLists = await this.resolveMailingListsForCategory(
         context,
         category,
         changeSet.chapters,
       );
-      candidates.push(...recipients);
+      candidates.push(...mailingLists);
     }
 
     const seen = new Set<string>();
@@ -87,7 +96,7 @@ export class TrusteeChangeNotificationUseCase {
     return unique;
   }
 
-  private async resolveRecipientsForCategory(
+  private async resolveMailingListsForCategory(
     context: ApplicationContext,
     category: RoutingCategory,
     chapters: TrusteeChangeSet['chapters'],
@@ -99,15 +108,15 @@ export class TrusteeChangeNotificationUseCase {
 
     if (routingKeys.length === 0) return [];
 
-    const recipients: NotificationRecipient[] = [];
+    const mailingLists: NotificationRecipient[] = [];
     for (const routingKey of routingKeys) {
-      const recipient = await this.resolveRecipientForRoutingKey(context, routingKey);
-      if (recipient) recipients.push(recipient);
+      const mailingList = await this.resolveMailingListForRoutingKey(context, routingKey);
+      if (mailingList) mailingLists.push(mailingList);
     }
-    return recipients;
+    return mailingLists;
   }
 
-  private async resolveRecipientForRoutingKey(
+  private async resolveMailingListForRoutingKey(
     context: ApplicationContext,
     routingKey: string,
   ): Promise<NotificationRecipient | null> {

--- a/backend/lib/use-cases/notifications/trustee-change-notification.ts
+++ b/backend/lib/use-cases/notifications/trustee-change-notification.ts
@@ -42,7 +42,15 @@ export class TrusteeChangeNotificationUseCase {
           correlationId: context.invocationId,
           replyTo,
         };
-        await this.notificationGateway.send(notification);
+        try {
+          await this.notificationGateway.send(notification);
+        } catch (error) {
+          context.logger.error(
+            MODULE_NAME,
+            `Failed to send trustee change notification to '${address}' (covers: ${recipient.covers.join(', ')}).`,
+            error,
+          );
+        }
       }
     }
   }

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 import { ApplicationContext } from '../../adapters/types/basic';
 import { createMockApplicationContext, getTheThrownError } from '../../testing/testing-utilities';
 import MockData from '@common/cams/test-utilities/mock-data';
-import { MODULE_NAME, TrusteesUseCase } from './trustees';
+import { TrusteesUseCase } from './trustees';
 import { MockMongoRepository } from '../../testing/mock-gateways/mock-mongo.repository';
 import { getCamsUserReference } from '@common/cams/session';
 import { BadRequestError } from '../../common-errors/bad-request';
@@ -2069,7 +2069,9 @@ describe('TrusteesUseCase tests', () => {
       const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
       vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
 
-      // Force the gateway to throw on send.
+      // Force the gateway to throw on send. The notification use case isolates this
+      // per-recipient failure, so it no longer bubbles up to dispatchChangeNotification's
+      // generic catch (see trustee-change-notification.ts).
       sendSpy.mockRejectedValue(new Error('Simulated provider failure'));
       const errorSpy = vi.spyOn(context.logger, 'error');
 
@@ -2080,8 +2082,8 @@ describe('TrusteesUseCase tests', () => {
       expect(result).toEqual(updatedTrustee);
       await vi.waitFor(() =>
         expect(errorSpy).toHaveBeenCalledWith(
-          MODULE_NAME,
-          'Failed to dispatch trustee change notification.',
+          'TRUSTEE-CHANGE-NOTIFICATION',
+          "Failed to send trustee change notification to 'ch7-oversight@example.test' (covers: chapter:7, chapter:11, chapter:12, chapter:13).",
           expect.any(Error),
         ),
       );

--- a/backend/lib/use-cases/trustees/trustees.test.ts
+++ b/backend/lib/use-cases/trustees/trustees.test.ts
@@ -2089,6 +2089,34 @@ describe('TrusteesUseCase tests', () => {
       );
     });
 
+    test('returns the updated trustee successfully when resolveChapters throws, outside the per-recipient send isolation', async () => {
+      const updatedTrustee = { ...existingTrustee, name: 'Henry G. Green' };
+      vi.spyOn(MockMongoRepository.prototype, 'updateTrustee').mockResolvedValue(updatedTrustee);
+
+      // Unlike the gateway-throws case above, this failure happens before notify() is ever
+      // called (in dispatchChangeNotification's own resolveChapters call), so it's still
+      // caught by dispatchChangeNotification's outer try/catch rather than notify()'s
+      // per-recipient isolation.
+      vi.spyOn(MockMongoRepository.prototype, 'getAppointmentsByTrusteeIds').mockRejectedValue(
+        new Error('Simulated repository failure'),
+      );
+      const errorSpy = vi.spyOn(context.logger, 'error');
+
+      const result = await trusteesUseCase.updateTrustee(context, trusteeId, {
+        name: 'Henry G. Green',
+      });
+
+      expect(result).toEqual(updatedTrustee);
+      await vi.waitFor(() =>
+        expect(errorSpy).toHaveBeenCalledWith(
+          'TRUSTEES-USE-CASE',
+          'Failed to dispatch trustee change notification.',
+          expect.any(Error),
+        ),
+      );
+      expect(MockNotificationGateway.getInstance().getRecorded()).toEqual([]);
+    });
+
     test('multi-field save produces one notification whose body contains every changed label', async () => {
       const newPublic = MockData.getContactInformation({ companyName: 'New Co' });
       const updatedTrustee = {

--- a/backend/lib/use-cases/trustees/trustees.ts
+++ b/backend/lib/use-cases/trustees/trustees.ts
@@ -61,7 +61,7 @@ import {
 import { TrusteeChangeNotificationUseCase } from '../notifications/trustee-change-notification';
 import DateHelper from '@common/date-helper';
 
-export const MODULE_NAME = 'TRUSTEES-USE-CASE';
+const MODULE_NAME = 'TRUSTEES-USE-CASE';
 
 const SYSTEM_USER: CamsUserReference = {
   id: 'SYSTEM',

--- a/common/src/api/response.ts
+++ b/common/src/api/response.ts
@@ -9,4 +9,5 @@ export type ResponseBody<T = unknown> = {
   meta?: ResponseMetaData;
   pagination?: Pagination;
   data: T;
+  warnings?: string[];
 };

--- a/ops/cloud-deployment/lib/app-insights/diagnostics-settings-email.bicep
+++ b/ops/cloud-deployment/lib/app-insights/diagnostics-settings-email.bicep
@@ -1,0 +1,57 @@
+/*
+  Enable email send/delivery diagnostic logs for the ACS Communication Services resource
+  used to send trustee change notification emails.
+
+  EmailSendMailOperational      - records that a send was accepted/initiated
+  EmailStatusUpdateOperational  - downstream per-recipient delivery result (bounce/reject detail)
+  EmailUserEngagementOperational - opens/clicks; disabled, matches userEngagementTracking: 'Disabled'
+    on the linked email domain resource (see email-communication-services.bicep)
+
+  Metrics category is 'Traffic' - Communication Services does not support the 'AllMetrics' alias
+  used by some other resource types; confirmed via `az monitor diagnostic-settings categories list`
+  against ustp-cams-comms.
+*/
+@description('Name of the diagnostic setting.')
+param settingName string
+
+@description('Name of the Communication Services resource that sends email.')
+param communicationServiceName string
+
+@description('Resource id of the Log Analytics workspace to send diagnostic data to.')
+param analyticsWorkspaceId string
+
+resource communicationService 'Microsoft.Communication/communicationServices@2023-04-01' existing = {
+  name: communicationServiceName
+}
+
+resource setting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: settingName
+  scope: communicationService
+  properties: {
+    workspaceId: analyticsWorkspaceId
+    logs: [
+      {
+        category: 'EmailSendMailOperational'
+        categoryGroup: null
+        enabled: true
+      }
+      {
+        category: 'EmailStatusUpdateOperational'
+        categoryGroup: null
+        enabled: true
+      }
+      {
+        category: 'EmailUserEngagementOperational'
+        categoryGroup: null
+        enabled: false
+      }
+    ]
+    metrics: [
+      {
+        timeGrain: null
+        enabled: true
+        category: 'Traffic'
+      }
+    ]
+  }
+}

--- a/ops/cloud-deployment/lib/email/acs-email.bicep
+++ b/ops/cloud-deployment/lib/email/acs-email.bicep
@@ -14,6 +14,9 @@ param tags object = {}
 @description('Custom domain FQDN (e.g. notifications.example.gov). Leave empty to use Azure-managed domain.')
 param customDomain string = ''
 
+@description('OPTIONAL. Resource id of Log Analytics workspace to send email send/delivery diagnostic logs to.')
+param analyticsWorkspaceId string = ''
+
 var emailServiceName = '${stackName}-email'
 var communicationServiceName = '${stackName}-comms'
 
@@ -57,6 +60,18 @@ module acsSenderAddressSecret '../keyvault/keyvault-secret.bicep' = {
     secretName: 'ACS-EMAIL-SENDER-ADDRESS' // pragma: allowlist secret
     secretValue: emailService.outputs.senderAddress
   }
+}
+
+module emailDiagnosticSetting '../app-insights/diagnostics-settings-email.bicep' = if (!empty(analyticsWorkspaceId)) {
+  name: '${stackName}-email-diagnostic-setting-module'
+  params: {
+    settingName: '${communicationServiceName}-diagnostic-setting'
+    communicationServiceName: communicationServiceName
+    analyticsWorkspaceId: analyticsWorkspaceId
+  }
+  dependsOn: [
+    communicationService
+  ]
 }
 
 output senderAddress string = emailService.outputs.senderAddress

--- a/ops/cloud-deployment/main.bicep
+++ b/ops/cloud-deployment/main.bicep
@@ -249,6 +249,7 @@ module acsEmail './lib/email/acs-email.bicep' = {
     kvAppConfigName: kvAppConfigName
     kvAppConfigResourceGroupName: kvAppConfigResourceGroupName
     customDomain: customDomain
+    analyticsWorkspaceId: analyticsWorkspaceId
     tags: {
       app: 'cams'
       component: 'email'

--- a/user-interface/src/admin/notification-routing/NotificationRouting.tsx
+++ b/user-interface/src/admin/notification-routing/NotificationRouting.tsx
@@ -43,6 +43,7 @@ export function NotificationRouting() {
   const [emailErrors, setEmailErrors] = useState<Record<string, (string | null)[]>>({});
   const [apiError, setApiError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [saveWarnings, setSaveWarnings] = useState<string[]>([]);
 
   async function loadData(): Promise<boolean> {
     try {
@@ -108,8 +109,10 @@ export function NotificationRouting() {
       return;
     }
     setApiError(null);
+    setSaveWarnings([]);
 
     const failedDefinitions: string[] = [];
+    const warnings: string[] = [];
     for (const def of NOTIFICATION_ROUTING_DEFINITIONS) {
       const addrs = (emails[def.id] ?? ['']).map((a) => a.trim()).filter(Boolean);
       const existingRecord = records.find((r) => r.id === def.id);
@@ -118,14 +121,18 @@ export function NotificationRouting() {
         addrs.length === existingAddrs.length && addrs.every((a, i) => a === existingAddrs[i]);
       if (!unchanged) {
         try {
-          await Api2.updateNotificationRouting(def.id, {
+          const response = await Api2.updateNotificationRouting(def.id, {
             recipientAddresses: addrs,
           });
+          if (response.warnings?.length) {
+            warnings.push(...response.warnings);
+          }
         } catch {
           failedDefinitions.push(def.displayName);
         }
       }
     }
+    setSaveWarnings(warnings);
 
     const reloadSucceeded = await loadData();
 
@@ -163,6 +170,14 @@ export function NotificationRouting() {
               type={UswdsAlertStyle.Success}
               show={true}
               timeout={5}
+            />
+          )}
+          {saveWarnings.length > 0 && (
+            <Alert
+              id="routing-save-warning"
+              message={saveWarnings.join(' ')}
+              type={UswdsAlertStyle.Warning}
+              show={true}
             />
           )}
           {NOTIFICATION_ROUTING_DEFINITIONS.map((def) => (

--- a/user-interface/src/lib/testing/mock-api2.ts
+++ b/user-interface/src/lib/testing/mock-api2.ts
@@ -3182,7 +3182,10 @@ async function getNotificationRouting() {
   };
 }
 
-async function updateNotificationRouting(routingId: string, data: NotificationRoutingUpdateInput) {
+async function updateNotificationRouting(
+  routingId: string,
+  data: NotificationRoutingUpdateInput,
+): Promise<ResponseBody<NotificationRoutingRecord>> {
   const def = NOTIFICATION_ROUTING_DEFINITIONS.find((d) => d.id === routingId);
   return {
     data: {


### PR DESCRIPTION
# Bug

Trustee change-notification emails were silently not delivered to some recipient groups because their NOTIFICATION_ROUTING records stored a wrong-but-syntactically-valid domain (@UST.DOJ.GOV instead of @usdoj.gov). ACS accepted the send since the address was well-formed, so nothing in CAMS ever signaled a delivery problem. Separately, a nested-loop bug meant a single bad recipient's send failure aborted every remaining recipient/address in that same notification run.

# Purpose

Close the observability and error-isolation gaps that let a bad recipient address fail silently: one recipient's send failure should never block delivery to the rest, obviously-wrong domains should be caught before they're saved, and delivery-status data should actually be flowing somewhere it can be inspected.

# Major Changes

* Isolated per-recipient/per-address send failures in `TrusteeChangeNotificationUseCase.notify()` so one bad address no longer aborts the rest of the batch; each failure is now logged individually
* Added DNS domain validation (MX with A/AAAA fallback) to the admin notification-routing PUT endpoint — a definitively nonexistent domain is rejected at save time, and an indeterminate DNS failure is saved but surfaced as a UI warning
* Enabled ACS Communication Services diagnostic logging (`EmailSendMailOperational`, `EmailStatusUpdateOperational`) forwarded to Log Analytics, giving per-recipient send/delivery visibility instead of only an aggregate metric count
* Renamed `notify()`'s internal recipient/mailing-list terminology (`recipient` → `mailingList`) to match what the resolved objects actually represent, and extracted the inner per-address send loop into its own `sendToMailingList` method for clarity
* Removed a dangling `MODULE_NAME` export left over from an earlier refactor

# Testing/Validation

Unit tests added for: per-recipient send-failure isolation in `trustee-change-notification.test.ts`; DNS domain validation branches (not-found, indeterminate, valid) in `notification-routing.controller.test.ts`. Full backend/common/user-interface test suites pass (2 pre-existing, unrelated flaky timeouts in `migrate-trustees*.test.ts` under full-suite load, confirmed to pass standalone and unaffected by this branch). Typecheck, lint, knip, and prettier all clean on changed files.

# Notes

This PR covers the send-time isolation and prevention pieces of CAMS-856. Two follow-up items remain, tracked separately: auditing/correcting the actual wrong-domain routing records across all environments (chapter 12/13 were fixed live in one environment during triage; chapter 7, chapter 11, subchapter-v, and zoom-341 are still unverified), and building admin/infra alerting on top of the new diagnostic logs for real bounces (an async ACS delivery-status signal that this PR's synchronous fixes cannot catch on their own).

# Definition of Done:

- [ ] Code refactored for clarity: Developers can understand the work simply by reviewing the code
- [ ] Dependency rule followed: More important code doesn't directly depend on less important code
- [ ] Development debt eliminated: UX and code aligns to the team's latest understanding of the domain
- [ ] No regressions: Changes do not cause regression in related or unrelated areas of the application

## Summary by Sourcery

Improve trustee notification reliability and observability by validating notification-routing email domains, isolating per-address send failures, and surfacing diagnostic signals end-to-end.

Bug Fixes:
- Prevent a single trustee notification send failure from aborting delivery to other addresses and mailing lists.
- Reject notification-routing updates that use domains that do not appear to accept email, avoiding silently undeliverable trustee notifications.

Enhancements:
- Add DNS-based domain validation (MX with A-record fallback and indeterminate handling) to the admin notification-routing update endpoint and flow warnings back to the UI.
- Propagate backend response warnings through the admin notification-routing UI so operators see when domain verification could not be completed.
- Refine trustee change notification mailing-list terminology and logging to clearly identify which routed mailing lists and chapters are affected by send failures.
- Remove an unused trustees module name export after refactoring notification error handling.

Build:
- Wire ACS Communication Services email diagnostic settings into the deployment templates, optionally sending send/delivery logs to a Log Analytics workspace.
- Extend the shared API response shape to support optional warnings alongside data and metadata.

Tests:
- Add unit tests for DNS domain validation behavior in the notification-routing controller, including not-found, fallback, indeterminate, and unique-domain lookup cases.
- Add unit tests ensuring trustee notifications continue sending after a failed address and emit appropriate error logs.
- Adjust trustees use-case tests to assert the new trustee change notification error logging behavior.